### PR TITLE
Setup Hasura Cloud Preview with Github Actions

### DIFF
--- a/.github/workflows/delete-hasura-preview.yml
+++ b/.github/workflows/delete-hasura-preview.yml
@@ -1,0 +1,21 @@
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  delete-hasura-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Hasura Cloud Preview Apps
+        uses: hasura/hasura-cloud-preview-apps@v0.1.4
+        with:
+          name: "coordinape-${{github.env.GITHUB_HEAD_REF}}${{github.event.number}}"
+          delete: true
+          postgresDBConfig: |
+            POSTGRES_SERVER_CONNECTION_URI=${{secrets.POSTGRES_STAGING_CONNECTION_URI}}
+            PG_ENV_VARS_FOR_HASURA=PG_DATABASE_URL
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          HASURA_CLOUD_ACCESS_TOKEN: ${{secrets.HASURA_CLOUD_ACCESS_TOKEN}}

--- a/.github/workflows/hasura-preview.yml
+++ b/.github/workflows/hasura-preview.yml
@@ -1,0 +1,82 @@
+name: 'hasura-cloud-preview'
+on:
+  pull_request:
+    types: [opened , reopened, synchronize]
+    paths:
+      - hasura # path to Hasura config, prevents creating deployments if no changes
+    branches:
+      - main
+
+jobs:
+  hasura-cloud-preview:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    env:
+      CI: true
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get branch name
+        id: branch-name
+        uses: tj-actions/branch-names@v5.1
+
+      - name: Remove old env in Vercel if it exists
+        continue-on-error: true
+        run: npx vercel --token ${{ env.VERCEL_TOKEN }} env rm REACT_APP_HASURA_URL preview ${{ steps.branch-name.outputs.current_branch }} -y
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+
+      # Setting this first before deploying Hasura so Vercels git integration can pick it up.
+      # Otherwise impossible to programatically redeploy Vercel git build
+      - name: Set environment variable for preview deployment in Vercel
+        run: |
+          echo https://coordinape-${{ github.event.number }}.hasura.app/v1/graphql | npx vercel --token ${{ env.VERCEL_TOKEN }} env add REACT_APP_HASURA_URL preview ${{ steps.branch-name.outputs.current_branch }}
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+
+      - name: Hasura Cloud Preview Apps
+        uses: hasura/hasura-cloud-preview-apps@v0.1.4
+        id: hasura_cloud_preview
+        with:
+          name: "coordinape-${{github.env.GITHUB_HEAD_REF}}${{github.event.number}}"
+          hasuraProjectDirectoryPath: hasura
+          postgresDBConfig: |
+            POSTGRES_SERVER_CONNECTION_URI=${{secrets.POSTGRES_STAGING_CONNECTION_URI}}
+            PG_ENV_VARS_FOR_HASURA=HASURA_GRAPHQL_DATABASE_URL
+          hasuraEnv: |
+            HASURA_GRAPHQL_AUTH_HOOK=https://coordinape-git-staging-coordinape.vercel.app/api/hasura/auth
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          HASURA_CLOUD_ACCESS_TOKEN: ${{secrets.HASURA_CLOUD_ACCESS_TOKEN}}
+
+      - uses: hasura/comment-progress@v2.1.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          id: hasura_preview_comment
+          number: ${{github.event.number}}
+          repository: ${{ github.repository }}
+          message: |
+            Console URL available at ${{steps.hasura_cloud_preview.outputs.consoleURL}}
+            GraphQL Endpoint available at ${{steps.hasura_cloud_preview.outputs.graphQLEndpoint}}
+
+  remove-cloud-preview-on-failure:
+    runs-on: ubuntu-latest
+    needs: [ hasura-cloud-preview ]
+    if: always() && needs.hasura-cloud-preview.result == 'failure'
+    steps:
+      - name: Delete failed preview app
+        uses: hasura/hasura-cloud-preview-apps@v0.1.4
+        with:
+          name: "coordinape-${{github.env.GITHUB_HEAD_REF}}${{github.event.number}}"
+          delete: true
+          postgresDBConfig: |
+            POSTGRES_SERVER_CONNECTION_URI=${{secrets.POSTGRES_STAGING_CONNECTION_URI}}
+            PG_ENV_VARS_FOR_HASURA=PG_DATABASE_URL
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          HASURA_CLOUD_ACCESS_TOKEN: ${{secrets.HASURA_CLOUD_ACCESS_TOKEN}}

--- a/api/hasura/auth.ts
+++ b/api/hasura/auth.ts
@@ -33,7 +33,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   } catch (e) {
     res.status(401).json({
       error: '401',
-      message: (e.message as string) || 'Unexpected error',
+      message: (e as Error).message || 'Unexpected error',
     });
   } finally {
     await prisma.$disconnect();

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -36,6 +36,10 @@ export const REACT_APP_HASURA_URL = getEnvValue(
   'https://missing-hasura-url.edu'
 );
 
+if (!IN_PRODUCTION) {
+  console.log(`Using GraphQL API URL: ${REACT_APP_HASURA_URL}`);
+}
+
 // Unused in practice
 export const REACT_APP_FORTMATIC_API_KEY = 'unused'; // getEnvValue('REACT_APP_FORTMATIC_API_KEY', 'no-formatic-api-key');
 export const REACT_APP_PORTIS_DAPP_ID = 'unused'; // getEnvValue('REACT_APP_PORTIS_DAPP_ID', 'no-portis-api-key');


### PR DESCRIPTION
closes #400 

This enables [Preview Apps](https://hasura.io/docs/latest/graphql/cloud/preview-apps.html) for PRs made to this repo that modify the Hasura state. It will create an ephemeral database in the staging Postgres server and try applying any new metadata / migrations to it in order to verify correctness before merging the PR.

Since a PR may also make frontend changes that depend on changes to the Hasura instance, the Github action will also trigger a Vercel deployment that has the ephemeral Hasura instance configured as the GraphQL endpoint using the `REACT_APP_HASURA_URL` env var.

Once the PR is merged, the `delete-hasura-preview.yml` action will cleanup the ephemeral database and Hasura instance since it's no longer needed.