### PR TITLE
Improve error handling and move api hooks

### DIFF
--- a/src/components/CircleSelectModal/CircleSelectModal.tsx
+++ b/src/components/CircleSelectModal/CircleSelectModal.tsx
@@ -154,10 +154,11 @@ export const CircleSelectModal = ({
             <CircleButton
               key={circle.id}
               circle={circle}
-              onClick={() => {
-                selectAndFetchCircle(circle.id);
-                onClose();
-              }}
+              onClick={() =>
+                selectAndFetchCircle(circle.id)
+                  .then(onClose)
+                  .catch((e) => console.warn(e))
+              }
             />
           ))}
           {hasAdminView ? (
@@ -171,10 +172,11 @@ export const CircleSelectModal = ({
                   <CircleButton
                     key={circle.id}
                     circle={circle}
-                    onClick={() => {
-                      selectAndFetchCircle(circle.id);
-                      onClose();
-                    }}
+                    onClick={() =>
+                      selectAndFetchCircle(circle.id)
+                        .then(onClose)
+                        .catch((e) => console.warn(e))
+                    }
                   />
                 ))}
             </>

--- a/src/components/CircleSelectModal/CircleSelectModal.tsx
+++ b/src/components/CircleSelectModal/CircleSelectModal.tsx
@@ -157,7 +157,7 @@ export const CircleSelectModal = ({
               onClick={() =>
                 selectAndFetchCircle(circle.id)
                   .then(onClose)
-                  .catch((e) => console.warn(e))
+                  .catch(console.warn)
               }
             />
           ))}
@@ -175,7 +175,7 @@ export const CircleSelectModal = ({
                     onClick={() =>
                       selectAndFetchCircle(circle.id)
                         .then(onClose)
-                        .catch((e) => console.warn(e))
+                        .catch(console.warn)
                     }
                   />
                 ))}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -12,3 +12,5 @@ export * from './usePrevious';
 export * from './useAdminApi';
 export * from './useVouching';
 export * from './useDeepChangeEffect';
+export * from './useVouching';
+export * from './useApi';

--- a/src/hooks/useAllocation.ts
+++ b/src/hooks/useAllocation.ts
@@ -303,7 +303,11 @@ export const useAllocation = (circleId: number | undefined) => {
         );
         triggerProfileReload();
       },
-      { success: 'Saved Teammates' }
+      {
+        success: 'Saved Teammates',
+        transformError: (e) =>
+          (e.message = `With hardware wallets, try shorter changes. ${e.message}`),
+      }
     );
 
   const saveGifts = () =>

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -8,6 +8,8 @@ import {
   rMyAddress,
   rMyProfile,
   rCirclesMap,
+  rSelectedCircle,
+  rSelectedMyUser,
   useTriggerProfileReload,
 } from 'recoilState';
 import { getApiService } from 'services/api';
@@ -15,7 +17,7 @@ import { createCircleWithDefaults } from 'utils/modelExtenders';
 
 import { useAsyncLoadCatch } from './useAsyncLoadCatch';
 
