### PR TITLE
Support ENS resolution in zEthAddress form helper

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,8 +8,8 @@ jobs:
     env:
       CI: true
       REACT_APP_S3_BASE_URL: https://coordinape.s3.amazonaws.com
-      REACT_APP_API_BASE_URL: https://myvault.live/api
-      ETHEREUM_RPC_URL: ${{ secrets.ETHEREUM_RPC_URL }}
+      REACT_APP_API_BASE_URL: https://staging-api.coordinape.com/api
+      ETHEREUM_RPC_URL: https://mainnet.infura.io/v3/275c8fc2ec294d6aac6bfc881d9a9dff
 
     steps:
       - uses: actions/checkout@v2

--- a/src/forms/formHelpers.ts
+++ b/src/forms/formHelpers.ts
@@ -10,5 +10,7 @@ export const zStringISODateUTC = z
 
 export const zEthAddress = z
   .string()
+  .transform(s => ethers.getDefaultProvider().resolveName(s))
+  .transform(s => s || '')
   .refine(s => ethers.utils.isAddress(s), 'Wallet address is invalid')
   .transform(s => s.toLowerCase());


### PR DESCRIPTION
Allows inputting ENS names anywhere we take an ETH address in a form. Closes #279 

Some screenshots of it in action:

1. Error states still work

![Screen Shot 2021-11-17 at 1 48 28 PM](https://user-images.githubusercontent.com/1297679/142264481-b55d7eee-4226-4ad0-9472-df848c820500.png)

2. ENS names now work
![Screen Shot 2021-11-17 at 1 50 44 PM](https://user-images.githubusercontent.com/1297679/142264550-59c9b61f-9697-486b-b69f-c9748bfc4e14.png)

3. ENS gets translated to bare address before it ends up in the database

![Screen Shot 2021-11-17 at 1 50 59 PM](https://user-images.githubusercontent.com/1297679/142264626-ab942977-9d8a-4a13-9996-4c0d55e88043.png)


