### PR TITLE
add buffer polyfill

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -1,3 +1,5 @@
+const webpack = require('webpack');
+
 module.exports = {
   webpack: {
     configure: {
@@ -21,8 +23,10 @@ module.exports = {
           stream: require.resolve('stream-browserify'),
           util: require.resolve('util/'),
           assert: require.resolve('assert/'),
+          buffer: require.resolve('buffer/'),
         },
       },
+      plugins: [new webpack.ProvidePlugin({ Buffer: ['buffer', 'Buffer'] })],
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "@typescript-eslint/eslint-plugin": "4.33.0",
     "@typescript-eslint/parser": "4.33.0",
     "assert": "2.0.0",
+    "buffer": "6.0.3",
     "crypto-browserify": "3.12.0",
     "eslint": "7.32.0",
     "eslint-config-prettier": "8.3.0",

--- a/src/hooks/useWallet.ts
+++ b/src/hooks/useWallet.ts
@@ -48,6 +48,7 @@ export const useWallet = (): {
 
     await web3Context.activate(newConnector, (error: Error) => {
       apeError(error);
+      console.error(error);
       deactivateWallet();
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4434,6 +4434,14 @@ buffer-xor@^1.0.3:
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
 
+buffer@6.0.3, buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
+
 buffer@^5.2.1, buffer@^5.4.3:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
@@ -4441,14 +4449,6 @@ buffer@^5.2.1, buffer@^5.4.3:
   dependencies:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
-
-buffer@^6.0.3:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
-  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
-  dependencies:
-    base64-js "^1.3.1"
-    ieee754 "^1.2.1"
 
 builtin-modules@^3.1.0:
   version "3.2.0"


### PR DESCRIPTION
this fixes broken WalletConnect in production by adding the Buffer polyfill, which is used by the ethereumjs-util dependency of WalletConnect