### PR TITLE
Fix admin role checks

### DIFF
--- a/src/forms/AdminUserForm.tsx
+++ b/src/forms/AdminUserForm.tsx
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { USER_ROLE_ADMIN } from 'config/constants';
+
 import { createForm } from './createForm';
 import { zEthAddress, zBooleanToNumber } from './formHelpers';
 
@@ -17,7 +19,7 @@ const schema = z
     non_giver: zBooleanToNumber,
     fixed_non_receiver: zBooleanToNumber,
     non_receiver: zBooleanToNumber,
-    role: zBooleanToNumber,
+    admin: zBooleanToNumber,
     starting_tokens: z.number(),
   })
   .strict();
@@ -32,7 +34,7 @@ const AdminUserForm = createForm({
     non_giver: !!(v.user?.non_giver ?? !v.circle.default_opt_in),
     fixed_non_receiver: !!v.user?.fixed_non_receiver ?? false,
     non_receiver: !!v.user?.fixed_non_receiver || !!v.user?.non_receiver,
-    role: !!v.user?.role ?? false,
+    admin: v.user?.role === USER_ROLE_ADMIN ?? false,
     starting_tokens: v.user?.starting_tokens ?? 100,
   }),
   fieldKeys: Object.keys(schema.shape),

--- a/src/pages/AdminPage/AdminPage.tsx
+++ b/src/pages/AdminPage/AdminPage.tsx
@@ -282,7 +282,7 @@ const AdminPage = () => {
         },
         {
           label: 'Are they admin?',
-          render: (u: IUser) => (u.role === 0 ? '-' : 'Admin'),
+          render: (u: IUser) => (u.role === 1 ? 'Admin' : '-'),
         },
         {
           label: 'GIVE sent',

--- a/src/pages/AdminPage/AdminPage.tsx
+++ b/src/pages/AdminPage/AdminPage.tsx
@@ -5,6 +5,7 @@ import { useHistory } from 'react-router-dom';
 import { makeStyles, Button, IconButton } from '@material-ui/core';
 
 import { StaticTable, NoticeBox, ApeAvatar, DialogNotice } from 'components';
+import { USER_ROLE_ADMIN } from 'config/constants';
 import { useAdminApi } from 'hooks';
 import { DeleteIcon, EditIcon, PlusCircleIcon } from 'icons';
 import {
@@ -282,7 +283,7 @@ const AdminPage = () => {
         },
         {
           label: 'Are they admin?',
-          render: (u: IUser) => (u.role === 1 ? 'Admin' : '-'),
+          render: (u: IUser) => (u.role === USER_ROLE_ADMIN ? 'Admin' : '-'),
         },
         {
           label: 'GIVE sent',

--- a/src/pages/AdminPage/AdminUserModal.tsx
+++ b/src/pages/AdminPage/AdminUserModal.tsx
@@ -102,7 +102,7 @@ export const AdminUserModal = ({
               fullWidth
               className={classes.ethInput}
             />
-            <ApeToggle {...fields.role} label="Are They Admin?" />
+            <ApeToggle {...fields.admin} label="Are They Admin?" />
             <ApeToggle
               {...non_giver}
               onChange={v => nonGiverOnChange(!v)}

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -3,6 +3,7 @@ import React, { lazy } from 'react';
 import { Route, Switch } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 
+import { USER_ROLE_ADMIN } from 'config/constants';
 import AdminPage from 'pages/AdminPage';
 import AllocationPage from 'pages/AllocationPage';
 import CreateCirclePage from 'pages/CreateCirclePage';
@@ -40,7 +41,7 @@ export const Routes = () => {
   }
   const SneakyAllocationPage = !asVoyeur ? AllocationPage : DefaultPage;
   const SneakyAdminPage =
-    (selectedMyUser && selectedMyUser.role === 1) || hasAdminView
+    (selectedMyUser && selectedMyUser.role === USER_ROLE_ADMIN) || hasAdminView
       ? AdminPage
       : DefaultPage;
 

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -40,7 +40,7 @@ export const Routes = () => {
   }
   const SneakyAllocationPage = !asVoyeur ? AllocationPage : DefaultPage;
   const SneakyAdminPage =
-    (selectedMyUser && selectedMyUser.role !== 0) || hasAdminView
+    (selectedMyUser && selectedMyUser.role === 1) || hasAdminView
       ? AdminPage
       : DefaultPage;
 


### PR DESCRIPTION
# What
Fix admin role checks


These admin role checks broke with the addition of another user role (2 - coordinape donation user), and I think
it makes a lot more sense to check if they are role admin, rather than if they are not role normal user.

I did a search for the role, but if there's anywhere else I may need to change this too, let me know.