### PR TITLE
Update own user

### DIFF
--- a/api-lib/HttpError.ts
+++ b/api-lib/HttpError.ts
@@ -1,4 +1,5 @@
 import { VercelResponse } from '@vercel/node';
+import { ZodIssue } from 'zod';
 
 export interface HttpError extends Error {
   httpStatus: number;
@@ -25,5 +26,16 @@ export function ErrorResponseWithStatusCode(
   return res.status(statusCode).json({
     error: `${statusCode}`,
     message: error.message || 'Unexpected error',
+  });
+}
+
+export function zodParserErrorResponse(
+  res: VercelResponse,
+  issues: ZodIssue[]
+): VercelResponse {
+  return res.status(422).json({
+    extensions: issues,
+    message: 'Invalid input',
+    code: '422',
   });
 }

--- a/api/hasura/actions/updateUser.ts
+++ b/api/hasura/actions/updateUser.ts
@@ -1,0 +1,90 @@
+import assert from 'assert';
+
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { z } from 'zod';
+
+import { gql } from '../../../api-lib/Gql';
+import { verifyHasuraRequestMiddleware } from '../../../api-lib/validate';
+import {
+  updateUserSchemaInput,
+  composeHasuraActionRequestBodyWithSession,
+  HasuraUserSessionVariables,
+} from '../../../src/lib/zod';
+
+async function handler(request: VercelRequest, response: VercelResponse) {
+  try {
+    const {
+      session_variables,
+      input: { payload },
+    } = composeHasuraActionRequestBodyWithSession(
+      updateUserSchemaInput,
+      HasuraUserSessionVariables
+    ).parse(request.body);
+
+    // Validate no epoches are active for the requested user
+    const { circle_id } = payload;
+    const { hasuraAddress: address } = session_variables;
+
+    const user = await gql.getUserAndCurrentEpoch(address, circle_id);
+    if (!user) {
+      return response.status(422).json({
+        message: `User with address ${address} does not exist`,
+        code: '422',
+      });
+    }
+
+    // Update the state after all external validations have passed
+
+    const mutationResult = await gql.q('mutation')({
+      update_users: [
+        {
+          _set: {
+            ...payload,
+            // reset give_token_received if a user is opted out of an
+            // active epoch
+            give_token_received:
+              user.fixed_non_receiver || payload.non_receiver
+                ? 0
+                : user.give_token_received,
+            // fixed_non_receiver === true is also set for non_receiver
+            non_receiver: user.fixed_non_receiver || payload.non_receiver,
+          },
+          where: {
+            _and: [
+              { circle_id: { _eq: circle_id } },
+              {
+                address: {
+                  _ilike: address,
+                },
+              },
+            ],
+          },
+        },
+        {
+          returning: {
+            id: true,
+          },
+        },
+      ],
+    });
+
+    const returnResult = mutationResult.update_users?.returning.pop();
+    assert(returnResult, 'No return from mutation');
+
+    response.status(200).json(returnResult);
+    return;
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      response.status(422).json({
+        extensions: err.issues,
+        message: 'Invalid input',
+        code: '422',
+      });
+      return;
+    }
+    // throw unexpected errors to be caught by the outer 500-level response
+    throw err;
+  }
+}
+
+export default verifyHasuraRequestMiddleware(handler);

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -15,6 +15,10 @@ type Mutation {
 }
 
 type Mutation {
+  updateUser(payload: UpdateUserInput!): UserResponse
+}
+
+type Mutation {
   uploadCircleLogo(payload: UploadCircleImageInput!): UpdateCircleResponse
 }
 
@@ -75,6 +79,14 @@ input CreateNomineeInput {
   circle_id: Int!
   address: String!
   description: String!
+}
+
+input UpdateUserInput {
+  circle_id: Int!
+  name: String
+  non_receiver: Boolean
+  epoch_first_visit: Boolean
+  bio: String
 }
 
 type CreateCircleResponse {

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -52,6 +52,17 @@ actions:
   permissions:
   - role: superadmin
   - role: user
+- name: updateUser
+  definition:
+    kind: synchronous
+    handler: '{{HASURA_API_BASE_URL}}/actions/updateUser'
+    headers:
+    - name: verification_key
+      value_from_env: HASURA_EVENT_SECRET
+  permissions:
+  - role: superadmin
+  - role: user
+  comment: Update own user
 - name: uploadCircleLogo
   definition:
     kind: synchronous
@@ -94,6 +105,7 @@ custom_types:
   - name: UploadCircleImageInput
   - name: AdminUpdateUserInput
   - name: CreateNomineeInput
+  - name: UpdateUserInput
   objects:
   - name: CreateCircleResponse
     relationships:

--- a/src/lib/zod/index.ts
+++ b/src/lib/zod/index.ts
@@ -40,8 +40,16 @@ export const createNomineeInputSchema = z
   })
   .strict();
 
-// this shape mirrors the shape of the original rest endpoint
-// it might be preferable to fold circle_id into the object
+export const updateUserSchemaInput = z
+  .object({
+    circle_id: z.number(),
+    name: z.string().min(3).max(255).optional(),
+    non_receiver: z.boolean().optional(),
+    epoch_first_visit: z.boolean().optional(),
+    bio: z.string().optional(),
+  })
+  .strict();
+
 export const createUserSchemaInput = z
   .object({
     circle_id: z.number(),


### PR DESCRIPTION
This endpoint itself doesn't handle any GIVE token accounting when `non_receiver` is
set from `false` to `true`. This is handled by the already-tested `PendingGiftRefund`
event trigger.

fixes #564

# Test Plan

1. grab a token from the browser interface and add it in the hasura graphiql explorer
2. disable the `x-hasura-admin-secret` and enable your user-level `Authorization` header with the token as the payload.
3. Execute the following command and observe that all changes are set in the database:
    ```gql
    mutation UpdateOwnUserTest {
      Me: updateUser(payload: {
        circle_id: 3
        non_receiver: false
        bio: "Yo wassup"
        name: "Bob"
      }) {
        id
        UserResponse {
         address
         non_receiver
         bio
         name
        }
      }
   }
   ```

4. Observe the following return
    ```json
    {
      "data": {
        "Me": {
          "id": 603,
          "UserResponse": {
            "address": "0xbfc7cae0fad9b346270ae8fde24827d2d779ef07",
            "non_receiver": false,
            "name": "Bob",
            "bio": "Yo wassup"
          }
        }
      }
    }
   ```


The one caveat here is that `non_receiver` should return `true` if `fixed_non_receiver` is already `true`. Also, input validation on name length, and the required circle_id input are worth testing out.