### PR TITLE
Port Vouching to Hasura

### DIFF
--- a/api-lib/HttpError.ts
+++ b/api-lib/HttpError.ts
@@ -6,6 +6,7 @@ export interface HttpError extends Error {
 }
 
 export class InternalServerError extends Error implements HttpError {
+  // TODO: it seems like hasura doesn't like 500s so we should pick a 4xx as the default error
   httpStatus = 500;
 }
 
@@ -13,19 +14,35 @@ export class PayloadTooLargeError extends Error implements HttpError {
   httpStatus = 413;
 }
 
-export function ErrorResponse(res: VercelResponse, error: any): VercelResponse {
-  const statusCode = error.httpStatus || 500;
-  return ErrorResponseWithStatusCode(res, error, statusCode);
+export class NotFoundError extends Error {
+  httpStatus = 404;
 }
 
-export function ErrorResponseWithStatusCode(
+export class ForbiddenError extends Error {
+  httpStatus = 403;
+}
+
+export class BadRequestError extends Error {
+  httpStatus = 400;
+}
+
+export function errorResponse(res: VercelResponse, error: any): VercelResponse {
+  const statusCode = error.httpStatus || 500;
+  return errorResponseWithStatusCode(res, error, statusCode);
+}
+
+export function errorResponseWithStatusCode(
   res: VercelResponse,
   error: any,
   statusCode: number
 ): VercelResponse {
   return res.status(statusCode).json({
-    error: `${statusCode}`,
     message: error.message || 'Unexpected error',
+    // included at this level for backwards compat w/ older hasura, perhaps can remove
+    code: `${statusCode}`,
+    extensions: {
+      code: `${statusCode}`,
+    },
   });
 }
 

--- a/api-lib/event_triggers/refundPendingGift.ts
+++ b/api-lib/event_triggers/refundPendingGift.ts
@@ -4,7 +4,7 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 
 import { ValueTypes } from '../../src/lib/gql/__generated__/zeusAdmin';
 import { gql } from '../Gql';
-import { ErrorResponse } from '../HttpError';
+import { errorResponse } from '../HttpError';
 import { EventTriggerPayload } from '../types';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -161,7 +161,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       results.push(newNonReceiverResult);
     }
   } catch (e) {
-    ErrorResponse(res, e);
+    errorResponse(res, e);
   }
 
   res.status(200).json({

--- a/api-lib/event_triggers/utils/handleVouchMsg.ts
+++ b/api-lib/event_triggers/utils/handleVouchMsg.ts
@@ -1,0 +1,41 @@
+import { gql } from '../../Gql';
+import { NotFoundError } from '../../HttpError';
+import { sendSocialMessage } from '../../sendSocialMessage';
+import { EventTriggerPayload } from '../../types';
+
+export default async function handleVouchMsg(
+  payload: EventTriggerPayload<'vouches', 'INSERT'>,
+  channels: { discord?: boolean; telegram?: boolean }
+) {
+  const {
+    event: { data },
+  } = payload;
+
+  // Unfortunately we have to look the vouch/voucher up here because the relationships aren't sent in the event
+  const { vouches } = await gql.getExistingVouch(
+    data.new.nominee_id,
+    data.new.voucher_id
+  );
+
+  const vouch = vouches.pop();
+  if (!vouch?.voucher) {
+    throw new NotFoundError('voucher not found');
+  }
+
+  const nomineeId = data.new.nominee_id;
+
+  const { nominees_by_pk } = await gql.getNominee(nomineeId);
+  if (!nominees_by_pk) {
+    throw 'nominee not found ' + nomineeId;
+  }
+
+  // announce the vouching
+  await sendSocialMessage({
+    message: `${nominees_by_pk.name} has been vouched for by ${vouch.voucher.name}!`,
+    circleId: nominees_by_pk.circle_id,
+    sanitize: true,
+    channels,
+  });
+
+  return true;
+}

--- a/api-lib/event_triggers/vouchDiscord.ts
+++ b/api-lib/event_triggers/vouchDiscord.ts
@@ -1,0 +1,18 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+import { errorResponse } from '../HttpError';
+import { EventTriggerPayload } from '../types';
+
+import handleVouchMsg from './utils/handleVouchMsg';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  try {
+    const payload: EventTriggerPayload<'vouches', 'INSERT'> = req.body;
+    const sent = await handleVouchMsg(payload, { discord: true });
+    res.status(200).json({
+      message: `Discord message ${sent ? 'sent' : 'not sent'}`,
+    });
+  } catch (e) {
+    return errorResponse(res, e);
+  }
+}

--- a/api-lib/event_triggers/vouchTelegram.ts
+++ b/api-lib/event_triggers/vouchTelegram.ts
@@ -1,0 +1,18 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+import { errorResponse } from '../HttpError';
+import { EventTriggerPayload } from '../types';
+
+import handleVouchMsg from './utils/handleVouchMsg';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  try {
+    const payload: EventTriggerPayload<'vouches', 'INSERT'> = req.body;
+    const sent = await handleVouchMsg(payload, { telegram: true });
+    return res.status(200).json({
+      message: `Telegram message ${sent ? 'sent' : 'not sent'}`,
+    });
+  } catch (e) {
+    return errorResponse(res, e);
+  }
+}

