### PR TITLE
add warning on opt out, rename DialogNotice to ActionDialog

### DIFF
--- a/src/components/ActionDialog/ActionDialog.tsx
+++ b/src/components/ActionDialog/ActionDialog.tsx
@@ -59,8 +59,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-// TODO: Rename to ActionDialog
-export const DialogNotice = ({
+export const ActionDialog = ({
   open,
   title,
   children,

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -32,7 +32,7 @@ export * from './FormCaptcha/FormCaptcha';
 export * from './ApeAutocomplete/ApeAutocomplete';
 export * from './FormAutocomplete/FormAutocomplete';
 export * from './ApeInfoTooltip/ApeInfoTooltip';
-export * from './DialogNotice/DialogNotice';
+export * from './ActionDialog/ActionDialog';
 export * from './ThreeDotMenu/ThreeDotMenu';
 export * from './OrganizationHeader/OrganizationHeader';
 export * from './ProfileSkills/ProfileSkills';

--- a/src/pages/AdminPage/AdminPage.tsx
+++ b/src/pages/AdminPage/AdminPage.tsx
@@ -8,7 +8,7 @@ import {
   StaticTable,
   NoticeBox,
   ApeAvatar,
-  DialogNotice,
+  ActionDialog,
   OrganizationHeader,
 } from 'components';
 import { USER_ROLE_ADMIN, USER_ROLE_COORDINAPE } from 'config/constants';
@@ -569,7 +569,7 @@ const AdminPage = ({ legacy }: { legacy?: boolean }) => {
           visible={editCircle}
         />
       )}
-      <DialogNotice
+      <ActionDialog
         open={newCircle}
         title="Congrats! You just launched a new circle."
         onClose={() => setNewCircle(false)}
@@ -577,9 +577,9 @@ const AdminPage = ({ legacy }: { legacy?: boolean }) => {
       >
         You’ll need to add your teammates to your circle and schedule an epoch
         before you can start allocating GIVE.
-      </DialogNotice>
+      </ActionDialog>
 
-      <DialogNotice
+      <ActionDialog
         open={!!deleteUserDialog}
         title={`Remove ${deleteUserDialog?.name} from circle`}
         onClose={() => setDeleteUserDialog(undefined)}
@@ -594,7 +594,7 @@ const AdminPage = ({ legacy }: { legacy?: boolean }) => {
         }
       />
 
-      <DialogNotice
+      <ActionDialog
         open={!!deleteEpochDialog}
         title={`Remove Epoch ${deleteEpochDialog?.number}`}
         onClose={() => setDeleteUserDialog(undefined)}

--- a/src/pages/AllocationPage/AllocationEpoch.tsx
+++ b/src/pages/AllocationPage/AllocationEpoch.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { makeStyles } from '@material-ui/core';
 
-import { OptInput } from 'components';
+import { OptInput, ActionDialog } from 'components';
 import { MAX_BIO_LENGTH } from 'config/constants';
 import { useSelectedCircle } from 'recoilState/app';
 import { capitalizedName } from 'utils/string';
@@ -116,10 +116,12 @@ const AllocationEpoch = ({
   fixedNonReceiver: boolean;
 }) => {
   const classes = useStyles();
+  const [optOutOpen, setOptOutOpen] = useState(false);
 
   const {
     circle: selectedCircle,
     circleEpochsStatus: { epochIsActive, timingMessage },
+    myUser,
   } = useSelectedCircle();
 
   const onChangeBio = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -159,7 +161,13 @@ const AllocationEpoch = ({
               isChecked={nonReceiver}
               subTitle="I am paid sufficiently via other channels"
               title="Opt Out"
-              updateOpt={() => setNonReceiver(true)}
+              updateOpt={() => {
+                if (myUser.give_token_received > 0) {
+                  setOptOutOpen(true);
+                } else {
+                  setNonReceiver(true);
+                }
+              }}
             />
             <OptInput
               isChecked={!nonReceiver}
@@ -169,6 +177,20 @@ const AllocationEpoch = ({
               title="Opt In"
               updateOpt={() => setNonReceiver(false)}
             />
+            <ActionDialog
+              open={optOutOpen}
+              title={`If you Opt Out you will lose your ${myUser.give_token_received} GIVE`}
+              onClose={() => setOptOutOpen(false)}
+              onPrimary={() => {
+                setNonReceiver(true);
+                setOptOutOpen(false);
+              }}
+              primaryText="Proceed to Opt Out"
+            >
+              Opting out during an in-progress epoch will result in any GIVE you
+              have received being returned to senders. Are you sure you wish to
+              proceed? This cannot be undone.
+            </ActionDialog>
           </div>
         </>
       ) : (


### PR DESCRIPTION
- add warning on opt out
- Remove TODO: rename DialogNotice to ActionDialog

Looks like this, the 0 GIVE value is there just for demo purpose, it will check for > 0 GIVE received.

<img width="952" alt="Screenshot 2021-12-14 at 9 45 59" src="https://user-images.githubusercontent.com/1258424/145954733-69a0aa93-8be7-4191-b486-2e4d346eee0a.png">

