### PR TITLE
Set X-Hasura-Eth-Address in auth context

### DIFF
--- a/api/hasura/auth.ts
+++ b/api/hasura/auth.ts
@@ -39,6 +39,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     res.status(200).json({
       'X-Hasura-User-Id': tokenRow.tokenable_id.toString(),
       'X-Hasura-Role': profile.admin_view ? 'superadmin' : 'user',
+      'X-Hasura-Eth-Address': profile.address,
     });
   } catch (e) {
     res.status(401).json({


### PR DESCRIPTION
Allows us to verify / prepopulate Eth addresses in Action handlers / mutations when we want to ensure the user can't take actions using someone elses ETH address.