### PR TITLE
Remove placeholder text

### DIFF
--- a/src/pages/VouchingPage/NewNominationModal.tsx
+++ b/src/pages/VouchingPage/NewNominationModal.tsx
@@ -107,7 +107,7 @@ export const NewNominationModal = ({
         />
         <ApeTextField
           label="Why are you nominating this person?"
-          placeholder="Tell us why the person should be added to the circle, such as what they have achieved or what they will do in the future, I need some better helper text here please feel free to edit."
+          placeholder="Tell us why the person should be added to the circle, such as what they have achieved or what they will do in the future."
           value={description}
           className={classes.gridAllColumns}
           onChange={onChangeWith(setDescription)}


### PR DESCRIPTION
https://linear.app/coordinape/issue/DEV-314/copy-mistake-in-vouching-nomination-form-placeholder-text

I thought about this for about 15 seconds, and couldn't come up with any significantly better text...

@AlexDistill did you have more concrete suggestions for changing this? For now, I'm removing the placeholder comment part of it.

Review: @exrhizo @levity 