### PR TITLE
restoring non-graphql endpoints and adding a HASURA_ENABLED env var to re-enable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,8 @@ NODE_HASURA_URL=http://localhost:8080/v1/graphql
 TELEGRAM_BOT_TOKEN=<your Telegram testing bot token>
 IMAGES_AWS_ENDPOINT=http://s3.localhost.localstack.cloud:4566
 IMAGES_AWS_BUCKET=coordinape
+# this forces the FE to use Hasura instead of laravel for the endpoints that have been converted
+REACT_APP_HASURA_ENABLED=true
 
 # Staging Environment
 #REACT_APP_API_BASE_URL=https://staging-api.coordinape.com/api

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -36,6 +36,8 @@ export const REACT_APP_HASURA_URL = getEnvValue(
   'https://missing-hasura-url.edu'
 );
 
+export const HASURA_ENABLED = process.env.REACT_APP_HASURA_ENABLED === 'true';
+
 // Unused in practice
 export const REACT_APP_FORTMATIC_API_KEY = 'unused'; // getEnvValue('REACT_APP_FORTMATIC_API_KEY', 'no-formatic-api-key');
 export const REACT_APP_PORTIS_DAPP_ID = 'unused'; // getEnvValue('REACT_APP_PORTIS_DAPP_ID', 'no-portis-api-key');

--- a/src/hooks/useApiWithProfile.ts
+++ b/src/hooks/useApiWithProfile.ts
@@ -3,7 +3,7 @@
 import { getGql } from 'lib/gql';
 
 import { fileToBase64 } from '../lib/base64';
-import { REACT_APP_HASURA_URL } from 'config/env';
+import { REACT_APP_HASURA_URL, HASURA_ENABLED } from 'config/env';
 import { useApiBase } from 'hooks';
 import { getApiService, getAuthToken } from 'services/api';
 
@@ -48,7 +48,11 @@ export const useApiWithProfile = () => {
     () => async (newAvatar: File) => {
       // TODO: ideally we would use useTypedMutation instead of this but I couldn't get the variables to work w/ mutation -CryptoGraffe
       const image_data_base64 = await fileToBase64(newAvatar);
-      await api.updateProfileAvatar(image_data_base64);
+      if (HASURA_ENABLED) {
+        await api.updateProfileAvatar(image_data_base64);
+      } else {
+        await getApiService().uploadAvatar(newAvatar);
+      }
       await fetchManifest();
     },
     []
@@ -57,7 +61,11 @@ export const useApiWithProfile = () => {
   const updateBackground = useRecoilLoadCatch(
     () => async (newAvatar: File) => {
       const image_data_base64 = await fileToBase64(newAvatar);
-      await api.updateProfileBackground(image_data_base64);
+      if (HASURA_ENABLED) {
+        await api.updateProfileBackground(image_data_base64);
+      } else {
+        await getApiService().uploadBackground(newAvatar);
+      }
       await fetchManifest();
     },
     []

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -229,6 +229,23 @@ export class APIService {
     return response.data;
   };
 
+  postProfileUpload = async (file: File, endpoint: string) => {
+    const formData = new FormData();
+    formData.append('file', file);
+    const response = await this.axios.post(`/v2/${endpoint}`, formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+    return response.data;
+  };
+
+  uploadAvatar = async (file: File): Promise<any> =>
+    this.postProfileUpload(file, 'upload-avatar');
+
+  uploadBackground = async (file: File): Promise<any> =>
+    this.postProfileUpload(file, 'upload-background');
+
   postTeammates = async (
     circleId: number,
     teammates: number[]


### PR DESCRIPTION
Follow the test plan from #547 to verify this works with laravel, but realy this needs to be tested in prod, which does not have hasura configured properly. 