### PR TITLE
add fallback initials avatar to Circle in ProfilePage

### DIFF
--- a/src/pages/AdminPage/AdminCircleModal.tsx
+++ b/src/pages/AdminPage/AdminCircleModal.tsx
@@ -9,7 +9,7 @@ import { ApeAvatar, FormModal, ApeTextField, ApeToggle } from 'components';
 import { useApiAdminCircle } from 'hooks';
 import { UploadIcon, EditIcon } from 'icons';
 import { useSelectedCircle } from 'recoilState/app';
-import { getAvatarPath } from 'utils/domain';
+import { getCircleAvatar } from 'utils/domain';
 
 import { ICircle } from 'types';
 
@@ -172,7 +172,10 @@ export const AdminCircleModal = ({
   const [logoData, setLogoData] = useState<{
     avatar: string;
     avatarRaw: File | null;
-  }>({ avatar: getAvatarPath(circle.logo), avatarRaw: null });
+  }>({
+    avatar: getCircleAvatar({ avatar: circle.logo, circleName: circle.name }),
+    avatarRaw: null,
+  });
   const [circleName, setCircleName] = useState(circle.name);
   const [vouching, setVouching] = useState(circle.vouching);
   const [tokenName, setTokenName] = useState(circle.tokenName);

--- a/src/pages/ProfilePage/ProfilePage.tsx
+++ b/src/pages/ProfilePage/ProfilePage.tsx
@@ -21,7 +21,7 @@ import {
 } from 'recoilState/app';
 import { useSetEditProfileOpen } from 'recoilState/ui';
 import { EXTERNAL_URL_FEEDBACK } from 'routes/paths';
-import { getAvatarPath } from 'utils/domain';
+import { getAvatarPath, getCircleAvatar } from 'utils/domain';
 
 import { IMyProfile, IProfile } from 'types';
 
@@ -317,36 +317,39 @@ const ProfilePageContent = ({
       {user && !user.isCoordinapeUser && (
         <div className={classes.sections}>
           <Section title="My Circles">
-            {profile?.users?.map(u =>
-              u.circle ? (
-                <div key={u.id} className={classes.circle}>
-                  <Avatar
-                    alt={u.circle.name}
-                    src={
-                      u.circle?.logo ? getAvatarPath(u.circle?.logo) : undefined
-                    }
-                  >
-                    {u.circle.name}
-                  </Avatar>
+            {profile?.users?.map(
+              u =>
+                u.circle && (
+                  <div key={u.id} className={classes.circle}>
+                    <Avatar
+                      alt={u.circle.name}
+                      src={getCircleAvatar({
+                        avatar: u.circle.logo,
+                        circleName: u.circle.name,
+                      })}
+                    >
+                      {u.circle.name}
+                    </Avatar>
 
-                  <span>
-                    {u.circle.protocol.name} {u.circle.name}
-                  </span>
-                  {u.non_receiver && <span>Opted-Out</span>}
-                </div>
-              ) : undefined
+                    <span>
+                      {u.circle.protocol.name} {u.circle.name}
+                    </span>
+                    {u.non_receiver && <span>Opted-Out</span>}
+                  </div>
+                )
             )}
           </Section>
           <Section title="Recent Epoch Activity" asColumn>
-            {recentEpochs?.map(({ bio, circle }, i) =>
-              circle ? (
-                <div className={classes.recentEpoch} key={i}>
-                  <div className={classes.recentEpochTitle}>
-                    {circle.protocol.name} {circle.name}
+            {recentEpochs?.map(
+              ({ bio, circle }, i) =>
+                circle && (
+                  <div className={classes.recentEpoch} key={i}>
+                    <div className={classes.recentEpochTitle}>
+                      {circle.protocol.name} {circle.name}
+                    </div>
+                    <div className={classes.recentEpochStatement}>{bio}</div>
                   </div>
-                  <div className={classes.recentEpochStatement}>{bio}</div>
-                </div>
-              ) : undefined
+                )
             )}
           </Section>
           {/* <Section title="Frequent Collaborators">TODO.</Section> */}

--- a/src/utils/domain.ts
+++ b/src/utils/domain.ts
@@ -45,6 +45,10 @@ export const APP_PATH_CREATE_CIRCLE = `/new-circle`;
 export const APP_URL_CREATE_CIRCLE = `${APP_URL}${APP_PATH_CREATE_CIRCLE}`;
 export const AVATAR_PLACEHOLDER = '/imgs/avatar/placeholder.jpg';
 
+const getInitialsUrl = (name: string) => {
+  return `https://ui-avatars.com/api/?name=${encodeURIComponent(name)}`;
+};
+
 export const getAvatarPath = (avatar?: string, placeholder?: string) => {
   if (!avatar) return placeholder || AVATAR_PLACEHOLDER;
 
@@ -61,9 +65,17 @@ export const getAvatarPath = (avatar?: string, placeholder?: string) => {
 };
 
 export const getAvatarPathWithFallback = (avatar?: string, name?: string) => {
-  const placeholder = name
-    ? `https://ui-avatars.com/api/?name=${encodeURIComponent(name ?? '')}`
-    : AVATAR_PLACEHOLDER;
+  const placeholder = name ? getInitialsUrl(name) : AVATAR_PLACEHOLDER;
 
   return avatar ? getAvatarPath(avatar) : placeholder;
+};
+
+export const getCircleAvatar = ({
+  avatar,
+  circleName,
+}: {
+  avatar?: string;
+  circleName: string;
+}) => {
+  return avatar ? getAvatarPath(avatar) : getInitialsUrl(circleName);
 };


### PR DESCRIPTION
- Added fallback initials avatar image to `ProfilePage` and `AdminCircleModal`.

I didn't find other pages that use `circle.logo` or `.logo` for this purpose, but let me know if there are others.

<img width="486" alt="Screenshot 2021-12-04 at 13 31 51" src="https://user-images.githubusercontent.com/1258424/144707907-2f992ad5-bfd5-4ade-bc64-9acd9894624d.png">

<img width="658" alt="Screenshot 2021-12-04 at 13 40 50" src="https://user-images.githubusercontent.com/1258424/144708136-760a85f8-da4e-4fff-8a81-1781d0c63dc8.png">

<img width="646" alt="Screenshot 2021-12-04 at 13 41 25" src="https://user-images.githubusercontent.com/1258424/144708148-9f650b7d-fe14-497d-8ec5-be7656cf41d5.png">

 