### PR TITLE
migrate deleteEpoch FE to hasura

### DIFF
--- a/api-lib/gql/__generated__/zeus/const.ts
+++ b/api-lib/gql/__generated__/zeus/const.ts
@@ -319,6 +319,20 @@ export const AllTypesProps: Record<string, any> = {
       required: false,
     },
   },
+  DeleteEpochInput: {
+    circle_id: {
+      type: 'Int',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+    id: {
+      type: 'Int',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+  },
   Int_comparison_exp: {
     _eq: {
       type: 'Int',
@@ -7856,6 +7870,14 @@ export const AllTypesProps: Record<string, any> = {
     createUser: {
       payload: {
         type: 'CreateUserInput',
+        array: false,
+        arrayRequired: false,
+        required: true,
+      },
+    },
+    deleteEpoch: {
+      payload: {
+        type: 'DeleteEpochInput',
         array: false,
         arrayRequired: false,
         required: true,
@@ -20531,6 +20553,9 @@ export const ReturnTypes: Record<string, any> = {
     id: 'Int',
     nominee: 'nominees',
   },
+  DeleteEpochResponse: {
+    success: 'Boolean',
+  },
   EpochResponse: {
     epoch: 'epochs',
     id: 'ID',
@@ -21620,6 +21645,7 @@ export const ReturnTypes: Record<string, any> = {
     createEpoch: 'EpochResponse',
     createNominee: 'CreateNomineeResponse',
     createUser: 'UserResponse',
+    deleteEpoch: 'DeleteEpochResponse',
     delete_burns: 'burns_mutation_response',
     delete_burns_by_pk: 'burns',
     delete_circle_integrations: 'circle_integrations_mutation_response',

--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -96,6 +96,14 @@ export type ValueTypes = {
     role?: number | null;
     starting_tokens?: number | null;
   };
+  ['DeleteEpochInput']: {
+    circle_id: number;
+    id: number;
+  };
+  ['DeleteEpochResponse']: AliasType<{
+    success?: boolean;
+    __typename?: boolean;
+  }>;
   ['EpochResponse']: AliasType<{
     /** An object relationship */
     epoch?: ValueTypes['epochs'];
@@ -3444,6 +3452,10 @@ columns and relationships of "distributions" */
     createUser?: [
       { payload: ValueTypes['CreateUserInput'] },
       ValueTypes['UserResponse']
+    ];
+    deleteEpoch?: [
+      { payload: ValueTypes['DeleteEpochInput'] },
+      ValueTypes['DeleteEpochResponse']
     ];
     delete_burns?: [
       {
@@ -9365,6 +9377,10 @@ export type ModelTypes = {
     nominee: ModelTypes['nominees'];
   };
   ['CreateUserInput']: GraphQLTypes['CreateUserInput'];
+  ['DeleteEpochInput']: GraphQLTypes['DeleteEpochInput'];
+  ['DeleteEpochResponse']: {
+    success: boolean;
+  };
   ['EpochResponse']: {
     /** An object relationship */
     epoch: ModelTypes['epochs'];
@@ -11019,6 +11035,7 @@ columns and relationships of "distributions" */
     createEpoch?: ModelTypes['EpochResponse'];
     createNominee?: ModelTypes['CreateNomineeResponse'];
     createUser?: ModelTypes['UserResponse'];
+    deleteEpoch?: ModelTypes['DeleteEpochResponse'];
     /** delete data from the table: "burns" */
     delete_burns?: ModelTypes['burns_mutation_response'];
     /** delete single row from the table: "burns" */
@@ -13468,6 +13485,14 @@ export type GraphQLTypes = {
     non_receiver?: boolean;
     role?: number;
     starting_tokens?: number;
+  };
+  ['DeleteEpochInput']: {
+    circle_id: number;
+    id: number;
+  };
+  ['DeleteEpochResponse']: {
+    __typename: 'DeleteEpochResponse';
+    success: boolean;
   };
   ['EpochResponse']: {
     __typename: 'EpochResponse';
@@ -16498,6 +16523,7 @@ columns and relationships of "distributions" */
     createEpoch?: GraphQLTypes['EpochResponse'];
     createNominee?: GraphQLTypes['CreateNomineeResponse'];
     createUser?: GraphQLTypes['UserResponse'];
+    deleteEpoch?: GraphQLTypes['DeleteEpochResponse'];
     /** delete data from the table: "burns" */
     delete_burns?: GraphQLTypes['burns_mutation_response'];
     /** delete single row from the table: "burns" */

--- a/src/hooks/useApiAdminCircle.ts
+++ b/src/hooks/useApiAdminCircle.ts
@@ -53,7 +53,7 @@ export const useApiAdminCircle = (circleId: number) => {
 
   const deleteEpoch = useRecoilLoadCatch(
     () => async (epochId: number) => {
-      await getApiService().deleteEpoch(circleId, epochId);
+      await mutations.deleteEpoch(circleId, epochId);
       await fetchManifest();
     },
     [circleId]

--- a/src/lib/gql/__generated__/zeus/const.ts
+++ b/src/lib/gql/__generated__/zeus/const.ts
@@ -287,6 +287,20 @@ export const AllTypesProps: Record<string, any> = {
       required: false,
     },
   },
+  DeleteEpochInput: {
+    circle_id: {
+      type: 'Int',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+    id: {
+      type: 'Int',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+  },
   Int_comparison_exp: {
     _eq: {
       type: 'Int',
@@ -5074,6 +5088,14 @@ export const AllTypesProps: Record<string, any> = {
     createUser: {
       payload: {
         type: 'CreateUserInput',
+        array: false,
+        arrayRequired: false,
+        required: true,
+      },
+    },
+    deleteEpoch: {
+      payload: {
+        type: 'DeleteEpochInput',
         array: false,
         arrayRequired: false,
         required: true,
@@ -11799,6 +11821,9 @@ export const ReturnTypes: Record<string, any> = {
     id: 'Int',
     nominee: 'nominees',
   },
+  DeleteEpochResponse: {
+    success: 'Boolean',
+  },
   EpochResponse: {
     epoch: 'epochs',
     id: 'ID',
@@ -11959,6 +11984,7 @@ export const ReturnTypes: Record<string, any> = {
     createEpoch: 'EpochResponse',
     createNominee: 'CreateNomineeResponse',
     createUser: 'UserResponse',
+    deleteEpoch: 'DeleteEpochResponse',
     delete_circle_integrations: 'circle_integrations_mutation_response',
     delete_circle_integrations_by_pk: 'circle_integrations',
     insert_circle_integrations: 'circle_integrations_mutation_response',

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -83,6 +83,14 @@ export type ValueTypes = {
     role?: number | null;
     starting_tokens?: number | null;
   };
+  ['DeleteEpochInput']: {
+    circle_id: number;
+    id: number;
+  };
+  ['DeleteEpochResponse']: AliasType<{
+    success?: boolean;
+    __typename?: boolean;
+  }>;
   ['EpochResponse']: AliasType<{
     /** An object relationship */
     epoch?: ValueTypes['epochs'];
@@ -1473,6 +1481,10 @@ columns and relationships of "distributions" */
     createUser?: [
       { payload: ValueTypes['CreateUserInput'] },
       ValueTypes['UserResponse']
+    ];
+    deleteEpoch?: [
+      { payload: ValueTypes['DeleteEpochInput'] },
+      ValueTypes['DeleteEpochResponse']
     ];
     delete_circle_integrations?: [
       {
@@ -3786,6 +3798,10 @@ export type ModelTypes = {
     nominee: ModelTypes['nominees'];
   };
   ['CreateUserInput']: GraphQLTypes['CreateUserInput'];
+  ['DeleteEpochInput']: GraphQLTypes['DeleteEpochInput'];
+  ['DeleteEpochResponse']: {
+    success: boolean;
+  };
   ['EpochResponse']: {
     /** An object relationship */
     epoch: ModelTypes['epochs'];
@@ -4213,6 +4229,7 @@ columns and relationships of "distributions" */
     createEpoch?: ModelTypes['EpochResponse'];
     createNominee?: ModelTypes['CreateNomineeResponse'];
     createUser?: ModelTypes['UserResponse'];
+    deleteEpoch?: ModelTypes['DeleteEpochResponse'];
     /** delete data from the table: "circle_integrations" */
     delete_circle_integrations?: ModelTypes['circle_integrations_mutation_response'];
     /** delete single row from the table: "circle_integrations" */
@@ -5024,6 +5041,14 @@ export type GraphQLTypes = {
     non_receiver?: boolean;
     role?: number;
     starting_tokens?: number;
+  };
+  ['DeleteEpochInput']: {
+    circle_id: number;
+    id: number;
+  };
+  ['DeleteEpochResponse']: {
+    __typename: 'DeleteEpochResponse';
+    success: boolean;
   };
   ['EpochResponse']: {
     __typename: 'EpochResponse';
@@ -6279,6 +6304,7 @@ columns and relationships of "distributions" */
     createEpoch?: GraphQLTypes['EpochResponse'];
     createNominee?: GraphQLTypes['CreateNomineeResponse'];
     createUser?: GraphQLTypes['UserResponse'];
+    deleteEpoch?: GraphQLTypes['DeleteEpochResponse'];
     /** delete data from the table: "circle_integrations" */
     delete_circle_integrations?: GraphQLTypes['circle_integrations_mutation_response'];
     /** delete single row from the table: "circle_integrations" */

--- a/src/lib/gql/mutations.ts
+++ b/src/lib/gql/mutations.ts
@@ -275,3 +275,20 @@ export const vouchUser = async (nomineeId: number) => {
   });
   return vouch;
 };
+
+export async function deleteEpoch(circleId: number, epochId: number) {
+  const { deleteEpoch } = await client.mutate({
+    deleteEpoch: [
+      {
+        payload: {
+          id: epochId,
+          circle_id: circleId,
+        },
+      },
+      {
+        success: true,
+      },
+    ],
+  });
+  return deleteEpoch;
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -138,13 +138,6 @@ export class APIService {
     return response.data as IApiEpoch;
   };
 
-  deleteEpoch = async (circleId: number, epochId: number): Promise<any> => {
-    const response = await this.axios.delete(
-      `/v2/${circleId}/admin/epoches/${epochId}`
-    );
-    return response.data;
-  };
-
   updateMyUser = async (
     circleId: number,
     params: PutUsersParam


### PR DESCRIPTION
Fixes #639 by migrating to hasura. 

Test plan:

1. Visit the admin page of a circle with an active epoch. In the fresh seed data Games in Collier and Sons. 
2. click the red trash next to the epoch on the top
3. click remove epoch button the dialog
4. observe that the epoch is deleted, but you have encountered bug #659 which is that the dialog does not dismiss. 
5. refresh the page to workaround #659 