### PR TITLE
Add .env setup instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
-STAGING_REACT_APP_API_BASE_URL=https://myvault.live/api
-REACT_APP_API_BASE_URL=https://coordinape.me/api
 REACT_APP_S3_BASE_URL=https://coordinape.s3.amazonaws.com
 REACT_APP_INFURA_PROJECT_ID=
 REACT_APP_FORTMATIC_API_KEY=
 REACT_APP_PORTIS_DAPP_ID=
+
+# production backend
+#REACT_APP_API_BASE_URL=https://coordinape.me/api
+
+# localhost backend
+REACT_APP_API_BASE_URL=http://localhost/api

--- a/README.md
+++ b/README.md
@@ -32,13 +32,16 @@ React Frontend                 ┃┃
 
 # Getting started:
 
-- `git clone` | `yarn install`
-- Setup .env file
-- `yarn start` | [http://localhost:3000](http://localhost:3000)
-
-Bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+1. Clone the git repo: `git clone git@github.com:coordinape/coordinape.git`
+2. Install packages: `yarn install`
+3. Setup a local .env file: `cp .env.example .env`
+4. Start yarn: `yarn start`
+5. Visit app: [http://localhost:3000](http://localhost:3000)
+6. Setup backend API: [follow instructions](https://github.com/coordinape/coordinape-backend/blob/main/README.md)
 
 # App Structure
+
+Bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
 ### See [HistoryPage](https://github.com/coordinape/coordinape/blob/master/src/pages/HistoryPage/HistoryPage.tsx) as an exemplar top level component.
 


### PR DESCRIPTION
# What
Add more detailed guide to setting up the `.env` file in setup instructions.

Why: Open source contributors were getting stuck on the the .env setup step.

Cleanup .env.example file.