### PR TITLE
Small Simplication of the adminUpdateUser mutation

### DIFF
--- a/api/hasura/actions/adminUpdateUser.ts
+++ b/api/hasura/actions/adminUpdateUser.ts
@@ -77,20 +77,13 @@ async function handler(request: VercelRequest, response: VercelResponse) {
             address: input.new_address,
             // set remaining tokens to starting tokens if starting tokens
             // has been changed.
-            give_token_remaining:
-              input.starting_tokens ?? user.give_token_remaining,
+            give_token_remaining: input.starting_tokens,
             // fixed_non_receiver === true is also set for non_receiver
             non_receiver: input.fixed_non_receiver || input.non_receiver,
           },
           where: {
-            _and: [
-              { circle_id: { _eq: circle_id } },
-              {
-                address: {
-                  _ilike: address,
-                },
-              },
-            ],
+            circle_id: { _eq: circle_id },
+            address: { _ilike: address },
           },
         },
         {


### PR DESCRIPTION
The logic was unnecessarily complex so I cut those pieces out.
It is functionally identical, except it now doesn't touch the
give_token_remaining column if there is no change to make.

merge plan: merge to hasura-next after #590 is merged