### PR TITLE
Change ApeAvatar component to default to user's initials

### DIFF
--- a/src/components/ApeAvatar/ApeAvatar.tsx
+++ b/src/components/ApeAvatar/ApeAvatar.tsx
@@ -19,18 +19,16 @@ export const ApeAvatar = ({
 }) => {
   // TODO: simplify so all: <ApeAvatar path={getAvatarPath(p?.avatar)} />
   const p = profile ?? user?.profile;
-  const src = p?.avatar ? getAvatarPath(p?.avatar) : path ?? AVATAR_PLACEHOLDER;
+  const placeholder = user?.name
+    ? `https://ui-avatars.com/api/?name=${encodeURIComponent(user?.name ?? '')}`
+    : AVATAR_PLACEHOLDER;
+  const src = p?.avatar ? getAvatarPath(p?.avatar) : path ?? placeholder;
   return (
     <Avatar src={src} alt={user?.name} {...props}>
       {children ? (
         children
       ) : (
-        <img
-          alt={user?.name}
-          src={AVATAR_PLACEHOLDER}
-          width="100%"
-          height="100%"
-        />
+        <img alt={user?.name} src={placeholder} width="100%" height="100%" />
       )}
     </Avatar>
   );


### PR DESCRIPTION
Uses https://ui-avatars.com/ to generate initial icons. It's a free API that does >800mm reqs/mo and I've used it for a few projects. It'll handle splitting a name into initials when given names with a segment, otherwise it uses the first two letters of a single name.

We can also customize the API output as desired.

Before:
![Screen Shot 2021-11-09 at 3 22 35 PM](https://user-images.githubusercontent.com/1297679/140999587-96eb5441-5bb3-433d-ba8b-a1366d13a1a4.png)

After:
![Screen Shot 2021-11-09 at 3 21 05 PM](https://user-images.githubusercontent.com/1297679/140999610-899af319-32e8-4579-8811-cbd1ea20971b.png)


Closes #272 