### PR TITLE
Add Coordinape User to all Circles

### DIFF
--- a/src/components/ApeInfoTooltip/ApeInfoTooltip.tsx
+++ b/src/components/ApeInfoTooltip/ApeInfoTooltip.tsx
@@ -1,6 +1,8 @@
 import { ReactNode } from 'react';
 
-import { makeStyles, Tooltip, Zoom } from '@material-ui/core';
+import clsx from 'clsx';
+
+import { makeStyles, Tooltip, Zoom, TooltipProps } from '@material-ui/core';
 
 import { InfoIcon } from 'icons';
 
@@ -8,8 +10,10 @@ const useStyles = makeStyles(theme => ({
   tooltip: {
     fontSize: 14,
     lineHeight: 1.4,
-    fontWeight: 400,
+    fontWeight: 300,
+    maxWidth: 240,
     padding: theme.spacing(1),
+    margin: theme.spacing(0, 2),
     borderRadius: 8,
     boxShadow: '0px 4px 6px rgba(181, 193, 199, 0.16)',
     color: theme.colors.text,
@@ -23,18 +27,28 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-export const ApeInfoTooltip = ({ children }: { children: ReactNode }) => {
-  const classes = useStyles();
+export const ApeInfoTooltip = ({
+  children,
+  classes,
+  className,
+  ...props
+}: { children: ReactNode } & Omit<TooltipProps, 'title' | 'children'>) => {
+  const localClasses = useStyles();
 
   return (
     <Tooltip
       title={<div>{children ?? 'blank'}</div>}
       placement="top-start"
       TransitionComponent={Zoom}
-      classes={{ tooltip: classes.tooltip }}
+      classes={{
+        ...classes,
+        tooltip: clsx(localClasses.tooltip, classes?.tooltip),
+      }}
+      interactive
+      {...props}
     >
-      <span>
-        <InfoIcon inherit="inherit" className={classes.icon} />
+      <span className={className}>
+        <InfoIcon inherit="inherit" className={localClasses.icon} />
       </span>
     </Tooltip>
   );

--- a/src/components/ProfileCard/ProfileCard.tsx
+++ b/src/components/ProfileCard/ProfileCard.tsx
@@ -10,13 +10,10 @@ import {
   ThreeDotMenu,
   ProfileSkills,
 } from 'components';
-import {
-  USER_ROLE_ADMIN,
-  USER_ROLE_COORDINAPE,
-  COORDINAPE_DONATION_APEINFO_TOOLTIP_TEXT,
-} from 'config/constants';
+import { USER_ROLE_ADMIN, USER_ROLE_COORDINAPE } from 'config/constants';
 import { useNavigation } from 'hooks';
 import { useSetEditProfileOpen } from 'recoilState';
+import { EXTERNAL_URL_FEEDBACK } from 'routes/paths';
 
 import { CardInfoText } from './CardInfoText';
 import { GiftInput } from './GiftInput';
@@ -68,13 +65,14 @@ const useStyles = makeStyles(theme => ({
     fontWeight: 600,
     color: theme.colors.text,
   },
-  coordinape_tooltip: {
-    width: '100%',
-    display: 'grid',
-    flexDirection: 'row-reverse',
-    gridTemplateColumns: '1fr 60px 1fr',
-    margin: theme.spacing(0.7),
-    fontWeight: 600,
+  tooltipLink: {
+    display: 'block',
+    margin: theme.spacing(2, 0, 0),
+    textAlign: 'center',
+    color: theme.colors.linkBlue,
+  },
+  tooltip: {
+    fontWeight: 400,
     color: theme.colors.text,
   },
   skillContainer: {
@@ -165,9 +163,21 @@ export const ProfileCard = ({
         <span className={classes.name}>
           {user.name}
           {user.role === USER_ROLE_COORDINAPE && (
-            <ApeInfoTooltip>
-              {' '}
-              {COORDINAPE_DONATION_APEINFO_TOOLTIP_TEXT}{' '}
+            <ApeInfoTooltip classes={{ tooltip: classes.tooltip }}>
+              <b>Why is Coordinape in my circle?</b>
+              <div>
+                To date Coordinape has offered our service for free. We decided
+                that using the gift circle mechanism as our revenue model might
+                make a lot of sense, so we’re trying that out.
+              </div>
+              <a
+                href={EXTERNAL_URL_FEEDBACK}
+                rel="noreferrer"
+                target="_blank"
+                className={classes.tooltipLink}
+              >
+                Let us know what you think
+              </a>
             </ApeInfoTooltip>
           )}
         </span>

--- a/src/components/ProfileCard/ProfileCard.tsx
+++ b/src/components/ProfileCard/ProfileCard.tsx
@@ -5,11 +5,16 @@ import { makeStyles, Button } from '@material-ui/core';
 import { ReactComponent as EditProfileSVG } from 'assets/svgs/button/edit-profile.svg';
 import {
   ApeAvatar,
+  ApeInfoTooltip,
   ProfileSocialIcons,
   ThreeDotMenu,
   ProfileSkills,
 } from 'components';
-import { USER_ROLE_ADMIN } from 'config/constants';
+import {
+  USER_ROLE_ADMIN,
+  USER_ROLE_COORDINAPE,
+  COORDINAPE_DONATION_APEINFO_TOOLTIP_TEXT,
+} from 'config/constants';
 import { useNavigation } from 'hooks';
 import { useSetEditProfileOpen } from 'recoilState';
 
@@ -60,6 +65,15 @@ const useStyles = makeStyles(theme => ({
     textAlign: 'center',
     margin: theme.spacing(0.5, 0),
     fontSize: 24,
+    fontWeight: 600,
+    color: theme.colors.text,
+  },
+  coordinape_tooltip: {
+    width: '100%',
+    display: 'grid',
+    flexDirection: 'row-reverse',
+    gridTemplateColumns: '1fr 60px 1fr',
+    margin: theme.spacing(0.7),
     fontWeight: 600,
     color: theme.colors.text,
   },
@@ -148,7 +162,16 @@ export const ProfileCard = ({
             ]}
           />
         </div>
-        <span className={classes.name}>{user.name}</span>
+        <span className={classes.name}>
+          {user.name}
+          {user.role === USER_ROLE_COORDINAPE && (
+            <ApeInfoTooltip>
+              {' '}
+              {COORDINAPE_DONATION_APEINFO_TOOLTIP_TEXT}{' '}
+            </ApeInfoTooltip>
+          )}
+        </span>
+
         <div className={classes.skillContainer}>
           <ProfileSkills
             skills={user?.profile?.skills ?? []}

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -16,6 +16,10 @@ export const MAX_NAME_LENGTH = 20;
 export const MAX_BIO_LENGTH = 560;
 
 export const USER_ROLE_ADMIN = 1;
+export const USER_ROLE_COORDINAPE = 2;
+
+export const COORDINAPE_DONATION_APEINFO_TOOLTIP_TEXT =
+  'Why is Coordinape in my circle? To date Coordinape has offered our service for free. We decided that using the gift circle mechanism as our revenue model might make a lot of sense, so we’re trying that out.';
 
 export const WALLET_ICONS: { [key in ConnectorNames]: React.ElementType } = {
   [ConnectorNames.Injected]: MetaMaskSVG,

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -18,9 +18,6 @@ export const MAX_BIO_LENGTH = 560;
 export const USER_ROLE_ADMIN = 1;
 export const USER_ROLE_COORDINAPE = 2;
 
-export const COORDINAPE_DONATION_APEINFO_TOOLTIP_TEXT =
-  'Why is Coordinape in my circle? To date Coordinape has offered our service for free. We decided that using the gift circle mechanism as our revenue model might make a lot of sense, so we’re trying that out.';
-
 export const WALLET_ICONS: { [key in ConnectorNames]: React.ElementType } = {
   [ConnectorNames.Injected]: MetaMaskSVG,
   [ConnectorNames.WalletConnect]: WalletConnectSVG,

--- a/src/pages/AdminPage/AdminPage.tsx
+++ b/src/pages/AdminPage/AdminPage.tsx
@@ -5,7 +5,7 @@ import { useHistory } from 'react-router-dom';
 import { makeStyles, Button, IconButton } from '@material-ui/core';
 
 import { StaticTable, NoticeBox, ApeAvatar, DialogNotice } from 'components';
-import { USER_ROLE_ADMIN } from 'config/constants';
+import { USER_ROLE_ADMIN, USER_ROLE_COORDINAPE } from 'config/constants';
 import { useAdminApi } from 'hooks';
 import { DeleteIcon, EditIcon, PlusCircleIcon } from 'icons';
 import {
@@ -149,6 +149,15 @@ const epochDetail = (e: IEpoch) => {
       }`;
 };
 
+const isEditable = (u: IUser): boolean => {
+  return !isCoordinapeUser(u);
+};
+
+//TODO move to a shared place?
+const isCoordinapeUser = (u: IUser): boolean => {
+  return u.role === USER_ROLE_COORDINAPE;
+};
+
 const AdminPage = () => {
   const classes = useStyles();
   const [keyword, setKeyword] = useState<string>('');
@@ -175,7 +184,7 @@ const AdminPage = () => {
     setKeyword(event.target.value);
   };
 
-  const renderActions = (onEdit: () => void, onDelete?: () => void) => (
+  const renderActions = (onEdit?: () => void, onDelete?: () => void) => (
     <div className={classes.tableActions}>
       {onEdit ? (
         <IconButton onClick={onEdit} size="small">
@@ -308,7 +317,7 @@ const AdminPage = () => {
           label: 'Actions',
           render: (u: IUser) =>
             renderActions(
-              () => setEditUser(u),
+              isEditable(u) ? () => setEditUser(u) : undefined,
               u.id !== me?.id
                 ? () => deleteUser(u.address).catch(console.warn)
                 : undefined

--- a/src/pages/AdminPage/AdminPage.tsx
+++ b/src/pages/AdminPage/AdminPage.tsx
@@ -6,7 +6,7 @@ import { makeStyles, Button, IconButton } from '@material-ui/core';
 
 import { StaticTable, NoticeBox, ApeAvatar, DialogNotice } from 'components';
 import { USER_ROLE_ADMIN, USER_ROLE_COORDINAPE } from 'config/constants';
-import { useAdminApi } from 'hooks';
+import { useNavigation, useAdminApi } from 'hooks';
 import { DeleteIcon, EditIcon, PlusCircleIcon } from 'icons';
 import {
   useSelectedCircle,
@@ -105,6 +105,9 @@ const useStyles = makeStyles(theme => ({
     width: 32,
     height: 32,
     marginRight: theme.spacing(1),
+    '&:hover': {
+      cursor: 'pointer',
+    },
   },
   avatarCell: {
     height: 48,
@@ -165,6 +168,7 @@ const AdminPage = () => {
   );
 
   const history = useHistory();
+  const { getToProfile } = useNavigation();
 
   const { deleteUser, deleteEpoch } = useAdminApi();
   const me = useSelectedMyUser();
@@ -262,7 +266,11 @@ const AdminPage = () => {
           render: function UserName(u: IUser) {
             return (
               <div className={classes.avatarCell}>
-                <ApeAvatar user={u} className={classes.avatar} />
+                <ApeAvatar
+                  user={u}
+                  className={classes.avatar}
+                  onClick={getToProfile({ address: u.address })}
+                />
                 <span>{u.name}</span>
               </div>
             );

--- a/src/pages/AdminPage/AdminPage.tsx
+++ b/src/pages/AdminPage/AdminPage.tsx
@@ -149,15 +149,6 @@ const epochDetail = (e: IEpoch) => {
       }`;
 };
 
-const isEditable = (u: IUser): boolean => {
-  return !isCoordinapeUser(u);
-};
-
-//TODO move to a shared place?
-const isCoordinapeUser = (u: IUser): boolean => {
-  return u.role === USER_ROLE_COORDINAPE;
-};
-
 const AdminPage = () => {
   const classes = useStyles();
   const [keyword, setKeyword] = useState<string>('');
@@ -317,7 +308,9 @@ const AdminPage = () => {
           label: 'Actions',
           render: (u: IUser) =>
             renderActions(
-              isEditable(u) ? () => setEditUser(u) : undefined,
+              u.role !== USER_ROLE_COORDINAPE
+                ? () => setEditUser(u)
+                : undefined,
               u.id !== me?.id
                 ? () => deleteUser(u.address).catch(console.warn)
                 : undefined

--- a/src/pages/AdminPage/AdminPage.tsx
+++ b/src/pages/AdminPage/AdminPage.tsx
@@ -118,6 +118,9 @@ const useStyles = makeStyles(theme => ({
     display: 'flex',
     justifyContent: 'center',
   },
+  actionSpacer: {
+    width: 30,
+  },
   errorColor: {
     color: theme.palette.error.main,
   },
@@ -181,7 +184,9 @@ const AdminPage = () => {
         <IconButton onClick={onEdit} size="small">
           <EditIcon />
         </IconButton>
-      ) : undefined}
+      ) : (
+        <div className={classes.actionSpacer} />
+      )}
 
       {onDelete ? (
         <IconButton
@@ -191,7 +196,9 @@ const AdminPage = () => {
         >
           <DeleteIcon />
         </IconButton>
-      ) : undefined}
+      ) : (
+        <div className={classes.actionSpacer} />
+      )}
     </div>
   );
 

--- a/src/pages/AdminPage/AdminPage.tsx
+++ b/src/pages/AdminPage/AdminPage.tsx
@@ -105,8 +105,11 @@ const useStyles = makeStyles(theme => ({
     width: 32,
     height: 32,
     marginRight: theme.spacing(1),
+    border: `1px solid ${theme.colors.border}`,
+    cursor: 'pointer',
+    transition: 'border-color .3s ease',
     '&:hover': {
-      cursor: 'pointer',
+      border: '1px solid rgba(239, 115, 118, 1)',
     },
   },
   avatarCell: {

--- a/src/pages/ProfilePage/ProfilePage.tsx
+++ b/src/pages/ProfilePage/ProfilePage.tsx
@@ -11,9 +11,11 @@ import {
   ApeAvatar,
   FormFileUpload,
 } from 'components';
+import { USER_ROLE_COORDINAPE } from 'config/constants';
 import { useProfile, useMe, useCircle, useImageUploader, useApi } from 'hooks';
 import { EditIcon } from 'icons';
 import { useSetEditProfileOpen } from 'recoilState';
+import { EXTERNAL_URL_FEEDBACK } from 'routes/paths';
 import { getAvatarPath } from 'utils/domain';
 
 const useStyles = makeStyles(theme => ({
@@ -283,39 +285,57 @@ export const ProfilePage = ({
         <div className={classes.socialGroup}>
           <ProfileSocialIcons profile={profile} />
         </div>
-        <div className={classes.bio}>{profile?.bio}</div>
+        <div className={classes.bio}>
+          {user?.role === USER_ROLE_COORDINAPE ? (
+            <div>
+              Coordinape is the platform you’re using right now! We currently
+              offer our service for free and invite people to allocate to us
+              from within your circles. All funds received go towards funding
+              the team and our operations.{' '}
+              <a href={EXTERNAL_URL_FEEDBACK} rel="noreferrer" target="_blank">
+                Let us know what you think.
+              </a>
+            </div>
+          ) : (
+            profile?.bio
+          )}
+        </div>
       </div>
 
-      <div className={classes.sections}>
-        <Section title="My Circles">
-          {profile?.users?.map(u => (
-            <div key={u.id} className={classes.circle}>
-              <Avatar
-                alt={u?.circle?.name}
-                src={u.circle?.logo ? getAvatarPath(u.circle?.logo) : undefined}
-              >
-                {u.circle.name}
-              </Avatar>
+      {user?.role !== USER_ROLE_COORDINAPE && (
+        <div className={classes.sections}>
+          <Section title="My Circles">
+            {profile?.users?.map(u => (
+              <div key={u.id} className={classes.circle}>
+                <Avatar
+                  alt={u?.circle?.name}
+                  src={
+                    u.circle?.logo ? getAvatarPath(u.circle?.logo) : undefined
+                  }
+                >
+                  {u.circle.name}
+                </Avatar>
 
-              <span>
-                {u.circle.protocol.name} {u.circle.name}
-              </span>
-              {u?.non_receiver !== 0 && <span>Opted-Out</span>}
-            </div>
-          ))}
-        </Section>
-        <Section title="Recent Epoch Activity" asColumn>
-          {recentEpochs?.map(({ bio, circle }, i) => (
-            <div className={classes.recentEpoch} key={i}>
-              <div className={classes.recentEpochTitle}>
-                {circle.protocol.name} {circle.name}
+                <span>
+                  {u.circle.protocol.name} {u.circle.name}
+                </span>
+                {u?.non_receiver !== 0 && <span>Opted-Out</span>}
               </div>
-              <div className={classes.recentEpochStatement}>{bio}</div>
-            </div>
-          ))}
-        </Section>
-        {/* <Section title="Frequent Collaborators">TODO.</Section> */}
-      </div>
+            ))}
+          </Section>
+          <Section title="Recent Epoch Activity" asColumn>
+            {recentEpochs?.map(({ bio, circle }, i) => (
+              <div className={classes.recentEpoch} key={i}>
+                <div className={classes.recentEpochTitle}>
+                  {circle.protocol.name} {circle.name}
+                </div>
+                <div className={classes.recentEpochStatement}>{bio}</div>
+              </div>
+            ))}
+          </Section>
+          {/* <Section title="Frequent Collaborators">TODO.</Section> */}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -12,6 +12,8 @@ export const EXTERNAL_URL_TWITTER = 'https://twitter.com/coordinape';
 export const EXTERNAL_URL_DISCORD = 'https://discord.gg/coordinape';
 export const EXTERNAL_URL_MEDIUM_ARTICLE =
   'https://medium.com/iearn/decentralized-payroll-management-for-daos-b2252160c543';
+// TODO: Change this to something more specific to feedback.
+export const EXTERNAL_URL_FEEDBACK = 'https://discord.gg/DPjmDWEUH5';
 
 const toSearchString = (params: Record<string, string | number>) =>
   Object.entries(params)

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -13,7 +13,8 @@ export const EXTERNAL_URL_DISCORD = 'https://discord.gg/coordinape';
 export const EXTERNAL_URL_MEDIUM_ARTICLE =
   'https://medium.com/iearn/decentralized-payroll-management-for-daos-b2252160c543';
 // TODO: Change this to something more specific to feedback.
-export const EXTERNAL_URL_FEEDBACK = 'https://discord.gg/DPjmDWEUH5';
+export const EXTERNAL_URL_FEEDBACK =
+  'https://coordinape.notion.site/Why-is-Coordinape-in-my-Circle-fd17133a82ef4cbf84d4738311fb557a';
 
 const toSearchString = (params: Record<string, string | number>) =>
   Object.entries(params)

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -18,6 +18,7 @@ const color = {
   lightBorder: '#DEDEDE',
   background: '#DFE7E8',
   lightBackground: '#E1E1E1',
+  linkBlue: '#00ABBF',
   // New for landing page
   almostWhite: '#F6F7F8',
   lightBlue: '#84C7CA',

--- a/src/types/material-ui.d.ts
+++ b/src/types/material-ui.d.ts
@@ -27,6 +27,7 @@ declare module '@material-ui/core/styles/createMuiTheme' {
       lightBorder: string;
       background: string;
       lightBackground: string;
+      linkBlue: string;
       almostWhite: string;
       lightBlue: string;
       darkBlue: string;


### PR DESCRIPTION
Summary: Add Coordinape User to all Circles

This PR joins the backend PR for implementing this feature: https://github.com/coordinape/coordinape-backend/pull/50

On the frontend we change the following:

- On Admin Page, hide the edit button by for the CoordinapeUser (allow deletes)
- Add tooltip with coordinape user info to display this user differently

- [x] Change URL for feedback to Notion page
- [x] Option re-add Coordinape User to a Circle if deleted - do this later in separate task
- [x] Fix styling on "delete" button
