### PR TITLE
don't re-render all ProfileCards on every allocation change

### DIFF
--- a/src/components/ProfileCard/ProfileCard.tsx
+++ b/src/components/ProfileCard/ProfileCard.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { useRecoilState } from 'recoil';
+
 import { makeStyles, Button } from '@material-ui/core';
 
 import { ReactComponent as EditProfileSVG } from 'assets/svgs/button/edit-profile.svg';
@@ -13,6 +15,7 @@ import {
 } from 'components';
 import { USER_ROLE_ADMIN, USER_ROLE_COORDINAPE } from 'config/constants';
 import { useNavigation } from 'hooks';
+import { rLocalGift } from 'recoilState';
 import { useSetEditProfileOpen } from 'recoilState/ui';
 import { EXTERNAL_URL_FEEDBACK } from 'routes/paths';
 
@@ -104,20 +107,12 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-type TUpdateGift = ({
-  note,
-  tokens,
-}: {
-  note?: string;
-  tokens?: number;
-}) => void;
-
-export const ProfileCard = ({
+const ProfileCardInner = ({
   user,
   tokens,
   note,
   disabled,
-  updateGift,
+  circleId,
   isMe,
   tokenName,
 }: {
@@ -125,7 +120,7 @@ export const ProfileCard = ({
   tokens: number;
   note: string;
   disabled?: boolean;
-  updateGift?: TUpdateGift;
+  circleId: number;
   isMe?: boolean;
   tokenName: string;
 }) => {
@@ -138,6 +133,16 @@ export const ProfileCard = ({
 
   const hideUserBio =
     (userBioTextLength > 93 && skillsLength > 2) || userBioTextLength > 270;
+
+  const [gift, setGift] = useRecoilState(rLocalGift(user.id, circleId));
+
+  const updateGift = ({ note, tokens }: { note?: string; tokens?: number }) => {
+    setGift({
+      user,
+      note: note || gift.note || '',
+      tokens: tokens || gift.tokens || 0,
+    });
+  };
 
   return (
     <div className={classes.root}>
@@ -159,7 +164,9 @@ export const ProfileCard = ({
               },
               {
                 label: 'View Profile',
-                onClick: getToProfile({ address: isMe ? 'me' : user.address }),
+                onClick: getToProfile({
+                  address: isMe ? 'me' : user.address,
+                }),
               },
             ]}
           />
@@ -203,7 +210,7 @@ export const ProfileCard = ({
         )}
       </div>
 
-      {!disabled && updateGift && (
+      {!disabled && !isMe && (
         <GiftInput
           tokens={
             user.fixed_non_receiver || user.non_receiver ? undefined : tokens
@@ -241,3 +248,6 @@ export const ProfileCard = ({
     </div>
   );
 };
+
+export const ProfileCard = React.memo(ProfileCardInner);
+ProfileCard.displayName = 'ProfileCard';

--- a/src/hooks/useAllocation.ts
+++ b/src/hooks/useAllocation.ts
@@ -56,7 +56,6 @@ export const useAllocation = (circleId: number) => {
 
   const [completedSteps] = useRecoilValue(rAllocationStepStatus(circleId));
   const availableTeammates = useRecoilValue(rAvailableTeammates);
-  const usersMap = useRecoilValue(rUsersMap);
   const localTeammatesChanged = useRecoilValue(
     rLocalTeammatesChanged(circleId)
   );
@@ -112,31 +111,6 @@ export const useAllocation = (circleId: number) => {
     }
     setLocalTeammates([]);
     setLocalGifts(getLocalGiftUpdater([]));
-  };
-
-  const updateGift = (
-    id: number,
-    { note, tokens }: { note?: string; tokens?: number }
-  ) => {
-    const idx = localGifts.findIndex(g => g.user.id === id);
-    const original = localGifts[idx];
-    const user = usersMap.get(id);
-    if (!user) {
-      throw `User ${id} not found in userMap`;
-    }
-    if (idx === -1) {
-      return [
-        ...localGifts,
-        { user, tokens: tokens ?? 0, note: note ?? '' } as ISimpleGift,
-      ];
-    }
-    const copy = localGifts.slice();
-    copy[idx] = {
-      user,
-      tokens: Math.max(0, tokens !== undefined ? tokens : original.tokens),
-      note: note !== undefined ? note : original.note,
-    };
-    setLocalGifts(copy);
   };
 
   const rebalanceGifts = () => {
@@ -212,7 +186,6 @@ export const useAllocation = (circleId: number) => {
     rebalanceGifts,
     saveGifts,
     saveTeammates,
-    updateGift,
   };
 };
 

--- a/src/pages/AllocationPage/AllocationGive.tsx
+++ b/src/pages/AllocationPage/AllocationGive.tsx
@@ -181,7 +181,7 @@ const AllocationGive = () => {
     circle: selectedCircle,
   } = useSelectedCircle();
 
-  const { givePerUser, localGifts, updateGift } = useAllocation(circleId);
+  const { givePerUser, localGifts } = useAllocation(circleId);
   const [orderType, setOrderType] = useState<OrderType>(OrderType.Alphabetical);
   const [filterType, setFilterType] = useState<number>(0);
 
@@ -262,6 +262,7 @@ const AllocationGive = () => {
           note=""
           isMe
           tokenName={myUser.circle.tokenName}
+          circleId={myUser.circle_id}
         />
         {localGifts
           .map(g => g.user)
@@ -299,9 +300,7 @@ const AllocationGive = () => {
               note={givePerUser.get(user.id)?.note || ''}
               tokens={givePerUser.get(user.id)?.tokens || 0}
               tokenName={myUser.circle.tokenName}
-              updateGift={(update: { note?: string; tokens?: number }) =>
-                updateGift(user.id, update)
-              }
+              circleId={myUser.circle.id}
               user={user}
             />
           ))}


### PR DESCRIPTION
1. wrap ProfileCard in React.memo

2. prevent ProfileCard's props from changing unnecessarily
    - we can't pass updateGift from the useAllocation hook to ProfileCard, because it's redefined every time any user's allocation or note is changed, causing all ProfileCards to re-render
    - instead, I created a new selectorFamily in order to give each ProfileCard a setter that's scoped to its user, so it only re-renders when its own user changes