### PR TITLE
Renaming vars to match .env.example and adding missing var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ LOCAL_POSTGRES_USER=postgres
 LOCAL_POSTGRES_PASSWORD=postgrespassword
 LOCAL_POSTGRES_DATABASE=postgres
 LOCAL_HASURA_ADMIN_SECRET=admin-secret
+LOCAL_HASURA_URL=http://localhost:8080/v1/graphql
 
 PRISMA_DATABASE_URL=postgres://postgres:postgrespassword@localhost:5432/postgres
 

--- a/api-lib/Gql.ts
+++ b/api-lib/Gql.ts
@@ -1,5 +1,6 @@
 import { Gql } from '../src/lib/gql/GqlHasuraAdmin';
-import { NODE_HASURA_ADMIN_SECRET, NODE_HASURA_URL } from './config';
+
+import { LOCAL_HASURA_ADMIN_SECRET, LOCAL_HASURA_URL } from './config';
 
 export * from '../src/lib/gql/GqlHasuraAdmin';
-export const gql = new Gql(NODE_HASURA_URL, NODE_HASURA_ADMIN_SECRET);
+export const gql = new Gql(LOCAL_HASURA_URL, LOCAL_HASURA_ADMIN_SECRET);

--- a/api-lib/config.ts
+++ b/api-lib/config.ts
@@ -18,6 +18,7 @@ function getEnvValue<T extends string | number>(
   return defaultVal;
 }
 
-export const NODE_HASURA_URL = <string>getEnvValue('NODE_HASURA_URL');
+export const LOCAL_HASURA_URL = <string>getEnvValue('LOCAL_HASURA_URL');
+export const LOCAL_HASURA_ADMIN_SECRET = <string>getEnvValue('LOCAL_HASURA_ADMIN_SECRET');
 export const LOCAL_SEED_ADDRESS = <string>getEnvValue('LOCAL_SEED_ADDRESS');
 export const IS_LOCAL_ENV = process.env.NODE_ENV === 'development';


### PR DESCRIPTION
Addresses #464 