### PR TITLE
Quickfix for Seeding the DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,11 @@ Stack: **React**, **Hasura** graphql server & **vercel** serverless functions
 - `yarn docker:start` - Start **laravel** legacy backend, **Hasura** and **postgres**
   - Clear the data stored in the docker volumes: `yarn docker:clean`
   - First time laravel is slow.
+- `yarn db-seed-fresh` - Seed the db w/ dummy data
+  > ⚠️ Don't seed the database with `vercel dev` running
 - `vercel dev`
   - First time setup: `Want to override the settings`? `Y`
   - Runs React and the serverless functions in `api/`
-- `yarn db-seed-fresh` - Seed the db w/ dummy data
 - Goto: http://localhost:3000 and starting giving!
 
 ### Storybook


### PR DESCRIPTION
Seeding the db with the vercel dev stateless functions causes a ton
of database events to be thrown, which eats up the processor and a ton
of memory. Typical options when this happens include either (a)
  restarting the machine or (b) waiting for the everything to pass.

This is obviously not a great solution, and a more resilient solution
should/could be implemented by refactoring the db-seed scripts to yield
sql-based hasura seeds, but this requires more discussion around what a
desirable seed script would be.

Test plan:

Try out this sequence for yourself and ensure your machine doesn't go
haywire.