### PR TITLE
Circle Integrations: database table, migrations and permissions

### DIFF
--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -9,6 +9,7 @@ type Mutation {
     object: create_circle_input!
   ): create_circle_response
 }
+
 input create_circle_input {
   user_name: String!
   circle_name: String!
@@ -43,3 +44,4 @@ type createUserResponse {
   role: Int!
   starting_tokens: Int!
 }
+

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -9,7 +9,6 @@ type Mutation {
     object: create_circle_input!
   ): create_circle_response
 }
-
 input create_circle_input {
   user_name: String!
   circle_name: String!
@@ -44,4 +43,3 @@ type createUserResponse {
   role: Int!
   starting_tokens: Int!
 }
-

--- a/hasura/metadata/databases/default/tables/public_circle_integrations.yaml
+++ b/hasura/metadata/databases/default/tables/public_circle_integrations.yaml
@@ -1,0 +1,45 @@
+table:
+  name: circle_integrations
+  schema: public
+object_relationships:
+- name: circle
+  using:
+    foreign_key_constraint_on: circle_id
+insert_permissions:
+- permission:
+    backend_only: false
+    check:
+      circle:
+        users:
+          _and:
+          - role:
+              _eq: 1
+          - address:
+              _eq: X-Hasura-Address
+    columns:
+    - circle_id
+    - data
+    - name
+    - type
+  role: user
+select_permissions:
+- permission:
+    columns:
+    - circle_id
+    - id
+    - data
+    - name
+    - type
+    filter: {}
+  role: user
+delete_permissions:
+- permission:
+    filter:
+      circle:
+        users:
+          _and:
+          - role:
+              _eq: 1
+          - address:
+              _eq: X-Hasura-Address
+  role: user

--- a/hasura/metadata/databases/default/tables/public_circle_integrations.yaml
+++ b/hasura/metadata/databases/default/tables/public_circle_integrations.yaml
@@ -21,6 +21,22 @@ insert_permissions:
     - data
     - name
     - type
+  role: superadmin
+- permission:
+    backend_only: false
+    check:
+      circle:
+        users:
+          _and:
+          - role:
+              _eq: 1
+          - address:
+              _eq: X-Hasura-Address
+    columns:
+    - circle_id
+    - data
+    - name
+    - type
   role: user
 select_permissions:
 - permission:
@@ -31,8 +47,27 @@ select_permissions:
     - name
     - type
     filter: {}
+  role: superadmin
+- permission:
+    columns:
+    - circle_id
+    - id
+    - data
+    - name
+    - type
+    filter: {}
   role: user
 delete_permissions:
+- permission:
+    filter:
+      circle:
+        users:
+          _and:
+          - role:
+              _eq: 1
+          - address:
+              _eq: X-Hasura-Address
+  role: superadmin
 - permission:
     filter:
       circle:

--- a/hasura/metadata/databases/default/tables/public_circles.yaml
+++ b/hasura/metadata/databases/default/tables/public_circles.yaml
@@ -44,6 +44,13 @@ array_relationships:
       remote_table:
         name: epoches
         schema: public
+- name: integrations
+  using:
+    foreign_key_constraint_on:
+      column: circle_id
+      table:
+        name: circle_integrations
+        schema: public
 - name: pending_token_gifts
   using:
     foreign_key_constraint_on:

--- a/hasura/metadata/databases/default/tables/tables.yaml
+++ b/hasura/metadata/databases/default/tables/tables.yaml
@@ -1,4 +1,5 @@
 - "!include public_burns.yaml"
+- "!include public_circle_integrations.yaml"
 - "!include public_circle_metadata.yaml"
 - "!include public_circle_private.yaml"
 - "!include public_circles.yaml"

--- a/hasura/migrations/default/1644709890772_create_table_public_circle_integrations/down.sql
+++ b/hasura/migrations/default/1644709890772_create_table_public_circle_integrations/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE "public"."circle_integrations";

--- a/hasura/migrations/default/1644709890772_create_table_public_circle_integrations/up.sql
+++ b/hasura/migrations/default/1644709890772_create_table_public_circle_integrations/up.sql
@@ -1,0 +1,1 @@
+CREATE TABLE "public"."circle_integrations" ("id" bigserial NOT NULL, "circle_id" bigint NOT NULL, "name" text NOT NULL, "type" text NOT NULL, "data" json NOT NULL, PRIMARY KEY ("id") , FOREIGN KEY ("circle_id") REFERENCES "public"."circles"("id") ON UPDATE restrict ON DELETE restrict, UNIQUE ("id"));


### PR DESCRIPTION
Short demo of what a v1 of a Dework integration that uses circle integrations could look like: https://www.loom.com/share/b1bf242508f647a983c5a8b4c7d7c74e

This PR adds a new table `circle_integrations`. Circle admins can insert and delete integrations. Everyone can read circle integrations.

In a future PR I will make the frontend use this table to create integrations and read/show epoch contributions using integrations