### PR TITLE
Extract getAvatarPathWithInitialsFallback, use in ApeAvatar and AMForceGraph

### DIFF
--- a/src/components/ApeAvatar/ApeAvatar.tsx
+++ b/src/components/ApeAvatar/ApeAvatar.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Avatar, AvatarProps } from '@material-ui/core';
 
-import { getAvatarPathWithInitialsFallback } from 'utils/domain';
+import { getAvatarPathWithFallback } from 'utils/domain';
 
 import { IUser, IProfile } from 'types';
 
@@ -19,7 +19,7 @@ export const ApeAvatar = ({
 }) => {
   // TODO: simplify so all: <ApeAvatar path={getAvatarPath(p?.avatar)} />
   const p = profile ?? user?.profile;
-  const avatarPath = getAvatarPathWithInitialsFallback(p?.avatar, user?.name);
+  const avatarPath = getAvatarPathWithFallback(p?.avatar, user?.name);
   const src = path ?? avatarPath;
   return (
     <Avatar src={src} alt={user?.name} {...props}>

--- a/src/components/ApeAvatar/ApeAvatar.tsx
+++ b/src/components/ApeAvatar/ApeAvatar.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Avatar, AvatarProps } from '@material-ui/core';
 
-import { getAvatarPath, AVATAR_PLACEHOLDER } from 'utils/domain';
+import { getAvatarPathWithInitialsFallback } from 'utils/domain';
 
 import { IUser, IProfile } from 'types';
 
@@ -19,16 +19,14 @@ export const ApeAvatar = ({
 }) => {
   // TODO: simplify so all: <ApeAvatar path={getAvatarPath(p?.avatar)} />
   const p = profile ?? user?.profile;
-  const placeholder = user?.name
-    ? `https://ui-avatars.com/api/?name=${encodeURIComponent(user?.name ?? '')}`
-    : AVATAR_PLACEHOLDER;
-  const src = p?.avatar ? getAvatarPath(p?.avatar) : path ?? placeholder;
+  const avatarPath = getAvatarPathWithInitialsFallback(p?.avatar, user?.name);
+  const src = path ?? avatarPath;
   return (
     <Avatar src={src} alt={user?.name} {...props}>
       {children ? (
         children
       ) : (
-        <img alt={user?.name} src={placeholder} width="100%" height="100%" />
+        <img alt={user?.name} src={src} width="100%" height="100%" />
       )}
     </Avatar>
   );

--- a/src/pages/AssetMapPage/AMForceGraph.tsx
+++ b/src/pages/AssetMapPage/AMForceGraph.tsx
@@ -13,7 +13,7 @@ import {
   useSetAmEgoAddress,
   AmContextDefault,
 } from 'recoilState';
-import { AVATAR_PLACEHOLDER, getAvatarPathWithFallback } from 'utils/domain';
+import { AVATAR_PLACEHOLDER } from 'utils/domain';
 
 import { IMapContext, IMapNodeFG, IMapEdgeFG } from 'types';
 
@@ -98,9 +98,7 @@ export const AMForceGraph = () => {
       images.current.set('', fallbackAvatar);
     }
     recoilMapGraphData.nodes.forEach(node => {
-      const { img, name } = node as IMapNodeFG;
-      const path = getAvatarPathWithFallback(img, name);
-
+      const path = (node as IMapNodeFG).img;
       if (path && !images.current.has(path)) {
         const img = new Image();
         img.src = path;

--- a/src/pages/AssetMapPage/AMForceGraph.tsx
+++ b/src/pages/AssetMapPage/AMForceGraph.tsx
@@ -13,7 +13,10 @@ import {
   useSetAmEgoAddress,
   AmContextDefault,
 } from 'recoilState';
-import { AVATAR_PLACEHOLDER, getAvatarPath } from 'utils/domain';
+import {
+  AVATAR_PLACEHOLDER,
+  getAvatarPathWithInitialsFallback,
+} from 'utils/domain';
 
 import { IMapContext, IMapNodeFG, IMapEdgeFG } from 'types';
 
@@ -98,10 +101,12 @@ export const AMForceGraph = () => {
       images.current.set('', fallbackAvatar);
     }
     recoilMapGraphData.nodes.forEach(node => {
-      const path = (node as IMapNodeFG).img;
+      const { img, name } = node as IMapNodeFG;
+      const path = getAvatarPathWithInitialsFallback(img, name);
+
       if (path && !images.current.has(path)) {
         const img = new Image();
-        img.src = getAvatarPath(path);
+        img.src = path;
         images.current.set(path, img);
       }
     });

--- a/src/pages/AssetMapPage/AMForceGraph.tsx
+++ b/src/pages/AssetMapPage/AMForceGraph.tsx
@@ -13,10 +13,7 @@ import {
   useSetAmEgoAddress,
   AmContextDefault,
 } from 'recoilState';
-import {
-  AVATAR_PLACEHOLDER,
-  getAvatarPathWithInitialsFallback,
-} from 'utils/domain';
+import { AVATAR_PLACEHOLDER, getAvatarPathWithFallback } from 'utils/domain';
 
 import { IMapContext, IMapNodeFG, IMapEdgeFG } from 'types';
 
@@ -102,7 +99,7 @@ export const AMForceGraph = () => {
     }
     recoilMapGraphData.nodes.forEach(node => {
       const { img, name } = node as IMapNodeFG;
-      const path = getAvatarPathWithInitialsFallback(img, name);
+      const path = getAvatarPathWithFallback(img, name);
 
       if (path && !images.current.has(path)) {
         const img = new Image();

--- a/src/recoilState/mapState.ts
+++ b/src/recoilState/mapState.ts
@@ -10,6 +10,7 @@ import {
   useSetRecoilState,
 } from 'recoil';
 
+import { getAvatarPathWithFallback } from 'utils/domain';
 import { toSearchRegExp, assertDef } from 'utils/tools';
 
 import {
@@ -270,7 +271,7 @@ export const rMapGraphData = selector<GraphData>({
 
           return {
             id: address,
-            img: profile.avatar ?? '',
+            img: getAvatarPathWithFallback(profile.avatar, user.name),
             profile,
             name: user.name,
             epochId: epoch.id,

--- a/src/utils/domain.ts
+++ b/src/utils/domain.ts
@@ -62,3 +62,14 @@ export const getAvatarPath = (avatar?: string, placeholder?: string) => {
 
   return `${STORAGE_URL}/${avatar}`;
 };
+
+export const getAvatarPathWithInitialsFallback = (
+  avatar?: string,
+  name?: string
+) => {
+  const placeholder = name
+    ? `https://ui-avatars.com/api/?name=${encodeURIComponent(name ?? '')}`
+    : AVATAR_PLACEHOLDER;
+
+  return avatar ? getAvatarPath(avatar) : placeholder;
+};

--- a/src/utils/domain.ts
+++ b/src/utils/domain.ts
@@ -63,10 +63,7 @@ export const getAvatarPath = (avatar?: string, placeholder?: string) => {
   return `${STORAGE_URL}/${avatar}`;
 };
 
-export const getAvatarPathWithInitialsFallback = (
-  avatar?: string,
-  name?: string
-) => {
+export const getAvatarPathWithFallback = (avatar?: string, name?: string) => {
   const placeholder = name
     ? `https://ui-avatars.com/api/?name=${encodeURIComponent(name ?? '')}`
     : AVATAR_PLACEHOLDER;


### PR DESCRIPTION
Closes #272 

This extracts placeholder logic from `ApeAvatar` in `util/domains` and uses the new logic in both `ApeAvatar` and `AMForceGraph`.

Builds on work from https://github.com/coordinape/coordinape/pull/278