### PR TITLE
Remove broken Portis and Fortmatic Wallet connections

### DIFF
--- a/src/components/ConnectWalletModal/ConnectWalletModal.tsx
+++ b/src/components/ConnectWalletModal/ConnectWalletModal.tsx
@@ -142,26 +142,6 @@ export const ConnectWalletModal = ({
                   text="Coinbase Wallet"
                 />
               </Grid>
-              <Grid item md={6} xs={12}>
-                <ConnectWalletButtonItem
-                  disabled={isConnectingToWallet}
-                  icon={ConnectorNames.Fortmatic}
-                  onClick={() => {
-                    activate(ConnectorNames.Fortmatic);
-                  }}
-                  text="Fortmatic"
-                />
-              </Grid>
-              <Grid item md={6} xs={12}>
-                <ConnectWalletButtonItem
-                  disabled={isConnectingToWallet}
-                  icon={ConnectorNames.Portis}
-                  onClick={() => {
-                    activate(ConnectorNames.Portis);
-                  }}
-                  text="Portis"
-                />
-              </Grid>
             </Grid>
           </div>
         )}


### PR DESCRIPTION
Portis and Fortmatic have never been setup - remove them as wallet connect options.

The UI looks a little empty...

<img width="1066" alt="Screen Shot 2021-09-28 at 2 31 52 PM" src="https://user-images.githubusercontent.com/83605543/135168660-286ca99d-c6f8-4192-97aa-f5150be74e35.png">

@levity @exrhizo 