### PR TITLE
Fixes #440 by implementing hasura action and FE changes for circle lo…

### DIFF
--- a/api-lib/images.ts
+++ b/api-lib/images.ts
@@ -23,6 +23,8 @@ function parseBase64(imageDataBase64: string): Buffer {
 }
 
 async function resizeAvatar(imageBytes: Buffer) {
+  // convert to a small jpeg w/ 80% quality
+  // This is small because of the map view which needs to show lots of small avatars in a canvas
   const img = sharp(imageBytes);
   return img
     .resize({
@@ -37,6 +39,7 @@ async function resizeAvatar(imageBytes: Buffer) {
 }
 
 async function resizeBackground(imageBytes: Buffer) {
+  // convert to jpeg w/ 80% image quality
   const img = sharp(imageBytes);
   return img
     .jpeg({
@@ -46,6 +49,7 @@ async function resizeBackground(imageBytes: Buffer) {
 }
 
 async function resizeCircleLogo(imageBytes: Buffer) {
+  // convert to jpeg w/ 80% image quality
   const img = sharp(imageBytes);
   return img
     .jpeg({

--- a/api-lib/images.ts
+++ b/api-lib/images.ts
@@ -45,4 +45,13 @@ async function resizeBackground(imageBytes: Buffer) {
     .toBuffer();
 }
 
-export { resizeAvatar, resizeBackground };
+async function resizeCircleLogo(imageBytes: Buffer) {
+  const img = sharp(imageBytes);
+  return img
+    .jpeg({
+      quality: 80,
+    })
+    .toBuffer();
+}
+
+export { resizeAvatar, resizeBackground, resizeCircleLogo };

--- a/api-lib/validate.ts
+++ b/api-lib/validate.ts
@@ -5,21 +5,22 @@ import { HASURA_EVENT_SECRET } from './config';
 export const verifyHasuraRequestMiddleware = (handler: VercelApiHandler) => {
   return async (req: VercelRequest, res: VercelResponse) => {
     if (
-        !req.headers.verification_key ||
-        (req.headers.verification_key as string) !== HASURA_EVENT_SECRET
+      !req.headers.verification_key ||
+      (req.headers.verification_key as string) !== HASURA_EVENT_SECRET
     ) {
       // return here to prevent further execution
       res.status(401).json({
         message: 'Unauthorized access',
-        code: 401,
+        code: '401',
       });
       return;
     }
     try {
       await handler(req, res);
     } catch (error: any) {
+      console.error(error);
       res.status(500).json({
-        code: 500,
+        code: '500',
         message: 'internal error: ' + error,
       });
     }

--- a/api-lib/validate.ts
+++ b/api-lib/validate.ts
@@ -18,7 +18,6 @@ export const verifyHasuraRequestMiddleware = (handler: VercelApiHandler) => {
     try {
       await handler(req, res);
     } catch (error: any) {
-      console.error(error);
       res.status(500).json({
         code: '500',
         message: 'internal error: ' + error,

--- a/api/hasura/actions/upload_circle_logo.ts
+++ b/api/hasura/actions/upload_circle_logo.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
-// import { authCircleAdminMiddleware } from '../../../api-lib/circleAdmin';
+import { authCircleAdminMiddleware } from '../../../api-lib/circleAdmin';
 import { gql } from '../../../api-lib/Gql';
 import { ErrorResponse } from '../../../api-lib/HttpError';
 import { resizeCircleLogo } from '../../../api-lib/images';
@@ -21,11 +21,11 @@ const handler = async function (req: VercelRequest, res: VercelResponse) {
   ).parse(req.body);
 
   try {
-    const previousLogo = await getPreviousLogo(input.id);
+    const previousLogo = await getPreviousLogo(input.circle_id);
 
     const updater = new ImageUpdater<{ id: number }>(
       resizeCircleLogo,
-      logoUpdater(input.id)
+      logoUpdater(input.circle_id)
     );
 
     const updatedProfile = await updater.uploadImage(
@@ -74,6 +74,4 @@ function logoUpdater(id: number) {
   };
 }
 
-export default handler;
-// TODO: this throws a 401 error even tho I am circle admin, so I can't enable it -Graffe
-// export default authCircleAdminMiddleware(handler);
+export default authCircleAdminMiddleware(handler);

--- a/api/hasura/actions/upload_circle_logo.ts
+++ b/api/hasura/actions/upload_circle_logo.ts
@@ -1,5 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
+// import { authCircleAdminMiddleware } from '../../../api-lib/circleAdmin';
 import { gql } from '../../../api-lib/Gql';
 import { ErrorResponse } from '../../../api-lib/HttpError';
 import { resizeCircleLogo } from '../../../api-lib/images';
@@ -10,7 +11,7 @@ import {
   uploadCircleImageInput,
 } from '../../../src/lib/zod';
 
-export default async function (req: VercelRequest, res: VercelResponse) {
+const handler = async function (req: VercelRequest, res: VercelResponse) {
   const {
     input: { object: input },
     // session_variables: sessionVariables,
@@ -35,7 +36,7 @@ export default async function (req: VercelRequest, res: VercelResponse) {
   } catch (e: any) {
     return ErrorResponse(res, e);
   }
-}
+};
 
 async function getPreviousLogo(id: number): Promise<string | undefined> {
   const { circles_by_pk } = await gql.q('query')({
@@ -73,5 +74,6 @@ function logoUpdater(id: number) {
   };
 }
 
-// TODO: this does not work and I'm not sure why
-//export default authCircleAdminMiddleware(handler);
+export default handler;
+// TODO: this throws a 401 error even tho I am circle admin, so I can't enable it -Graffe
+// export default authCircleAdminMiddleware(handler);

--- a/api/hasura/actions/upload_circle_logo.ts
+++ b/api/hasura/actions/upload_circle_logo.ts
@@ -1,0 +1,77 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+import { gql } from '../../../api-lib/Gql';
+import { ErrorResponse } from '../../../api-lib/HttpError';
+import { resizeCircleLogo } from '../../../api-lib/images';
+import { ImageUpdater } from '../../../api-lib/ImageUpdater';
+import {
+  composeHasuraActionRequestBodyWithSession,
+  HasuraUserSessionVariables,
+  uploadCircleImageInput,
+} from '../../../src/lib/zod';
+
+export default async function (req: VercelRequest, res: VercelResponse) {
+  const {
+    input: { object: input },
+    // session_variables: sessionVariables,
+  } = composeHasuraActionRequestBodyWithSession(
+    uploadCircleImageInput,
+    HasuraUserSessionVariables
+  ).parse(req.body);
+
+  try {
+    const previousLogo = await getPreviousLogo(input.id);
+
+    const updater = new ImageUpdater<{ id: number }>(
+      resizeCircleLogo,
+      logoUpdater(input.id)
+    );
+
+    const updatedProfile = await updater.uploadImage(
+      input.image_data_base64,
+      previousLogo
+    );
+    return res.status(200).json(updatedProfile);
+  } catch (e: any) {
+    return ErrorResponse(res, e);
+  }
+}
+
+async function getPreviousLogo(id: number): Promise<string | undefined> {
+  const { circles_by_pk } = await gql.q('query')({
+    circles_by_pk: [
+      {
+        id: id,
+      },
+      { logo: true },
+    ],
+  });
+
+  return circles_by_pk?.logo;
+}
+
+function logoUpdater(id: number) {
+  return async (fileName: string) => {
+    const mutationResult = await gql.q('mutation')({
+      update_circles_by_pk: [
+        {
+          _set: { logo: fileName },
+          pk_columns: { id: id },
+        },
+        {
+          id: true,
+        },
+      ],
+    });
+
+    if (!mutationResult.update_circles_by_pk) {
+      throw 'circle mutation was not successful';
+    }
+    return {
+      id: mutationResult.update_circles_by_pk.id,
+    };
+  };
+}
+
+// TODO: this does not work and I'm not sure why
+//export default authCircleAdminMiddleware(handler);

--- a/api/hasura/actions/upload_profile_avatar.ts
+++ b/api/hasura/actions/upload_profile_avatar.ts
@@ -8,8 +8,9 @@ import {
   profileUpdateAvatarMutation,
   userAndImageData,
 } from '../../../api-lib/profileImages';
+import { verifyHasuraRequestMiddleware } from '../../../api-lib/validate';
 
-export default async function (req: VercelRequest, res: VercelResponse) {
+async function handler(req: VercelRequest, res: VercelResponse) {
   const { input, hasuraProfileId } = userAndImageData(req);
   const { avatar: previousAvatar } = await profileImages(hasuraProfileId);
 
@@ -28,3 +29,5 @@ export default async function (req: VercelRequest, res: VercelResponse) {
     return ErrorResponse(res, e);
   }
 }
+
+export default verifyHasuraRequestMiddleware(handler);

--- a/api/hasura/actions/upload_profile_background.ts
+++ b/api/hasura/actions/upload_profile_background.ts
@@ -8,8 +8,9 @@ import {
   profileUpdateBackgroundMutation,
   userAndImageData,
 } from '../../../api-lib/profileImages';
+import { verifyHasuraRequestMiddleware } from '../../../api-lib/validate';
 
-export default async function (req: VercelRequest, res: VercelResponse) {
+async function handler(req: VercelRequest, res: VercelResponse) {
   const { input, hasuraProfileId } = userAndImageData(req);
   const { background: previousBackground } = await profileImages(
     hasuraProfileId
@@ -30,3 +31,5 @@ export default async function (req: VercelRequest, res: VercelResponse) {
     return ErrorResponse(res, e);
   }
 }
+
+export default verifyHasuraRequestMiddleware(handler);

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -11,6 +11,12 @@ type Mutation {
 }
 
 type Mutation {
+  upload_circle_logo(
+    object: upload_circle_image_input!
+  ): update_circle_response
+}
+
+type Mutation {
   upload_profile_avatar(
     object: upload_image_input!
   ): update_profile_response
@@ -45,6 +51,11 @@ input upload_image_input {
   image_data_base64: String!
 }
 
+input upload_circle_image_input {
+  id: Int!
+  image_data_base64: String!
+}
+
 type create_circle_response {
   id: Int!
 }
@@ -62,6 +73,10 @@ type createUserResponse {
 }
 
 type update_profile_response {
+  id: Int!
+}
+
+type update_circle_response {
   id: Int!
 }
 

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -52,7 +52,7 @@ input upload_image_input {
 }
 
 input upload_circle_image_input {
-  id: Int!
+  circle_id: Int!
   image_data_base64: String!
 }
 

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -25,6 +25,10 @@ actions:
   definition:
     kind: synchronous
     handler: '{{HASURA_API_BASE_URL}}/actions/upload_circle_logo'
+    forward_client_headers: true
+    headers:
+    - name: verification_key
+      value_from_env: HASURA_EVENT_SECRET
   permissions:
   - role: superadmin
   - role: user
@@ -32,6 +36,10 @@ actions:
   definition:
     kind: synchronous
     handler: '{{HASURA_API_BASE_URL}}/actions/upload_profile_avatar'
+    forward_client_headers: true
+    headers:
+    - name: verification_key
+      value_from_env: HASURA_EVENT_SECRET
   permissions:
   - role: user
   - role: superadmin
@@ -39,6 +47,10 @@ actions:
   definition:
     kind: synchronous
     handler: '{{HASURA_API_BASE_URL}}/actions/upload_profile_background'
+    forward_client_headers: true
+    headers:
+    - name: verification_key
+      value_from_env: HASURA_EVENT_SECRET
   permissions:
   - role: user
   - role: superadmin

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -21,26 +21,34 @@ actions:
   permissions:
   - role: user
   - role: superadmin
+- name: upload_circle_logo
+  definition:
+    kind: synchronous
+    handler: '{{HASURA_API_BASE_URL}}/actions/upload_circle_logo'
+  permissions:
+  - role: superadmin
+  - role: user
 - name: upload_profile_avatar
   definition:
     kind: synchronous
     handler: '{{HASURA_API_BASE_URL}}/actions/upload_profile_avatar'
   permissions:
-  - role: superadmin
   - role: user
+  - role: superadmin
 - name: upload_profile_background
   definition:
     kind: synchronous
     handler: '{{HASURA_API_BASE_URL}}/actions/upload_profile_background'
   permissions:
-  - role: superadmin
   - role: user
+  - role: superadmin
 custom_types:
   enums: []
   input_objects:
   - name: create_circle_input
   - name: createUserInput
   - name: upload_image_input
+  - name: upload_circle_image_input
   objects:
   - name: create_circle_response
     relationships:
@@ -67,6 +75,16 @@ custom_types:
         schema: public
         name: profiles
       name: profile
+      source: default
+      type: object
+      field_mapping:
+        id: id
+  - name: update_circle_response
+    relationships:
+    - remote_table:
+        schema: public
+        name: circles
+      name: circle
       source: default
       type: object
       field_mapping:

--- a/src/lib/gql/index.ts
+++ b/src/lib/gql/index.ts
@@ -55,10 +55,35 @@ export function getGql(url: string, getToken: () => string) {
       }
     );
 
+  const updateCircleLogo = async (
+    circleId: number,
+    image_data_base64: string
+  ) =>
+    makeQuery(url, getToken)('mutation')(
+      {
+        upload_circle_logo: [
+          {
+            object: {
+              image_data_base64: $`image_data_base64`,
+              id: $`circleId`,
+            },
+          },
+          { id: true },
+        ],
+      },
+      {
+        variables: {
+          circleId: circleId,
+          image_data_base64,
+        },
+      }
+    );
+
   return {
-    updateProfile: updateProfile,
+    updateProfile,
     updateProfileAvatar,
     updateProfileBackground,
+    updateCircleLogo,
   };
 }
 

--- a/src/lib/gql/index.ts
+++ b/src/lib/gql/index.ts
@@ -65,7 +65,7 @@ export function getGql(url: string, getToken: () => string) {
           {
             object: {
               image_data_base64: $`image_data_base64`,
-              id: $`circleId`,
+              circle_id: $`circleId`,
             },
           },
           { id: true },

--- a/src/lib/gql/zeusHasuraAdmin/const.ts
+++ b/src/lib/gql/zeusHasuraAdmin/const.ts
@@ -6810,6 +6810,14 @@ export const AllTypesProps: Record<string, any> = {
         required: true,
       },
     },
+    upload_circle_logo: {
+      object: {
+        type: 'upload_circle_image_input',
+        array: false,
+        arrayRequired: false,
+        required: true,
+      },
+    },
     upload_profile_avatar: {
       object: {
         type: 'upload_image_input',
@@ -13683,6 +13691,20 @@ export const AllTypesProps: Record<string, any> = {
       required: false,
     },
   },
+  upload_circle_image_input: {
+    id: {
+      type: 'Int',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+    image_data_base64: {
+      type: 'String',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+  },
   upload_image_input: {
     image_data_base64: {
       type: 'String',
@@ -16593,6 +16615,7 @@ export const ReturnTypes: Record<string, any> = {
     update_users_by_pk: 'users',
     update_vouches: 'vouches_mutation_response',
     update_vouches_by_pk: 'vouches',
+    upload_circle_logo: 'update_circle_response',
     upload_profile_avatar: 'update_profile_response',
     upload_profile_background: 'update_profile_response',
   },
@@ -17504,6 +17527,10 @@ export const ReturnTypes: Record<string, any> = {
     recipient_id: 'Float',
     sender_id: 'Float',
     tokens: 'Float',
+  },
+  update_circle_response: {
+    circle: 'circles',
+    id: 'Int',
   },
   update_profile_response: {
     id: 'Int',

--- a/src/lib/gql/zeusHasuraAdmin/const.ts
+++ b/src/lib/gql/zeusHasuraAdmin/const.ts
@@ -14483,7 +14483,7 @@ export const AllTypesProps: Record<string, any> = {
     },
   },
   upload_circle_image_input: {
-    id: {
+    circle_id: {
       type: 'Int',
       array: false,
       arrayRequired: false,

--- a/src/lib/gql/zeusHasuraAdmin/const.ts
+++ b/src/lib/gql/zeusHasuraAdmin/const.ts
@@ -1219,6 +1219,487 @@ export const AllTypesProps: Record<string, any> = {
       required: false,
     },
   },
+  circle_integrations: {
+    data: {
+      path: {
+        type: 'String',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+    },
+  },
+  circle_integrations_aggregate_fields: {
+    count: {
+      columns: {
+        type: 'circle_integrations_select_column',
+        array: true,
+        arrayRequired: false,
+        required: true,
+      },
+      distinct: {
+        type: 'Boolean',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+    },
+  },
+  circle_integrations_aggregate_order_by: {
+    avg: {
+      type: 'circle_integrations_avg_order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    count: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    max: {
+      type: 'circle_integrations_max_order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    min: {
+      type: 'circle_integrations_min_order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    stddev: {
+      type: 'circle_integrations_stddev_order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    stddev_pop: {
+      type: 'circle_integrations_stddev_pop_order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    stddev_samp: {
+      type: 'circle_integrations_stddev_samp_order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    sum: {
+      type: 'circle_integrations_sum_order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    var_pop: {
+      type: 'circle_integrations_var_pop_order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    var_samp: {
+      type: 'circle_integrations_var_samp_order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    variance: {
+      type: 'circle_integrations_variance_order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
+  circle_integrations_arr_rel_insert_input: {
+    data: {
+      type: 'circle_integrations_insert_input',
+      array: true,
+      arrayRequired: true,
+      required: true,
+    },
+    on_conflict: {
+      type: 'circle_integrations_on_conflict',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
+  circle_integrations_avg_order_by: {
+    circle_id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
+  circle_integrations_bool_exp: {
+    _and: {
+      type: 'circle_integrations_bool_exp',
+      array: true,
+      arrayRequired: false,
+      required: true,
+    },
+    _not: {
+      type: 'circle_integrations_bool_exp',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    _or: {
+      type: 'circle_integrations_bool_exp',
+      array: true,
+      arrayRequired: false,
+      required: true,
+    },
+    circle: {
+      type: 'circles_bool_exp',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    circle_id: {
+      type: 'bigint_comparison_exp',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    data: {
+      type: 'json_comparison_exp',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    id: {
+      type: 'bigint_comparison_exp',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    name: {
+      type: 'String_comparison_exp',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    type: {
+      type: 'String_comparison_exp',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
+  circle_integrations_constraint: 'enum',
+  circle_integrations_inc_input: {
+    circle_id: {
+      type: 'bigint',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    id: {
+      type: 'bigint',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
+  circle_integrations_insert_input: {
+    circle: {
+      type: 'circles_obj_rel_insert_input',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    circle_id: {
+      type: 'bigint',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    data: {
+      type: 'json',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    id: {
+      type: 'bigint',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    name: {
+      type: 'String',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    type: {
+      type: 'String',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
+  circle_integrations_max_order_by: {
+    circle_id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    name: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    type: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
+  circle_integrations_min_order_by: {
+    circle_id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    name: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    type: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
+  circle_integrations_on_conflict: {
+    constraint: {
+      type: 'circle_integrations_constraint',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+    update_columns: {
+      type: 'circle_integrations_update_column',
+      array: true,
+      arrayRequired: true,
+      required: true,
+    },
+    where: {
+      type: 'circle_integrations_bool_exp',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
+  circle_integrations_order_by: {
+    circle: {
+      type: 'circles_order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    circle_id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    data: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    name: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    type: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
+  circle_integrations_pk_columns_input: {
+    id: {
+      type: 'bigint',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+  },
+  circle_integrations_select_column: 'enum',
+  circle_integrations_set_input: {
+    circle_id: {
+      type: 'bigint',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    data: {
+      type: 'json',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    id: {
+      type: 'bigint',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    name: {
+      type: 'String',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    type: {
+      type: 'String',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
+  circle_integrations_stddev_order_by: {
+    circle_id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
+  circle_integrations_stddev_pop_order_by: {
+    circle_id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
+  circle_integrations_stddev_samp_order_by: {
+    circle_id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
+  circle_integrations_sum_order_by: {
+    circle_id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
+  circle_integrations_update_column: 'enum',
+  circle_integrations_var_pop_order_by: {
+    circle_id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
+  circle_integrations_var_samp_order_by: {
+    circle_id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
+  circle_integrations_variance_order_by: {
+    circle_id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
   circle_metadata: {
     json: {
       path: {
@@ -2018,6 +2499,70 @@ export const AllTypesProps: Record<string, any> = {
         required: false,
       },
     },
+    integrations: {
+      distinct_on: {
+        type: 'circle_integrations_select_column',
+        array: true,
+        arrayRequired: false,
+        required: true,
+      },
+      limit: {
+        type: 'Int',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+      offset: {
+        type: 'Int',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+      order_by: {
+        type: 'circle_integrations_order_by',
+        array: true,
+        arrayRequired: false,
+        required: true,
+      },
+      where: {
+        type: 'circle_integrations_bool_exp',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+    },
+    integrations_aggregate: {
+      distinct_on: {
+        type: 'circle_integrations_select_column',
+        array: true,
+        arrayRequired: false,
+        required: true,
+      },
+      limit: {
+        type: 'Int',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+      offset: {
+        type: 'Int',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+      order_by: {
+        type: 'circle_integrations_order_by',
+        array: true,
+        arrayRequired: false,
+        required: true,
+      },
+      where: {
+        type: 'circle_integrations_bool_exp',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+    },
     pending_token_gifts: {
       distinct_on: {
         type: 'pending_token_gifts_select_column',
@@ -2414,6 +2959,12 @@ export const AllTypesProps: Record<string, any> = {
       arrayRequired: false,
       required: false,
     },
+    integrations: {
+      type: 'circle_integrations_bool_exp',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
     is_verified: {
       type: 'Boolean_comparison_exp',
       array: false,
@@ -2607,6 +3158,12 @@ export const AllTypesProps: Record<string, any> = {
     },
     id: {
       type: 'bigint',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    integrations: {
+      type: 'circle_integrations_arr_rel_insert_input',
       array: false,
       arrayRequired: false,
       required: false,
@@ -2983,6 +3540,12 @@ export const AllTypesProps: Record<string, any> = {
     },
     id: {
       type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    integrations_aggregate: {
+      type: 'circle_integrations_aggregate_order_by',
       array: false,
       arrayRequired: false,
       required: false,
@@ -5518,6 +6081,22 @@ export const AllTypesProps: Record<string, any> = {
         required: true,
       },
     },
+    delete_circle_integrations: {
+      where: {
+        type: 'circle_integrations_bool_exp',
+        array: false,
+        arrayRequired: false,
+        required: true,
+      },
+    },
+    delete_circle_integrations_by_pk: {
+      id: {
+        type: 'bigint',
+        array: false,
+        arrayRequired: false,
+        required: true,
+      },
+    },
     delete_circle_metadata: {
       where: {
         type: 'circle_metadata_bool_exp',
@@ -5773,6 +6352,34 @@ export const AllTypesProps: Record<string, any> = {
       },
       on_conflict: {
         type: 'burns_on_conflict',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+    },
+    insert_circle_integrations: {
+      objects: {
+        type: 'circle_integrations_insert_input',
+        array: true,
+        arrayRequired: true,
+        required: true,
+      },
+      on_conflict: {
+        type: 'circle_integrations_on_conflict',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+    },
+    insert_circle_integrations_one: {
+      object: {
+        type: 'circle_integrations_insert_input',
+        array: false,
+        arrayRequired: false,
+        required: true,
+      },
+      on_conflict: {
+        type: 'circle_integrations_on_conflict',
         array: false,
         arrayRequired: false,
         required: false,
@@ -6225,6 +6832,46 @@ export const AllTypesProps: Record<string, any> = {
       },
       pk_columns: {
         type: 'burns_pk_columns_input',
+        array: false,
+        arrayRequired: false,
+        required: true,
+      },
+    },
+    update_circle_integrations: {
+      _inc: {
+        type: 'circle_integrations_inc_input',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+      _set: {
+        type: 'circle_integrations_set_input',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+      where: {
+        type: 'circle_integrations_bool_exp',
+        array: false,
+        arrayRequired: false,
+        required: true,
+      },
+    },
+    update_circle_integrations_by_pk: {
+      _inc: {
+        type: 'circle_integrations_inc_input',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+      _set: {
+        type: 'circle_integrations_set_input',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+      pk_columns: {
+        type: 'circle_integrations_pk_columns_input',
         array: false,
         arrayRequired: false,
         required: true,
@@ -9992,6 +10639,78 @@ export const AllTypesProps: Record<string, any> = {
         required: true,
       },
     },
+    circle_integrations: {
+      distinct_on: {
+        type: 'circle_integrations_select_column',
+        array: true,
+        arrayRequired: false,
+        required: true,
+      },
+      limit: {
+        type: 'Int',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+      offset: {
+        type: 'Int',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+      order_by: {
+        type: 'circle_integrations_order_by',
+        array: true,
+        arrayRequired: false,
+        required: true,
+      },
+      where: {
+        type: 'circle_integrations_bool_exp',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+    },
+    circle_integrations_aggregate: {
+      distinct_on: {
+        type: 'circle_integrations_select_column',
+        array: true,
+        arrayRequired: false,
+        required: true,
+      },
+      limit: {
+        type: 'Int',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+      offset: {
+        type: 'Int',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+      order_by: {
+        type: 'circle_integrations_order_by',
+        array: true,
+        arrayRequired: false,
+        required: true,
+      },
+      where: {
+        type: 'circle_integrations_bool_exp',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+    },
+    circle_integrations_by_pk: {
+      id: {
+        type: 'bigint',
+        array: false,
+        arrayRequired: false,
+        required: true,
+      },
+    },
     circle_metadata: {
       distinct_on: {
         type: 'circle_metadata_select_column',
@@ -11187,6 +11906,78 @@ export const AllTypesProps: Record<string, any> = {
       },
     },
     burns_by_pk: {
+      id: {
+        type: 'bigint',
+        array: false,
+        arrayRequired: false,
+        required: true,
+      },
+    },
+    circle_integrations: {
+      distinct_on: {
+        type: 'circle_integrations_select_column',
+        array: true,
+        arrayRequired: false,
+        required: true,
+      },
+      limit: {
+        type: 'Int',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+      offset: {
+        type: 'Int',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+      order_by: {
+        type: 'circle_integrations_order_by',
+        array: true,
+        arrayRequired: false,
+        required: true,
+      },
+      where: {
+        type: 'circle_integrations_bool_exp',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+    },
+    circle_integrations_aggregate: {
+      distinct_on: {
+        type: 'circle_integrations_select_column',
+        array: true,
+        arrayRequired: false,
+        required: true,
+      },
+      limit: {
+        type: 'Int',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+      offset: {
+        type: 'Int',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+      order_by: {
+        type: 'circle_integrations_order_by',
+        array: true,
+        arrayRequired: false,
+        required: true,
+      },
+      where: {
+        type: 'circle_integrations_bool_exp',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+    },
+    circle_integrations_by_pk: {
       id: {
         type: 'bigint',
         array: false,
@@ -15895,6 +16686,79 @@ export const ReturnTypes: Record<string, any> = {
     tokens_burnt: 'Float',
     user_id: 'Float',
   },
+  circle_integrations: {
+    circle: 'circles',
+    circle_id: 'bigint',
+    data: 'json',
+    id: 'bigint',
+    name: 'String',
+    type: 'String',
+  },
+  circle_integrations_aggregate: {
+    aggregate: 'circle_integrations_aggregate_fields',
+    nodes: 'circle_integrations',
+  },
+  circle_integrations_aggregate_fields: {
+    avg: 'circle_integrations_avg_fields',
+    count: 'Int',
+    max: 'circle_integrations_max_fields',
+    min: 'circle_integrations_min_fields',
+    stddev: 'circle_integrations_stddev_fields',
+    stddev_pop: 'circle_integrations_stddev_pop_fields',
+    stddev_samp: 'circle_integrations_stddev_samp_fields',
+    sum: 'circle_integrations_sum_fields',
+    var_pop: 'circle_integrations_var_pop_fields',
+    var_samp: 'circle_integrations_var_samp_fields',
+    variance: 'circle_integrations_variance_fields',
+  },
+  circle_integrations_avg_fields: {
+    circle_id: 'Float',
+    id: 'Float',
+  },
+  circle_integrations_max_fields: {
+    circle_id: 'bigint',
+    id: 'bigint',
+    name: 'String',
+    type: 'String',
+  },
+  circle_integrations_min_fields: {
+    circle_id: 'bigint',
+    id: 'bigint',
+    name: 'String',
+    type: 'String',
+  },
+  circle_integrations_mutation_response: {
+    affected_rows: 'Int',
+    returning: 'circle_integrations',
+  },
+  circle_integrations_stddev_fields: {
+    circle_id: 'Float',
+    id: 'Float',
+  },
+  circle_integrations_stddev_pop_fields: {
+    circle_id: 'Float',
+    id: 'Float',
+  },
+  circle_integrations_stddev_samp_fields: {
+    circle_id: 'Float',
+    id: 'Float',
+  },
+  circle_integrations_sum_fields: {
+    circle_id: 'bigint',
+    id: 'bigint',
+  },
+  circle_integrations_var_pop_fields: {
+    circle_id: 'Float',
+    id: 'Float',
+  },
+  circle_integrations_var_samp_fields: {
+    circle_id: 'Float',
+    id: 'Float',
+  },
+  circle_integrations_variance_fields: {
+    circle_id: 'Float',
+    id: 'Float',
+  },
   circle_metadata: {
     circle: 'circles',
     circle_id: 'bigint',
@@ -16040,6 +16904,8 @@ export const ReturnTypes: Record<string, any> = {
     epochs: 'epochs',
     epochs_aggregate: 'epochs_aggregate',
     id: 'bigint',
+    integrations: 'circle_integrations',
+    integrations_aggregate: 'circle_integrations_aggregate',
     is_verified: 'Boolean',
     logo: 'String',
     min_vouches: 'Int',
@@ -16521,6 +17387,8 @@ export const ReturnTypes: Record<string, any> = {
     create_circle: 'create_circle_response',
     delete_burns: 'burns_mutation_response',
     delete_burns_by_pk: 'burns',
+    delete_circle_integrations: 'circle_integrations_mutation_response',
+    delete_circle_integrations_by_pk: 'circle_integrations',
     delete_circle_metadata: 'circle_metadata_mutation_response',
     delete_circle_metadata_by_pk: 'circle_metadata',
     delete_circle_private: 'circle_private_mutation_response',
@@ -16552,6 +17420,8 @@ export const ReturnTypes: Record<string, any> = {
     delete_vouches_by_pk: 'vouches',
     insert_burns: 'burns_mutation_response',
     insert_burns_one: 'burns',
+    insert_circle_integrations: 'circle_integrations_mutation_response',
+    insert_circle_integrations_one: 'circle_integrations',
     insert_circle_metadata: 'circle_metadata_mutation_response',
     insert_circle_metadata_one: 'circle_metadata',
     insert_circle_private: 'circle_private_mutation_response',
@@ -16586,6 +17456,8 @@ export const ReturnTypes: Record<string, any> = {
     insert_vouches_one: 'vouches',
     update_burns: 'burns_mutation_response',
     update_burns_by_pk: 'burns',
+    update_circle_integrations: 'circle_integrations_mutation_response',
+    update_circle_integrations_by_pk: 'circle_integrations',
     update_circle_metadata: 'circle_metadata_mutation_response',
     update_circle_metadata_by_pk: 'circle_metadata',
     update_circle_private: 'circle_private_mutation_response',
@@ -17217,6 +18089,9 @@ export const ReturnTypes: Record<string, any> = {
     burns: 'burns',
     burns_aggregate: 'burns_aggregate',
     burns_by_pk: 'burns',
+    circle_integrations: 'circle_integrations',
+    circle_integrations_aggregate: 'circle_integrations_aggregate',
+    circle_integrations_by_pk: 'circle_integrations',
     circle_metadata: 'circle_metadata',
     circle_metadata_aggregate: 'circle_metadata_aggregate',
     circle_metadata_by_pk: 'circle_metadata',
@@ -17267,6 +18142,9 @@ export const ReturnTypes: Record<string, any> = {
     burns: 'burns',
     burns_aggregate: 'burns_aggregate',
     burns_by_pk: 'burns',
+    circle_integrations: 'circle_integrations',
+    circle_integrations_aggregate: 'circle_integrations_aggregate',
+    circle_integrations_by_pk: 'circle_integrations',
     circle_metadata: 'circle_metadata',
     circle_metadata_aggregate: 'circle_metadata_aggregate',
     circle_metadata_by_pk: 'circle_metadata',

--- a/src/lib/gql/zeusHasuraAdmin/index.ts
+++ b/src/lib/gql/zeusHasuraAdmin/index.ts
@@ -6700,7 +6700,7 @@ export type ValueTypes = {
     __typename?: boolean;
   }>;
   ['upload_circle_image_input']: {
-    id: number;
+    circle_id: number;
     image_data_base64: string;
   };
   ['upload_image_input']: {
@@ -15643,7 +15643,7 @@ export type GraphQLTypes = {
     profile: GraphQLTypes['profiles'];
   };
   ['upload_circle_image_input']: {
-    id: number;
+    circle_id: number;
     image_data_base64: string;
   };
   ['upload_image_input']: {

--- a/src/lib/gql/zeusHasuraAdmin/index.ts
+++ b/src/lib/gql/zeusHasuraAdmin/index.ts
@@ -3181,6 +3181,10 @@ export type ValueTypes = {
       },
       ValueTypes['vouches']
     ];
+    upload_circle_logo?: [
+      { object: ValueTypes['upload_circle_image_input'] },
+      ValueTypes['update_circle_response']
+    ];
     upload_profile_avatar?: [
       { object: ValueTypes['upload_image_input'] },
       ValueTypes['update_profile_response']
@@ -6291,12 +6295,22 @@ export type ValueTypes = {
     sender_id?: ValueTypes['order_by'] | null;
     tokens?: ValueTypes['order_by'] | null;
   };
+  ['update_circle_response']: AliasType<{
+    /** An object relationship */
+    circle?: ValueTypes['circles'];
+    id?: boolean;
+    __typename?: boolean;
+  }>;
   ['update_profile_response']: AliasType<{
     id?: boolean;
     /** An object relationship */
     profile?: ValueTypes['profiles'];
     __typename?: boolean;
   }>;
+  ['upload_circle_image_input']: {
+    id: number;
+    image_data_base64: string;
+  };
   ['upload_image_input']: {
     image_data_base64: string;
   };
@@ -8472,6 +8486,7 @@ export type ModelTypes = {
     update_vouches?: ModelTypes['vouches_mutation_response'];
     /** update single row of the table: "vouches" */
     update_vouches_by_pk?: ModelTypes['vouches'];
+    upload_circle_logo?: ModelTypes['update_circle_response'];
     upload_profile_avatar?: ModelTypes['update_profile_response'];
     upload_profile_background?: ModelTypes['update_profile_response'];
   };
@@ -9850,11 +9865,17 @@ export type ModelTypes = {
   };
   /** order by variance() on columns of table "token_gifts" */
   ['token_gifts_variance_order_by']: GraphQLTypes['token_gifts_variance_order_by'];
+  ['update_circle_response']: {
+    /** An object relationship */
+    circle: ModelTypes['circles'];
+    id: number;
+  };
   ['update_profile_response']: {
     id: number;
     /** An object relationship */
     profile: ModelTypes['profiles'];
   };
+  ['upload_circle_image_input']: GraphQLTypes['upload_circle_image_input'];
   ['upload_image_input']: GraphQLTypes['upload_image_input'];
   /** columns and relationships of "users" */
   ['users']: {
@@ -12549,6 +12570,7 @@ export type GraphQLTypes = {
     update_vouches?: GraphQLTypes['vouches_mutation_response'];
     /** update single row of the table: "vouches" */
     update_vouches_by_pk?: GraphQLTypes['vouches'];
+    upload_circle_logo?: GraphQLTypes['update_circle_response'];
     upload_profile_avatar?: GraphQLTypes['update_profile_response'];
     upload_profile_background?: GraphQLTypes['update_profile_response'];
   };
@@ -14786,11 +14808,21 @@ export type GraphQLTypes = {
     sender_id?: GraphQLTypes['order_by'];
     tokens?: GraphQLTypes['order_by'];
   };
+  ['update_circle_response']: {
+    __typename: 'update_circle_response';
+    /** An object relationship */
+    circle: GraphQLTypes['circles'];
+    id: number;
+  };
   ['update_profile_response']: {
     __typename: 'update_profile_response';
     id: number;
     /** An object relationship */
     profile: GraphQLTypes['profiles'];
+  };
+  ['upload_circle_image_input']: {
+    id: number;
+    image_data_base64: string;
   };
   ['upload_image_input']: {
     image_data_base64: string;

--- a/src/lib/gql/zeusHasuraAdmin/index.ts
+++ b/src/lib/gql/zeusHasuraAdmin/index.ts
@@ -452,6 +452,254 @@ export type ValueTypes = {
     tokens_burnt?: ValueTypes['order_by'] | null;
     user_id?: ValueTypes['order_by'] | null;
   };
+  /** columns and relationships of "circle_integrations" */
+  ['circle_integrations']: AliasType<{
+    /** An object relationship */
+    circle?: ValueTypes['circles'];
+    circle_id?: boolean;
+    data?: [
+      {
+        /** JSON select path */ path?: string | null;
+      },
+      boolean
+    ];
+    id?: boolean;
+    name?: boolean;
+    type?: boolean;
+    __typename?: boolean;
+  }>;
+  /** aggregated selection of "circle_integrations" */
+  ['circle_integrations_aggregate']: AliasType<{
+    aggregate?: ValueTypes['circle_integrations_aggregate_fields'];
+    nodes?: ValueTypes['circle_integrations'];
+    __typename?: boolean;
+  }>;
+  /** aggregate fields of "circle_integrations" */
+  ['circle_integrations_aggregate_fields']: AliasType<{
+    avg?: ValueTypes['circle_integrations_avg_fields'];
+    count?: [
+      {
+        columns?: ValueTypes['circle_integrations_select_column'][];
+        distinct?: boolean | null;
+      },
+      boolean
+    ];
+    max?: ValueTypes['circle_integrations_max_fields'];
+    min?: ValueTypes['circle_integrations_min_fields'];
+    stddev?: ValueTypes['circle_integrations_stddev_fields'];
+    stddev_pop?: ValueTypes['circle_integrations_stddev_pop_fields'];
+    stddev_samp?: ValueTypes['circle_integrations_stddev_samp_fields'];
+    sum?: ValueTypes['circle_integrations_sum_fields'];
+    var_pop?: ValueTypes['circle_integrations_var_pop_fields'];
+    var_samp?: ValueTypes['circle_integrations_var_samp_fields'];
+    variance?: ValueTypes['circle_integrations_variance_fields'];
+    __typename?: boolean;
+  }>;
+  /** order by aggregate values of table "circle_integrations" */
+  ['circle_integrations_aggregate_order_by']: {
+    avg?: ValueTypes['circle_integrations_avg_order_by'] | null;
+    count?: ValueTypes['order_by'] | null;
+    max?: ValueTypes['circle_integrations_max_order_by'] | null;
+    min?: ValueTypes['circle_integrations_min_order_by'] | null;
+    stddev?: ValueTypes['circle_integrations_stddev_order_by'] | null;
+    stddev_pop?: ValueTypes['circle_integrations_stddev_pop_order_by'] | null;
+    stddev_samp?: ValueTypes['circle_integrations_stddev_samp_order_by'] | null;
+    sum?: ValueTypes['circle_integrations_sum_order_by'] | null;
+    var_pop?: ValueTypes['circle_integrations_var_pop_order_by'] | null;
+    var_samp?: ValueTypes['circle_integrations_var_samp_order_by'] | null;
+    variance?: ValueTypes['circle_integrations_variance_order_by'] | null;
+  };
+  /** input type for inserting array relation for remote table "circle_integrations" */
+  ['circle_integrations_arr_rel_insert_input']: {
+    data: ValueTypes['circle_integrations_insert_input'][];
+    /** on conflict condition */
+    on_conflict?: ValueTypes['circle_integrations_on_conflict'] | null;
+  };
+  /** aggregate avg on columns */
+  ['circle_integrations_avg_fields']: AliasType<{
+    circle_id?: boolean;
+    id?: boolean;
+    __typename?: boolean;
+  }>;
+  /** order by avg() on columns of table "circle_integrations" */
+  ['circle_integrations_avg_order_by']: {
+    circle_id?: ValueTypes['order_by'] | null;
+    id?: ValueTypes['order_by'] | null;
+  };
+  /** Boolean expression to filter rows from the table "circle_integrations". All fields are combined with a logical 'AND'. */
+  ['circle_integrations_bool_exp']: {
+    _and?: ValueTypes['circle_integrations_bool_exp'][];
+    _not?: ValueTypes['circle_integrations_bool_exp'] | null;
+    _or?: ValueTypes['circle_integrations_bool_exp'][];
+    circle?: ValueTypes['circles_bool_exp'] | null;
+    circle_id?: ValueTypes['bigint_comparison_exp'] | null;
+    data?: ValueTypes['json_comparison_exp'] | null;
+    id?: ValueTypes['bigint_comparison_exp'] | null;
+    name?: ValueTypes['String_comparison_exp'] | null;
+    type?: ValueTypes['String_comparison_exp'] | null;
+  };
+  /** unique or primary key constraints on table "circle_integrations" */
+  ['circle_integrations_constraint']: circle_integrations_constraint;
+  /** input type for incrementing numeric columns in table "circle_integrations" */
+  ['circle_integrations_inc_input']: {
+    circle_id?: ValueTypes['bigint'] | null;
+    id?: ValueTypes['bigint'] | null;
+  };
+  /** input type for inserting data into table "circle_integrations" */
+  ['circle_integrations_insert_input']: {
+    circle?: ValueTypes['circles_obj_rel_insert_input'] | null;
+    circle_id?: ValueTypes['bigint'] | null;
+    data?: ValueTypes['json'] | null;
+    id?: ValueTypes['bigint'] | null;
+    name?: string | null;
+    type?: string | null;
+  };
+  /** aggregate max on columns */
+  ['circle_integrations_max_fields']: AliasType<{
+    circle_id?: boolean;
+    id?: boolean;
+    name?: boolean;
+    type?: boolean;
+    __typename?: boolean;
+  }>;
+  /** order by max() on columns of table "circle_integrations" */
+  ['circle_integrations_max_order_by']: {
+    circle_id?: ValueTypes['order_by'] | null;
+    id?: ValueTypes['order_by'] | null;
+    name?: ValueTypes['order_by'] | null;
+    type?: ValueTypes['order_by'] | null;
+  };
+  /** aggregate min on columns */
+  ['circle_integrations_min_fields']: AliasType<{
+    circle_id?: boolean;
+    id?: boolean;
+    name?: boolean;
+    type?: boolean;
+    __typename?: boolean;
+  }>;
+  /** order by min() on columns of table "circle_integrations" */
+  ['circle_integrations_min_order_by']: {
+    circle_id?: ValueTypes['order_by'] | null;
+    id?: ValueTypes['order_by'] | null;
+    name?: ValueTypes['order_by'] | null;
+    type?: ValueTypes['order_by'] | null;
+  };
+  /** response of any mutation on the table "circle_integrations" */
+  ['circle_integrations_mutation_response']: AliasType<{
+    /** number of rows affected by the mutation */
+    affected_rows?: boolean;
+    /** data from the rows affected by the mutation */
+    returning?: ValueTypes['circle_integrations'];
+    __typename?: boolean;
+  }>;
+  /** on conflict condition type for table "circle_integrations" */
+  ['circle_integrations_on_conflict']: {
+    constraint: ValueTypes['circle_integrations_constraint'];
+    update_columns: ValueTypes['circle_integrations_update_column'][];
+    where?: ValueTypes['circle_integrations_bool_exp'] | null;
+  };
+  /** Ordering options when selecting data from "circle_integrations". */
+  ['circle_integrations_order_by']: {
+    circle?: ValueTypes['circles_order_by'] | null;
+    circle_id?: ValueTypes['order_by'] | null;
+    data?: ValueTypes['order_by'] | null;
+    id?: ValueTypes['order_by'] | null;
+    name?: ValueTypes['order_by'] | null;
+    type?: ValueTypes['order_by'] | null;
+  };
+  /** primary key columns input for table: circle_integrations */
+  ['circle_integrations_pk_columns_input']: {
+    id: ValueTypes['bigint'];
+  };
+  /** select columns of table "circle_integrations" */
+  ['circle_integrations_select_column']: circle_integrations_select_column;
+  /** input type for updating data in table "circle_integrations" */
+  ['circle_integrations_set_input']: {
+    circle_id?: ValueTypes['bigint'] | null;
+    data?: ValueTypes['json'] | null;
+    id?: ValueTypes['bigint'] | null;
+    name?: string | null;
+    type?: string | null;
+  };
+  /** aggregate stddev on columns */
+  ['circle_integrations_stddev_fields']: AliasType<{
+    circle_id?: boolean;
+    id?: boolean;
+    __typename?: boolean;
+  }>;
+  /** order by stddev() on columns of table "circle_integrations" */
+  ['circle_integrations_stddev_order_by']: {
+    circle_id?: ValueTypes['order_by'] | null;
+    id?: ValueTypes['order_by'] | null;
+  };
+  /** aggregate stddev_pop on columns */
+  ['circle_integrations_stddev_pop_fields']: AliasType<{
+    circle_id?: boolean;
+    id?: boolean;
+    __typename?: boolean;
+  }>;
+  /** order by stddev_pop() on columns of table "circle_integrations" */
+  ['circle_integrations_stddev_pop_order_by']: {
+    circle_id?: ValueTypes['order_by'] | null;
+    id?: ValueTypes['order_by'] | null;
+  };
+  /** aggregate stddev_samp on columns */
+  ['circle_integrations_stddev_samp_fields']: AliasType<{
+    circle_id?: boolean;
+    id?: boolean;
+    __typename?: boolean;
+  }>;
+  /** order by stddev_samp() on columns of table "circle_integrations" */
+  ['circle_integrations_stddev_samp_order_by']: {
+    circle_id?: ValueTypes['order_by'] | null;
+    id?: ValueTypes['order_by'] | null;
+  };
+  /** aggregate sum on columns */
+  ['circle_integrations_sum_fields']: AliasType<{
+    circle_id?: boolean;
+    id?: boolean;
+    __typename?: boolean;
+  }>;
+  /** order by sum() on columns of table "circle_integrations" */
+  ['circle_integrations_sum_order_by']: {
+    circle_id?: ValueTypes['order_by'] | null;
+    id?: ValueTypes['order_by'] | null;
+  };
+  /** update columns of table "circle_integrations" */
+  ['circle_integrations_update_column']: circle_integrations_update_column;
+  /** aggregate var_pop on columns */
+  ['circle_integrations_var_pop_fields']: AliasType<{
+    circle_id?: boolean;
+    id?: boolean;
+    __typename?: boolean;
+  }>;
+  /** order by var_pop() on columns of table "circle_integrations" */
+  ['circle_integrations_var_pop_order_by']: {
+    circle_id?: ValueTypes['order_by'] | null;
+    id?: ValueTypes['order_by'] | null;
+  };
+  /** aggregate var_samp on columns */
+  ['circle_integrations_var_samp_fields']: AliasType<{
+    circle_id?: boolean;
+    id?: boolean;
+    __typename?: boolean;
+  }>;
+  /** order by var_samp() on columns of table "circle_integrations" */
+  ['circle_integrations_var_samp_order_by']: {
+    circle_id?: ValueTypes['order_by'] | null;
+    id?: ValueTypes['order_by'] | null;
+  };
+  /** aggregate variance on columns */
+  ['circle_integrations_variance_fields']: AliasType<{
+    circle_id?: boolean;
+    id?: boolean;
+    __typename?: boolean;
+  }>;
+  /** order by variance() on columns of table "circle_integrations" */
+  ['circle_integrations_variance_order_by']: {
+    circle_id?: ValueTypes['order_by'] | null;
+    id?: ValueTypes['order_by'] | null;
+  };
   /** columns and relationships of "circle_metadata" */
   ['circle_metadata']: AliasType<{
     /** An object relationship */
@@ -919,6 +1167,32 @@ export type ValueTypes = {
       ValueTypes['epochs_aggregate']
     ];
     id?: boolean;
+    integrations?: [
+      {
+        /** distinct select on columns */
+        distinct_on?: ValueTypes['circle_integrations_select_column'][] /** limit the number of rows returned */;
+        limit?:
+          | number
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?: number | null /** sort the rows by one or more columns */;
+        order_by?: ValueTypes['circle_integrations_order_by'][] /** filter the rows returned */;
+        where?: ValueTypes['circle_integrations_bool_exp'] | null;
+      },
+      ValueTypes['circle_integrations']
+    ];
+    integrations_aggregate?: [
+      {
+        /** distinct select on columns */
+        distinct_on?: ValueTypes['circle_integrations_select_column'][] /** limit the number of rows returned */;
+        limit?:
+          | number
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?: number | null /** sort the rows by one or more columns */;
+        order_by?: ValueTypes['circle_integrations_order_by'][] /** filter the rows returned */;
+        where?: ValueTypes['circle_integrations_bool_exp'] | null;
+      },
+      ValueTypes['circle_integrations_aggregate']
+    ];
     is_verified?: boolean;
     logo?: boolean;
     min_vouches?: boolean;
@@ -1092,6 +1366,7 @@ export type ValueTypes = {
     discord_webhook?: ValueTypes['String_comparison_exp'] | null;
     epochs?: ValueTypes['epochs_bool_exp'] | null;
     id?: ValueTypes['bigint_comparison_exp'] | null;
+    integrations?: ValueTypes['circle_integrations_bool_exp'] | null;
     is_verified?: ValueTypes['Boolean_comparison_exp'] | null;
     logo?: ValueTypes['String_comparison_exp'] | null;
     min_vouches?: ValueTypes['Int_comparison_exp'] | null;
@@ -1132,6 +1407,9 @@ export type ValueTypes = {
     discord_webhook?: string | null;
     epochs?: ValueTypes['epochs_arr_rel_insert_input'] | null;
     id?: ValueTypes['bigint'] | null;
+    integrations?:
+      | ValueTypes['circle_integrations_arr_rel_insert_input']
+      | null;
     is_verified?: boolean | null;
     logo?: string | null;
     min_vouches?: number | null;
@@ -1257,6 +1535,9 @@ export type ValueTypes = {
     discord_webhook?: ValueTypes['order_by'] | null;
     epochs_aggregate?: ValueTypes['epochs_aggregate_order_by'] | null;
     id?: ValueTypes['order_by'] | null;
+    integrations_aggregate?:
+      | ValueTypes['circle_integrations_aggregate_order_by']
+      | null;
     is_verified?: ValueTypes['order_by'] | null;
     logo?: ValueTypes['order_by'] | null;
     min_vouches?: ValueTypes['order_by'] | null;
@@ -2382,6 +2663,17 @@ export type ValueTypes = {
       ValueTypes['burns_mutation_response']
     ];
     delete_burns_by_pk?: [{ id: ValueTypes['bigint'] }, ValueTypes['burns']];
+    delete_circle_integrations?: [
+      {
+        /** filter the rows which have to be deleted */
+        where: ValueTypes['circle_integrations_bool_exp'];
+      },
+      ValueTypes['circle_integrations_mutation_response']
+    ];
+    delete_circle_integrations_by_pk?: [
+      { id: ValueTypes['bigint'] },
+      ValueTypes['circle_integrations']
+    ];
     delete_circle_metadata?: [
       {
         /** filter the rows which have to be deleted */
@@ -2555,6 +2847,22 @@ export type ValueTypes = {
         on_conflict?: ValueTypes['burns_on_conflict'] | null;
       },
       ValueTypes['burns']
+    ];
+    insert_circle_integrations?: [
+      {
+        /** the rows to be inserted */
+        objects: ValueTypes['circle_integrations_insert_input'][] /** on conflict condition */;
+        on_conflict?: ValueTypes['circle_integrations_on_conflict'] | null;
+      },
+      ValueTypes['circle_integrations_mutation_response']
+    ];
+    insert_circle_integrations_one?: [
+      {
+        /** the row to be inserted */
+        object: ValueTypes['circle_integrations_insert_input'] /** on conflict condition */;
+        on_conflict?: ValueTypes['circle_integrations_on_conflict'] | null;
+      },
+      ValueTypes['circle_integrations']
     ];
     insert_circle_metadata?: [
       {
@@ -2829,6 +3137,30 @@ export type ValueTypes = {
         pk_columns: ValueTypes['burns_pk_columns_input'];
       },
       ValueTypes['burns']
+    ];
+    update_circle_integrations?: [
+      {
+        /** increments the numeric columns with given value of the filtered values */
+        _inc?:
+          | ValueTypes['circle_integrations_inc_input']
+          | null /** sets the columns of the filtered rows to the given values */;
+        _set?:
+          | ValueTypes['circle_integrations_set_input']
+          | null /** filter the rows which have to be updated */;
+        where: ValueTypes['circle_integrations_bool_exp'];
+      },
+      ValueTypes['circle_integrations_mutation_response']
+    ];
+    update_circle_integrations_by_pk?: [
+      {
+        /** increments the numeric columns with given value of the filtered values */
+        _inc?:
+          | ValueTypes['circle_integrations_inc_input']
+          | null /** sets the columns of the filtered rows to the given values */;
+        _set?: ValueTypes['circle_integrations_set_input'] | null;
+        pk_columns: ValueTypes['circle_integrations_pk_columns_input'];
+      },
+      ValueTypes['circle_integrations']
     ];
     update_circle_metadata?: [
       {
@@ -4771,6 +5103,36 @@ export type ValueTypes = {
       ValueTypes['burns_aggregate']
     ];
     burns_by_pk?: [{ id: ValueTypes['bigint'] }, ValueTypes['burns']];
+    circle_integrations?: [
+      {
+        /** distinct select on columns */
+        distinct_on?: ValueTypes['circle_integrations_select_column'][] /** limit the number of rows returned */;
+        limit?:
+          | number
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?: number | null /** sort the rows by one or more columns */;
+        order_by?: ValueTypes['circle_integrations_order_by'][] /** filter the rows returned */;
+        where?: ValueTypes['circle_integrations_bool_exp'] | null;
+      },
+      ValueTypes['circle_integrations']
+    ];
+    circle_integrations_aggregate?: [
+      {
+        /** distinct select on columns */
+        distinct_on?: ValueTypes['circle_integrations_select_column'][] /** limit the number of rows returned */;
+        limit?:
+          | number
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?: number | null /** sort the rows by one or more columns */;
+        order_by?: ValueTypes['circle_integrations_order_by'][] /** filter the rows returned */;
+        where?: ValueTypes['circle_integrations_bool_exp'] | null;
+      },
+      ValueTypes['circle_integrations_aggregate']
+    ];
+    circle_integrations_by_pk?: [
+      { id: ValueTypes['bigint'] },
+      ValueTypes['circle_integrations']
+    ];
     circle_metadata?: [
       {
         /** distinct select on columns */
@@ -5245,6 +5607,36 @@ export type ValueTypes = {
       ValueTypes['burns_aggregate']
     ];
     burns_by_pk?: [{ id: ValueTypes['bigint'] }, ValueTypes['burns']];
+    circle_integrations?: [
+      {
+        /** distinct select on columns */
+        distinct_on?: ValueTypes['circle_integrations_select_column'][] /** limit the number of rows returned */;
+        limit?:
+          | number
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?: number | null /** sort the rows by one or more columns */;
+        order_by?: ValueTypes['circle_integrations_order_by'][] /** filter the rows returned */;
+        where?: ValueTypes['circle_integrations_bool_exp'] | null;
+      },
+      ValueTypes['circle_integrations']
+    ];
+    circle_integrations_aggregate?: [
+      {
+        /** distinct select on columns */
+        distinct_on?: ValueTypes['circle_integrations_select_column'][] /** limit the number of rows returned */;
+        limit?:
+          | number
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?: number | null /** sort the rows by one or more columns */;
+        order_by?: ValueTypes['circle_integrations_order_by'][] /** filter the rows returned */;
+        where?: ValueTypes['circle_integrations_bool_exp'] | null;
+      },
+      ValueTypes['circle_integrations_aggregate']
+    ];
+    circle_integrations_by_pk?: [
+      { id: ValueTypes['bigint'] },
+      ValueTypes['circle_integrations']
+    ];
     circle_metadata?: [
       {
         /** distinct select on columns */
@@ -7351,6 +7743,140 @@ export type ModelTypes = {
   };
   /** order by variance() on columns of table "burns" */
   ['burns_variance_order_by']: GraphQLTypes['burns_variance_order_by'];
+  /** columns and relationships of "circle_integrations" */
+  ['circle_integrations']: {
+    /** An object relationship */
+    circle: ModelTypes['circles'];
+    circle_id: ModelTypes['bigint'];
+    data: ModelTypes['json'];
+    id: ModelTypes['bigint'];
+    name: string;
+    type: string;
+  };
+  /** aggregated selection of "circle_integrations" */
+  ['circle_integrations_aggregate']: {
+    aggregate?: ModelTypes['circle_integrations_aggregate_fields'];
+    nodes: ModelTypes['circle_integrations'][];
+  };
+  /** aggregate fields of "circle_integrations" */
+  ['circle_integrations_aggregate_fields']: {
+    avg?: ModelTypes['circle_integrations_avg_fields'];
+    count: number;
+    max?: ModelTypes['circle_integrations_max_fields'];
+    min?: ModelTypes['circle_integrations_min_fields'];
+    stddev?: ModelTypes['circle_integrations_stddev_fields'];
+    stddev_pop?: ModelTypes['circle_integrations_stddev_pop_fields'];
+    stddev_samp?: ModelTypes['circle_integrations_stddev_samp_fields'];
+    sum?: ModelTypes['circle_integrations_sum_fields'];
+    var_pop?: ModelTypes['circle_integrations_var_pop_fields'];
+    var_samp?: ModelTypes['circle_integrations_var_samp_fields'];
+    variance?: ModelTypes['circle_integrations_variance_fields'];
+  };
+  /** order by aggregate values of table "circle_integrations" */
+  ['circle_integrations_aggregate_order_by']: GraphQLTypes['circle_integrations_aggregate_order_by'];
+  /** input type for inserting array relation for remote table "circle_integrations" */
+  ['circle_integrations_arr_rel_insert_input']: GraphQLTypes['circle_integrations_arr_rel_insert_input'];
+  /** aggregate avg on columns */
+  ['circle_integrations_avg_fields']: {
+    circle_id?: number;
+    id?: number;
+  };
+  /** order by avg() on columns of table "circle_integrations" */
+  ['circle_integrations_avg_order_by']: GraphQLTypes['circle_integrations_avg_order_by'];
+  /** Boolean expression to filter rows from the table "circle_integrations". All fields are combined with a logical 'AND'. */
+  ['circle_integrations_bool_exp']: GraphQLTypes['circle_integrations_bool_exp'];
+  /** unique or primary key constraints on table "circle_integrations" */
+  ['circle_integrations_constraint']: GraphQLTypes['circle_integrations_constraint'];
+  /** input type for incrementing numeric columns in table "circle_integrations" */
+  ['circle_integrations_inc_input']: GraphQLTypes['circle_integrations_inc_input'];
+  /** input type for inserting data into table "circle_integrations" */
+  ['circle_integrations_insert_input']: GraphQLTypes['circle_integrations_insert_input'];
+  /** aggregate max on columns */
+  ['circle_integrations_max_fields']: {
+    circle_id?: ModelTypes['bigint'];
+    id?: ModelTypes['bigint'];
+    name?: string;
+    type?: string;
+  };
+  /** order by max() on columns of table "circle_integrations" */
+  ['circle_integrations_max_order_by']: GraphQLTypes['circle_integrations_max_order_by'];
+  /** aggregate min on columns */
+  ['circle_integrations_min_fields']: {
+    circle_id?: ModelTypes['bigint'];
+    id?: ModelTypes['bigint'];
+    name?: string;
+    type?: string;
+  };
+  /** order by min() on columns of table "circle_integrations" */
+  ['circle_integrations_min_order_by']: GraphQLTypes['circle_integrations_min_order_by'];
+  /** response of any mutation on the table "circle_integrations" */
+  ['circle_integrations_mutation_response']: {
+    /** number of rows affected by the mutation */
+    affected_rows: number;
+    /** data from the rows affected by the mutation */
+    returning: ModelTypes['circle_integrations'][];
+  };
+  /** on conflict condition type for table "circle_integrations" */
+  ['circle_integrations_on_conflict']: GraphQLTypes['circle_integrations_on_conflict'];
+  /** Ordering options when selecting data from "circle_integrations". */
+  ['circle_integrations_order_by']: GraphQLTypes['circle_integrations_order_by'];
+  /** primary key columns input for table: circle_integrations */
+  ['circle_integrations_pk_columns_input']: GraphQLTypes['circle_integrations_pk_columns_input'];
+  /** select columns of table "circle_integrations" */
+  ['circle_integrations_select_column']: GraphQLTypes['circle_integrations_select_column'];
+  /** input type for updating data in table "circle_integrations" */
+  ['circle_integrations_set_input']: GraphQLTypes['circle_integrations_set_input'];
+  /** aggregate stddev on columns */
+  ['circle_integrations_stddev_fields']: {
+    circle_id?: number;
+    id?: number;
+  };
+  /** order by stddev() on columns of table "circle_integrations" */
+  ['circle_integrations_stddev_order_by']: GraphQLTypes['circle_integrations_stddev_order_by'];
+  /** aggregate stddev_pop on columns */
+  ['circle_integrations_stddev_pop_fields']: {
+    circle_id?: number;
+    id?: number;
+  };
+  /** order by stddev_pop() on columns of table "circle_integrations" */
+  ['circle_integrations_stddev_pop_order_by']: GraphQLTypes['circle_integrations_stddev_pop_order_by'];
+  /** aggregate stddev_samp on columns */
+  ['circle_integrations_stddev_samp_fields']: {
+    circle_id?: number;
+    id?: number;
+  };
+  /** order by stddev_samp() on columns of table "circle_integrations" */
+  ['circle_integrations_stddev_samp_order_by']: GraphQLTypes['circle_integrations_stddev_samp_order_by'];
+  /** aggregate sum on columns */
+  ['circle_integrations_sum_fields']: {
+    circle_id?: ModelTypes['bigint'];
+    id?: ModelTypes['bigint'];
+  };
+  /** order by sum() on columns of table "circle_integrations" */
+  ['circle_integrations_sum_order_by']: GraphQLTypes['circle_integrations_sum_order_by'];
+  /** update columns of table "circle_integrations" */
+  ['circle_integrations_update_column']: GraphQLTypes['circle_integrations_update_column'];
+  /** aggregate var_pop on columns */
+  ['circle_integrations_var_pop_fields']: {
+    circle_id?: number;
+    id?: number;
+  };
+  /** order by var_pop() on columns of table "circle_integrations" */
+  ['circle_integrations_var_pop_order_by']: GraphQLTypes['circle_integrations_var_pop_order_by'];
+  /** aggregate var_samp on columns */
+  ['circle_integrations_var_samp_fields']: {
+    circle_id?: number;
+    id?: number;
+  };
+  /** order by var_samp() on columns of table "circle_integrations" */
+  ['circle_integrations_var_samp_order_by']: GraphQLTypes['circle_integrations_var_samp_order_by'];
+  /** aggregate variance on columns */
+  ['circle_integrations_variance_fields']: {
+    circle_id?: number;
+    id?: number;
+  };
+  /** order by variance() on columns of table "circle_integrations" */
+  ['circle_integrations_variance_order_by']: GraphQLTypes['circle_integrations_variance_order_by'];
   /** columns and relationships of "circle_metadata" */
   ['circle_metadata']: {
     /** An object relationship */
@@ -7596,6 +8122,10 @@ export type ModelTypes = {
     /** An aggregate relationship */
     epochs_aggregate: ModelTypes['epochs_aggregate'];
     id: ModelTypes['bigint'];
+    /** An array relationship */
+    integrations: ModelTypes['circle_integrations'][];
+    /** An aggregate relationship */
+    integrations_aggregate: ModelTypes['circle_integrations_aggregate'];
     is_verified: boolean;
     logo?: string;
     min_vouches: number;
@@ -8298,6 +8828,10 @@ export type ModelTypes = {
     delete_burns?: ModelTypes['burns_mutation_response'];
     /** delete single row from the table: "burns" */
     delete_burns_by_pk?: ModelTypes['burns'];
+    /** delete data from the table: "circle_integrations" */
+    delete_circle_integrations?: ModelTypes['circle_integrations_mutation_response'];
+    /** delete single row from the table: "circle_integrations" */
+    delete_circle_integrations_by_pk?: ModelTypes['circle_integrations'];
     /** delete data from the table: "circle_metadata" */
     delete_circle_metadata?: ModelTypes['circle_metadata_mutation_response'];
     /** delete single row from the table: "circle_metadata" */
@@ -8360,6 +8894,10 @@ export type ModelTypes = {
     insert_burns?: ModelTypes['burns_mutation_response'];
     /** insert a single row into the table: "burns" */
     insert_burns_one?: ModelTypes['burns'];
+    /** insert data into the table: "circle_integrations" */
+    insert_circle_integrations?: ModelTypes['circle_integrations_mutation_response'];
+    /** insert a single row into the table: "circle_integrations" */
+    insert_circle_integrations_one?: ModelTypes['circle_integrations'];
     /** insert data into the table: "circle_metadata" */
     insert_circle_metadata?: ModelTypes['circle_metadata_mutation_response'];
     /** insert a single row into the table: "circle_metadata" */
@@ -8428,6 +8966,10 @@ export type ModelTypes = {
     update_burns?: ModelTypes['burns_mutation_response'];
     /** update single row of the table: "burns" */
     update_burns_by_pk?: ModelTypes['burns'];
+    /** update data of the table: "circle_integrations" */
+    update_circle_integrations?: ModelTypes['circle_integrations_mutation_response'];
+    /** update single row of the table: "circle_integrations" */
+    update_circle_integrations_by_pk?: ModelTypes['circle_integrations'];
     /** update data of the table: "circle_metadata" */
     update_circle_metadata?: ModelTypes['circle_metadata_mutation_response'];
     /** update single row of the table: "circle_metadata" */
@@ -9353,6 +9895,12 @@ export type ModelTypes = {
     burns_aggregate: ModelTypes['burns_aggregate'];
     /** fetch data from the table: "burns" using primary key columns */
     burns_by_pk?: ModelTypes['burns'];
+    /** fetch data from the table: "circle_integrations" */
+    circle_integrations: ModelTypes['circle_integrations'][];
+    /** fetch aggregated fields from the table: "circle_integrations" */
+    circle_integrations_aggregate: ModelTypes['circle_integrations_aggregate'];
+    /** fetch data from the table: "circle_integrations" using primary key columns */
+    circle_integrations_by_pk?: ModelTypes['circle_integrations'];
     /** An array relationship */
     circle_metadata: ModelTypes['circle_metadata'][];
     /** An aggregate relationship */
@@ -9451,6 +9999,12 @@ export type ModelTypes = {
     burns_aggregate: ModelTypes['burns_aggregate'];
     /** fetch data from the table: "burns" using primary key columns */
     burns_by_pk?: ModelTypes['burns'];
+    /** fetch data from the table: "circle_integrations" */
+    circle_integrations: ModelTypes['circle_integrations'][];
+    /** fetch aggregated fields from the table: "circle_integrations" */
+    circle_integrations_aggregate: ModelTypes['circle_integrations_aggregate'];
+    /** fetch data from the table: "circle_integrations" using primary key columns */
+    circle_integrations_by_pk?: ModelTypes['circle_integrations'];
     /** An array relationship */
     circle_metadata: ModelTypes['circle_metadata'][];
     /** An aggregate relationship */
@@ -10684,6 +11238,243 @@ export type GraphQLTypes = {
     tokens_burnt?: GraphQLTypes['order_by'];
     user_id?: GraphQLTypes['order_by'];
   };
+  /** columns and relationships of "circle_integrations" */
+  ['circle_integrations']: {
+    __typename: 'circle_integrations';
+    /** An object relationship */
+    circle: GraphQLTypes['circles'];
+    circle_id: GraphQLTypes['bigint'];
+    data: GraphQLTypes['json'];
+    id: GraphQLTypes['bigint'];
+    name: string;
+    type: string;
+  };
+  /** aggregated selection of "circle_integrations" */
+  ['circle_integrations_aggregate']: {
+    __typename: 'circle_integrations_aggregate';
+    aggregate?: GraphQLTypes['circle_integrations_aggregate_fields'];
+    nodes: Array<GraphQLTypes['circle_integrations']>;
+  };
+  /** aggregate fields of "circle_integrations" */
+  ['circle_integrations_aggregate_fields']: {
+    __typename: 'circle_integrations_aggregate_fields';
+    avg?: GraphQLTypes['circle_integrations_avg_fields'];
+    count: number;
+    max?: GraphQLTypes['circle_integrations_max_fields'];
+    min?: GraphQLTypes['circle_integrations_min_fields'];
+    stddev?: GraphQLTypes['circle_integrations_stddev_fields'];
+    stddev_pop?: GraphQLTypes['circle_integrations_stddev_pop_fields'];
+    stddev_samp?: GraphQLTypes['circle_integrations_stddev_samp_fields'];
+    sum?: GraphQLTypes['circle_integrations_sum_fields'];
+    var_pop?: GraphQLTypes['circle_integrations_var_pop_fields'];
+    var_samp?: GraphQLTypes['circle_integrations_var_samp_fields'];
+    variance?: GraphQLTypes['circle_integrations_variance_fields'];
+  };
+  /** order by aggregate values of table "circle_integrations" */
+  ['circle_integrations_aggregate_order_by']: {
+    avg?: GraphQLTypes['circle_integrations_avg_order_by'];
+    count?: GraphQLTypes['order_by'];
+    max?: GraphQLTypes['circle_integrations_max_order_by'];
+    min?: GraphQLTypes['circle_integrations_min_order_by'];
+    stddev?: GraphQLTypes['circle_integrations_stddev_order_by'];
+    stddev_pop?: GraphQLTypes['circle_integrations_stddev_pop_order_by'];
+    stddev_samp?: GraphQLTypes['circle_integrations_stddev_samp_order_by'];
+    sum?: GraphQLTypes['circle_integrations_sum_order_by'];
+    var_pop?: GraphQLTypes['circle_integrations_var_pop_order_by'];
+    var_samp?: GraphQLTypes['circle_integrations_var_samp_order_by'];
+    variance?: GraphQLTypes['circle_integrations_variance_order_by'];
+  };
+  /** input type for inserting array relation for remote table "circle_integrations" */
+  ['circle_integrations_arr_rel_insert_input']: {
+    data: Array<GraphQLTypes['circle_integrations_insert_input']>;
+    /** on conflict condition */
+    on_conflict?: GraphQLTypes['circle_integrations_on_conflict'];
+  };
+  /** aggregate avg on columns */
+  ['circle_integrations_avg_fields']: {
+    __typename: 'circle_integrations_avg_fields';
+    circle_id?: number;
+    id?: number;
+  };
+  /** order by avg() on columns of table "circle_integrations" */
+  ['circle_integrations_avg_order_by']: {
+    circle_id?: GraphQLTypes['order_by'];
+    id?: GraphQLTypes['order_by'];
+  };
+  /** Boolean expression to filter rows from the table "circle_integrations". All fields are combined with a logical 'AND'. */
+  ['circle_integrations_bool_exp']: {
+    _and?: Array<GraphQLTypes['circle_integrations_bool_exp']>;
+    _not?: GraphQLTypes['circle_integrations_bool_exp'];
+    _or?: Array<GraphQLTypes['circle_integrations_bool_exp']>;
+    circle?: GraphQLTypes['circles_bool_exp'];
+    circle_id?: GraphQLTypes['bigint_comparison_exp'];
+    data?: GraphQLTypes['json_comparison_exp'];
+    id?: GraphQLTypes['bigint_comparison_exp'];
+    name?: GraphQLTypes['String_comparison_exp'];
+    type?: GraphQLTypes['String_comparison_exp'];
+  };
+  /** unique or primary key constraints on table "circle_integrations" */
+  ['circle_integrations_constraint']: circle_integrations_constraint;
+  /** input type for incrementing numeric columns in table "circle_integrations" */
+  ['circle_integrations_inc_input']: {
+    circle_id?: GraphQLTypes['bigint'];
+    id?: GraphQLTypes['bigint'];
+  };
+  /** input type for inserting data into table "circle_integrations" */
+  ['circle_integrations_insert_input']: {
+    circle?: GraphQLTypes['circles_obj_rel_insert_input'];
+    circle_id?: GraphQLTypes['bigint'];
+    data?: GraphQLTypes['json'];
+    id?: GraphQLTypes['bigint'];
+    name?: string;
+    type?: string;
+  };
+  /** aggregate max on columns */
+  ['circle_integrations_max_fields']: {
+    __typename: 'circle_integrations_max_fields';
+    circle_id?: GraphQLTypes['bigint'];
+    id?: GraphQLTypes['bigint'];
+    name?: string;
+    type?: string;
+  };
+  /** order by max() on columns of table "circle_integrations" */
+  ['circle_integrations_max_order_by']: {
+    circle_id?: GraphQLTypes['order_by'];
+    id?: GraphQLTypes['order_by'];
+    name?: GraphQLTypes['order_by'];
+    type?: GraphQLTypes['order_by'];
+  };
+  /** aggregate min on columns */
+  ['circle_integrations_min_fields']: {
+    __typename: 'circle_integrations_min_fields';
+    circle_id?: GraphQLTypes['bigint'];
+    id?: GraphQLTypes['bigint'];
+    name?: string;
+    type?: string;
+  };
+  /** order by min() on columns of table "circle_integrations" */
+  ['circle_integrations_min_order_by']: {
+    circle_id?: GraphQLTypes['order_by'];
+    id?: GraphQLTypes['order_by'];
+    name?: GraphQLTypes['order_by'];
+    type?: GraphQLTypes['order_by'];
+  };
+  /** response of any mutation on the table "circle_integrations" */
+  ['circle_integrations_mutation_response']: {
+    __typename: 'circle_integrations_mutation_response';
+    /** number of rows affected by the mutation */
+    affected_rows: number;
+    /** data from the rows affected by the mutation */
+    returning: Array<GraphQLTypes['circle_integrations']>;
+  };
+  /** on conflict condition type for table "circle_integrations" */
+  ['circle_integrations_on_conflict']: {
+    constraint: GraphQLTypes['circle_integrations_constraint'];
+    update_columns: Array<GraphQLTypes['circle_integrations_update_column']>;
+    where?: GraphQLTypes['circle_integrations_bool_exp'];
+  };
+  /** Ordering options when selecting data from "circle_integrations". */
+  ['circle_integrations_order_by']: {
+    circle?: GraphQLTypes['circles_order_by'];
+    circle_id?: GraphQLTypes['order_by'];
+    data?: GraphQLTypes['order_by'];
+    id?: GraphQLTypes['order_by'];
+    name?: GraphQLTypes['order_by'];
+    type?: GraphQLTypes['order_by'];
+  };
+  /** primary key columns input for table: circle_integrations */
+  ['circle_integrations_pk_columns_input']: {
+    id: GraphQLTypes['bigint'];
+  };
+  /** select columns of table "circle_integrations" */
+  ['circle_integrations_select_column']: circle_integrations_select_column;
+  /** input type for updating data in table "circle_integrations" */
+  ['circle_integrations_set_input']: {
+    circle_id?: GraphQLTypes['bigint'];
+    data?: GraphQLTypes['json'];
+    id?: GraphQLTypes['bigint'];
+    name?: string;
+    type?: string;
+  };
+  /** aggregate stddev on columns */
+  ['circle_integrations_stddev_fields']: {
+    __typename: 'circle_integrations_stddev_fields';
+    circle_id?: number;
+    id?: number;
+  };
+  /** order by stddev() on columns of table "circle_integrations" */
+  ['circle_integrations_stddev_order_by']: {
+    circle_id?: GraphQLTypes['order_by'];
+    id?: GraphQLTypes['order_by'];
+  };
+  /** aggregate stddev_pop on columns */
+  ['circle_integrations_stddev_pop_fields']: {
+    __typename: 'circle_integrations_stddev_pop_fields';
+    circle_id?: number;
+    id?: number;
+  };
+  /** order by stddev_pop() on columns of table "circle_integrations" */
+  ['circle_integrations_stddev_pop_order_by']: {
+    circle_id?: GraphQLTypes['order_by'];
+    id?: GraphQLTypes['order_by'];
+  };
+  /** aggregate stddev_samp on columns */
+  ['circle_integrations_stddev_samp_fields']: {
+    __typename: 'circle_integrations_stddev_samp_fields';
+    circle_id?: number;
+    id?: number;
+  };
+  /** order by stddev_samp() on columns of table "circle_integrations" */
+  ['circle_integrations_stddev_samp_order_by']: {
+    circle_id?: GraphQLTypes['order_by'];
+    id?: GraphQLTypes['order_by'];
+  };
+  /** aggregate sum on columns */
+  ['circle_integrations_sum_fields']: {
+    __typename: 'circle_integrations_sum_fields';
+    circle_id?: GraphQLTypes['bigint'];
+    id?: GraphQLTypes['bigint'];
+  };
+  /** order by sum() on columns of table "circle_integrations" */
+  ['circle_integrations_sum_order_by']: {
+    circle_id?: GraphQLTypes['order_by'];
+    id?: GraphQLTypes['order_by'];
+  };
+  /** update columns of table "circle_integrations" */
+  ['circle_integrations_update_column']: circle_integrations_update_column;
+  /** aggregate var_pop on columns */
+  ['circle_integrations_var_pop_fields']: {
+    __typename: 'circle_integrations_var_pop_fields';
+    circle_id?: number;
+    id?: number;
+  };
+  /** order by var_pop() on columns of table "circle_integrations" */
+  ['circle_integrations_var_pop_order_by']: {
+    circle_id?: GraphQLTypes['order_by'];
+    id?: GraphQLTypes['order_by'];
+  };
+  /** aggregate var_samp on columns */
+  ['circle_integrations_var_samp_fields']: {
+    __typename: 'circle_integrations_var_samp_fields';
+    circle_id?: number;
+    id?: number;
+  };
+  /** order by var_samp() on columns of table "circle_integrations" */
+  ['circle_integrations_var_samp_order_by']: {
+    circle_id?: GraphQLTypes['order_by'];
+    id?: GraphQLTypes['order_by'];
+  };
+  /** aggregate variance on columns */
+  ['circle_integrations_variance_fields']: {
+    __typename: 'circle_integrations_variance_fields';
+    circle_id?: number;
+    id?: number;
+  };
+  /** order by variance() on columns of table "circle_integrations" */
+  ['circle_integrations_variance_order_by']: {
+    circle_id?: GraphQLTypes['order_by'];
+    id?: GraphQLTypes['order_by'];
+  };
   /** columns and relationships of "circle_metadata" */
   ['circle_metadata']: {
     __typename: 'circle_metadata';
@@ -11069,6 +11860,10 @@ export type GraphQLTypes = {
     /** An aggregate relationship */
     epochs_aggregate: GraphQLTypes['epochs_aggregate'];
     id: GraphQLTypes['bigint'];
+    /** An array relationship */
+    integrations: Array<GraphQLTypes['circle_integrations']>;
+    /** An aggregate relationship */
+    integrations_aggregate: GraphQLTypes['circle_integrations_aggregate'];
     is_verified: boolean;
     logo?: string;
     min_vouches: number;
@@ -11169,6 +11964,7 @@ export type GraphQLTypes = {
     discord_webhook?: GraphQLTypes['String_comparison_exp'];
     epochs?: GraphQLTypes['epochs_bool_exp'];
     id?: GraphQLTypes['bigint_comparison_exp'];
+    integrations?: GraphQLTypes['circle_integrations_bool_exp'];
     is_verified?: GraphQLTypes['Boolean_comparison_exp'];
     logo?: GraphQLTypes['String_comparison_exp'];
     min_vouches?: GraphQLTypes['Int_comparison_exp'];
@@ -11209,6 +12005,7 @@ export type GraphQLTypes = {
     discord_webhook?: string;
     epochs?: GraphQLTypes['epochs_arr_rel_insert_input'];
     id?: GraphQLTypes['bigint'];
+    integrations?: GraphQLTypes['circle_integrations_arr_rel_insert_input'];
     is_verified?: boolean;
     logo?: string;
     min_vouches?: number;
@@ -11330,6 +12127,7 @@ export type GraphQLTypes = {
     discord_webhook?: GraphQLTypes['order_by'];
     epochs_aggregate?: GraphQLTypes['epochs_aggregate_order_by'];
     id?: GraphQLTypes['order_by'];
+    integrations_aggregate?: GraphQLTypes['circle_integrations_aggregate_order_by'];
     is_verified?: GraphQLTypes['order_by'];
     logo?: GraphQLTypes['order_by'];
     min_vouches?: GraphQLTypes['order_by'];
@@ -12382,6 +13180,10 @@ export type GraphQLTypes = {
     delete_burns?: GraphQLTypes['burns_mutation_response'];
     /** delete single row from the table: "burns" */
     delete_burns_by_pk?: GraphQLTypes['burns'];
+    /** delete data from the table: "circle_integrations" */
+    delete_circle_integrations?: GraphQLTypes['circle_integrations_mutation_response'];
+    /** delete single row from the table: "circle_integrations" */
+    delete_circle_integrations_by_pk?: GraphQLTypes['circle_integrations'];
     /** delete data from the table: "circle_metadata" */
     delete_circle_metadata?: GraphQLTypes['circle_metadata_mutation_response'];
     /** delete single row from the table: "circle_metadata" */
@@ -12444,6 +13246,10 @@ export type GraphQLTypes = {
     insert_burns?: GraphQLTypes['burns_mutation_response'];
     /** insert a single row into the table: "burns" */
     insert_burns_one?: GraphQLTypes['burns'];
+    /** insert data into the table: "circle_integrations" */
+    insert_circle_integrations?: GraphQLTypes['circle_integrations_mutation_response'];
+    /** insert a single row into the table: "circle_integrations" */
+    insert_circle_integrations_one?: GraphQLTypes['circle_integrations'];
     /** insert data into the table: "circle_metadata" */
     insert_circle_metadata?: GraphQLTypes['circle_metadata_mutation_response'];
     /** insert a single row into the table: "circle_metadata" */
@@ -12512,6 +13318,10 @@ export type GraphQLTypes = {
     update_burns?: GraphQLTypes['burns_mutation_response'];
     /** update single row of the table: "burns" */
     update_burns_by_pk?: GraphQLTypes['burns'];
+    /** update data of the table: "circle_integrations" */
+    update_circle_integrations?: GraphQLTypes['circle_integrations_mutation_response'];
+    /** update single row of the table: "circle_integrations" */
+    update_circle_integrations_by_pk?: GraphQLTypes['circle_integrations'];
     /** update data of the table: "circle_metadata" */
     update_circle_metadata?: GraphQLTypes['circle_metadata_mutation_response'];
     /** update single row of the table: "circle_metadata" */
@@ -14026,6 +14836,12 @@ export type GraphQLTypes = {
     burns_aggregate: GraphQLTypes['burns_aggregate'];
     /** fetch data from the table: "burns" using primary key columns */
     burns_by_pk?: GraphQLTypes['burns'];
+    /** fetch data from the table: "circle_integrations" */
+    circle_integrations: Array<GraphQLTypes['circle_integrations']>;
+    /** fetch aggregated fields from the table: "circle_integrations" */
+    circle_integrations_aggregate: GraphQLTypes['circle_integrations_aggregate'];
+    /** fetch data from the table: "circle_integrations" using primary key columns */
+    circle_integrations_by_pk?: GraphQLTypes['circle_integrations'];
     /** An array relationship */
     circle_metadata: Array<GraphQLTypes['circle_metadata']>;
     /** An aggregate relationship */
@@ -14125,6 +14941,12 @@ export type GraphQLTypes = {
     burns_aggregate: GraphQLTypes['burns_aggregate'];
     /** fetch data from the table: "burns" using primary key columns */
     burns_by_pk?: GraphQLTypes['burns'];
+    /** fetch data from the table: "circle_integrations" */
+    circle_integrations: Array<GraphQLTypes['circle_integrations']>;
+    /** fetch aggregated fields from the table: "circle_integrations" */
+    circle_integrations_aggregate: GraphQLTypes['circle_integrations_aggregate'];
+    /** fetch data from the table: "circle_integrations" using primary key columns */
+    circle_integrations_by_pk?: GraphQLTypes['circle_integrations'];
     /** An array relationship */
     circle_metadata: Array<GraphQLTypes['circle_metadata']>;
     /** An aggregate relationship */
@@ -15557,6 +16379,26 @@ export const enum burns_update_column {
   updated_at = 'updated_at',
   user_id = 'user_id',
 }
+/** unique or primary key constraints on table "circle_integrations" */
+export const enum circle_integrations_constraint {
+  circle_integrations_pkey = 'circle_integrations_pkey',
+}
+/** select columns of table "circle_integrations" */
+export const enum circle_integrations_select_column {
+  circle_id = 'circle_id',
+  data = 'data',
+  id = 'id',
+  name = 'name',
+  type = 'type',
+}
+/** update columns of table "circle_integrations" */
+export const enum circle_integrations_update_column {
+  circle_id = 'circle_id',
+  data = 'data',
+  id = 'id',
+  name = 'name',
+  type = 'type',
+}
 /** unique or primary key constraints on table "circle_metadata" */
 export const enum circle_metadata_constraint {
   circle_metadata_pkey = 'circle_metadata_pkey',
@@ -15986,6 +16828,7 @@ export const enum users_update_column {
 /** unique or primary key constraints on table "vouches" */
 export const enum vouches_constraint {
   vouches_pkey = 'vouches_pkey',
+  vouches_unique = 'vouches_unique',
 }
 /** select columns of table "vouches" */
 export const enum vouches_select_column {

--- a/src/lib/gql/zeusUser/const.ts
+++ b/src/lib/gql/zeusUser/const.ts
@@ -3305,6 +3305,14 @@ export const AllTypesProps: Record<string, any> = {
         required: true,
       },
     },
+    upload_circle_logo: {
+      object: {
+        type: 'upload_circle_image_input',
+        array: false,
+        arrayRequired: false,
+        required: true,
+      },
+    },
     upload_profile_avatar: {
       object: {
         type: 'upload_image_input',
@@ -6983,6 +6991,20 @@ export const AllTypesProps: Record<string, any> = {
       required: false,
     },
   },
+  upload_circle_image_input: {
+    id: {
+      type: 'Int',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+    image_data_base64: {
+      type: 'String',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+  },
   upload_image_input: {
     image_data_base64: {
       type: 'String',
@@ -8543,6 +8565,7 @@ export const ReturnTypes: Record<string, any> = {
     update_circles_by_pk: 'circles',
     update_profiles: 'profiles_mutation_response',
     update_profiles_by_pk: 'profiles',
+    upload_circle_logo: 'update_circle_response',
     upload_profile_avatar: 'update_profile_response',
     upload_profile_background: 'update_profile_response',
   },
@@ -8808,6 +8831,10 @@ export const ReturnTypes: Record<string, any> = {
     recipient_id: 'Float',
     sender_id: 'Float',
     tokens: 'Float',
+  },
+  update_circle_response: {
+    circle: 'circles',
+    id: 'Int',
   },
   update_profile_response: {
     id: 'Int',

--- a/src/lib/gql/zeusUser/const.ts
+++ b/src/lib/gql/zeusUser/const.ts
@@ -7568,7 +7568,7 @@ export const AllTypesProps: Record<string, any> = {
     },
   },
   upload_circle_image_input: {
-    id: {
+    circle_id: {
       type: 'Int',
       array: false,
       arrayRequired: false,

--- a/src/lib/gql/zeusUser/const.ts
+++ b/src/lib/gql/zeusUser/const.ts
@@ -985,6 +985,369 @@ export const AllTypesProps: Record<string, any> = {
       required: false,
     },
   },
+  circle_integrations: {
+    data: {
+      path: {
+        type: 'String',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+    },
+  },
+  circle_integrations_aggregate_order_by: {
+    avg: {
+      type: 'circle_integrations_avg_order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    count: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    max: {
+      type: 'circle_integrations_max_order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    min: {
+      type: 'circle_integrations_min_order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    stddev: {
+      type: 'circle_integrations_stddev_order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    stddev_pop: {
+      type: 'circle_integrations_stddev_pop_order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    stddev_samp: {
+      type: 'circle_integrations_stddev_samp_order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    sum: {
+      type: 'circle_integrations_sum_order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    var_pop: {
+      type: 'circle_integrations_var_pop_order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    var_samp: {
+      type: 'circle_integrations_var_samp_order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    variance: {
+      type: 'circle_integrations_variance_order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
+  circle_integrations_avg_order_by: {
+    circle_id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
+  circle_integrations_bool_exp: {
+    _and: {
+      type: 'circle_integrations_bool_exp',
+      array: true,
+      arrayRequired: false,
+      required: true,
+    },
+    _not: {
+      type: 'circle_integrations_bool_exp',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    _or: {
+      type: 'circle_integrations_bool_exp',
+      array: true,
+      arrayRequired: false,
+      required: true,
+    },
+    circle: {
+      type: 'circles_bool_exp',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    circle_id: {
+      type: 'bigint_comparison_exp',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    data: {
+      type: 'json_comparison_exp',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    id: {
+      type: 'bigint_comparison_exp',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    name: {
+      type: 'String_comparison_exp',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    type: {
+      type: 'String_comparison_exp',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
+  circle_integrations_insert_input: {
+    circle_id: {
+      type: 'bigint',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    data: {
+      type: 'json',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    name: {
+      type: 'String',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    type: {
+      type: 'String',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
+  circle_integrations_max_order_by: {
+    circle_id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    name: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    type: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
+  circle_integrations_min_order_by: {
+    circle_id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    name: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    type: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
+  circle_integrations_order_by: {
+    circle: {
+      type: 'circles_order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    circle_id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    data: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    name: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    type: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
+  circle_integrations_select_column: 'enum',
+  circle_integrations_stddev_order_by: {
+    circle_id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
+  circle_integrations_stddev_pop_order_by: {
+    circle_id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
+  circle_integrations_stddev_samp_order_by: {
+    circle_id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
+  circle_integrations_sum_order_by: {
+    circle_id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
+  circle_integrations_var_pop_order_by: {
+    circle_id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
+  circle_integrations_var_samp_order_by: {
+    circle_id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
+  circle_integrations_variance_order_by: {
+    circle_id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    id: {
+      type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+  },
   circle_private_bool_exp: {
     _and: {
       type: 'circle_private_bool_exp',
@@ -1104,6 +1467,38 @@ export const AllTypesProps: Record<string, any> = {
       },
       where: {
         type: 'epochs_bool_exp',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+    },
+    integrations: {
+      distinct_on: {
+        type: 'circle_integrations_select_column',
+        array: true,
+        arrayRequired: false,
+        required: true,
+      },
+      limit: {
+        type: 'Int',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+      offset: {
+        type: 'Int',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+      order_by: {
+        type: 'circle_integrations_order_by',
+        array: true,
+        arrayRequired: false,
+        required: true,
+      },
+      where: {
+        type: 'circle_integrations_bool_exp',
         array: false,
         arrayRequired: false,
         required: false,
@@ -1395,6 +1790,12 @@ export const AllTypesProps: Record<string, any> = {
     },
     id: {
       type: 'bigint_comparison_exp',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    integrations: {
+      type: 'circle_integrations_bool_exp',
       array: false,
       arrayRequired: false,
       required: false,
@@ -1709,6 +2110,12 @@ export const AllTypesProps: Record<string, any> = {
     },
     id: {
       type: 'order_by',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    integrations_aggregate: {
+      type: 'circle_integrations_aggregate_order_by',
       array: false,
       arrayRequired: false,
       required: false,
@@ -3220,6 +3627,63 @@ export const AllTypesProps: Record<string, any> = {
     },
   },
   gift_private_select_column: 'enum',
+  json: 'String',
+  json_comparison_exp: {
+    _eq: {
+      type: 'json',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    _gt: {
+      type: 'json',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    _gte: {
+      type: 'json',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    _in: {
+      type: 'json',
+      array: true,
+      arrayRequired: false,
+      required: true,
+    },
+    _is_null: {
+      type: 'Boolean',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    _lt: {
+      type: 'json',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    _lte: {
+      type: 'json',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    _neq: {
+      type: 'json',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    _nin: {
+      type: 'json',
+      array: true,
+      arrayRequired: false,
+      required: true,
+    },
+  },
   mutation_root: {
     createUser: {
       object: {
@@ -3232,6 +3696,38 @@ export const AllTypesProps: Record<string, any> = {
     create_circle: {
       object: {
         type: 'create_circle_input',
+        array: false,
+        arrayRequired: false,
+        required: true,
+      },
+    },
+    delete_circle_integrations: {
+      where: {
+        type: 'circle_integrations_bool_exp',
+        array: false,
+        arrayRequired: false,
+        required: true,
+      },
+    },
+    delete_circle_integrations_by_pk: {
+      id: {
+        type: 'bigint',
+        array: false,
+        arrayRequired: false,
+        required: true,
+      },
+    },
+    insert_circle_integrations: {
+      objects: {
+        type: 'circle_integrations_insert_input',
+        array: true,
+        arrayRequired: true,
+        required: true,
+      },
+    },
+    insert_circle_integrations_one: {
+      object: {
+        type: 'circle_integrations_insert_input',
         array: false,
         arrayRequired: false,
         required: true,
@@ -4944,6 +5440,46 @@ export const AllTypesProps: Record<string, any> = {
         required: true,
       },
     },
+    circle_integrations: {
+      distinct_on: {
+        type: 'circle_integrations_select_column',
+        array: true,
+        arrayRequired: false,
+        required: true,
+      },
+      limit: {
+        type: 'Int',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+      offset: {
+        type: 'Int',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+      order_by: {
+        type: 'circle_integrations_order_by',
+        array: true,
+        arrayRequired: false,
+        required: true,
+      },
+      where: {
+        type: 'circle_integrations_bool_exp',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+    },
+    circle_integrations_by_pk: {
+      id: {
+        type: 'bigint',
+        array: false,
+        arrayRequired: false,
+        required: true,
+      },
+    },
     circle_private: {
       distinct_on: {
         type: 'circle_private_select_column',
@@ -5507,6 +6043,46 @@ export const AllTypesProps: Record<string, any> = {
       },
     },
     burns_by_pk: {
+      id: {
+        type: 'bigint',
+        array: false,
+        arrayRequired: false,
+        required: true,
+      },
+    },
+    circle_integrations: {
+      distinct_on: {
+        type: 'circle_integrations_select_column',
+        array: true,
+        arrayRequired: false,
+        required: true,
+      },
+      limit: {
+        type: 'Int',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+      offset: {
+        type: 'Int',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+      order_by: {
+        type: 'circle_integrations_order_by',
+        array: true,
+        arrayRequired: false,
+        required: true,
+      },
+      where: {
+        type: 'circle_integrations_bool_exp',
+        array: false,
+        arrayRequired: false,
+        required: false,
+      },
+    },
+    circle_integrations_by_pk: {
       id: {
         type: 'bigint',
         array: false,
@@ -8478,6 +9054,18 @@ export const ReturnTypes: Record<string, any> = {
     user: 'users',
     user_id: 'bigint',
   },
+  circle_integrations: {
+    circle: 'circles',
+    circle_id: 'bigint',
+    data: 'json',
+    id: 'bigint',
+    name: 'String',
+    type: 'String',
+  },
+  circle_integrations_mutation_response: {
+    affected_rows: 'Int',
+    returning: 'circle_integrations',
+  },
   circle_private: {
     circle: 'circles',
     circle_id: 'bigint',
@@ -8492,6 +9080,7 @@ export const ReturnTypes: Record<string, any> = {
     default_opt_in: 'Boolean',
     epochs: 'epochs',
     id: 'bigint',
+    integrations: 'circle_integrations',
     is_verified: 'Boolean',
     logo: 'String',
     min_vouches: 'Int',
@@ -8561,6 +9150,10 @@ export const ReturnTypes: Record<string, any> = {
   mutation_root: {
     createUser: 'createUserResponse',
     create_circle: 'create_circle_response',
+    delete_circle_integrations: 'circle_integrations_mutation_response',
+    delete_circle_integrations_by_pk: 'circle_integrations',
+    insert_circle_integrations: 'circle_integrations_mutation_response',
+    insert_circle_integrations_one: 'circle_integrations',
     update_circles: 'circles_mutation_response',
     update_circles_by_pk: 'circles',
     update_profiles: 'profiles_mutation_response',
@@ -8646,6 +9239,8 @@ export const ReturnTypes: Record<string, any> = {
   query_root: {
     burns: 'burns',
     burns_by_pk: 'burns',
+    circle_integrations: 'circle_integrations',
+    circle_integrations_by_pk: 'circle_integrations',
     circle_private: 'circle_private',
     circles: 'circles',
     circles_by_pk: 'circles',
@@ -8674,6 +9269,8 @@ export const ReturnTypes: Record<string, any> = {
   subscription_root: {
     burns: 'burns',
     burns_by_pk: 'burns',
+    circle_integrations: 'circle_integrations',
+    circle_integrations_by_pk: 'circle_integrations',
     circle_private: 'circle_private',
     circles: 'circles',
     circles_by_pk: 'circles',

--- a/src/lib/gql/zeusUser/index.ts
+++ b/src/lib/gql/zeusUser/index.ts
@@ -2439,7 +2439,7 @@ export type ValueTypes = {
     __typename?: boolean;
   }>;
   ['upload_circle_image_input']: {
-    id: number;
+    circle_id: number;
     image_data_base64: string;
   };
   ['upload_image_input']: {
@@ -5627,7 +5627,7 @@ export type GraphQLTypes = {
     profile: GraphQLTypes['profiles'];
   };
   ['upload_circle_image_input']: {
-    id: number;
+    circle_id: number;
     image_data_base64: string;
   };
   ['upload_image_input']: {

--- a/src/lib/gql/zeusUser/index.ts
+++ b/src/lib/gql/zeusUser/index.ts
@@ -931,6 +931,10 @@ export type ValueTypes = {
       },
       ValueTypes['profiles']
     ];
+    upload_circle_logo?: [
+      { object: ValueTypes['upload_circle_image_input'] },
+      ValueTypes['update_circle_response']
+    ];
     upload_profile_avatar?: [
       { object: ValueTypes['upload_image_input'] },
       ValueTypes['update_profile_response']
@@ -2211,12 +2215,22 @@ export type ValueTypes = {
     sender_id?: ValueTypes['order_by'] | null;
     tokens?: ValueTypes['order_by'] | null;
   };
+  ['update_circle_response']: AliasType<{
+    /** An object relationship */
+    circle?: ValueTypes['circles'];
+    id?: boolean;
+    __typename?: boolean;
+  }>;
   ['update_profile_response']: AliasType<{
     id?: boolean;
     /** An object relationship */
     profile?: ValueTypes['profiles'];
     __typename?: boolean;
   }>;
+  ['upload_circle_image_input']: {
+    id: number;
+    image_data_base64: string;
+  };
   ['upload_image_input']: {
     image_data_base64: string;
   };
@@ -2884,6 +2898,7 @@ export type ModelTypes = {
     update_profiles?: ModelTypes['profiles_mutation_response'];
     /** update single row of the table: "profiles" */
     update_profiles_by_pk?: ModelTypes['profiles'];
+    upload_circle_logo?: ModelTypes['update_circle_response'];
     upload_profile_avatar?: ModelTypes['update_profile_response'];
     upload_profile_background?: ModelTypes['update_profile_response'];
   };
@@ -3344,11 +3359,17 @@ export type ModelTypes = {
   };
   /** order by variance() on columns of table "token_gifts" */
   ['token_gifts_variance_order_by']: GraphQLTypes['token_gifts_variance_order_by'];
+  ['update_circle_response']: {
+    /** An object relationship */
+    circle: ModelTypes['circles'];
+    id: number;
+  };
   ['update_profile_response']: {
     id: number;
     /** An object relationship */
     profile: ModelTypes['profiles'];
   };
+  ['upload_circle_image_input']: GraphQLTypes['upload_circle_image_input'];
   ['upload_image_input']: GraphQLTypes['upload_image_input'];
   /** columns and relationships of "users" */
   ['users']: {
@@ -4255,6 +4276,7 @@ export type GraphQLTypes = {
     update_profiles?: GraphQLTypes['profiles_mutation_response'];
     /** update single row of the table: "profiles" */
     update_profiles_by_pk?: GraphQLTypes['profiles'];
+    upload_circle_logo?: GraphQLTypes['update_circle_response'];
     upload_profile_avatar?: GraphQLTypes['update_profile_response'];
     upload_profile_background?: GraphQLTypes['update_profile_response'];
   };
@@ -5163,11 +5185,21 @@ export type GraphQLTypes = {
     sender_id?: GraphQLTypes['order_by'];
     tokens?: GraphQLTypes['order_by'];
   };
+  ['update_circle_response']: {
+    __typename: 'update_circle_response';
+    /** An object relationship */
+    circle: GraphQLTypes['circles'];
+    id: number;
+  };
   ['update_profile_response']: {
     __typename: 'update_profile_response';
     id: number;
     /** An object relationship */
     profile: GraphQLTypes['profiles'];
+  };
+  ['upload_circle_image_input']: {
+    id: number;
+    image_data_base64: string;
   };
   ['upload_image_input']: {
     image_data_base64: string;

--- a/src/lib/gql/zeusUser/index.ts
+++ b/src/lib/gql/zeusUser/index.ts
@@ -246,6 +246,128 @@ export type ValueTypes = {
     tokens_burnt?: ValueTypes['order_by'] | null;
     user_id?: ValueTypes['order_by'] | null;
   };
+  /** columns and relationships of "circle_integrations" */
+  ['circle_integrations']: AliasType<{
+    /** An object relationship */
+    circle?: ValueTypes['circles'];
+    circle_id?: boolean;
+    data?: [
+      {
+        /** JSON select path */ path?: string | null;
+      },
+      boolean
+    ];
+    id?: boolean;
+    name?: boolean;
+    type?: boolean;
+    __typename?: boolean;
+  }>;
+  /** order by aggregate values of table "circle_integrations" */
+  ['circle_integrations_aggregate_order_by']: {
+    avg?: ValueTypes['circle_integrations_avg_order_by'] | null;
+    count?: ValueTypes['order_by'] | null;
+    max?: ValueTypes['circle_integrations_max_order_by'] | null;
+    min?: ValueTypes['circle_integrations_min_order_by'] | null;
+    stddev?: ValueTypes['circle_integrations_stddev_order_by'] | null;
+    stddev_pop?: ValueTypes['circle_integrations_stddev_pop_order_by'] | null;
+    stddev_samp?: ValueTypes['circle_integrations_stddev_samp_order_by'] | null;
+    sum?: ValueTypes['circle_integrations_sum_order_by'] | null;
+    var_pop?: ValueTypes['circle_integrations_var_pop_order_by'] | null;
+    var_samp?: ValueTypes['circle_integrations_var_samp_order_by'] | null;
+    variance?: ValueTypes['circle_integrations_variance_order_by'] | null;
+  };
+  /** order by avg() on columns of table "circle_integrations" */
+  ['circle_integrations_avg_order_by']: {
+    circle_id?: ValueTypes['order_by'] | null;
+    id?: ValueTypes['order_by'] | null;
+  };
+  /** Boolean expression to filter rows from the table "circle_integrations". All fields are combined with a logical 'AND'. */
+  ['circle_integrations_bool_exp']: {
+    _and?: ValueTypes['circle_integrations_bool_exp'][];
+    _not?: ValueTypes['circle_integrations_bool_exp'] | null;
+    _or?: ValueTypes['circle_integrations_bool_exp'][];
+    circle?: ValueTypes['circles_bool_exp'] | null;
+    circle_id?: ValueTypes['bigint_comparison_exp'] | null;
+    data?: ValueTypes['json_comparison_exp'] | null;
+    id?: ValueTypes['bigint_comparison_exp'] | null;
+    name?: ValueTypes['String_comparison_exp'] | null;
+    type?: ValueTypes['String_comparison_exp'] | null;
+  };
+  /** input type for inserting data into table "circle_integrations" */
+  ['circle_integrations_insert_input']: {
+    circle_id?: ValueTypes['bigint'] | null;
+    data?: ValueTypes['json'] | null;
+    name?: string | null;
+    type?: string | null;
+  };
+  /** order by max() on columns of table "circle_integrations" */
+  ['circle_integrations_max_order_by']: {
+    circle_id?: ValueTypes['order_by'] | null;
+    id?: ValueTypes['order_by'] | null;
+    name?: ValueTypes['order_by'] | null;
+    type?: ValueTypes['order_by'] | null;
+  };
+  /** order by min() on columns of table "circle_integrations" */
+  ['circle_integrations_min_order_by']: {
+    circle_id?: ValueTypes['order_by'] | null;
+    id?: ValueTypes['order_by'] | null;
+    name?: ValueTypes['order_by'] | null;
+    type?: ValueTypes['order_by'] | null;
+  };
+  /** response of any mutation on the table "circle_integrations" */
+  ['circle_integrations_mutation_response']: AliasType<{
+    /** number of rows affected by the mutation */
+    affected_rows?: boolean;
+    /** data from the rows affected by the mutation */
+    returning?: ValueTypes['circle_integrations'];
+    __typename?: boolean;
+  }>;
+  /** Ordering options when selecting data from "circle_integrations". */
+  ['circle_integrations_order_by']: {
+    circle?: ValueTypes['circles_order_by'] | null;
+    circle_id?: ValueTypes['order_by'] | null;
+    data?: ValueTypes['order_by'] | null;
+    id?: ValueTypes['order_by'] | null;
+    name?: ValueTypes['order_by'] | null;
+    type?: ValueTypes['order_by'] | null;
+  };
+  /** select columns of table "circle_integrations" */
+  ['circle_integrations_select_column']: circle_integrations_select_column;
+  /** order by stddev() on columns of table "circle_integrations" */
+  ['circle_integrations_stddev_order_by']: {
+    circle_id?: ValueTypes['order_by'] | null;
+    id?: ValueTypes['order_by'] | null;
+  };
+  /** order by stddev_pop() on columns of table "circle_integrations" */
+  ['circle_integrations_stddev_pop_order_by']: {
+    circle_id?: ValueTypes['order_by'] | null;
+    id?: ValueTypes['order_by'] | null;
+  };
+  /** order by stddev_samp() on columns of table "circle_integrations" */
+  ['circle_integrations_stddev_samp_order_by']: {
+    circle_id?: ValueTypes['order_by'] | null;
+    id?: ValueTypes['order_by'] | null;
+  };
+  /** order by sum() on columns of table "circle_integrations" */
+  ['circle_integrations_sum_order_by']: {
+    circle_id?: ValueTypes['order_by'] | null;
+    id?: ValueTypes['order_by'] | null;
+  };
+  /** order by var_pop() on columns of table "circle_integrations" */
+  ['circle_integrations_var_pop_order_by']: {
+    circle_id?: ValueTypes['order_by'] | null;
+    id?: ValueTypes['order_by'] | null;
+  };
+  /** order by var_samp() on columns of table "circle_integrations" */
+  ['circle_integrations_var_samp_order_by']: {
+    circle_id?: ValueTypes['order_by'] | null;
+    id?: ValueTypes['order_by'] | null;
+  };
+  /** order by variance() on columns of table "circle_integrations" */
+  ['circle_integrations_variance_order_by']: {
+    circle_id?: ValueTypes['order_by'] | null;
+    id?: ValueTypes['order_by'] | null;
+  };
   /** columns and relationships of "circle_private" */
   ['circle_private']: AliasType<{
     /** An object relationship */
@@ -306,6 +428,19 @@ export type ValueTypes = {
       ValueTypes['epochs']
     ];
     id?: boolean;
+    integrations?: [
+      {
+        /** distinct select on columns */
+        distinct_on?: ValueTypes['circle_integrations_select_column'][] /** limit the number of rows returned */;
+        limit?:
+          | number
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?: number | null /** sort the rows by one or more columns */;
+        order_by?: ValueTypes['circle_integrations_order_by'][] /** filter the rows returned */;
+        where?: ValueTypes['circle_integrations_bool_exp'] | null;
+      },
+      ValueTypes['circle_integrations']
+    ];
     is_verified?: boolean;
     logo?: boolean;
     min_vouches?: boolean;
@@ -409,6 +544,7 @@ export type ValueTypes = {
     default_opt_in?: ValueTypes['Boolean_comparison_exp'] | null;
     epochs?: ValueTypes['epochs_bool_exp'] | null;
     id?: ValueTypes['bigint_comparison_exp'] | null;
+    integrations?: ValueTypes['circle_integrations_bool_exp'] | null;
     is_verified?: ValueTypes['Boolean_comparison_exp'] | null;
     logo?: ValueTypes['String_comparison_exp'] | null;
     min_vouches?: ValueTypes['Int_comparison_exp'] | null;
@@ -480,6 +616,9 @@ export type ValueTypes = {
     default_opt_in?: ValueTypes['order_by'] | null;
     epochs_aggregate?: ValueTypes['epochs_aggregate_order_by'] | null;
     id?: ValueTypes['order_by'] | null;
+    integrations_aggregate?:
+      | ValueTypes['circle_integrations_aggregate_order_by']
+      | null;
     is_verified?: ValueTypes['order_by'] | null;
     logo?: ValueTypes['order_by'] | null;
     min_vouches?: ValueTypes['order_by'] | null;
@@ -879,6 +1018,19 @@ export type ValueTypes = {
   };
   /** select columns of table "gift_private" */
   ['gift_private_select_column']: gift_private_select_column;
+  ['json']: unknown;
+  /** Boolean expression to compare columns of type "json". All fields are combined with logical 'AND'. */
+  ['json_comparison_exp']: {
+    _eq?: ValueTypes['json'] | null;
+    _gt?: ValueTypes['json'] | null;
+    _gte?: ValueTypes['json'] | null;
+    _in?: ValueTypes['json'][];
+    _is_null?: boolean | null;
+    _lt?: ValueTypes['json'] | null;
+    _lte?: ValueTypes['json'] | null;
+    _neq?: ValueTypes['json'] | null;
+    _nin?: ValueTypes['json'][];
+  };
   /** mutation root */
   ['mutation_root']: AliasType<{
     createUser?: [
@@ -888,6 +1040,31 @@ export type ValueTypes = {
     create_circle?: [
       { object: ValueTypes['create_circle_input'] },
       ValueTypes['create_circle_response']
+    ];
+    delete_circle_integrations?: [
+      {
+        /** filter the rows which have to be deleted */
+        where: ValueTypes['circle_integrations_bool_exp'];
+      },
+      ValueTypes['circle_integrations_mutation_response']
+    ];
+    delete_circle_integrations_by_pk?: [
+      { id: ValueTypes['bigint'] },
+      ValueTypes['circle_integrations']
+    ];
+    insert_circle_integrations?: [
+      {
+        /** the rows to be inserted */
+        objects: ValueTypes['circle_integrations_insert_input'][];
+      },
+      ValueTypes['circle_integrations_mutation_response']
+    ];
+    insert_circle_integrations_one?: [
+      {
+        /** the row to be inserted */
+        object: ValueTypes['circle_integrations_insert_input'];
+      },
+      ValueTypes['circle_integrations']
     ];
     update_circles?: [
       {
@@ -1415,6 +1592,23 @@ export type ValueTypes = {
       ValueTypes['burns']
     ];
     burns_by_pk?: [{ id: ValueTypes['bigint'] }, ValueTypes['burns']];
+    circle_integrations?: [
+      {
+        /** distinct select on columns */
+        distinct_on?: ValueTypes['circle_integrations_select_column'][] /** limit the number of rows returned */;
+        limit?:
+          | number
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?: number | null /** sort the rows by one or more columns */;
+        order_by?: ValueTypes['circle_integrations_order_by'][] /** filter the rows returned */;
+        where?: ValueTypes['circle_integrations_bool_exp'] | null;
+      },
+      ValueTypes['circle_integrations']
+    ];
+    circle_integrations_by_pk?: [
+      { id: ValueTypes['bigint'] },
+      ValueTypes['circle_integrations']
+    ];
     circle_private?: [
       {
         /** distinct select on columns */
@@ -1633,6 +1827,23 @@ export type ValueTypes = {
       ValueTypes['burns']
     ];
     burns_by_pk?: [{ id: ValueTypes['bigint'] }, ValueTypes['burns']];
+    circle_integrations?: [
+      {
+        /** distinct select on columns */
+        distinct_on?: ValueTypes['circle_integrations_select_column'][] /** limit the number of rows returned */;
+        limit?:
+          | number
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?: number | null /** sort the rows by one or more columns */;
+        order_by?: ValueTypes['circle_integrations_order_by'][] /** filter the rows returned */;
+        where?: ValueTypes['circle_integrations_bool_exp'] | null;
+      },
+      ValueTypes['circle_integrations']
+    ];
+    circle_integrations_by_pk?: [
+      { id: ValueTypes['bigint'] },
+      ValueTypes['circle_integrations']
+    ];
     circle_private?: [
       {
         /** distinct select on columns */
@@ -2702,6 +2913,53 @@ export type ModelTypes = {
   ['burns_var_samp_order_by']: GraphQLTypes['burns_var_samp_order_by'];
   /** order by variance() on columns of table "burns" */
   ['burns_variance_order_by']: GraphQLTypes['burns_variance_order_by'];
+  /** columns and relationships of "circle_integrations" */
+  ['circle_integrations']: {
+    /** An object relationship */
+    circle: ModelTypes['circles'];
+    circle_id: ModelTypes['bigint'];
+    data: ModelTypes['json'];
+    id: ModelTypes['bigint'];
+    name: string;
+    type: string;
+  };
+  /** order by aggregate values of table "circle_integrations" */
+  ['circle_integrations_aggregate_order_by']: GraphQLTypes['circle_integrations_aggregate_order_by'];
+  /** order by avg() on columns of table "circle_integrations" */
+  ['circle_integrations_avg_order_by']: GraphQLTypes['circle_integrations_avg_order_by'];
+  /** Boolean expression to filter rows from the table "circle_integrations". All fields are combined with a logical 'AND'. */
+  ['circle_integrations_bool_exp']: GraphQLTypes['circle_integrations_bool_exp'];
+  /** input type for inserting data into table "circle_integrations" */
+  ['circle_integrations_insert_input']: GraphQLTypes['circle_integrations_insert_input'];
+  /** order by max() on columns of table "circle_integrations" */
+  ['circle_integrations_max_order_by']: GraphQLTypes['circle_integrations_max_order_by'];
+  /** order by min() on columns of table "circle_integrations" */
+  ['circle_integrations_min_order_by']: GraphQLTypes['circle_integrations_min_order_by'];
+  /** response of any mutation on the table "circle_integrations" */
+  ['circle_integrations_mutation_response']: {
+    /** number of rows affected by the mutation */
+    affected_rows: number;
+    /** data from the rows affected by the mutation */
+    returning: ModelTypes['circle_integrations'][];
+  };
+  /** Ordering options when selecting data from "circle_integrations". */
+  ['circle_integrations_order_by']: GraphQLTypes['circle_integrations_order_by'];
+  /** select columns of table "circle_integrations" */
+  ['circle_integrations_select_column']: GraphQLTypes['circle_integrations_select_column'];
+  /** order by stddev() on columns of table "circle_integrations" */
+  ['circle_integrations_stddev_order_by']: GraphQLTypes['circle_integrations_stddev_order_by'];
+  /** order by stddev_pop() on columns of table "circle_integrations" */
+  ['circle_integrations_stddev_pop_order_by']: GraphQLTypes['circle_integrations_stddev_pop_order_by'];
+  /** order by stddev_samp() on columns of table "circle_integrations" */
+  ['circle_integrations_stddev_samp_order_by']: GraphQLTypes['circle_integrations_stddev_samp_order_by'];
+  /** order by sum() on columns of table "circle_integrations" */
+  ['circle_integrations_sum_order_by']: GraphQLTypes['circle_integrations_sum_order_by'];
+  /** order by var_pop() on columns of table "circle_integrations" */
+  ['circle_integrations_var_pop_order_by']: GraphQLTypes['circle_integrations_var_pop_order_by'];
+  /** order by var_samp() on columns of table "circle_integrations" */
+  ['circle_integrations_var_samp_order_by']: GraphQLTypes['circle_integrations_var_samp_order_by'];
+  /** order by variance() on columns of table "circle_integrations" */
+  ['circle_integrations_variance_order_by']: GraphQLTypes['circle_integrations_variance_order_by'];
   /** columns and relationships of "circle_private" */
   ['circle_private']: {
     /** An object relationship */
@@ -2728,6 +2986,8 @@ export type ModelTypes = {
     /** An array relationship */
     epochs: ModelTypes['epochs'][];
     id: ModelTypes['bigint'];
+    /** An array relationship */
+    integrations: ModelTypes['circle_integrations'][];
     is_verified: boolean;
     logo?: string;
     min_vouches: number;
@@ -2886,10 +3146,21 @@ export type ModelTypes = {
   ['gift_private_order_by']: GraphQLTypes['gift_private_order_by'];
   /** select columns of table "gift_private" */
   ['gift_private_select_column']: GraphQLTypes['gift_private_select_column'];
+  ['json']: any;
+  /** Boolean expression to compare columns of type "json". All fields are combined with logical 'AND'. */
+  ['json_comparison_exp']: GraphQLTypes['json_comparison_exp'];
   /** mutation root */
   ['mutation_root']: {
     createUser?: ModelTypes['createUserResponse'];
     create_circle?: ModelTypes['create_circle_response'];
+    /** delete data from the table: "circle_integrations" */
+    delete_circle_integrations?: ModelTypes['circle_integrations_mutation_response'];
+    /** delete single row from the table: "circle_integrations" */
+    delete_circle_integrations_by_pk?: ModelTypes['circle_integrations'];
+    /** insert data into the table: "circle_integrations" */
+    insert_circle_integrations?: ModelTypes['circle_integrations_mutation_response'];
+    /** insert a single row into the table: "circle_integrations" */
+    insert_circle_integrations_one?: ModelTypes['circle_integrations'];
     /** update data of the table: "circles" */
     update_circles?: ModelTypes['circles_mutation_response'];
     /** update single row of the table: "circles" */
@@ -3063,6 +3334,10 @@ export type ModelTypes = {
     burns: ModelTypes['burns'][];
     /** fetch data from the table: "burns" using primary key columns */
     burns_by_pk?: ModelTypes['burns'];
+    /** fetch data from the table: "circle_integrations" */
+    circle_integrations: ModelTypes['circle_integrations'][];
+    /** fetch data from the table: "circle_integrations" using primary key columns */
+    circle_integrations_by_pk?: ModelTypes['circle_integrations'];
     /** fetch data from the table: "circle_private" */
     circle_private: ModelTypes['circle_private'][];
     /** An array relationship */
@@ -3117,6 +3392,10 @@ export type ModelTypes = {
     burns: ModelTypes['burns'][];
     /** fetch data from the table: "burns" using primary key columns */
     burns_by_pk?: ModelTypes['burns'];
+    /** fetch data from the table: "circle_integrations" */
+    circle_integrations: ModelTypes['circle_integrations'][];
+    /** fetch data from the table: "circle_integrations" using primary key columns */
+    circle_integrations_by_pk?: ModelTypes['circle_integrations'];
     /** fetch data from the table: "circle_private" */
     circle_private: ModelTypes['circle_private'][];
     /** An array relationship */
@@ -3720,6 +3999,123 @@ export type GraphQLTypes = {
     tokens_burnt?: GraphQLTypes['order_by'];
     user_id?: GraphQLTypes['order_by'];
   };
+  /** columns and relationships of "circle_integrations" */
+  ['circle_integrations']: {
+    __typename: 'circle_integrations';
+    /** An object relationship */
+    circle: GraphQLTypes['circles'];
+    circle_id: GraphQLTypes['bigint'];
+    data: GraphQLTypes['json'];
+    id: GraphQLTypes['bigint'];
+    name: string;
+    type: string;
+  };
+  /** order by aggregate values of table "circle_integrations" */
+  ['circle_integrations_aggregate_order_by']: {
+    avg?: GraphQLTypes['circle_integrations_avg_order_by'];
+    count?: GraphQLTypes['order_by'];
+    max?: GraphQLTypes['circle_integrations_max_order_by'];
+    min?: GraphQLTypes['circle_integrations_min_order_by'];
+    stddev?: GraphQLTypes['circle_integrations_stddev_order_by'];
+    stddev_pop?: GraphQLTypes['circle_integrations_stddev_pop_order_by'];
+    stddev_samp?: GraphQLTypes['circle_integrations_stddev_samp_order_by'];
+    sum?: GraphQLTypes['circle_integrations_sum_order_by'];
+    var_pop?: GraphQLTypes['circle_integrations_var_pop_order_by'];
+    var_samp?: GraphQLTypes['circle_integrations_var_samp_order_by'];
+    variance?: GraphQLTypes['circle_integrations_variance_order_by'];
+  };
+  /** order by avg() on columns of table "circle_integrations" */
+  ['circle_integrations_avg_order_by']: {
+    circle_id?: GraphQLTypes['order_by'];
+    id?: GraphQLTypes['order_by'];
+  };
+  /** Boolean expression to filter rows from the table "circle_integrations". All fields are combined with a logical 'AND'. */
+  ['circle_integrations_bool_exp']: {
+    _and?: Array<GraphQLTypes['circle_integrations_bool_exp']>;
+    _not?: GraphQLTypes['circle_integrations_bool_exp'];
+    _or?: Array<GraphQLTypes['circle_integrations_bool_exp']>;
+    circle?: GraphQLTypes['circles_bool_exp'];
+    circle_id?: GraphQLTypes['bigint_comparison_exp'];
+    data?: GraphQLTypes['json_comparison_exp'];
+    id?: GraphQLTypes['bigint_comparison_exp'];
+    name?: GraphQLTypes['String_comparison_exp'];
+    type?: GraphQLTypes['String_comparison_exp'];
+  };
+  /** input type for inserting data into table "circle_integrations" */
+  ['circle_integrations_insert_input']: {
+    circle_id?: GraphQLTypes['bigint'];
+    data?: GraphQLTypes['json'];
+    name?: string;
+    type?: string;
+  };
+  /** order by max() on columns of table "circle_integrations" */
+  ['circle_integrations_max_order_by']: {
+    circle_id?: GraphQLTypes['order_by'];
+    id?: GraphQLTypes['order_by'];
+    name?: GraphQLTypes['order_by'];
+    type?: GraphQLTypes['order_by'];
+  };
+  /** order by min() on columns of table "circle_integrations" */
+  ['circle_integrations_min_order_by']: {
+    circle_id?: GraphQLTypes['order_by'];
+    id?: GraphQLTypes['order_by'];
+    name?: GraphQLTypes['order_by'];
+    type?: GraphQLTypes['order_by'];
+  };
+  /** response of any mutation on the table "circle_integrations" */
+  ['circle_integrations_mutation_response']: {
+    __typename: 'circle_integrations_mutation_response';
+    /** number of rows affected by the mutation */
+    affected_rows: number;
+    /** data from the rows affected by the mutation */
+    returning: Array<GraphQLTypes['circle_integrations']>;
+  };
+  /** Ordering options when selecting data from "circle_integrations". */
+  ['circle_integrations_order_by']: {
+    circle?: GraphQLTypes['circles_order_by'];
+    circle_id?: GraphQLTypes['order_by'];
+    data?: GraphQLTypes['order_by'];
+    id?: GraphQLTypes['order_by'];
+    name?: GraphQLTypes['order_by'];
+    type?: GraphQLTypes['order_by'];
+  };
+  /** select columns of table "circle_integrations" */
+  ['circle_integrations_select_column']: circle_integrations_select_column;
+  /** order by stddev() on columns of table "circle_integrations" */
+  ['circle_integrations_stddev_order_by']: {
+    circle_id?: GraphQLTypes['order_by'];
+    id?: GraphQLTypes['order_by'];
+  };
+  /** order by stddev_pop() on columns of table "circle_integrations" */
+  ['circle_integrations_stddev_pop_order_by']: {
+    circle_id?: GraphQLTypes['order_by'];
+    id?: GraphQLTypes['order_by'];
+  };
+  /** order by stddev_samp() on columns of table "circle_integrations" */
+  ['circle_integrations_stddev_samp_order_by']: {
+    circle_id?: GraphQLTypes['order_by'];
+    id?: GraphQLTypes['order_by'];
+  };
+  /** order by sum() on columns of table "circle_integrations" */
+  ['circle_integrations_sum_order_by']: {
+    circle_id?: GraphQLTypes['order_by'];
+    id?: GraphQLTypes['order_by'];
+  };
+  /** order by var_pop() on columns of table "circle_integrations" */
+  ['circle_integrations_var_pop_order_by']: {
+    circle_id?: GraphQLTypes['order_by'];
+    id?: GraphQLTypes['order_by'];
+  };
+  /** order by var_samp() on columns of table "circle_integrations" */
+  ['circle_integrations_var_samp_order_by']: {
+    circle_id?: GraphQLTypes['order_by'];
+    id?: GraphQLTypes['order_by'];
+  };
+  /** order by variance() on columns of table "circle_integrations" */
+  ['circle_integrations_variance_order_by']: {
+    circle_id?: GraphQLTypes['order_by'];
+    id?: GraphQLTypes['order_by'];
+  };
   /** columns and relationships of "circle_private" */
   ['circle_private']: {
     __typename: 'circle_private';
@@ -3759,6 +4155,8 @@ export type GraphQLTypes = {
     /** An array relationship */
     epochs: Array<GraphQLTypes['epochs']>;
     id: GraphQLTypes['bigint'];
+    /** An array relationship */
+    integrations: Array<GraphQLTypes['circle_integrations']>;
     is_verified: boolean;
     logo?: string;
     min_vouches: number;
@@ -3817,6 +4215,7 @@ export type GraphQLTypes = {
     default_opt_in?: GraphQLTypes['Boolean_comparison_exp'];
     epochs?: GraphQLTypes['epochs_bool_exp'];
     id?: GraphQLTypes['bigint_comparison_exp'];
+    integrations?: GraphQLTypes['circle_integrations_bool_exp'];
     is_verified?: GraphQLTypes['Boolean_comparison_exp'];
     logo?: GraphQLTypes['String_comparison_exp'];
     min_vouches?: GraphQLTypes['Int_comparison_exp'];
@@ -3888,6 +4287,7 @@ export type GraphQLTypes = {
     default_opt_in?: GraphQLTypes['order_by'];
     epochs_aggregate?: GraphQLTypes['epochs_aggregate_order_by'];
     id?: GraphQLTypes['order_by'];
+    integrations_aggregate?: GraphQLTypes['circle_integrations_aggregate_order_by'];
     is_verified?: GraphQLTypes['order_by'];
     logo?: GraphQLTypes['order_by'];
     min_vouches?: GraphQLTypes['order_by'];
@@ -4263,11 +4663,32 @@ export type GraphQLTypes = {
   };
   /** select columns of table "gift_private" */
   ['gift_private_select_column']: gift_private_select_column;
+  ['json']: any;
+  /** Boolean expression to compare columns of type "json". All fields are combined with logical 'AND'. */
+  ['json_comparison_exp']: {
+    _eq?: GraphQLTypes['json'];
+    _gt?: GraphQLTypes['json'];
+    _gte?: GraphQLTypes['json'];
+    _in?: Array<GraphQLTypes['json']>;
+    _is_null?: boolean;
+    _lt?: GraphQLTypes['json'];
+    _lte?: GraphQLTypes['json'];
+    _neq?: GraphQLTypes['json'];
+    _nin?: Array<GraphQLTypes['json']>;
+  };
   /** mutation root */
   ['mutation_root']: {
     __typename: 'mutation_root';
     createUser?: GraphQLTypes['createUserResponse'];
     create_circle?: GraphQLTypes['create_circle_response'];
+    /** delete data from the table: "circle_integrations" */
+    delete_circle_integrations?: GraphQLTypes['circle_integrations_mutation_response'];
+    /** delete single row from the table: "circle_integrations" */
+    delete_circle_integrations_by_pk?: GraphQLTypes['circle_integrations'];
+    /** insert data into the table: "circle_integrations" */
+    insert_circle_integrations?: GraphQLTypes['circle_integrations_mutation_response'];
+    /** insert a single row into the table: "circle_integrations" */
+    insert_circle_integrations_one?: GraphQLTypes['circle_integrations'];
     /** update data of the table: "circles" */
     update_circles?: GraphQLTypes['circles_mutation_response'];
     /** update single row of the table: "circles" */
@@ -4708,6 +5129,10 @@ export type GraphQLTypes = {
     burns: Array<GraphQLTypes['burns']>;
     /** fetch data from the table: "burns" using primary key columns */
     burns_by_pk?: GraphQLTypes['burns'];
+    /** fetch data from the table: "circle_integrations" */
+    circle_integrations: Array<GraphQLTypes['circle_integrations']>;
+    /** fetch data from the table: "circle_integrations" using primary key columns */
+    circle_integrations_by_pk?: GraphQLTypes['circle_integrations'];
     /** fetch data from the table: "circle_private" */
     circle_private: Array<GraphQLTypes['circle_private']>;
     /** An array relationship */
@@ -4763,6 +5188,10 @@ export type GraphQLTypes = {
     burns: Array<GraphQLTypes['burns']>;
     /** fetch data from the table: "burns" using primary key columns */
     burns_by_pk?: GraphQLTypes['burns'];
+    /** fetch data from the table: "circle_integrations" */
+    circle_integrations: Array<GraphQLTypes['circle_integrations']>;
+    /** fetch data from the table: "circle_integrations" using primary key columns */
+    circle_integrations_by_pk?: GraphQLTypes['circle_integrations'];
     /** fetch data from the table: "circle_private" */
     circle_private: Array<GraphQLTypes['circle_private']>;
     /** An array relationship */
@@ -5543,6 +5972,14 @@ export const enum burns_select_column {
   tokens_burnt = 'tokens_burnt',
   updated_at = 'updated_at',
   user_id = 'user_id',
+}
+/** select columns of table "circle_integrations" */
+export const enum circle_integrations_select_column {
+  circle_id = 'circle_id',
+  data = 'data',
+  id = 'id',
+  name = 'name',
+  type = 'type',
 }
 /** select columns of table "circle_private" */
 export const enum circle_private_select_column {

--- a/src/lib/zod/index.ts
+++ b/src/lib/zod/index.ts
@@ -43,6 +43,13 @@ export const uploadImageInput = z
   .object({ image_data_base64: z.string() })
   .strict();
 
+export const uploadCircleImageInput = z
+  .object({
+    id: z.number(),
+    image_data_base64: z.string(),
+  })
+  .strict();
+
 export const HasuraAdminSessionVariables = z
   .object({
     'x-hasura-role': z.literal('admin'),

--- a/src/lib/zod/index.ts
+++ b/src/lib/zod/index.ts
@@ -45,7 +45,7 @@ export const uploadImageInput = z
 
 export const uploadCircleImageInput = z
   .object({
-    id: z.number(),
+    circle_id: z.number(),
     image_data_base64: z.string(),
   })
   .strict();


### PR DESCRIPTION
Fixes #440 by implementing hasura action and FE changes for circle logo upload. Currently targeting merge into 435-hasura-upload-avatar but will move to main after that is merged. 

Test plan after deploy to staging/local:

set 
`REACT_APP_HASURA_ENABLED=true`
in .env to enable this. It's disabled by default so it doesn't disrupt production. 

1. visit the admin page  for a circle
2. click Edit settings
3. click the pencil icon on the circle logo
4. choose an image
5. click save at the bottom of the modal dialog
6. make sure it finishes ok
7.  close the modal
8. reopen the edit settings modal
7. right click on the logo now and copy the image url, open it in a new tab , should be an s3 image url
8. change the logo again (steps 3-6)
9. reload the other tab, that image should be gone/deleted now
