### PR TITLE
Refactor refundPendingGift Event Trigger

### DIFF
--- a/hasura/metadata/databases/default/tables/public_pending_token_gifts.yaml
+++ b/hasura/metadata/databases/default/tables/public_pending_token_gifts.yaml
@@ -99,19 +99,3 @@ event_triggers:
     num_retries: 5
     timeout_sec: 60
   webhook: "{{HASURA_API_BASE_URL}}/event_triggers/refundGiveTelegram"
-- definition:
-    delete:
-      columns: "*"
-    enable_manual: false
-    update:
-      columns:
-      - tokens
-  headers:
-  - name: verification_key
-    value_from_env: HASURA_EVENT_SECRET
-  name: refundPendingGift
-  retry_conf:
-    interval_sec: 10
-    num_retries: 5
-    timeout_sec: 60
-  webhook: "{{HASURA_API_BASE_URL}}/event_triggers/refundPendingGift"

--- a/hasura/metadata/databases/default/tables/public_users.yaml
+++ b/hasura/metadata/databases/default/tables/public_users.yaml
@@ -146,3 +146,18 @@ event_triggers:
     num_retries: 5
     timeout_sec: 60
   webhook: "{{HASURA_API_BASE_URL}}/event_triggers/optOutTelegram"
+- definition:
+    enable_manual: false
+    update:
+      columns:
+      - non_giver
+      - non_receiver
+  headers:
+  - name: verification_key
+    value_from_env: HASURA_EVENT_SECRET
+  name: refundPendingGift
+  retry_conf:
+    interval_sec: 10
+    num_retries: 5
+    timeout_sec: 60
+  webhook: "{{HASURA_API_BASE_URL}}/event_triggers/refundPendingGift"

--- a/src/lib/gql/GqlHasuraAdmin.ts
+++ b/src/lib/gql/GqlHasuraAdmin.ts
@@ -132,6 +132,8 @@ export class Gql {
             {
               id: true,
               epoch_id: true,
+              sender_id: true,
+              sender_address: true,
               recipient_id: true,
               recipient_address: true,
               note: true,
@@ -146,6 +148,8 @@ export class Gql {
               epoch_id: true,
               sender_id: true,
               sender_address: true,
+              recipient_id: true,
+              recipient_address: true,
               note: true,
               tokens: true,
             },


### PR DESCRIPTION
I was really not a fan of my initial work on this and refactored it
in preparation for the non-admin `updateUser` action.
so:
- the separation of concerns is cleaner
- all accounting updates are atomic and clean
- it's still an nice idiomatic business logic event handler

Now all changes occur in a single transaction when a user is
updated to be non_giver or non_receiver. This includes refunds to or
from counterparties who have either given or received tokens from the
modifier user.

Additionally, no pending_gift or give_token accounting logic leaks
from this event handler. Anything related to GIVE token accounting
during and user updates is handled here.

test plan:
0. purge all seeded pending gifts for a chosen epoch from the pending_token
   gifts table. If you don't do this, the accounting won't balance with your
   allocations.
1. allocate GIVE to four user during an epoch in the UI. add a note for
   two of them.
2. run adminUpdateUser `non_receiver: true` on 1 user with and 1 user without
   a note. Verify that the pending_token_gift with the note is not
   delete, but set to 0, while the other entry is deleted.
3. run adminUpdateUser `non_giver: true` on your user in the circle and
   verify the same behavior with the notes.
4. check the balances of all involved users and ensure they have
   returned to their original values.