### PR TITLE
Remove Coinbase Wallet option

### DIFF
--- a/src/components/ConnectWalletModal/ConnectWalletModal.tsx
+++ b/src/components/ConnectWalletModal/ConnectWalletModal.tsx
@@ -132,16 +132,6 @@ export const ConnectWalletModal = ({
                   text="Wallet Connect"
                 />
               </Grid>
-              <Grid item md={6} xs={12}>
-                <ConnectWalletButtonItem
-                  disabled={isConnectingToWallet}
-                  icon={ConnectorNames.WalletLink}
-                  onClick={() => {
-                    activate(ConnectorNames.WalletLink);
-                  }}
-                  text="Coinbase Wallet"
-                />
-              </Grid>
             </Grid>
           </div>
         )}


### PR DESCRIPTION
https://linear.app/coordinape/issue/DEV-135/coinbase-wallet-signature-not-authorized

Remove Coinbase Wallet connection option - because it doesn't work.

Maybe if we use scaffold-eth we can use all their wallet options that hopefully are fully supported.

Reviewers: @exrhizo @levity 