### PR TITLE
Link directly to Discord #support channel

### DIFF
--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -8,7 +8,7 @@ import {
   SnackbarKey,
 } from 'notistack';
 
-import { EXTERNAL_URL_DISCORD } from 'routes/paths';
+import { EXTERNAL_URL_DISCORD_SUPPORT } from 'routes/paths';
 
 interface IInnerProps {
   children: ReactNode;
@@ -83,8 +83,9 @@ class InnerErrorBoundary extends Component<IInnerProps, State> {
           <h1>Oh Geez!</h1>
           <h5>An uncaught error hit the react error boundary.</h5>
           <p>
-            Get technical support on <a href={EXTERNAL_URL_DISCORD}>Discord</a>{' '}
-            or refresh to return to the app.
+            Get technical support on{' '}
+            <a href={EXTERNAL_URL_DISCORD_SUPPORT}>Discord</a> or refresh to
+            return to the app.
           </p>
         </div>
         <div

--- a/src/pages/CreateCirclePage/CreateCirclePage.tsx
+++ b/src/pages/CreateCirclePage/CreateCirclePage.tsx
@@ -230,7 +230,7 @@ export const SummonCirclePage = () => {
                   </div>
                   <a
                     className={classes.link}
-                    href={paths.EXTERNAL_URL_DISCORD}
+                    href={paths.EXTERNAL_URL_DISCORD_SUPPORT}
                     rel="noreferrer"
                     target="_blank"
                   >

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -10,6 +10,7 @@ export const EXTERNAL_URL_LANDING_PAGE = 'https://coordinape.com';
 export const EXTERNAL_URL_DOCS_REGIFT = `${EXTERNAL_URL_DOCS}/welcome/new-feature-regift`;
 export const EXTERNAL_URL_TWITTER = 'https://twitter.com/coordinape';
 export const EXTERNAL_URL_DISCORD = 'https://discord.gg/coordinape';
+export const EXTERNAL_URL_DISCORD_SUPPORT = 'https://discord.gg/BG3fDAvzuB';
 export const EXTERNAL_URL_MEDIUM_ARTICLE =
   'https://medium.com/iearn/decentralized-payroll-management-for-daos-b2252160c543';
 // TODO: Change this to something more specific to feedback.


### PR DESCRIPTION
After talking with Ivy, seems it's most helpful to send folks directly to our #support channel for errors and questions with onboarding, rather than just our entire Discord.

Creating both options on the site, linking to general Discord still on footer, but linking to #support channel from our error page and the "Create new circle" page.