### PR TITLE
Lint clean, allocate page not epoch,  improve login

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -52,7 +52,7 @@
       }
     ],
     "semi": ["error", "always"],
-    "no-warning-comments": "warn",
+    "no-warning-comments": "off",
     "import/extensions": 0,
     "import/no-unresolved": 0,
     "import/no-extraneous-dependencies": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Launch Chrome against localhost",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}/src"
+    }
+  ]
+}

--- a/src/components/ApeTabs/ApeTabs.tsx
+++ b/src/components/ApeTabs/ApeTabs.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import clsx from 'clsx';
 

--- a/src/components/CoordinapeLogo/index.tsx
+++ b/src/components/CoordinapeLogo/index.tsx
@@ -6,7 +6,7 @@ import { makeStyles, Typography, Box } from '@material-ui/core';
 
 import { ReactComponent as CoordinapeLogoSvg } from 'assets/svgs/coordinape-logo.svg';
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   root: {
     display: 'flex',
     alignItems: 'center',

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -24,7 +24,7 @@ class InnerErrorBoundary extends Component<IInnerProps, State> {
     hasError: false,
   };
 
-  public static getDerivedStateFromError(_: Error): State {
+  public static getDerivedStateFromError(): State {
     // Update state so the next render will show the fallback UI.
     return { hasError: true };
   }

--- a/src/components/MainLayout/MainHeader.tsx
+++ b/src/components/MainLayout/MainHeader.tsx
@@ -150,7 +150,7 @@ export const HeaderButtons = () => {
   );
 };
 
-export const MainHeader = ({ className }: { className?: string }) => {
+export const MainHeader = () => {
   const theme = useTheme();
   const classes = useStyles();
 

--- a/src/components/MainLayout/MainLayout.tsx
+++ b/src/components/MainLayout/MainLayout.tsx
@@ -7,7 +7,7 @@ import useCommonStyles from 'styles/common';
 
 import MainHeader from './MainHeader';
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   root: {
     position: 'fixed',
     top: 0,

--- a/src/hooks/useApeSnackbar.ts
+++ b/src/hooks/useApeSnackbar.ts
@@ -2,10 +2,20 @@ import { useSnackbar } from 'notistack';
 
 export const useApeSnackbar = (): {
   apeInfo: (message: string) => void;
+  apeError: (error: any) => void;
 } => {
   const { enqueueSnackbar } = useSnackbar();
   return {
     apeInfo: (message: string) =>
       enqueueSnackbar(message, { variant: 'default' }),
+    apeError: (error: any) =>
+      enqueueSnackbar(
+        typeof error === 'string'
+          ? error
+          : error?.response?.data?.message ||
+              error?.message ||
+              'Something went wrong!',
+        { variant: 'error' }
+      ),
   };
 };

--- a/src/hooks/useAsync.ts
+++ b/src/hooks/useAsync.ts
@@ -1,15 +1,15 @@
-import React, { useState, useCallback } from 'react';
+import { useCallback } from 'react';
 
 import { useSetRecoilState } from 'recoil';
 
 import { rGlobalLoading } from 'recoilState';
 
-// Making async calls error into the error boundary and have loading available.
-// Inspired by
-// https://medium.com/trabe/catching-asynchronous-errors-in-react-using-error-boundaries-5e8a5fd7b971
+import { useApeSnackbar } from './useApeSnackbar';
+
+// Making async calls with errors and loading
 export const useAsync = () => {
   const setGlobalLoading = useSetRecoilState(rGlobalLoading);
-  const [_, setError] = useState();
+  const { apeError } = useApeSnackbar();
 
   return useCallback(
     async <T>(promise: Promise<T>, showLoading: boolean) => {
@@ -22,13 +22,11 @@ export const useAsync = () => {
           })
           .catch((e) => {
             showLoading && setGlobalLoading((v) => v - 1);
-            setError(() => {
-              throw e;
-            });
+            apeError(e);
             reject(e);
           });
       });
     },
-    [setError, setGlobalLoading]
+    [setGlobalLoading, apeError]
   );
 };

--- a/src/hooks/useMe.ts
+++ b/src/hooks/useMe.ts
@@ -77,7 +77,7 @@ export const useMe = (): {
       if (!selectedMyUser) {
         throw 'Need to select a circle to update circle user';
       }
-      const result = await api.postTeammates(
+      await api.postTeammates(
         selectedMyUser.circle_id,
         selectedMyUser.address,
         teammateIds
@@ -93,13 +93,12 @@ export const useMe = (): {
       if (!selectedMyUser || !selectedCircle) {
         throw 'Need to select a circle to update circle user';
       }
-      const result = await api.postUploadImage(
+      await api.postUploadImage(
         selectedCircle.id,
         selectedMyUser.address,
         newAvatar
       );
 
-      console.log('updateAvatar result: ', result);
       setMyProfileStaleSignal(myProfileStaleSignal + 1);
     };
     return <Promise<void>>asyncCall(call(), true);

--- a/src/pages/AdminPage/components/Content/index.tsx
+++ b/src/pages/AdminPage/components/Content/index.tsx
@@ -14,7 +14,7 @@ import { useUserInfo } from 'hooks';
 import { shortenAddress } from 'utils';
 import { getAvatarPath } from 'utils/domain';
 
-import { IUser, ICircle } from 'types';
+import { IUser } from 'types';
 
 const useStyles = makeStyles((theme) => ({
   root: {

--- a/src/pages/AdminPage/components/EditCircleModal/index.tsx
+++ b/src/pages/AdminPage/components/EditCircleModal/index.tsx
@@ -4,7 +4,6 @@ import { Button, Hidden, Modal, makeStyles } from '@material-ui/core';
 
 import { ReactComponent as SaveAdminSVG } from 'assets/svgs/button/save-admin.svg';
 import { useUserInfo } from 'hooks';
-import { capitalizedName } from 'utils/string';
 
 import { ICircle } from 'types';
 

--- a/src/pages/AdminPage/index.tsx
+++ b/src/pages/AdminPage/index.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 
-import { Button, Hidden, makeStyles } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core';
 
 import { Content, Header } from './components';
 

--- a/src/pages/AllocationPage/AllocationEpoch.tsx
+++ b/src/pages/AllocationPage/AllocationEpoch.tsx
@@ -4,7 +4,7 @@ import { makeStyles } from '@material-ui/core';
 
 import { OptInput } from 'components';
 import { MAX_BIO_LENGTH } from 'config/constants';
-import { useCircle } from 'hooks';
+import { useCircle, useSelectedCircleEpoch } from 'hooks';
 import { capitalizedName } from 'utils/string';
 
 const useStyles = makeStyles((theme) => ({
@@ -14,14 +14,13 @@ const useStyles = makeStyles((theme) => ({
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
-    padding: theme.spacing(10, 4, 20),
+    padding: theme.spacing(7, 4, 20),
     [theme.breakpoints.down('sm')]: {
       padding: theme.spacing(5, 1, 20),
     },
   },
   title: {
     margin: 0,
-    paddingLeft: theme.spacing(1),
     maxWidth: theme.breakpoints.values.md,
     fontSize: 30,
     fontWeight: 700,
@@ -31,10 +30,18 @@ const useStyles = makeStyles((theme) => ({
   },
   titleTwo: {
     margin: 0,
-    paddingLeft: theme.spacing(1),
     fontSize: 27,
     fontWeight: 300,
     lineHeight: 1.3,
+    color: theme.colors.primary,
+    textAlign: 'center',
+  },
+  epochTiming: {
+    margin: 0,
+    maxWidth: theme.breakpoints.values.md,
+    fontSize: 20,
+    fontWeight: 300,
+    lineHeight: 2,
     color: theme.colors.primary,
     textAlign: 'center',
   },
@@ -109,6 +116,7 @@ const ProfilePage = ({
   fixedNonReceiver: boolean;
 }) => {
   const classes = useStyles();
+  const { epochIsActive, timingMessage } = useSelectedCircleEpoch();
   const { selectedCircle } = useCircle();
 
   const onChangeBio = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -117,8 +125,13 @@ const ProfilePage = ({
 
   return (
     <div className={classes.root}>
+      {!epochIsActive && (
+        <h2 className={classes.epochTiming}>{timingMessage}</h2>
+      )}
       <span className={classes.title}>
-        What have you been working on this epoch?
+        {epochIsActive
+          ? 'What have you been working on this epoch?'
+          : 'What have you been working on?'}
       </span>
       <hr className={classes.hrWithMax} />
       <textarea

--- a/src/pages/AllocationPage/AllocationPage.tsx
+++ b/src/pages/AllocationPage/AllocationPage.tsx
@@ -53,13 +53,13 @@ const useStyles = makeStyles((theme) => ({
     maxWidth: '190px',
   },
   title: {
-    margin: theme.spacing(8, 0, 0),
-    paddingLeft: theme.spacing(1),
+    margin: theme.spacing(2, 0, 0),
     fontSize: 30,
     fontWeight: 700,
     lineHeight: 1.3,
     color: theme.colors.primary,
     textAlign: 'center',
+    backgroundColor: 'red',
   },
   buttonContainer: {
     position: 'fixed',
@@ -150,7 +150,7 @@ export const AllocationPage = () => {
     saveGifts,
     saveTeammates,
   } = useSelectedAllocation();
-  const { epochIsActive, timingMessage } = useSelectedCircleEpoch();
+  const { epochIsActive } = useSelectedCircleEpoch();
   const { selectedMyUser, updateMyUser, selectedCircle } = useMe();
 
   const fixedNonReceiver = selectedMyUser?.fixed_non_receiver !== 0;
@@ -190,8 +190,10 @@ export const AllocationPage = () => {
 
   const handleSaveTeamList = async () => {
     await saveTeammates();
-    setActiveStep(STEP_ALLOCATION.key);
-    history.push(STEP_ALLOCATION.path);
+    if (epochIsActive) {
+      setActiveStep(STEP_ALLOCATION.key);
+      history.push(STEP_ALLOCATION.path);
+    }
   };
 
   const handleSaveAllocations = async () => {
@@ -201,12 +203,6 @@ export const AllocationPage = () => {
     await saveGifts();
   };
 
-  const handleBack = () => {
-    const previous = activeStep - 1;
-    previous >= 0 && setActiveStep(previous);
-    history.push(STEPS[previous].path);
-  };
-
   const getHandleStep = (step: IAllocationStep) => () => {
     history.push(step.path);
     setActiveStep(step.key);
@@ -214,29 +210,26 @@ export const AllocationPage = () => {
 
   return (
     <div className={classes.root}>
-      {epochIsActive ? (
-        <Stepper
-          nonLinear
-          activeStep={activeStep}
-          classes={{ root: classes.stepperRoot }}
-        >
-          {STEPS.map((step) => (
-            <Step key={step.key} classes={{ root: classes.stepRoot }}>
-              <StepButton
-                onClick={getHandleStep(step)}
-                completed={completedSteps.has(step)}
-              >
-                {step.label}
-              </StepButton>
-            </Step>
-          ))}
-        </Stepper>
-      ) : (
-        <h2 className={classes.title}>{timingMessage}</h2>
-      )}
+      <Stepper
+        nonLinear
+        activeStep={activeStep}
+        classes={{ root: classes.stepperRoot }}
+      >
+        {STEPS.map((step) => (
+          <Step key={step.key} classes={{ root: classes.stepRoot }}>
+            <StepButton
+              onClick={getHandleStep(step)}
+              completed={completedSteps.has(step)}
+              disabled={step === STEP_ALLOCATION && !epochIsActive}
+            >
+              {step.label}
+            </StepButton>
+          </Step>
+        ))}
+      </Stepper>
 
       <div className={classes.body}>
-        {epochIsActive && selectedMyUser && activeStep === 0 && (
+        {selectedMyUser && activeStep === 0 && (
           <>
             <AllocationEpoch
               epochBio={epochBio}
@@ -265,7 +258,7 @@ export const AllocationPage = () => {
           </>
         )}
 
-        {epochIsActive && selectedMyUser && activeStep === 1 && (
+        {selectedMyUser && activeStep === 1 && (
           <>
             <AllocationTeam />
             <div className={classes.buttonContainer}>
@@ -279,6 +272,7 @@ export const AllocationPage = () => {
               ) : (
                 <Button
                   className={classes.saveButton}
+                  disabled={!epochIsActive}
                   onClick={getHandleStep(STEP_ALLOCATION)}
                 >
                   Continue with this team

--- a/src/pages/AllocationPage/AllocationTeam.tsx
+++ b/src/pages/AllocationPage/AllocationTeam.tsx
@@ -7,10 +7,12 @@ import { Button, makeStyles } from '@material-ui/core';
 
 import { ReactComponent as CheckmarkSVG } from 'assets/svgs/button/checkmark.svg';
 import { Img } from 'components';
-import { useCircle, useMe, useSelectedAllocation } from 'hooks';
+import {
+  useCircle,
+  useSelectedAllocation,
+  useSelectedCircleEpoch,
+} from 'hooks';
 import { getAvatarPath } from 'utils/domain';
-
-import { IUser } from 'types';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -20,7 +22,7 @@ const useStyles = makeStyles((theme) => ({
   header: {
     marginLeft: 'auto',
     marginRight: 'auto',
-    paddingTop: 70,
+    paddingTop: 60,
     maxWidth: '80%',
     textAlign: 'center',
   },
@@ -38,6 +40,15 @@ const useStyles = makeStyles((theme) => ({
     fontWeight: 300,
     color: theme.colors.primary,
     margin: 0,
+  },
+  epochTiming: {
+    margin: 0,
+    maxWidth: theme.breakpoints.values.md,
+    fontSize: 20,
+    fontWeight: 300,
+    lineHeight: 2,
+    color: theme.colors.primary,
+    textAlign: 'center',
   },
   description: {
     padding: '0 100px',
@@ -287,6 +298,8 @@ enum OrderType {
 const AllocationTeam = () => {
   const classes = useStyles();
   const { availableTeammates, selectedCircle } = useCircle();
+  const { epochIsActive, timingMessage } = useSelectedCircleEpoch();
+
   const {
     localTeammates,
     givePerUser,
@@ -296,7 +309,7 @@ const AllocationTeam = () => {
   } = useSelectedAllocation();
 
   const [keyword, setKeyword] = useState<string>('');
-  const [orderType, setOrderType] = useState<OrderType>(OrderType.Alphabetical);
+  const orderType = OrderType.Alphabetical as OrderType; // Was useState
 
   const onChangeKeyword = (event: React.ChangeEvent<HTMLInputElement>) => {
     setKeyword(event.target.value);
@@ -305,6 +318,9 @@ const AllocationTeam = () => {
   return (
     <div className={classes.root}>
       <div className={classes.header}>
+        {!epochIsActive && (
+          <h2 className={classes.epochTiming}>{timingMessage}</h2>
+        )}
         <p className={classes.title}>
           Who are your Teammates in the {selectedCircle?.name} Circle?
         </p>

--- a/src/pages/GraphPage/FilterDrawer.tsx
+++ b/src/pages/GraphPage/FilterDrawer.tsx
@@ -6,8 +6,6 @@ import {
   makeStyles,
   Typography,
   TextField,
-  MenuItem,
-  Select,
   Box,
   Divider,
 } from '@material-ui/core';
@@ -15,7 +13,6 @@ import SearchIcon from '@material-ui/icons/Search';
 import { Autocomplete } from '@material-ui/lab';
 
 import { Drawer, Spacer, Img } from 'components';
-import useCommonStyles from 'styles/common';
 import { getAvatarPath } from 'utils/domain';
 import { getNotableWords } from 'utils/string';
 
@@ -125,7 +122,6 @@ const FilterDrawer = ({
   onSearchChange,
 }: IProps) => {
   const classes = useStyles();
-  const commonClasses = useCommonStyles();
   const [open, setOpen] = useState<boolean>(true);
   const [notableWords, setNotableWords] = useState<string[]>([]);
 

--- a/src/pages/LandingPage/index.tsx
+++ b/src/pages/LandingPage/index.tsx
@@ -282,7 +282,7 @@ interface IPartnerProps {
   name: string;
 }
 
-const Partner = ({ imageSrc, give, epochs, name }: IPartnerProps) => {
+const Partner = ({ imageSrc, name }: IPartnerProps) => {
   const classes = useStyles();
   return (
     <div className={classes.partner}>

--- a/src/recoilState/allocationState.ts
+++ b/src/recoilState/allocationState.ts
@@ -54,7 +54,11 @@ export const rAllocationStepStatus = selectorFamily<
     if (user.epoch_first_visit === 0) {
       completedSteps.add(STEP_MY_EPOCH);
     }
-    if (user.teammates && user.teammates.length > 0) {
+    if (
+      user.epoch_first_visit === 0 &&
+      user.teammates &&
+      user.teammates.length > 0
+    ) {
       completedSteps.add(STEP_MY_TEAM);
     }
     if (pendingGiftsFrom.length > 0) {

--- a/src/recoilState/walletState.ts
+++ b/src/recoilState/walletState.ts
@@ -1,22 +1,17 @@
-import { Web3Provider } from '@ethersproject/providers';
 import {
   atom,
-  selector,
   DefaultValue,
   useRecoilValue,
   useRecoilState,
   useSetRecoilState,
 } from 'recoil';
 
-import { APIService } from 'services/api';
 import { ConnectorNames } from 'utils/enums';
 import storage from 'utils/storage';
 
-import { IRecoilGetParams } from 'types';
-
 export const rMyAddress = atom<string | undefined>({
   key: 'rMyAddress',
-  default: storage.getAddress(),
+  default: storage.getConnectorName() ? storage.getAddress() : undefined,
   effects_UNSTABLE: [
     ({ onSet }) => {
       onSet((newAddress) => {
@@ -35,7 +30,7 @@ export const useSetMyAddress = () => useSetRecoilState(rMyAddress);
 
 export const rConnectorName = atom<ConnectorNames | undefined>({
   key: 'rConnectorName',
-  default: storage.getConnectorName(),
+  default: storage.getAddress() ? storage.getConnectorName() : undefined,
   effects_UNSTABLE: [
     ({ onSet }) => {
       onSet((newId) => {

--- a/src/styles/common.ts
+++ b/src/styles/common.ts
@@ -1,5 +1,3 @@
-import { opacify, transparentize } from 'polished';
-
 import { makeStyles } from '@material-ui/core';
 
 const useCommonStyles = makeStyles((theme) => ({

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,5 +1,3 @@
-import { transparentize } from 'polished';
-
 const color = {
   transparent: '#0000',
   white: '#fff',

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -70,6 +70,13 @@ const themeOptions = {
         color: customColor.black,
       },
     },
+    MuiStepButton: {
+      root: {
+        '&.Mui-disabled': {
+          opacity: 0.4,
+        },
+      },
+    },
     MuiSkeleton: {
       root: {
         backgroundColor: 'rgba(255, 255, 255, 0.9)',

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -115,8 +115,8 @@ export const timingToDoubleUnits = (timing: ITiming) => {
   return 'The Past';
 };
 
-const wait = <T>(something: T): Promise<T> =>
-  new Promise((resolve, reject) => {
+export const wait = <T>(something: T): Promise<T> =>
+  new Promise((resolve) => {
     const wait = setTimeout(() => {
       clearTimeout(wait);
       resolve(something);


### PR DESCRIPTION
# Grab bag of changes

## Fix issues with wallet logon and logout
 - Simplified
 - Shows the wallet connect popup on first load
 - Errors no longer crash the app

## Allocation
 - You can now see epoch and team when out of epoch
 - One step towards trezor -> saving allocation uses diff
 - TODO: batch 7 at a time for trezor

#### Add VSCode debug config

#### Fix a bunch of linter warnings and stop alerting on some
 - Deleted unused variables
 - Let's keep these at zero moving forward
 - Enabled TODO
 - Turned off react-hooks/exhaustive-deps
   - It's a weird thing where the practice seems to be not aligned with React design vision
   - I'd rather just go with standard practice