-import { CreateCircleParam } from 'types';
+import { CreateCircleParam, PutUsersParam, PostProfileParam } from 'types';
 
 export const useApi = () => {
   const api = getApiService();
@@ -32,6 +34,16 @@ export const useApi = () => {
   const getProfile = useRecoilCallback(
     ({ snapshot }: CallbackInterface) => async () =>
       await snapshot.getPromise(rMyProfile)
+  );
+
+  const getSelectedCircle = useRecoilCallback(
+    ({ snapshot }: CallbackInterface) => async () =>
+      await snapshot.getPromise(rSelectedCircle)
+  );
+
+  const getSelectedMyUser = useRecoilCallback(
+    ({ snapshot }: CallbackInterface) => async () =>
+      await snapshot.getPromise(rSelectedMyUser)
   );
 
   const createCircle = (
@@ -60,7 +72,73 @@ export const useApi = () => {
       return newCircle;
     });
 
+  const updateMyUser = async (params: PutUsersParam) =>
+    callWithLoadCatch(async () => {
+      const selectedCircle = await getSelectedCircle();
+      const selectedMyUser = await getSelectedMyUser();
+      if (!selectedMyUser || !selectedCircle) {
+        throw 'Need to select a circle to update circle user';
+      }
+      const updatedUser = await api.updateMyUser(
+        selectedCircle.id,
+        selectedMyUser.address,
+        {
+          name: selectedMyUser.name,
+          bio: selectedMyUser.bio,
+          non_receiver: selectedMyUser.non_receiver,
+          non_giver: selectedMyUser.non_giver,
+          epoch_first_visit: selectedMyUser.epoch_first_visit,
+          ...params,
+        }
+      );
+
+      triggerProfileReload();
+
+      return updatedUser;
+    });
+
+  const updateAvatar = async (newAvatar: File) =>
+    callWithLoadCatch(async () => {
+      const selectedCircle = await getSelectedCircle();
+      const selectedMyUser = await getSelectedMyUser();
+      if (!selectedMyUser || !selectedCircle) {
+        throw 'Need to select a circle to update circle user';
+      }
+      await api.uploadAvatar(selectedMyUser.address, newAvatar);
+
+      triggerProfileReload();
+    });
+
+  const updateBackground = async (newAvatar: File) =>
+    callWithLoadCatch(async () => {
+      const selectedCircle = await getSelectedCircle();
+      const selectedMyUser = await getSelectedMyUser();
+      if (!selectedMyUser || !selectedCircle) {
+        throw 'Need to select a circle to update circle user';
+      }
+      await api.uploadBackground(selectedMyUser.address, newAvatar);
+
+      triggerProfileReload();
+    });
+
+  const updateMyProfile = async (params: PostProfileParam) =>
+    callWithLoadCatch(async () => {
+      const selectedMyUser = await getSelectedMyUser();
+      if (!selectedMyUser) {
+        throw 'Need to select a circle to update circle user';
+      }
+      const result = await api.updateProfile(selectedMyUser.address, params);
+
+      // TODO: Could we just update with result here?
+      triggerProfileReload();
+      return result;
+    });
+
   return {
     createCircle,
+    updateMyUser,
+    updateAvatar,
+    updateBackground,
+    updateMyProfile,
   };
 };

--- a/src/hooks/useMe.ts
+++ b/src/hooks/useMe.ts
@@ -2,118 +2,28 @@ import {
   useHasAdminView,
   useSelectedMyUser,
   useMyCircles,
-  useTriggerProfileReload,
   useSelectedCircle,
   useMyProfile,
 } from 'recoilState';
-import { getApiService } from 'services/api';
 import { getAvatarPath } from 'utils/domain';
 
-import { useAsyncLoadCatch } from './useAsyncLoadCatch';
-
-import { PutUsersParam, PostProfileParam } from 'types';
-
 export const useMe = () => {
-  const api = getApiService();
-  const callWithLoadCatch = useAsyncLoadCatch();
-
   const selectedMyUser = useSelectedMyUser();
   const hasAdminView = useHasAdminView();
   const selectedCircle = useSelectedCircle();
   const myCircles = useMyCircles();
   const myProfile = useMyProfile();
-  const triggerProfileReload = useTriggerProfileReload();
 
-  const updateMyUser = async (params: PutUsersParam) =>
-    callWithLoadCatch(async () => {
-      if (!selectedMyUser || !selectedCircle) {
-        throw 'Need to select a circle to update circle user';
-      }
-      const updatedUser = await api.updateMyUser(
-        selectedCircle.id,
-        selectedMyUser.address,
-        {
-          name: selectedMyUser.name,
-          bio: selectedMyUser.bio,
-          non_receiver: selectedMyUser.non_receiver,
-          non_giver: selectedMyUser.non_giver,
-          epoch_first_visit: selectedMyUser.epoch_first_visit,
-          ...params,
-        }
-      );
-
-      triggerProfileReload();
-
-      return updatedUser;
-    });
-
-  const updateTeammates = async (teammateIds: number[]) =>
-    callWithLoadCatch(async () => {
-      if (!selectedMyUser) {
-        throw 'Need to select a circle to update circle user';
-      }
-      await api.postTeammates(
-        selectedMyUser.circle_id,
-        selectedMyUser.address,
-        teammateIds
-      );
-
-      triggerProfileReload();
-    });
-
-  const updateAvatar = async (newAvatar: File) =>
-    callWithLoadCatch(async () => {
-      if (!selectedMyUser || !selectedCircle) {
-        throw 'Need to select a circle to update circle user';
-      }
-      await api.uploadAvatar(selectedMyUser.address, newAvatar);
-
-      triggerProfileReload();
-    });
-
-  const updateBackground = async (newAvatar: File) =>
-    callWithLoadCatch(async () => {
-      if (!selectedMyUser || !selectedCircle) {
-        throw 'Need to select a circle to update circle user';
-      }
-      await api.uploadBackground(selectedMyUser.address, newAvatar);
-
-      triggerProfileReload();
-    });
-
-  const updateProfile = async (params: PostProfileParam) =>
-    callWithLoadCatch(async () => {
-      if (!selectedMyUser) {
-        throw 'Need to select a circle to update circle user';
-      }
-      const result = await api.updateProfile(selectedMyUser.address, params);
-
-      // TODO: Could we just update with result here?
-      triggerProfileReload();
-      return result;
-    });
-
-  const refreshMyUser = async () => {
-    // Is it possible to use recoilCallback to have loading during this?
-    triggerProfileReload();
-  };
   return {
     myProfile,
     selectedMyUser,
     selectedCircle,
     myCircles,
-    // avatarPath: getAvatarPath(selectedMyUser?.avatar),
     avatarPath: getAvatarPath(myProfile?.avatar),
     backgroundPath: getAvatarPath(
       myProfile?.background,
       '/imgs/background/profile-bg.jpg'
     ),
     hasAdminView,
-    updateMyUser,
-    updateTeammates,
-    updateAvatar,
-    updateBackground,
-    refreshMyUser,
-    updateProfile,
   };
 };

--- a/src/pages/AdminPage/AdminCircleModal.tsx
+++ b/src/pages/AdminPage/AdminCircleModal.tsx
@@ -173,9 +173,13 @@ export const AdminCircleModal = ({
   };
 
   const editDiscordWebhook = async () => {
-    const _webhook = await getDiscordWebhook();
-    setWebhook(_webhook);
-    setAllowEdit(true);
+    try {
+      const _webhook = await getDiscordWebhook();
+      setWebhook(_webhook);
+      setAllowEdit(true);
+    } catch (e) {
+      console.warn(e);
+    }
   };
 
   const onChangeWith = (set: (v: string) => void) => (
@@ -189,46 +193,50 @@ export const AdminCircleModal = ({
   ) => set(Math.max(0, parseInt(e.target.value) || 0));
 
   const onSubmit = async () => {
-    if (logoData.avatarRaw) {
-      await updateCircleLogo(logoData.avatarRaw);
-      setLogoData({
-        ...logoData,
-        avatarRaw: null,
-      });
-    }
+    try {
+      if (logoData.avatarRaw) {
+        await updateCircleLogo(logoData.avatarRaw);
+        setLogoData({
+          ...logoData,
+          avatarRaw: null,
+        });
+      }
 
-    if (
-      circleName !== circle.name ||
-      vouching !== circle.vouching ||
-      tokenName !== circle.tokenName ||
-      minVouches !== circle.min_vouches ||
-      teamSelText !== circle.teamSelText ||
-      allocText !== circle.allocText ||
-      allowEdit ||
-      defaultOptIn !== circle.default_opt_in ||
-      nominationDaysLimit !== circle.nomination_days_limit ||
-      allocText !== circle.allocText ||
-      vouchingText !== circle.vouchingText ||
-      onlyGiverVouch !== circle.only_giver_vouch ||
-      teamSelection !== circle.team_selection
-    ) {
-      updateCircle({
-        name: circleName,
-        vouching: vouching,
-        token_name: tokenName,
-        min_vouches: minVouches,
-        team_sel_text: teamSelText,
-        nomination_days_limit: nominationDaysLimit,
-        alloc_text: allocText,
-        discord_webhook: webhook,
-        update_webhook: allowEdit ? 1 : 0,
-        default_opt_in: defaultOptIn,
-        vouching_text: vouchingText,
-        only_giver_vouch: onlyGiverVouch,
-        team_selection: teamSelection,
-      }).then(() => {
-        onClose();
-      });
+      if (
+        circleName !== circle.name ||
+        vouching !== circle.vouching ||
+        tokenName !== circle.tokenName ||
+        minVouches !== circle.min_vouches ||
+        teamSelText !== circle.teamSelText ||
+        allocText !== circle.allocText ||
+        allowEdit ||
+        defaultOptIn !== circle.default_opt_in ||
+        nominationDaysLimit !== circle.nomination_days_limit ||
+        allocText !== circle.allocText ||
+        vouchingText !== circle.vouchingText ||
+        onlyGiverVouch !== circle.only_giver_vouch ||
+        teamSelection !== circle.team_selection
+      ) {
+        updateCircle({
+          name: circleName,
+          vouching: vouching,
+          token_name: tokenName,
+          min_vouches: minVouches,
+          team_sel_text: teamSelText,
+          nomination_days_limit: nominationDaysLimit,
+          alloc_text: allocText,
+          discord_webhook: webhook,
+          update_webhook: allowEdit ? 1 : 0,
+          default_opt_in: defaultOptIn,
+          vouching_text: vouchingText,
+          only_giver_vouch: onlyGiverVouch,
+          team_selection: teamSelection,
+        }).then(() => {
+          onClose();
+        });
+      }
+    } catch (e) {
+      console.warn(e);
     }
   };
 

--- a/src/pages/AdminPage/AdminCircleModal.tsx
+++ b/src/pages/AdminPage/AdminCircleModal.tsx
@@ -217,7 +217,7 @@ export const AdminCircleModal = ({
         onlyGiverVouch !== circle.only_giver_vouch ||
         teamSelection !== circle.team_selection
       ) {
-        updateCircle({
+        await updateCircle({
           name: circleName,
           vouching: vouching,
           token_name: tokenName,

--- a/src/pages/AdminPage/AdminEpochModal.tsx
+++ b/src/pages/AdminPage/AdminEpochModal.tsx
@@ -90,7 +90,7 @@ export const AdminEpochModal = ({
       submit={(params) =>
         (epoch ? updateEpoch(epoch.id, params) : createEpoch(params))
           .then(() => onClose())
-          .catch((e) => console.warn(e))
+          .catch(console.warn)
       }
     >
       {({ fields, errors, changedOutput, value, handleSubmit }) => (

--- a/src/pages/AdminPage/AdminEpochModal.tsx
+++ b/src/pages/AdminPage/AdminEpochModal.tsx
@@ -88,9 +88,9 @@ export const AdminEpochModal = ({
     <EpochForm.FormController
       source={source}
       submit={(params) =>
-        (epoch ? updateEpoch(epoch.id, params) : createEpoch(params)).then(() =>
-          onClose()
-        )
+        (epoch ? updateEpoch(epoch.id, params) : createEpoch(params))
+          .then(() => onClose())
+          .catch((e) => console.warn(e))
       }
     >
       {({ fields, errors, changedOutput, value, handleSubmit }) => (

--- a/src/pages/AdminPage/AdminPage.tsx
+++ b/src/pages/AdminPage/AdminPage.tsx
@@ -241,9 +241,7 @@ const AdminPage = () => {
     ) : (
       renderActions(
         () => setEditEpoch(e),
-        !e.started
-          ? () => deleteEpoch(e.id).catch((e) => console.warn(e))
-          : undefined
+        !e.started ? () => deleteEpoch(e.id).catch(console.warn) : undefined
       )
     );
 
@@ -311,7 +309,7 @@ const AdminPage = () => {
             renderActions(
               () => setEditUser(u),
               u.id !== me?.id
-                ? () => deleteUser(u.address).catch((e) => console.warn(e))
+                ? () => deleteUser(u.address).catch(console.warn)
                 : undefined
             ),
           noSort: true,

--- a/src/pages/AdminPage/AdminPage.tsx
+++ b/src/pages/AdminPage/AdminPage.tsx
@@ -241,7 +241,9 @@ const AdminPage = () => {
     ) : (
       renderActions(
         () => setEditEpoch(e),
-        !e.started ? () => deleteEpoch(e.id) : undefined
+        !e.started
+          ? () => deleteEpoch(e.id).catch((e) => console.warn(e))
+          : undefined
       )
     );
 
@@ -308,7 +310,9 @@ const AdminPage = () => {
           render: (u: IUser) =>
             renderActions(
               () => setEditUser(u),
-              u.id !== me?.id ? () => deleteUser(u.address) : undefined
+              u.id !== me?.id
+                ? () => deleteUser(u.address).catch((e) => console.warn(e))
+                : undefined
             ),
           noSort: true,
         },

--- a/src/pages/AdminPage/AdminUserModal.tsx
+++ b/src/pages/AdminPage/AdminUserModal.tsx
@@ -62,10 +62,9 @@ export const AdminUserModal = ({
       source={source}
       hideFieldErrors
       submit={(params) =>
-        (user
-          ? updateUser(user.address, params)
-          : createUser(params)
-        ).then(() => onClose())
+        (user ? updateUser(user.address, params) : createUser(params))
+          .then(() => onClose())
+          .catch((e) => console.warn(e))
       }
     >
       {({

--- a/src/pages/AdminPage/AdminUserModal.tsx
+++ b/src/pages/AdminPage/AdminUserModal.tsx
@@ -64,7 +64,7 @@ export const AdminUserModal = ({
       submit={(params) =>
         (user ? updateUser(user.address, params) : createUser(params))
           .then(() => onClose())
-          .catch((e) => console.warn(e))
+          .catch(console.warn)
       }
     >
       {({

--- a/src/pages/CreateCirclePage/CreateCirclePage.tsx
+++ b/src/pages/CreateCirclePage/CreateCirclePage.tsx
@@ -12,7 +12,7 @@ import {
   FormAutocomplete,
 } from 'components';
 import CreateCircleForm from 'forms/CreateCircleForm';
-import { useApi } from 'hooks/useApi';
+import { useApi } from 'hooks';
 import {
   useMyAddress,
   useMyAdminCircles,
@@ -121,24 +121,28 @@ export const SummonCirclePage = () => {
           research_contact,
           ...params
         }) => {
-          const newCircle = await createCircle(
-            { ...params },
-            captcha_token,
-            JSON.stringify({
-              address: myAddress,
-              research_what,
-              research_who,
-              research_how_much,
-              research_org_link,
-              research_contact,
-              ...params,
-            })
-          );
-          setSelectedCircleId(newCircle.id);
-          history.push({
-            pathname: paths.getAdminPath(),
-            search: paths.NEW_CIRCLE_CREATED_PARAMS,
-          });
+          try {
+            const newCircle = await createCircle(
+              { ...params },
+              captcha_token,
+              JSON.stringify({
+                address: myAddress,
+                research_what,
+                research_who,
+                research_how_much,
+                research_org_link,
+                research_contact,
+                ...params,
+              })
+            );
+            setSelectedCircleId(newCircle.id);
+            history.push({
+              pathname: paths.getAdminPath(),
+              search: paths.NEW_CIRCLE_CREATED_PARAMS,
+            });
+          } catch (e) {
+            console.warn(e);
+          }
         }}
       >
         {({ fields, changedOutput, handleSubmit }) => (

--- a/src/pages/ProfilePage/ProfilePage.tsx
+++ b/src/pages/ProfilePage/ProfilePage.tsx
@@ -1,9 +1,9 @@
-/* eslint-disable import/order */
 import React, { useState, useEffect } from 'react';
 
-import { RouteComponentProps } from 'react-router-dom';
 import omit from 'lodash/omit';
 import pick from 'lodash/pick';
+import { RouteComponentProps } from 'react-router-dom';
+import ShowMore from 'react-show-more';
 
 import { makeStyles, withStyles, Tooltip, Zoom } from '@material-ui/core';
 import Avatar from '@material-ui/core/Avatar';
@@ -14,7 +14,6 @@ import Link from '@material-ui/core/Link';
 import Typography from '@material-ui/core/Typography';
 import CloudUploadIcon from '@material-ui/icons/CloudUpload';
 import EditOutlinedIcon from '@material-ui/icons/EditOutlined';
-import ShowMore from 'react-show-more';
 
 import discord from '../../assets/svgs/social/discord.svg';
 import github from '../../assets/svgs/social/github.svg';
@@ -22,9 +21,9 @@ import medium from '../../assets/svgs/social/medium.svg';
 import telegram from '../../assets/svgs/social/telegram-icon.svg';
 import twitter from '../../assets/svgs/social/twitter-icon.svg';
 import website from '../../assets/svgs/social/website.svg';
-import { useProfile, useMe, useCircle } from 'hooks';
-
+import { useProfile, useMe, useApi, useCircle } from 'hooks';
 import { getAvatarPath } from 'utils/domain';
+
 import EditModal, { IProfileData } from './EditModal';
 
 const useStyles = makeStyles((theme) => ({
@@ -206,11 +205,10 @@ export const ProfilePage = ({
   const { profile: aProfile, avatarPath, backgroundPath } = useProfile(
     seemsAddress ? params?.profileAddress : undefined
   );
+  const { updateMyProfile, updateAvatar, updateBackground } = useApi();
+
   const {
     myProfile,
-    updateProfile: updateMyProfile,
-    updateAvatar,
-    updateBackground,
     avatarPath: myAvatarPath,
     backgroundPath: myBackgroundPath,
   } = useMe();

--- a/src/pages/VouchingPage/NewNominationModal.tsx
+++ b/src/pages/VouchingPage/NewNominationModal.tsx
@@ -75,9 +75,11 @@ export const NewNominationModal = ({
       name,
       address,
       description,
-    }).then(() => {
-      onClose();
-    });
+    })
+      .then(() => {
+        onClose();
+      })
+      .catch((e) => console.warn(e));
   };
 
   return (

--- a/src/pages/VouchingPage/NewNominationModal.tsx
+++ b/src/pages/VouchingPage/NewNominationModal.tsx
@@ -79,7 +79,7 @@ export const NewNominationModal = ({
       .then(() => {
         onClose();
       })
-      .catch((e) => console.warn(e));
+      .catch(console.warn);
   };
 
   return (

--- a/src/pages/VouchingPage/NomineeCard.tsx
+++ b/src/pages/VouchingPage/NomineeCard.tsx
@@ -223,7 +223,7 @@ const NomineeCard = ({ nominee }: { nominee: INominee }) => {
         color="secondary"
         size="small"
         disabled={vouchDisabled}
-        onClick={() => vouchUser(nominee.id)}
+        onClick={() => vouchUser(nominee.id).catch((e) => console.warn(e))}
       >
         Vouch for {nominee.name}
       </Button>

--- a/src/pages/VouchingPage/NomineeCard.tsx
+++ b/src/pages/VouchingPage/NomineeCard.tsx
@@ -223,7 +223,7 @@ const NomineeCard = ({ nominee }: { nominee: INominee }) => {
         color="secondary"
         size="small"
         disabled={vouchDisabled}
-        onClick={() => vouchUser(nominee.id).catch((e) => console.warn(e))}
+        onClick={() => vouchUser(nominee.id).catch(console.warn)}
       >
         Vouch for {nominee.name}
       </Button>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,3 +1,4 @@
+import { Web3Provider } from '@ethersproject/providers';
 import axios from 'axios';
 
 import { API_URL } from 'utils/domain';
@@ -25,13 +26,13 @@ import {
 axios.defaults.baseURL = API_URL;
 
 export class APIService {
-  provider = undefined;
+  provider = undefined as Web3Provider | undefined;
 
-  constructor(provider?: any) {
+  constructor(provider?: Web3Provider) {
     this.provider = provider;
   }
 
-  setProvider(provider?: any) {
+  setProvider(provider?: Web3Provider) {
     this.provider = provider;
   }
 

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -1,39 +1,46 @@
-import { Wallet, ethers } from 'ethers';
+import { Web3Provider } from '@ethersproject/providers';
+import { ethers } from 'ethers';
 
-export const getSignature = async (data: string, provider?: any) => {
+export const getSignature = async (data: string, provider?: Web3Provider) => {
   if (!provider) throw 'Missing provider for getSignature';
 
-  const signer: Wallet = provider.getSigner();
+  const signer = provider.getSigner();
   const address = await signer.getAddress();
-  const signature: any = await (async () =>
-    new Promise((resolve) => {
-      const t = setTimeout(() => resolve(false), 60000);
-      signer.signMessage(data).then((sig) => {
+  const signature = await new Promise<string>((resolve, reject) => {
+    const t = setTimeout(
+      () => reject('Waiting for signature, timed out.'),
+      60000
+    );
+    signer
+      .signMessage(data)
+      .then((sig) => {
         clearTimeout(t);
         resolve(sig);
+      })
+      .catch((e) => {
+        // if (e.code === 'CODE_FOR_HARDWAREWALLET_ERROR') {
+        //   e.message = 'There was an error signing the message with your hardware wallet. Try sending a shorter message.';
+        // }
+        reject(e);
       });
-    }))();
-  if (!signature) {
-    throw 'There was an error signing the message with your hardware wallet. Try sending a shorter message.';
-  }
+  });
 
   const byteCode = await provider.getCode(address);
   const isSmartContract =
-    byteCode && ethers.utils.hexStripZeros(byteCode) !== '0x';
-  let hash = '';
-  if (isSmartContract) {
-    hash = ethers.utils.hashMessage(data);
-    // validate smart contract signature (might work for other other types of smart contract wallets )
-    // comment out when not testing
-    //_validateContractSignature(signature, hash, provider, address);
-  }
+    !!byteCode && ethers.utils.hexStripZeros(byteCode) !== '0x';
+  const hash = isSmartContract ? ethers.utils.hashMessage(data) : '';
+
+  // validate smart contract signature (might work for other other types of smart contract wallets )
+  // comment out when not testing
+  //_validateContractSignature(signature, hash, provider, address);
+
   return { signature, hash };
 };
 
 export const _validateContractSignature = async (
   signedData: string,
   hashMessage: string,
-  provider: any,
+  provider: Web3Provider,
   address: string
 ) => {
   try {


### PR DESCRIPTION
### Moved functions that call API into useApi
 - Move towards separating state from mutations
 - `useMe`: `updateProfile`, `updateAvatar`, `updateBackground`

### Error Handling cleanups
 - Provider types included
 - When signature fails, fail immediately with the error message
 - If allocating give, mention the smaller transaction size there
 - wrap all `useAsyncLoadCatch.ts` usages with `try{}catch(e){}` or `.catch()`
 - just show a info alert if the user rejects the signature