### PR TITLE
added zero address to allow for eth vault creation

### DIFF
--- a/src/config/networks.ts
+++ b/src/config/networks.ts
@@ -136,9 +136,9 @@ export const knownTokens: { [name in KnownToken]: IKnownTokenData } = {
     symbol: 'ETH',
     decimals: 18,
     addresses: {
-      [networkIds.MAINNET]: '0x0000000000000000000000000000000000000000',
+      [networkIds.MAINNET]: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
       [networkIds.HARDHAT]: '0x0000000000000000000000000000000000000000',
-      [networkIds.RINKEBY]: '0x0000000000000000000000000000000000000000',
+      [networkIds.RINKEBY]: '0xc778417e063141139fce010982780140aa0cd5ab',
     },
   },
 };

--- a/src/config/networks.ts
+++ b/src/config/networks.ts
@@ -16,6 +16,7 @@ export type KnownToken =
   | 'YFI'
   | 'SUSHI'
   | 'ALUSD'
+  | 'ETH'
   | 'USDT';
 
 export const networkIds = {
@@ -129,6 +130,15 @@ export const knownTokens: { [name in KnownToken]: IKnownTokenData } = {
       [networkIds.MAINNET]: '0xdac17f958d2ee523a2206206994597c13d831ec7',
       [networkIds.HARDHAT]: '0xdac17f958d2ee523a2206206994597c13d831ec7',
       [networkIds.RINKEBY]: '0x01547ef97f9140dbdf5ae50f06b77337b95cf4bb',
+    },
+  },
+  ETH: {
+    symbol: 'ETH',
+    decimals: 18,
+    addresses: {
+      [networkIds.MAINNET]: '0x0000000000000000000000000000000000000000',
+      [networkIds.HARDHAT]: '0x0000000000000000000000000000000000000000',
+      [networkIds.RINKEBY]: '0x0000000000000000000000000000000000000000',
     },
   },
 };


### PR DESCRIPTION
This PR rounds out the fixes for vault creation. You can now mint a vault with any given token. I used a zero address for eth to allow use of same data structure.