--- a/api-lib/findUser.ts
+++ b/api-lib/findUser.ts
@@ -3,8 +3,8 @@ import assert from 'assert';
 import { gql } from './Gql';
 
 export const getUserFromProfileId = async (
-    profileId: number,
-    circleId: number
+  profileId: number,
+  circleId: number
 ) => {
   const { profiles_by_pk } = await gql.q('query')({
     profiles_by_pk: [
@@ -21,6 +21,7 @@ export const getUserFromProfileId = async (
           {
             id: true,
             role: true,
+            name: true,
             address: true,
             circle_id: true,
             give_token_remaining: true,
@@ -40,10 +41,7 @@ export const getUserFromProfileId = async (
   return user;
 };
 
-export const getUserFromAddress = async (
-    address: string,
-    circleId: number
-) => {
+export const getUserFromAddress = async (address: string, circleId: number) => {
   const { users } = await gql.q('query')({
     users: [
       {

--- a/api-lib/ts4.5shim.ts
+++ b/api-lib/ts4.5shim.ts
@@ -1,0 +1,2 @@
+// TODO: delete this file after we upgrade to TypeScript 4.5
+export type Awaited<T> = T extends PromiseLike<infer U> ? U : T;

--- a/api/hasura/actions/adminUpdateUser.ts
+++ b/api/hasura/actions/adminUpdateUser.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 
 import { authCircleAdminMiddleware } from '../../../api-lib/circleAdmin';
 import { gql } from '../../../api-lib/Gql';
-import { ErrorResponseWithStatusCode } from '../../../api-lib/HttpError';
+import { errorResponseWithStatusCode } from '../../../api-lib/HttpError';
 import {
   adminUpdateUserSchemaInput,
   composeHasuraActionRequestBody,
@@ -41,7 +41,7 @@ async function handler(request: VercelRequest, response: VercelResponse) {
       });
 
       if (existingUserWithNewAddress) {
-        ErrorResponseWithStatusCode(
+        errorResponseWithStatusCode(
           response,
           { message: 'address exists' },
           422

--- a/api/hasura/actions/createNominee.ts
+++ b/api/hasura/actions/createNominee.ts
@@ -3,8 +3,8 @@ import { z } from 'zod';
 
 import { getUserFromAddress } from '../../../api-lib/findUser';
 import {
-  ErrorResponse,
-  ErrorResponseWithStatusCode,
+  errorResponse,
+  errorResponseWithStatusCode,
 } from '../../../api-lib/HttpError';
 import {
   insertNominee,
@@ -37,7 +37,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
       circle_id
     );
     if (!nominator) {
-      return ErrorResponseWithStatusCode(
+      return errorResponseWithStatusCode(
         res,
         { message: 'Nominator does not belong to this circle' },
         422
@@ -52,7 +52,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     // check if address already exists in the circle
     const user = await getUserFromAddress(address, circle_id);
     if (user) {
-      return ErrorResponseWithStatusCode(
+      return errorResponseWithStatusCode(
         res,
         { message: 'User with address already exists in the circle' },
         422
@@ -62,7 +62,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     // check if user exists in nominee table same circle and not ended
     const checkAddressExists = await getNomineeFromAddress(address, circle_id);
     if (checkAddressExists) {
-      return ErrorResponseWithStatusCode(
+      return errorResponseWithStatusCode(
         res,
         { message: 'User with address already exists as a nominee' },
         422
@@ -82,13 +82,13 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(200).json(nominee);
   } catch (err) {
     if (err instanceof z.ZodError) {
-      return ErrorResponseWithStatusCode(
+      return errorResponseWithStatusCode(
         res,
         { message: 'Invalid input' },
         422
       );
     }
-    return ErrorResponse(res, err);
+    return errorResponse(res, err);
   }
 }
 

--- a/api/hasura/actions/updateUser.ts
+++ b/api/hasura/actions/updateUser.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import { gql } from '../../../api-lib/Gql';
 import {
   zodParserErrorResponse,
-  ErrorResponse,
+  errorResponse,
 } from '../../../api-lib/HttpError';
 import { verifyHasuraRequestMiddleware } from '../../../api-lib/validate';
 import {
@@ -31,7 +31,7 @@ async function handler(request: VercelRequest, response: VercelResponse) {
 
     const user = await gql.getUserAndCurrentEpoch(address, circle_id);
     if (!user) {
-      return ErrorResponse(response, {
+      return errorResponse(response, {
         message: `User with address ${address} does not exist`,
         code: 422,
       });

--- a/api/hasura/actions/uploadCircleLogo.ts
+++ b/api/hasura/actions/uploadCircleLogo.ts
@@ -2,7 +2,7 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 
 import { authCircleAdminMiddleware } from '../../../api-lib/circleAdmin';
 import { gql } from '../../../api-lib/Gql';
-import { ErrorResponse } from '../../../api-lib/HttpError';
+import { errorResponse } from '../../../api-lib/HttpError';
 import { resizeCircleLogo } from '../../../api-lib/images';
 import { ImageUpdater } from '../../../api-lib/ImageUpdater';
 import {
@@ -34,7 +34,7 @@ const handler = async function (req: VercelRequest, res: VercelResponse) {
     );
     return res.status(200).json(updatedProfile);
   } catch (e: any) {
-    return ErrorResponse(res, e);
+    return errorResponse(res, e);
   }
 };
 

--- a/api/hasura/actions/uploadProfileAvatar.ts
+++ b/api/hasura/actions/uploadProfileAvatar.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
-import { ErrorResponse } from '../../../api-lib/HttpError';
+import { errorResponse } from '../../../api-lib/HttpError';
 import { resizeAvatar } from '../../../api-lib/images';
 import { ImageUpdater } from '../../../api-lib/ImageUpdater';
 import {
@@ -26,7 +26,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     );
     return res.status(200).json(updatedProfile);
   } catch (e: any) {
-    return ErrorResponse(res, e);
+    return errorResponse(res, e);
   }
 }
 

--- a/api/hasura/actions/uploadProfileBackground.ts
+++ b/api/hasura/actions/uploadProfileBackground.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
-import { ErrorResponse } from '../../../api-lib/HttpError';
+import { errorResponse } from '../../../api-lib/HttpError';
 import { resizeBackground } from '../../../api-lib/images';
 import { ImageUpdater } from '../../../api-lib/ImageUpdater';
 import {
@@ -28,7 +28,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     );
     return res.status(200).json(updatedProfile);
   } catch (e: any) {
-    return ErrorResponse(res, e);
+    return errorResponse(res, e);
   }
 }
 

--- a/api/hasura/actions/vouch.ts
+++ b/api/hasura/actions/vouch.ts
@@ -1,0 +1,153 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+import { getUserFromProfileId } from '../../../api-lib/findUser';
+import { gql } from '../../../api-lib/Gql';
+import {
+  BadRequestError,
+  errorResponse,
+  ForbiddenError,
+  InternalServerError,
+  NotFoundError,
+} from '../../../api-lib/HttpError';
+import { Awaited } from '../../../api-lib/ts4.5shim';
+import { verifyHasuraRequestMiddleware } from '../../../api-lib/validate';
+import {
+  composeHasuraActionRequestBodyWithSession,
+  HasuraUserSessionVariables,
+  vouchInput,
+} from '../../../src/lib/zod';
+
+type Voucher = Awaited<ReturnType<typeof getUserFromProfileId>>;
+type Nominee = Awaited<ReturnType<typeof getNominee>>;
+
+async function handler(req: VercelRequest, res: VercelResponse) {
+  try {
+    const {
+      input: { payload: input },
+      session_variables: sessionVariables,
+    } = composeHasuraActionRequestBodyWithSession(
+      vouchInput,
+      HasuraUserSessionVariables
+    ).parse(req.body);
+
+    const { hasuraProfileId: voucherProfileId } = sessionVariables;
+    const { nominee_id: nomineeId } = input;
+
+    // validate that this is allowed
+    const { voucher } = await validate(nomineeId, voucherProfileId);
+
+    // vouch and build user if needed
+    const updatedNominee = await vouch(nomineeId, voucher);
+
+    return res.status(200).json({ id: updatedNominee.id });
+  } catch (e: any) {
+    return errorResponse(res, e);
+  }
+}
+
+async function validate(nomineeId: number, voucherProfileId: number) {
+  // Get the nominee
+  const nominee = await getNominee(nomineeId);
+
+  // make sure circle exists
+  if (!nominee.circle) {
+    throw new NotFoundError('circle not found');
+  }
+
+  // Check if voucher exists in the same circle as the nominee
+  // TODO: this uses assert for error handling
+  const voucher = await getUserFromProfileId(
+    voucherProfileId,
+    nominee.circle_id
+  );
+
+  // If circle only allows giver to vouch, make sure voucher is a giver
+  if (nominee.circle.only_giver_vouch && voucher.non_giver) {
+    throw new ForbiddenError(
+      "voucher is a 'non-giver' so is not allowed to vouch"
+    );
+  }
+
+  // make sure the nomination period hasn't ended
+  if (nominee.ended) {
+    throw new BadRequestError('nomination has already ended for this nominee');
+  }
+
+  // TODO: could this be handled by a unique index in the vouches table?
+  // Check if voucher already has an existing vouch for the nominee
+  if (nominee.nominated_by_user_id === voucher.id) {
+    throw new ForbiddenError(
+      "voucher nominated this nominee so can't additionally vouch"
+    );
+  }
+
+  const { vouches } = await gql.getExistingVouch(nomineeId, voucher.id);
+
+  if (vouches.pop()) {
+    throw new ForbiddenError('voucher has already vouched for this nominee');
+  }
+
+  return {
+    voucher,
+  };
+}
+
+async function vouch(nomineeId: number, voucher: Voucher) {
+  // vouch for the nominee
+
+  // this inserts the vouch and also fetches the nominee with updated vouch count
+  const insert_vouches = await gql.insertVouch(nomineeId, voucher.id);
+  if (!insert_vouches?.nominee) {
+    throw new InternalServerError('unable to add vouch');
+  }
+
+  // the vouching is announced with an event trigger
+
+  const nominee = insert_vouches.nominee;
+
+  // if there are enough nominations, go ahead and add the user to the circle
+  const nomCount = nominee.nominations_aggregate.aggregate?.count || 0;
+  if (nominee.vouches_required - 1 <= nomCount) {
+    return await convertNomineeToUser(nominee);
+  }
+
+  return nominee;
+}
+
+async function convertNomineeToUser(nominee: Nominee) {
+  // Get the nominee into the user table
+  let userId = nominee.user_id;
+  if (!userId) {
+    const addedUser = await gql.insertUser(
+      nominee.address,
+      nominee.name,
+      nominee.circle_id
+    );
+    if (!addedUser) {
+      throw new InternalServerError('unable to add user');
+    }
+    userId = addedUser.id;
+  }
+
+  // The profile is automatically created by the createProfile event trigger, if needed
+
+  // attach the user id to the nominee, and mark the nomination ended
+  const updatedNominee = await gql.updateNomineeUser(nominee.id, userId);
+  if (!updatedNominee) {
+    throw new InternalServerError('unable to update nominee userId');
+  }
+
+  // the nomineeVouchedIn event handlers will run and announce the user being vouched in
+
+  return updatedNominee;
+}
+
+async function getNominee(nomineeId: number) {
+  const nom = await gql.getNominee(nomineeId);
+  if (!nom.nominees_by_pk) {
+    throw `nominee ${nomineeId} not found`;
+  }
+  return nom.nominees_by_pk;
+}
+
+export default verifyHasuraRequestMiddleware(handler);

--- a/api/hasura/event_triggers/eventManager.ts
+++ b/api/hasura/event_triggers/eventManager.ts
@@ -12,6 +12,8 @@ import optOutTelegram from '../../../api-lib/event_triggers/optOutTelegram';
 import refundGiveDiscord from '../../../api-lib/event_triggers/refundGiveDiscord';
 import refundGiveTelegram from '../../../api-lib/event_triggers/refundGiveTelegram';
 import refundPendingGift from '../../../api-lib/event_triggers/refundPendingGift';
+import vouchDiscord from '../../../api-lib/event_triggers/vouchDiscord';
+import vouchTelegram from '../../../api-lib/event_triggers/vouchTelegram';
 import { EventTriggerPayload } from '../../../api-lib/types';
 import { verifyHasuraRequestMiddleware } from '../../../api-lib/validate';
 import { GraphQLTypes } from '../../../src/lib/gql/__generated__/zeusAdmin';
@@ -33,6 +35,8 @@ const STAGING_HANDLERS: HandlerDict = {
   refundGiveTelegram,
   refundGiveDiscord,
   refundPendingGift,
+  vouchDiscord,
+  vouchTelegram,
 };
 
 async function eventHandler(req: VercelRequest, res: VercelResponse) {

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -7,6 +7,10 @@ type Mutation {
 }
 
 type Mutation {
+  createNominee(payload: CreateNomineeInput!): CreateNomineeResponse
+}
+
+type Mutation {
   createUser(payload: CreateUserInput!): UserResponse
 }
 
@@ -31,7 +35,7 @@ type Mutation {
 }
 
 type Mutation {
-  createNominee(payload: CreateNomineeInput!): CreateNomineeResponse
+  vouch(payload: VouchInput!): VouchOutput
 }
 
 input CreateCircleInput {
@@ -89,6 +93,10 @@ input UpdateUserInput {
   bio: String
 }
 
+input VouchInput {
+  nominee_id: Int!
+}
+
 type CreateCircleResponse {
   id: Int!
 }
@@ -111,4 +119,8 @@ type UserResponse {
 
 type CreateNomineeResponse {
   id: Int
+}
+
+type VouchOutput {
+  id: Int!
 }

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -96,6 +96,16 @@ actions:
   permissions:
   - role: user
   - role: superadmin
+- name: vouch
+  definition:
+    kind: synchronous
+    handler: '{{HASURA_API_BASE_URL}}/actions/vouch'
+    headers:
+    - name: verification_key
+      value_from_env: HASURA_EVENT_SECRET
+  permissions:
+  - role: user
+  - role: superadmin
 custom_types:
   enums: []
   input_objects:
@@ -106,6 +116,7 @@ custom_types:
   - name: AdminUpdateUserInput
   - name: CreateNomineeInput
   - name: UpdateUserInput
+  - name: VouchInput
   objects:
   - name: CreateCircleResponse
     relationships:
@@ -166,6 +177,16 @@ custom_types:
       field_mapping:
         id: id
   - name: CreateNomineeResponse
+    relationships:
+    - remote_table:
+        schema: public
+        name: nominees
+      name: nominee
+      source: default
+      type: object
+      field_mapping:
+        id: id
+  - name: VouchOutput
     relationships:
     - remote_table:
         schema: public

--- a/hasura/metadata/databases/default/tables/public_vouches.yaml
+++ b/hasura/metadata/databases/default/tables/public_vouches.yaml
@@ -45,3 +45,30 @@ select_permissions:
               id:
                 _eq: X-Hasura-User-Id
   role: user
+event_triggers:
+- definition:
+    enable_manual: false
+    insert:
+      columns: "*"
+  headers:
+  - name: verification_key
+    value_from_env: HASURA_EVENT_SECRET
+  name: vouchDiscord
+  retry_conf:
+    interval_sec: 3600
+    num_retries: 5
+    timeout_sec: 60
+  webhook: "{{HASURA_API_BASE_URL}}/event_triggers/eventManager"
+- definition:
+    enable_manual: false
+    insert:
+      columns: "*"
+  headers:
+  - name: verification_key
+    value_from_env: HASURA_EVENT_SECRET
+  name: vouchTelegram
+  retry_conf:
+    interval_sec: 3600
+    num_retries: 5
+    timeout_sec: 60
+  webhook: "{{HASURA_API_BASE_URL}}/event_triggers/eventManager"

--- a/src/lib/gql/__generated__/zeusAdmin/const.ts
+++ b/src/lib/gql/__generated__/zeusAdmin/const.ts
@@ -481,6 +481,14 @@ export const AllTypesProps: Record<string, any> = {
       required: true,
     },
   },
+  VouchInput: {
+    nominee_id: {
+      type: 'Int',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+  },
   bigint: 'String',
   bigint_comparison_exp: {
     _eq: {
@@ -8520,6 +8528,14 @@ export const AllTypesProps: Record<string, any> = {
     uploadProfileBackground: {
       payload: {
         type: 'UploadImageInput',
+        array: false,
+        arrayRequired: false,
+        required: true,
+      },
+    },
+    vouch: {
+      payload: {
+        type: 'VouchInput',
         array: false,
         arrayRequired: false,
         required: true,
@@ -18871,6 +18887,10 @@ export const ReturnTypes: Record<string, any> = {
     UserResponse: 'users',
     id: 'ID',
   },
+  VouchOutput: {
+    id: 'Int',
+    nominee: 'nominees',
+  },
   burns: {
     circle: 'circles',
     circle_id: 'bigint',
@@ -20018,6 +20038,7 @@ export const ReturnTypes: Record<string, any> = {
     uploadCircleLogo: 'UpdateCircleResponse',
     uploadProfileAvatar: 'UpdateProfileResponse',
     uploadProfileBackground: 'UpdateProfileResponse',
+    vouch: 'VouchOutput',
   },
   nominees: {
     address: 'String',

--- a/src/lib/gql/__generated__/zeusAdmin/index.ts
+++ b/src/lib/gql/__generated__/zeusAdmin/index.ts
@@ -164,6 +164,15 @@ export type ValueTypes = {
     id?: boolean;
     __typename?: boolean;
   }>;
+  ['VouchInput']: {
+    nominee_id: number;
+  };
+  ['VouchOutput']: AliasType<{
+    id?: boolean;
+    /** An object relationship */
+    nominee?: ValueTypes['nominees'];
+    __typename?: boolean;
+  }>;
   ['bigint']: number;
   /** Boolean expression to compare columns of type "bigint". All fields are combined with logical 'AND'. */
   ['bigint_comparison_exp']: {
@@ -4188,6 +4197,7 @@ export type ValueTypes = {
       { payload: ValueTypes['UploadImageInput'] },
       ValueTypes['UpdateProfileResponse']
     ];
+    vouch?: [{ payload: ValueTypes['VouchInput'] }, ValueTypes['VouchOutput']];
     __typename?: boolean;
   }>;
   /** columns and relationships of "nominees" */
@@ -8916,6 +8926,12 @@ export type ModelTypes = {
     UserResponse: ModelTypes['users'];
     id: string;
   };
+  ['VouchInput']: GraphQLTypes['VouchInput'];
+  ['VouchOutput']: {
+    id: number;
+    /** An object relationship */
+    nominee: ModelTypes['nominees'];
+  };
   ['bigint']: number;
   /** Boolean expression to compare columns of type "bigint". All fields are combined with logical 'AND'. */
   ['bigint_comparison_exp']: GraphQLTypes['bigint_comparison_exp'];
@@ -10701,6 +10717,7 @@ export type ModelTypes = {
     uploadCircleLogo?: ModelTypes['UpdateCircleResponse'];
     uploadProfileAvatar?: ModelTypes['UpdateProfileResponse'];
     uploadProfileBackground?: ModelTypes['UpdateProfileResponse'];
+    vouch?: ModelTypes['VouchOutput'];
   };
   /** columns and relationships of "nominees" */
   ['nominees']: {
@@ -12937,6 +12954,15 @@ export type GraphQLTypes = {
     /** An object relationship */
     UserResponse: GraphQLTypes['users'];
     id: string;
+  };
+  ['VouchInput']: {
+    nominee_id: number;
+  };
+  ['VouchOutput']: {
+    __typename: 'VouchOutput';
+    id: number;
+    /** An object relationship */
+    nominee: GraphQLTypes['nominees'];
   };
   ['bigint']: number;
   /** Boolean expression to compare columns of type "bigint". All fields are combined with logical 'AND'. */
@@ -15882,6 +15908,7 @@ export type GraphQLTypes = {
     uploadCircleLogo?: GraphQLTypes['UpdateCircleResponse'];
     uploadProfileAvatar?: GraphQLTypes['UpdateProfileResponse'];
     uploadProfileBackground?: GraphQLTypes['UpdateProfileResponse'];
+    vouch?: GraphQLTypes['VouchOutput'];
   };
   /** columns and relationships of "nominees" */
   ['nominees']: {

--- a/src/lib/gql/__generated__/zeusUser/const.ts
+++ b/src/lib/gql/__generated__/zeusUser/const.ts
@@ -449,6 +449,14 @@ export const AllTypesProps: Record<string, any> = {
       required: true,
     },
   },
+  VouchInput: {
+    nominee_id: {
+      type: 'Int',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+  },
   bigint: 'String',
   bigint_comparison_exp: {
     _eq: {
@@ -3940,6 +3948,14 @@ export const AllTypesProps: Record<string, any> = {
     uploadProfileBackground: {
       payload: {
         type: 'UploadImageInput',
+        array: false,
+        arrayRequired: false,
+        required: true,
+      },
+    },
+    vouch: {
+      payload: {
+        type: 'VouchInput',
         array: false,
         arrayRequired: false,
         required: true,
@@ -9163,6 +9179,10 @@ export const ReturnTypes: Record<string, any> = {
     UserResponse: 'users',
     id: 'ID',
   },
+  VouchOutput: {
+    id: 'Int',
+    nominee: 'nominees',
+  },
   burns: {
     circle: 'circles',
     circle_id: 'bigint',
@@ -9271,6 +9291,7 @@ export const ReturnTypes: Record<string, any> = {
     uploadCircleLogo: 'UpdateCircleResponse',
     uploadProfileAvatar: 'UpdateProfileResponse',
     uploadProfileBackground: 'UpdateProfileResponse',
+    vouch: 'VouchOutput',
   },
   nominees: {
     address: 'String',

--- a/src/lib/gql/__generated__/zeusUser/index.ts
+++ b/src/lib/gql/__generated__/zeusUser/index.ts
@@ -151,6 +151,15 @@ export type ValueTypes = {
     id?: boolean;
     __typename?: boolean;
   }>;
+  ['VouchInput']: {
+    nominee_id: number;
+  };
+  ['VouchOutput']: AliasType<{
+    id?: boolean;
+    /** An object relationship */
+    nominee?: ValueTypes['nominees'];
+    __typename?: boolean;
+  }>;
   ['bigint']: number;
   /** Boolean expression to compare columns of type "bigint". All fields are combined with logical 'AND'. */
   ['bigint_comparison_exp']: {
@@ -1168,6 +1177,7 @@ export type ValueTypes = {
       { payload: ValueTypes['UploadImageInput'] },
       ValueTypes['UpdateProfileResponse']
     ];
+    vouch?: [{ payload: ValueTypes['VouchInput'] }, ValueTypes['VouchOutput']];
     __typename?: boolean;
   }>;
   /** columns and relationships of "nominees" */
@@ -2931,6 +2941,12 @@ export type ModelTypes = {
     UserResponse: ModelTypes['users'];
     id: string;
   };
+  ['VouchInput']: GraphQLTypes['VouchInput'];
+  ['VouchOutput']: {
+    id: number;
+    /** An object relationship */
+    nominee: ModelTypes['nominees'];
+  };
   ['bigint']: number;
   /** Boolean expression to compare columns of type "bigint". All fields are combined with logical 'AND'. */
   ['bigint_comparison_exp']: GraphQLTypes['bigint_comparison_exp'];
@@ -3219,6 +3235,7 @@ export type ModelTypes = {
     uploadCircleLogo?: ModelTypes['UpdateCircleResponse'];
     uploadProfileAvatar?: ModelTypes['UpdateProfileResponse'];
     uploadProfileBackground?: ModelTypes['UpdateProfileResponse'];
+    vouch?: ModelTypes['VouchOutput'];
   };
   /** columns and relationships of "nominees" */
   ['nominees']: {
@@ -3927,6 +3944,15 @@ export type GraphQLTypes = {
     /** An object relationship */
     UserResponse: GraphQLTypes['users'];
     id: string;
+  };
+  ['VouchInput']: {
+    nominee_id: number;
+  };
+  ['VouchOutput']: {
+    __typename: 'VouchOutput';
+    id: number;
+    /** An object relationship */
+    nominee: GraphQLTypes['nominees'];
   };
   ['bigint']: number;
   /** Boolean expression to compare columns of type "bigint". All fields are combined with logical 'AND'. */
@@ -4777,6 +4803,7 @@ export type GraphQLTypes = {
     uploadCircleLogo?: GraphQLTypes['UpdateCircleResponse'];
     uploadProfileAvatar?: GraphQLTypes['UpdateProfileResponse'];
     uploadProfileBackground?: GraphQLTypes['UpdateProfileResponse'];
+    vouch?: GraphQLTypes['VouchOutput'];
   };
   /** columns and relationships of "nominees" */
   ['nominees']: {

--- a/src/lib/zod/index.ts
+++ b/src/lib/zod/index.ts
@@ -81,6 +81,12 @@ export const uploadCircleImageInput = z
   })
   .strict();
 
+export const vouchInput = z
+  .object({
+    nominee_id: z.number(),
+  })
+  .strict();
+
 export const HasuraAdminSessionVariables = z
   .object({
     'x-hasura-role': z.literal('admin'),


### PR DESCRIPTION
Fixes #519 by porting vouching to hasura. 

To test: 

1. have a bearer token set up in hasura console for a user in circle_id 6
2. run mutation for a user who is nominated but needs vouching. I used this: 
```

mutation MyMutation {
  vouch(payload: {circle_id: 6, nominee_id: 61}) {
    nominee {
      address
      ended
    }
  }
}
```
should return ended false

3. run again and should get a dupe error
4. go into sql or use a mutation to fudge the user id of the vouch, i ran `update vouches set voucher_id=607;` where my real userid is 606
5. run vouch mutation again, now ended should be true and user is in the circle (i just verified in DB cuz UI is giving me hell)