### PR TITLE
Create CONTRIBUTING.md doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contribute to Coordinape
+
+Coordinape is open source. Want to help build Coordinape? Welcome! You are in the right place. This guide serves as the first entry point in helping a new developer get the Coordinape app running and writing code. Have questions? Is the guide out of date? Submit a PR and help the next contributor.
+
+## Code Repositories
+
+Our [code is hosted on Github](http://github.com/coordinape/) in three separate repositories.
+
+- [Frontend repo](https://github.com/coordinape/coordinape)
+- [Backend repo](https://github.com/coordinape/coordinape-backend)
+- [Solidity / Protocols repo](https://github.com/coordinape/coordinape-protocol)
+
+Each repository above includes a README.md in the root of the repo with instructions on getting that app running. Our current Coordinape app runs off-chain using the Frontend and Backend repos. Our solidity repo is under active development as we move Coordinape on-chain.
+
+## Getting Started
+
+To get your development environment started begin with following the [README](https://github.com/coordinape/coordinape-backend/blob/main/README.md) in the Backend repo. Once the backend is up and running next follow the [README](https://github.com/coordinape/coordinape/blob/master/README.md) the Frontend repo.
+
+## Questions and Help
+
+Github Issues and Discord are the best places for the community to collaborate.


### PR DESCRIPTION
Linear: APE-319

Create a CONTRIBUTING.md guide that serves as the entry point that we can send any new dev to as a first place to start contributing to Coordinape.

Long term this ideally includes or links to:
- easy links to main resources for the project.
- mission
- goals
- roadmap
- contact info
- teams
- dev env setup 
- pr process
- code review process
- compensation strategy for open devs