### PR TITLE
Fix past repeat epoch and cleanup user admin

### DIFF
--- a/src/components/ApeToggle/ApeToggle.tsx
+++ b/src/components/ApeToggle/ApeToggle.tsx
@@ -54,11 +54,15 @@ const useStyles = makeStyles((theme) => ({
     marginTop: theme.spacing(1.5),
     color: theme.colors.red,
   },
+  disabled: {
+    opacity: 0.6,
+  },
 }));
 
 export const ApeToggle = ({
   value,
   onChange,
+  disabled,
   label,
   helperText,
   errorText,
@@ -67,6 +71,7 @@ export const ApeToggle = ({
 }: {
   value: boolean;
   onChange: (newValue: boolean) => void;
+  disabled?: boolean;
   label?: string;
   helperText?: string;
   errorText?: string;
@@ -77,7 +82,11 @@ export const ApeToggle = ({
   const [groupId] = useState(uniqueId('text-field-'));
 
   return (
-    <div className={clsx(className, classes.root)}>
+    <div
+      className={clsx(className, classes.root, {
+        [classes.disabled]: disabled,
+      })}
+    >
       {!!label && (
         <label htmlFor={groupId} className={classes.label}>
           {label}
@@ -88,8 +97,10 @@ export const ApeToggle = ({
         variant="contained"
         color="default"
         disableElevation
+        disabled={disabled}
         classes={{
           grouped: classes.grouped,
+          disabled: classes.disabled,
         }}
       >
         <Button

--- a/src/forms/AdminUserForm.tsx
+++ b/src/forms/AdminUserForm.tsx
@@ -16,6 +16,7 @@ const schema = z
     address: zEthAddress,
     non_giver: zBooleanToNumber,
     fixed_non_receiver: zBooleanToNumber,
+    non_receiver: zBooleanToNumber,
     role: zBooleanToNumber,
     starting_tokens: z.number(),
   })
@@ -30,6 +31,7 @@ const AdminUserForm = createForm({
     address: v.user?.address ?? '',
     non_giver: !!(v.user?.non_giver ?? !v.circle.default_opt_in),
     fixed_non_receiver: !!v.user?.fixed_non_receiver ?? false,
+    non_receiver: !!v.user?.fixed_non_receiver || !!v.user?.non_receiver,
     role: !!v.user?.role ?? false,
     starting_tokens: v.user?.starting_tokens ?? 100,
   }),

--- a/src/hooks/useAdminApi.ts
+++ b/src/hooks/useAdminApi.ts
@@ -1,4 +1,8 @@
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import {
+  useRecoilCallback,
+  useSetRecoilState,
+  CallbackInterface,
+} from 'recoil';
 
 import {
   rSelectedCircleId,
@@ -30,12 +34,21 @@ export const useAdminApi = () => {
   const updateEpochsMap = useSetRecoilState(rEpochsRaw);
   const updateUsersMap = useSetRecoilState(rUsersMapRaw);
 
-  // A fake circleId will just return nothing
-  const selectedCircleId = useRecoilValue(rSelectedCircleId) ?? -1;
-  const myAddress = useRecoilValue(rMyAddress);
+  const getState = useRecoilCallback(
+    ({ snapshot }: CallbackInterface) => async () => {
+      const selectedCircleId =
+        (await snapshot.getPromise(rSelectedCircleId)) ?? -1;
+      const myAddress = await snapshot.getPromise(rMyAddress);
+      return {
+        selectedCircleId,
+        myAddress,
+      };
+    }
+  );
 
   const updateCircle = (params: PutCirclesParam) =>
     callWithLoadCatch(async () => {
+      const { myAddress, selectedCircleId } = await getState();
       if (myAddress === undefined) throw 'myAddress required';
       const newCircle = await api.putCircles(
         selectedCircleId,
@@ -55,6 +68,7 @@ export const useAdminApi = () => {
 
   const updateCircleLogo = async (newAvatar: File) =>
     callWithLoadCatch(async () => {
+      const { myAddress, selectedCircleId } = await getState();
       if (myAddress === undefined) throw 'myAddress required';
       const newCircle = await api.uploadCircleLogo(
         selectedCircleId,
@@ -75,6 +89,7 @@ export const useAdminApi = () => {
   const createEpoch = (params: UpdateCreateEpochParam) =>
     callWithLoadCatch(
       async () => {
+        const { myAddress, selectedCircleId } = await getState();
         if (myAddress === undefined) throw 'myAddress required';
         const newEpoch = await api.createEpoch(
           myAddress,
@@ -92,6 +107,7 @@ export const useAdminApi = () => {
   const updateEpoch = (epochId: number, params: UpdateCreateEpochParam) =>
     callWithLoadCatch(
       async () => {
+        const { myAddress, selectedCircleId } = await getState();
         if (myAddress === undefined) throw 'myAddress required';
         const newEpoch = await api.updateEpoch(
           myAddress,
@@ -109,6 +125,7 @@ export const useAdminApi = () => {
 
   const deleteEpoch = (epochId: number) =>
     callWithLoadCatch(async () => {
+      const { myAddress, selectedCircleId } = await getState();
       if (myAddress === undefined) throw 'myAddress required';
       await api.deleteEpoch(myAddress, selectedCircleId, epochId);
 
@@ -121,6 +138,7 @@ export const useAdminApi = () => {
   // What if they update themselves? refresh?
   const updateUser = (userAddress: string, params: UpdateUsersParam) =>
     callWithLoadCatch(async () => {
+      const { myAddress, selectedCircleId } = await getState();
       if (myAddress === undefined) throw 'myAddress required';
       const updatedUser = await api.updateUsers(
         selectedCircleId,
@@ -138,6 +156,7 @@ export const useAdminApi = () => {
 
   const createUser = (params: PostUsersParam) =>
     callWithLoadCatch(async () => {
+      const { myAddress, selectedCircleId } = await getState();
       if (myAddress === undefined) throw 'myAddress required';
       const newUser = await api.createUser(selectedCircleId, myAddress, params);
 
@@ -148,6 +167,7 @@ export const useAdminApi = () => {
 
   const deleteUser = (userAddress: string) =>
     callWithLoadCatch(async () => {
+      const { myAddress, selectedCircleId } = await getState();
       if (myAddress === undefined) throw 'myAddress required';
       if (myAddress === userAddress) {
         throw 'Cannot delete your own address';
@@ -164,6 +184,7 @@ export const useAdminApi = () => {
     });
   const getDiscordWebhook = () =>
     callWithLoadCatch(async () => {
+      const { myAddress, selectedCircleId } = await getState();
       if (myAddress === undefined) throw 'myAddress required';
       const webhook = await api.getDiscordWebhook(myAddress, selectedCircleId);
       return webhook;

--- a/src/pages/AdminPage/AdminEpochModal.tsx
+++ b/src/pages/AdminPage/AdminEpochModal.tsx
@@ -79,7 +79,7 @@ export const AdminEpochModal = ({
   const source = useMemo(
     () => ({
       epoch: epoch,
-      epochs: epochs.filter((e) => e.id !== epoch?.id),
+      epochs: epochs.filter((e) => e.id !== epoch?.id && !e.ended),
     }),
     [epoch, epochs]
   );

--- a/src/pages/AdminPage/AdminPage.tsx
+++ b/src/pages/AdminPage/AdminPage.tsx
@@ -253,12 +253,17 @@ const AdminPage = () => {
           render: (u: IUser) => shortenAddress(u.address),
         },
         {
-          label: 'Can they give?',
-          render: (u: IUser) => (u.non_giver === 0 ? 'Yes' : 'No'),
+          label: 'Non Giver?',
+          render: (u: IUser) => (!u.non_giver ? '-' : 'Non Giver'),
         },
         {
-          label: 'Force Opt Out?',
-          render: (u: IUser) => (u.fixed_non_receiver === 0 ? 'No' : 'Yes'),
+          label: 'Opted Out?',
+          render: (u: IUser) =>
+            u.fixed_non_receiver
+              ? 'Forced Opt Out'
+              : u.non_receiver
+              ? 'Opted Out'
+              : '-',
         },
         {
           label: 'Are they admin?',
@@ -266,11 +271,22 @@ const AdminPage = () => {
         },
         {
           label: 'GIVE sent',
-          render: (u: IUser) => u.starting_tokens - u.give_token_remaining,
+          accessor: 'give_token_remaining',
+          render: (u: IUser) =>
+            !u.non_giver || u.starting_tokens - u.give_token_remaining != 0
+              ? `${u.starting_tokens - u.give_token_remaining}/${
+                  u.starting_tokens
+                }`
+              : '-',
         },
         {
           label: 'GIVE received',
           accessor: 'give_token_received',
+          render: (u: IUser) =>
+            u.give_token_received === 0 &&
+            (!!u.fixed_non_receiver || !!u.non_receiver)
+              ? '-'
+              : u.give_token_received,
         },
         {
           label: 'Actions',

--- a/src/pages/AdminPage/AdminPage.tsx
+++ b/src/pages/AdminPage/AdminPage.tsx
@@ -188,19 +188,6 @@ const AdminPage = () => {
     [keyword]
   );
 
-  const RenderUserName = (u: IUser) => (
-    <div className={classes.avatarCell}>
-      <ApeAvatar user={u} className={classes.avatar} />
-      <span>{u.name}</span>
-    </div>
-  );
-
-  const RenderUserActions = (u: IUser) =>
-    renderActions(
-      () => setEditUser(u),
-      u.id !== me?.id ? () => deleteUser(u.address) : undefined
-    );
-
   // Epoch Columns
   const RenderEpochDetails = (e: IEpoch) => (
     <div className={classes.twoLineCell}>
@@ -249,7 +236,14 @@ const AdminPage = () => {
         {
           label: 'Name',
           accessor: 'name',
-          render: RenderUserName,
+          render: function UserName(u: IUser) {
+            return (
+              <div className={classes.avatarCell}>
+                <ApeAvatar user={u} className={classes.avatar} />
+                <span>{u.name}</span>
+              </div>
+            );
+          },
           wide: true,
           leftAlign: true,
         },
@@ -268,7 +262,7 @@ const AdminPage = () => {
         },
         {
           label: 'Are they admin?',
-          render: (u: IUser) => (u.role === 0 ? 'No' : 'Yes'),
+          render: (u: IUser) => (u.role === 0 ? '-' : 'Admin'),
         },
         {
           label: 'GIVE sent',
@@ -280,7 +274,11 @@ const AdminPage = () => {
         },
         {
           label: 'Actions',
-          render: RenderUserActions,
+          render: (u: IUser) =>
+            renderActions(
+              () => setEditUser(u),
+              u.id !== me?.id ? () => deleteUser(u.address) : undefined
+            ),
           noSort: true,
         },
       ] as ITableColumn[],

--- a/src/pages/AdminPage/AdminUserModal.tsx
+++ b/src/pages/AdminPage/AdminUserModal.tsx
@@ -104,7 +104,7 @@ export const AdminUserModal = ({
             <ApeToggle
               {...fields.non_receiver}
               disabled={fields.fixed_non_receiver.value}
-              label="Opt'd Out"
+              label="Opted Out"
             />
           </div>
           <FormTextField

--- a/src/pages/AdminPage/AdminUserModal.tsx
+++ b/src/pages/AdminPage/AdminUserModal.tsx
@@ -64,7 +64,19 @@ export const AdminUserModal = ({
         ).then(() => onClose())
       }
     >
-      {({ fields, errors, changedOutput, handleSubmit }) => (
+      {({
+        fields: {
+          non_giver: {
+            value: nonGiverValue,
+            onChange: nonGiverOnChange,
+            ...non_giver
+          },
+          ...fields
+        },
+        errors,
+        changedOutput,
+        handleSubmit,
+      }) => (
         <FormModal
           onClose={onClose}
           open={open}
@@ -76,13 +88,23 @@ export const AdminUserModal = ({
         >
           <div className={classes.twoColumn}>
             <FormTextField {...fields.name} label="Contributor Name" />
-            <ApeToggle {...fields.non_giver} label="Blocked From Giving?" />
-            <ApeToggle {...fields.fixed_non_receiver} label="Forced Opt Out" />
             <ApeToggle {...fields.role} label="Are They Admin?" />
             <FormTextField
               {...fields.starting_tokens}
               type="number"
               label="Starting Tokens"
+            />
+            <ApeToggle
+              {...non_giver}
+              onChange={(v) => nonGiverOnChange(!v)}
+              value={!nonGiverValue}
+              label="Can Give?"
+            />
+            <ApeToggle {...fields.fixed_non_receiver} label="Force Opt'd Out" />
+            <ApeToggle
+              {...fields.non_receiver}
+              disabled={fields.fixed_non_receiver.value}
+              label="Opt'd Out"
             />
           </div>
           <FormTextField

--- a/src/pages/AdminPage/AdminUserModal.tsx
+++ b/src/pages/AdminPage/AdminUserModal.tsx
@@ -100,7 +100,7 @@ export const AdminUserModal = ({
               value={!nonGiverValue}
               label="Can Give?"
             />
-            <ApeToggle {...fields.fixed_non_receiver} label="Force Opt'd Out" />
+            <ApeToggle {...fields.fixed_non_receiver} label="Force Opted Out" />
             <ApeToggle
               {...fields.non_receiver}
               disabled={fields.fixed_non_receiver.value}


### PR DESCRIPTION
Require: https://github.com/coordinape/coordinape-backend/pull/46

After seeing Moonshot use the admin user epoch, I reordered the fields and switched the polarity of non_giver.

Also, `const { deleteUser, deleteEpoch } = useAdminApi()` had been kept in the action renderer and would be called with stale values.