### PR TITLE
Fixing bug #389 - choosing the same background image twice in a row

### DIFF
--- a/src/components/FormFileUpload/FormFileUpload.tsx
+++ b/src/components/FormFileUpload/FormFileUpload.tsx
@@ -72,7 +72,13 @@ export const FormFileUpload = ({
         )}
         {hasChanged && (
           <Button
-            onClick={() => onChange(undefined)}
+            onClick={() => {
+              onChange(undefined);
+              // This clears the fileInput so that if the user chooses the same file again, onChange still fires
+              if (fileInput.current) {
+                fileInput.current.value = '';
+              }
+            }}
             startIcon={<CloseIcon />}
             size="small"
             className={buttonClass}


### PR DESCRIPTION
Fixes bug #389 where choosing the same background image twice in a row doesn't work. This also fixes same for avatar and other future usages of `FormFileUpload`