### PR TITLE
use node-fetch in serverless functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "@types/lodash": "4.14.168",
     "@types/luxon": "2.0.2",
     "@types/node": "12.20.1",
+    "@types/node-fetch": "2.5.12",
     "@types/react": "17.0.27",
     "@types/react-dom": "17.0.9",
     "@types/react-router-dom": "5.1.7",

--- a/src/lib/gql/zeusHasuraAdmin/index.ts
+++ b/src/lib/gql/zeusHasuraAdmin/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-
+import nodeFetch from 'node-fetch';
 import { AllTypesProps, ReturnTypes } from './const';
 type ZEUS_INTERFACES = never;
 type ZEUS_UNIONS = never;
@@ -16240,6 +16240,9 @@ const handleFetchResponse = (
 export const apiFetch =
   (options: fetchOptions) =>
   (query: string, variables: Record<string, any> = {}) => {
+    if (!globalThis.fetch) {
+      globalThis.fetch = nodeFetch as unknown as typeof fetch;
+    }
     let fetchFunction = fetch;
     let queryString = query;
     let fetchOptions = options[1] || {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3425,6 +3425,14 @@
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
   integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
+"@types/node-fetch@2.5.12":
+  version "2.5.12"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.12.tgz#8a6f779b1d4e60b7a57fb6fd48d84fb545b9cc66"
+  integrity sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
 "@types/node@*":
   version "16.10.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.10.3.tgz#7a8f2838603ea314d1d22bb3171d899e15c57bd5"


### PR DESCRIPTION
Node.js does not have `fetch` available globally, thus we need to include `node-fetch` when querying the db with Hasura from serverless functions.