### PR TITLE
Fixes pfp issue on map page

### DIFF
--- a/src/components/ApeAvatar/ApeAvatar.tsx
+++ b/src/components/ApeAvatar/ApeAvatar.tsx
@@ -18,10 +18,10 @@ export const ApeAvatar = ({
   profile?: IProfile;
 }) => {
   // TODO: simplify so all: <ApeAvatar path={getAvatarPath(p?.avatar)} />
-  const p = profile ?? user?.profile;
-  let avatar = p?.avatar;
-  if (avatar === '') avatar = user?.profile?.avatar;
-  const avatarPath = getAvatarPathWithFallback(avatar, user?.name);
+  const avatarPath = getAvatarPathWithFallback(
+    profile?.avatar || user?.profile?.avatar,
+    user?.name
+  );
   const src = path ?? avatarPath;
   return (
     <Avatar src={src} alt={user?.name} {...props}>

--- a/src/components/ApeAvatar/ApeAvatar.tsx
+++ b/src/components/ApeAvatar/ApeAvatar.tsx
@@ -19,7 +19,9 @@ export const ApeAvatar = ({
 }) => {
   // TODO: simplify so all: <ApeAvatar path={getAvatarPath(p?.avatar)} />
   const p = profile ?? user?.profile;
-  const avatarPath = getAvatarPathWithFallback(p?.avatar, user?.name);
+  let avatar = p?.avatar;
+  if (avatar === '') avatar = user?.profile?.avatar;
+  const avatarPath = getAvatarPathWithFallback(avatar, user?.name);
   const src = path ?? avatarPath;
   return (
     <Avatar src={src} alt={user?.name} {...props}>

--- a/src/recoilState/app.ts
+++ b/src/recoilState/app.ts
@@ -205,9 +205,11 @@ export const rCircle = selectorFamily<ICircleState, number>({
         iti(users)
           .filter(u => u.circle_id === circleId)
           .filter(u => !u.deleted_at);
-      const myUser = get(rMyProfile).myUsers.find(
-        u => u.circle_id === circleId
-      );
+
+      const myProfile = get(rMyProfile);
+
+      const myUser = myProfile.myUsers.find(u => u.circle_id === circleId);
+
       const circleEpochsStatus = get(rCircleEpochsStatus(circleId));
       const activeNominees = iti(get(rNomineesMap).values())
         .filter(n => n.circle_id === circleId)
@@ -218,17 +220,17 @@ export const rCircle = selectorFamily<ICircleState, number>({
       const firstUser = getCircleUsers().first();
 
       const impersonate = !myUser && hasAdminView;
-      const meOrPretend =
-        myUser ??
-        (impersonate
-          ? ({
-              ...firstUser,
-              circle: circle,
-              teammates: getCircleUsers()
-                .filter(u => u.id !== firstUser?.id)
-                .toArray(),
-            } as IMyUser)
-          : undefined);
+      const meOrPretend = myUser
+        ? { ...myUser, profile: myProfile }
+        : impersonate
+        ? ({
+            ...firstUser,
+            circle: circle,
+            teammates: getCircleUsers()
+              .filter(u => u.id !== firstUser?.id)
+              .toArray(),
+          } as IMyUser)
+        : undefined;
 
       if (meOrPretend === undefined || circle === undefined) {
         return neverEndingPromise();
@@ -237,7 +239,7 @@ export const rCircle = selectorFamily<ICircleState, number>({
       return {
         circleId,
         circle,
-        myUser: { ...meOrPretend, profile: firstUser?.profile },
+        myUser: meOrPretend,
         impersonate,
         users: getCircleUsers().toArray(),
         usersNotMe: getCircleUsers()

--- a/src/recoilState/app.ts
+++ b/src/recoilState/app.ts
@@ -237,7 +237,7 @@ export const rCircle = selectorFamily<ICircleState, number>({
       return {
         circleId,
         circle,
-        myUser: meOrPretend,
+        myUser: { ...meOrPretend, profile: firstUser?.profile },
         impersonate,
         users: getCircleUsers().toArray(),
         usersNotMe: getCircleUsers()

--- a/src/recoilState/map.ts
+++ b/src/recoilState/map.ts
@@ -181,13 +181,12 @@ export const rMapGraphData = selector<GraphData>({
             `Missing user of circle = ${epoch.circle_id} in rMapGraphData at ${profile.address}`
           );
 
-          const p = profile ?? user?.profile;
-          let avatar = p?.avatar;
-          if (avatar === '') avatar = user?.profile?.avatar;
-
           return {
             id: address,
-            img: getAvatarPathWithFallback(avatar, user.name),
+            img: getAvatarPathWithFallback(
+              profile?.avatar || user?.profile?.avatar,
+              user.name
+            ),
             profile,
             name: user.name,
             epochId: epoch.id,

--- a/src/recoilState/map.ts
+++ b/src/recoilState/map.ts
@@ -181,9 +181,13 @@ export const rMapGraphData = selector<GraphData>({
             `Missing user of circle = ${epoch.circle_id} in rMapGraphData at ${profile.address}`
           );
 
+          const p = profile ?? user?.profile;
+          let avatar = p?.avatar;
+          if (avatar === '') avatar = user?.profile?.avatar;
+
           return {
             id: address,
-            img: getAvatarPathWithFallback(profile.avatar, user.name),
+            img: getAvatarPathWithFallback(avatar, user.name),
             profile,
             name: user.name,
             epochId: epoch.id,


### PR DESCRIPTION
fixes #417 

### problem
the `profile.avatar` is for some reason an empty string that's the reason why the map page is not loading the pfp.

![image](https://user-images.githubusercontent.com/5679878/150922952-ed31d23f-02af-4940-98be-78f88c374597.png)

### Solution

A non-empty string validation for the avatar value.

```
const p = profile ?? user?.profile;
let avatar = p?.avatar;
if (avatar === '') avatar = user?.profile?.avatar;
```
<img width="1049" alt="Screen Shot 2022-01-25 at 00 20 37" src="https://user-images.githubusercontent.com/5679878/150923105-0679a102-f39e-45b9-ab9d-3e66db42f47c.png">

PS. @zashton address the `profile.updated_at` is not updated like the `user.updated_at` 
![image](https://user-images.githubusercontent.com/5679878/150923389-3a2c0ec0-077f-42f2-9d3e-87fd1eb0b05d.png)

@exrhizo it could be something about the recoil state profile object request here? 
![image](https://user-images.githubusercontent.com/5679878/150923613-7db4c760-04eb-4c99-8a62-6b51621a59f9.png)

