### PR TITLE
Clean up useAllocation to fix allocation not working

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -11,3 +11,4 @@ export * from './useApeSnackbar';
 export * from './usePrevious';
 export * from './useAdminApi';
 export * from './useVouching';
+export * from './useDeepChangeEffect';

--- a/src/hooks/useDeepChangeEffect.ts
+++ b/src/hooks/useDeepChangeEffect.ts
@@ -1,0 +1,18 @@
+import { useEffect, DependencyList } from 'react';
+
+import isEqual from 'lodash/isEqual';
+
+import { usePrevious } from 'hooks';
+
+/**
+ * It's like useEffect but runs when the deps list has a deep change.
+ * See: {@link isEqual}.
+ */
+export function useDeepChangeEffect(func: () => void, deps: DependencyList) {
+  const prev = usePrevious(deps);
+  useEffect(() => {
+    if (!prev || !isEqual(deps, prev)) {
+      func();
+    }
+  }, deps);
+}

--- a/src/hooks/useDeepChangeEffect.ts
+++ b/src/hooks/useDeepChangeEffect.ts
@@ -5,7 +5,7 @@ import isEqual from 'lodash/isEqual';
 import { usePrevious } from 'hooks';
 
 /**
- * It's like useEffect but runs when the deps list has a deep change.
+ * It's like useEffect but runs only when the deps list has a deep change.
  * See: {@link isEqual}.
  */
 export function useDeepChangeEffect(func: () => void, deps: DependencyList) {

--- a/src/hooks/useDeepChangeEffect.ts
+++ b/src/hooks/useDeepChangeEffect.ts
@@ -12,7 +12,7 @@ export function useDeepChangeEffect(func: () => void, deps: DependencyList) {
   const prev = usePrevious(deps);
   useEffect(() => {
     if (!prev || !isEqual(deps, prev)) {
-      func();
+      return func();
     }
   }, deps);
 }

--- a/src/pages/AllocationPage/AllocationGive.tsx
+++ b/src/pages/AllocationPage/AllocationGive.tsx
@@ -6,7 +6,6 @@ import { Button, makeStyles } from '@material-ui/core';
 
 import { TeammateCard } from 'components';
 import { useMe, useSelectedAllocation, useSelectedCircleEpoch } from 'hooks';
-import { useSelectedCircleUsers } from 'recoilState';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -175,11 +174,11 @@ const AllocationGive = () => {
   const classes = useStyles();
 
   const { epochIsActive, longTimingMessage } = useSelectedCircleEpoch();
-  const { selectedMyUser, selectedCircle } = useMe();
-  const visibleUsers = useSelectedCircleUsers();
-  const { givePerUser, localTeammates, updateGift } = useSelectedAllocation();
+  const { selectedCircle } = useMe();
+  const { givePerUser, localGifts, updateGift } = useSelectedAllocation();
   const [orderType, setOrderType] = useState<OrderType>(OrderType.Alphabetical);
   const [filterType, setFilterType] = useState<number>(0);
+
   return (
     <div className={classes.root}>
       <div className={classes.headerContainer}>
@@ -251,16 +250,14 @@ const AllocationGive = () => {
         </div>
       </div>
       <div className={classes.teammateContainer}>
-        {(selectedMyUser ? visibleUsers : [])
+        {localGifts
+          .map((g) => g.user)
           .filter((a) => {
             if (filterType & FilterType.OptIn) {
               return !a.non_receiver;
             }
             if (filterType & FilterType.NewMember) {
               return +new Date() - +new Date(a.created_at) < 24 * 3600 * 1000;
-            }
-            if (selectedCircle?.team_selection === 1) {
-              return localTeammates.includes(a) || givePerUser.get(a.id);
             }
             return true;
           })
@@ -282,20 +279,18 @@ const AllocationGive = () => {
               }
             }
           })
-          .map((user) =>
-            user.id === selectedMyUser?.id ? undefined : (
-              <TeammateCard
-                disabled={!epochIsActive}
-                key={user.id}
-                note={givePerUser.get(user.id)?.note || ''}
-                tokenName={selectedCircle?.token_name || 'GIVE'}
-                tokens={givePerUser.get(user.id)?.tokens || 0}
-                updateNote={(note) => updateGift(user.id, { note })}
-                updateTokens={(tokens) => updateGift(user.id, { tokens })}
-                user={user}
-              />
-            )
-          )}
+          .map((user) => (
+            <TeammateCard
+              disabled={!epochIsActive}
+              key={user.id}
+              note={givePerUser.get(user.id)?.note || ''}
+              tokenName={selectedCircle?.token_name || 'GIVE'}
+              tokens={givePerUser.get(user.id)?.tokens || 0}
+              updateNote={(note) => updateGift(user.id, { note })}
+              updateTokens={(tokens) => updateGift(user.id, { tokens })}
+              user={user}
+            />
+          ))}
       </div>
     </div>
   );

--- a/src/recoilState/appState.ts
+++ b/src/recoilState/appState.ts
@@ -251,7 +251,7 @@ export const rPastGiftsMap = selector<Map<number, ITokenGift>>({
   },
 });
 
-export const rPendingGiftsRaw = atom<Map<number, ITokenGift>>({
+export const rPendingGiftsRaw = atom<Map<number, IApiTokenGift>>({
   key: 'rPendingGiftsRaw',
   default: new Map(),
 });

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -300,7 +300,7 @@ export class APIService {
     circleId: number,
     address: string,
     teammates: number[]
-  ): Promise<IApiUser> => {
+  ): Promise<IApiUser & { pending_sent_gifts: IApiTokenGift[] }> => {
     const data = JSON.stringify({ teammates: teammates });
     const { signature, hash } = await getSignature(data, this.provider);
     const response = await axios.post(`${circleId}/teammates`, {
@@ -336,7 +336,7 @@ export class APIService {
     circleId: number,
     address: string,
     params: PostTokenGiftsParam[]
-  ): Promise<any> => {
+  ): Promise<IApiUser & { pending_sent_gifts: IApiTokenGift[] }> => {
     const data = JSON.stringify(params);
     const { signature, hash } = await getSignature(data, this.provider);
     const response = await axios.post(`${circleId}/v2/token-gifts/${address}`, {


### PR DESCRIPTION
https://linear.app/coordinape/issue/DEV-286/allocation-buttons-not-working-buttons-are-disabled

The `useAllocation` hooks were not easily readable,
so I rewrote them to be more simple and organized.

Now the give page shows cards for teammates that are in the local state's `pendingGive` that way there can't be a discrepancy between what there are controls for and the underlying state.

when the teammate selector is disabled, there is still a teammates data structure, it is just set to be all available teammates and the hook throws an error if you try to change them.
