### PR TITLE
Warning component when opting in or opting out

### DIFF
--- a/src/pages/AdminPage/AdminUserModal.tsx
+++ b/src/pages/AdminPage/AdminUserModal.tsx
@@ -51,11 +51,6 @@ export const AdminUserModal = ({
   const { circle: selectedCircle, circleId } = useSelectedCircle();
   const { updateUser, createUser } = useApiAdminCircle(circleId);
 
-  const [cachedOptOutStatus] = useState(
-    !!user?.fixed_non_receiver ||
-      !!user?.non_receiver ||
-      !selectedCircle.default_opt_in
-  );
   const [showOptOutChangeWarning, setShowOptOutChangeWarning] = useState(false);
   const [hasAcceptedOptOutWarning, setHasAcceptedOptOutWarning] =
     useState(false);
@@ -64,6 +59,10 @@ export const AdminUserModal = ({
     setHasAcceptedOptOutWarning(false);
   }, [user?.address]);
 
+  const isOptedOut =
+    !!user?.fixed_non_receiver ||
+    !!user?.non_receiver ||
+    !selectedCircle.default_opt_in;
   const hasGiveAllocated = !!user?.give_token_received;
   const userIsAccount =
     account?.toLocaleLowerCase() === user?.address.toLocaleLowerCase();
@@ -83,8 +82,8 @@ export const AdminUserModal = ({
         hideFieldErrors
         submit={params => {
           const showWarning =
-            cachedOptOutStatus !== params.non_receiver && hasGiveAllocated;
-          if (showWarning && !hasAcceptedOptOutWarning) {
+            isOptedOut && hasGiveAllocated && !hasAcceptedOptOutWarning;
+          if (showWarning) {
             setShowOptOutChangeWarning(true);
           } else {
             setShowOptOutChangeWarning(false);

--- a/src/pages/AdminPage/AdminUserModal.tsx
+++ b/src/pages/AdminPage/AdminUserModal.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-console */
-
 import { useEffect, useMemo, useState } from 'react';
 
 import { useWeb3React } from '@web3-react/core';
@@ -66,6 +64,10 @@ export const AdminUserModal = ({
     setHasAcceptedOptOutWarning(false);
   }, [user?.address]);
 
+  const hasGiveAllocated = !!user?.give_token_received;
+  const userIsAccount =
+    account?.toLocaleLowerCase() === user?.address.toLocaleLowerCase();
+
   const source = useMemo(
     () => ({
       user: user,
@@ -73,12 +75,6 @@ export const AdminUserModal = ({
     }),
     [user, selectedCircle]
   );
-
-  const hasGiveAllocated = true;
-  const userIsAccount =
-    account?.toLocaleLowerCase() === user?.address.toLocaleLowerCase();
-  console.log(userIsAccount, account, user?.address);
-  // console.log(user, cachedOptOutStatus, hasGiveAllocated);
 
   return (
     <>
@@ -88,7 +84,6 @@ export const AdminUserModal = ({
         submit={params => {
           const showWarning =
             cachedOptOutStatus !== params.non_receiver && hasGiveAllocated;
-          console.log(showWarning, !hasAcceptedOptOutWarning);
           if (showWarning && !hasAcceptedOptOutWarning) {
             setShowOptOutChangeWarning(true);
           } else {


### PR DESCRIPTION
<img width="742" alt="image" src="https://user-images.githubusercontent.com/15604932/158089319-d452d6bf-8c33-48f8-9fe9-bf8970f395d9.png">

fixes #381 

Used the `ActionDialog` component to render a warning when the optedOut value is changed **and** the user has allocated GIVE.

Copy for the dialog varies depending if the user being edited is the connected account or not.