### PR TITLE
Propagate profile update and prefer useHooks

### DIFF
--- a/src/hooks/useAdminApi.ts
+++ b/src/hooks/useAdminApi.ts
@@ -5,7 +5,7 @@ import {
   rMyAddress,
   rCirclesMap,
   rEpochsRaw,
-  rUsersMap,
+  rUsersMapRaw,
 } from 'recoilState';
 import { getApiService } from 'services/api';
 import {
@@ -28,7 +28,7 @@ export const useAdminApi = () => {
 
   const updateCirclesMap = useSetRecoilState(rCirclesMap);
   const updateEpochsMap = useSetRecoilState(rEpochsRaw);
-  const updateUsersMap = useSetRecoilState(rUsersMap);
+  const updateUsersMap = useSetRecoilState(rUsersMapRaw);
 
   // A fake circleId will just return nothing
   const selectedCircleId = useRecoilValue(rSelectedCircleId) ?? -1;

--- a/src/hooks/useCircle.ts
+++ b/src/hooks/useCircle.ts
@@ -6,7 +6,7 @@ import {
   rSelectedCircleId,
   rPastGiftsRaw,
   rPendingGiftsRaw,
-  rUsersMap,
+  rUsersMapRaw,
   rEpochsRaw,
   rAvailableTeammates,
   rSelectedCircle,
@@ -71,8 +71,8 @@ export const useCircle = (): {
   );
 
   const fetchUsers = useRecoilFetcher(
-    'rUsersMap',
-    rUsersMap,
+    'rUsersMapRaw',
+    rUsersMapRaw,
     updaterMergeArrayToIdMap
   );
   const fetchGifts = useRecoilFetcher(


### PR DESCRIPTION
https://linear.app/yearn/issue/APE-217/propagate-profile-update-to-recoilstate-eg-map-doesnt-show-changes

Profile changes need to show up in the users object, so have an intermediate map

Really, this is kinda weird


Also, I like the idea of not using the recoil rValues outside of recoil, rather to have hooks for all of those.

and typescript will infer function return types, and this is simpler mostly