### PR TITLE
Add Discord Support to Creat Circle Form

### DIFF
--- a/src/components/ApeTextField/ApeTextField.tsx
+++ b/src/components/ApeTextField/ApeTextField.tsx
@@ -22,6 +22,7 @@ type ApeTextVariantType = typeof ApeTextVariants[keyof typeof ApeTextVariants];
 
 interface ApeTextStyleProps {
   infoTooltip?: React.ReactNode;
+  subtitle?: React.ReactNode;
   apeVariant?: ApeTextVariantType;
 }
 
@@ -33,6 +34,7 @@ export type ApeTextFieldProps = TextFieldProps & ApeTextStyleProps;
 
 export const ApeTextField = ({
   infoTooltip,
+  subtitle,
   apeVariant = 'default',
   ...props
 }: ApeTextFieldProps) => {
@@ -141,6 +143,7 @@ export const ApeTextField = ({
           {infoTooltip && <ApeInfoTooltip>{infoTooltip}</ApeInfoTooltip>}
         </label>
       )}
+      {subtitle && <label className={classes.subLabel}>{subtitle}</label>}
       <InputBase {...mergedInputProps} />
       <div className={classes.helperBox}>
         {helperText && (
@@ -212,11 +215,18 @@ const useBaseStyles = makeStyles<Theme, { variant: ApeTextVariantType }>(
       fontSize: 16,
       lineHeight: 1.3,
       fontWeight: 700,
-      marginBottom: theme.spacing(1),
+      // marginBottom: theme.spacing(1),
       color: theme.colors.text,
       ...apeVariants(theme, variant)?.label,
     }),
+    subLabel: {
+      padding: theme.spacing(0, 0, 1),
+      fontSize: 15,
+      lineHeight: 1,
+      color: theme.colors.text + '80',
+    },
     inputRoot: ({ variant }) => ({
+      margin: theme.spacing(1),
       backgroundColor: theme.colors.third,
       borderRadius: 8,
       color: theme.colors.text,

--- a/src/components/ApeTextField/ApeTextField.tsx
+++ b/src/components/ApeTextField/ApeTextField.tsx
@@ -215,7 +215,6 @@ const useBaseStyles = makeStyles<Theme, { variant: ApeTextVariantType }>(
       fontSize: 16,
       lineHeight: 1.3,
       fontWeight: 700,
-      // marginBottom: theme.spacing(1),
       color: theme.colors.text,
       ...apeVariants(theme, variant)?.label,
     }),

--- a/src/forms/CreateCircleForm.tsx
+++ b/src/forms/CreateCircleForm.tsx
@@ -18,7 +18,7 @@ const schema = z
     // TODO: Implment nested fields in createForm
     // Research Questions
     research_org_link: z.string(),
-    research_contact: z.string(),
+    research_contact: z.string().min(4, 'Circle Point of Contact is Required.'),
     research_what: z.string(),
     research_who: z.string(),
     research_how_much: z.string(),

--- a/src/pages/CreateCirclePage/CreateCirclePage.tsx
+++ b/src/pages/CreateCirclePage/CreateCirclePage.tsx
@@ -220,7 +220,7 @@ export const SummonCirclePage = () => {
                   {...fields.research_contact}
                   fullWidth
                   label="Circle Point of Contact"
-                  placeholder="Discord, Telegram, email, etc."
+                  placeholder="Discord #0000, Telegram, Twitter or Email "
                   subtitle="We use this as follow-up & support"
                 />
                 <div className={classes.root}>

--- a/src/pages/CreateCirclePage/CreateCirclePage.tsx
+++ b/src/pages/CreateCirclePage/CreateCirclePage.tsx
@@ -13,6 +13,7 @@ import {
 } from 'components';
 import CreateCircleForm from 'forms/CreateCircleForm';
 import { useApiWithProfile, useApiBase } from 'hooks';
+import { DiscordIcon } from 'icons';
 import { useMyProfile } from 'recoilState/app';
 import * as paths from 'routes/paths';
 
@@ -71,6 +72,34 @@ const useStyles = makeStyles(theme => ({
   },
   saveButton: {
     margin: theme.spacing(3, 0, 5),
+  },
+  titleSupport: {
+    fontSize: 20,
+    lineHeight: 1,
+    fontWeight: 300,
+    color: theme.colors.primary,
+    margin: theme.spacing(7, 2, 4),
+  },
+  label: {
+    fontSize: 16,
+    lineHeight: 1.3,
+    fontWeight: 700,
+    color: theme.colors.text,
+  },
+  subLabel: {
+    padding: theme.spacing(0, 0, 1),
+    fontSize: 15,
+    lineHeight: 1,
+    color: theme.colors.text + '80',
+  },
+  discordButton: {
+    backgroundColor: '#5865F2',
+    width: '100%',
+    margin: theme.spacing(1),
+    borderRadius: 8,
+  },
+  link: {
+    width: '100%',
   },
 }));
 
@@ -183,12 +212,39 @@ export const SummonCirclePage = () => {
                   infoTooltip="A circle admin can add to an existing organization."
                 />
               )}
-              <FormTextField
-                {...fields.research_contact}
-                fullWidth
-                label="Circle Point of Contact"
-                placeholder="Discord, Telegram, email, etc."
-              />
+            </div>
+            <div className={classes.titleSupport}>Coordinape Support</div>
+            <div className={classes.bodyInner}>
+              <div className={classes.twoColumnGrid}>
+                <FormTextField
+                  {...fields.research_contact}
+                  fullWidth
+                  label="Circle Point of Contact"
+                  placeholder="Discord, Telegram, email, etc."
+                  subtitle="We use this as follow-up & support"
+                />
+                <div className={classes.root}>
+                  <div className={classes.label}>Need More Help?</div>
+                  <div className={classes.subLabel}>
+                    Join Our Discord for Information & Support
+                  </div>
+                  <a
+                    className={classes.link}
+                    href={paths.EXTERNAL_URL_DISCORD}
+                    rel="noreferrer"
+                    target="_blank"
+                  >
+                    <Button
+                      className={classes.discordButton}
+                      variant="contained"
+                      disableElevation
+                      startIcon={<DiscordIcon />}
+                    >
+                      Join Coordinape Discord
+                    </Button>
+                  </a>
+                </div>
+              </div>
             </div>
             <FormCaptcha {...fields.captcha_token} error={false} />
             <Button


### PR DESCRIPTION
fixes #601 

This adds the Coordinape Discord support to the Create Circle and follow up the new design described in the #601.
 