### PR TITLE
remove color of Arrow icon on ClaimCard

### DIFF
--- a/src/components/ClaimCard/ClaimCard.tsx
+++ b/src/components/ClaimCard/ClaimCard.tsx
@@ -62,7 +62,6 @@ export const ClaimCard: React.FC<ClaimCardProps> = (props): JSX.Element => (
           }}
         >
           <ArrowDownLeftIcon
-            color="darkRed"
             data-testid="arrow-diagonal-icon"
           />
           <Text css={{ fontSize: '$3', color: '$lightText' }}>

--- a/src/components/ClaimCard/ClaimCard.tsx
+++ b/src/components/ClaimCard/ClaimCard.tsx
@@ -61,9 +61,7 @@ export const ClaimCard: React.FC<ClaimCardProps> = (props): JSX.Element => (
             gap: '$xs',
           }}
         >
-          <ArrowDownLeftIcon
-            data-testid="arrow-diagonal-icon"
-          />
+          <ArrowDownLeftIcon data-testid="arrow-diagonal-icon" />
           <Text css={{ fontSize: '$3', color: '$lightText' }}>
             {epoch.giveInfo}
           </Text>


### PR DESCRIPTION
This was an undesired change, that changes the color of the icon that originally is green

coming soon, a `svg` component styled with stitches to control `size` `color` through variants