### PR TITLE
Add working frontend test

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 
 import { render, screen } from '@testing-library/react';
 
-import App from './App';
+import AppLandingPage from './AppLandingPage';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+test('renders landing page', () => {
+  render(<AppLandingPage />);
+  const descriptionElement = screen.getByText(
+    /Scale your community with tools to reward contributors, incentivize participation and manage resources/i
+  );
+  expect(descriptionElement).toBeInTheDocument();
 });


### PR DESCRIPTION
This is part of the project to setup CI for master merges.

I've setup frontend test build in buildkite (see: https://buildkite.com/coordinape/frontend-test). There's a single test in the suite right now, and its failing because it expects some default page included with `create-react-app`. This PR checks for some content on the landing page. If the landing page content is likely to change Im happy to change it to something else!

Next steps after this:
- Spin up backend server during tests
- Write end-to-end test