### PR TITLE
Fix misalignment in Form after adding Discord support & blue underline bug under links

### DIFF
--- a/src/components/MyAvatarMenu/MyAvatarMenu.tsx
+++ b/src/components/MyAvatarMenu/MyAvatarMenu.tsx
@@ -105,7 +105,6 @@ const useStyles = makeStyles(theme => ({
   },
   feedbackButton: {
     backgroundColor: '#2a849b',
-    width: '100%',
     margin: theme.spacing(1.5, 0, 0),
     padding: theme.spacing(1.5, 0, 1.5, 5),
     borderRadius: 0,
@@ -192,23 +191,20 @@ export const MyAvatarMenu = () => {
               <CirclesSelectorSection handleOnClick={() => setAnchorEl(null)} />
             </>
           )}
-          <a
-            href={
-              'https://notionforms.io/forms/give-us-your-feedback-improve-coordinape'
-            }
-            rel="noreferrer"
-            target="_blank"
-          >
             <Button
               className={classes.feedbackButton}
               disableElevation
+              fullWidth
               variant="contained"
               color="primary"
+              href={
+                'https://notionforms.io/forms/give-us-your-feedback-improve-coordinape'
+              }
+              target="_blank"
               onClick={() => {}}
             >
               Give Feedback
             </Button>
-          </a>
         </Popover>
       </Hidden>
     </>

--- a/src/pages/CreateCirclePage/CreateCirclePage.tsx
+++ b/src/pages/CreateCirclePage/CreateCirclePage.tsx
@@ -91,12 +91,14 @@ const useStyles = makeStyles(theme => ({
     fontSize: 15,
     lineHeight: 1,
     color: theme.colors.text + '80',
+    textAlign: 'center',
   },
   discordButton: {
     backgroundColor: '#5865F2',
     margin: theme.spacing(1),
     borderRadius: 8,
     fontSize: 15, 
+    textAlign: 'center',
     height: '100%'
   },
 }));

--- a/src/pages/CreateCirclePage/CreateCirclePage.tsx
+++ b/src/pages/CreateCirclePage/CreateCirclePage.tsx
@@ -94,12 +94,8 @@ const useStyles = makeStyles(theme => ({
   },
   discordButton: {
     backgroundColor: '#5865F2',
-    width: '100%',
     margin: theme.spacing(1),
     borderRadius: 8,
-  },
-  link: {
-    width: '100%',
   },
 }));
 
@@ -214,36 +210,31 @@ export const SummonCirclePage = () => {
               )}
             </div>
             <div className={classes.titleSupport}>Coordinape Support</div>
-            <div className={classes.bodyInner}>
-              <div className={classes.twoColumnGrid}>
-                <FormTextField
-                  {...fields.research_contact}
-                  fullWidth
-                  label="Circle Point of Contact"
-                  placeholder="Discord #0000, Telegram, Twitter or Email "
-                  subtitle="We use this as follow-up & support"
-                />
-                <div className={classes.root}>
-                  <div className={classes.label}>Need More Help?</div>
-                  <div className={classes.subLabel}>
-                    Join Our Discord for Information & Support
-                  </div>
-                  <a
-                    className={classes.link}
-                    href={paths.EXTERNAL_URL_DISCORD_SUPPORT}
-                    rel="noreferrer"
-                    target="_blank"
-                  >
-                    <Button
-                      className={classes.discordButton}
-                      variant="contained"
-                      disableElevation
-                      startIcon={<DiscordIcon />}
-                    >
-                      Join Coordinape Discord
-                    </Button>
-                  </a>
+            <div className={classes.twoColumnGrid}>
+              <FormTextField
+                {...fields.research_contact}
+                fullWidth
+                label="Circle Point of Contact"
+                placeholder="Discord #0000, Telegram, Twitter or Email "
+                subtitle="We use this as follow-up & support"
+              />
+              <div className={classes.root}>
+                <div className={classes.label}>Need More Help?</div>
+                <div className={classes.subLabel}>
+                  Join Our Discord for Information & Support
                 </div>
+                <Button
+                  className={classes.discordButton}
+                  variant="contained"
+                  disableElevation
+                  startIcon={<DiscordIcon />}
+                  fullWidth
+                  target="_blank"
+                  rel="noreferrer"
+                  href={paths.EXTERNAL_URL_DISCORD_SUPPORT}
+                >
+                  Join Coordinape Discord
+                </Button>
               </div>
             </div>
             <FormCaptcha {...fields.captcha_token} error={false} />

--- a/src/pages/CreateCirclePage/CreateCirclePage.tsx
+++ b/src/pages/CreateCirclePage/CreateCirclePage.tsx
@@ -96,6 +96,8 @@ const useStyles = makeStyles(theme => ({
     backgroundColor: '#5865F2',
     margin: theme.spacing(1),
     borderRadius: 8,
+    fontSize: 15, 
+    height: '100%'
   },
 }));
 


### PR DESCRIPTION
### Summary
While I was working on #606, I didn't make an accurate review for form's fields alignment, the reason for that is using `</a>` tag around `<Button>` component. 

Using `</a>` tag around `<Button>` introduced two visual bugs: 
- **blue underline** for links in Discord Support Button in **Create Circle Page** & **Give Feedback** in the menu. 
- **Misalignment** among some fields in **Create Circle Page** Form.

I found a better solution that solves both issues at once by using the `href` that comes included with the [`<Button>` API](https://mui.com/api/button/). This allows MUI to decide how to include the `</a>` tag, in addition, this is more concise and encapsulated than the old way.


### Details
This PR solves two issues at once.
#### Blue underline
Blue underline is showing in couple of places: Discord button in create
new circle and in Give Feedback link in the menu.

Worth noting that the blue underline bug **only appears in Google Chrome** 
(inherently maybe all chrome-based browsers) but this underline doesn't show 
at all in Mozilla Firefox.

This issue was reported in this [comment](https://github.com/coordinape/coordinape/pull/617#issuecomment-1071899863), but also noticed in the Discord button. 


#### Misalignment
Finally, `</a>` component wasn't playing nicely with the form which caused Discord support button to not be perfectly aligned. 
Here are some examples: 
**Large Screen**
<img width="500" alt="large screen screenshot" src="https://user-images.githubusercontent.com/12991700/159361524-c3e53a51-2d27-444a-a7fd-0727b703ec46.png">
**Small Screen**
<img width="391" alt="small screen screenshot" src="https://user-images.githubusercontent.com/12991700/159361615-4da6672c-45a9-45f9-a0a0-77e81d97633d.png">

Actually, the behavior varies based on the breakpoints.


### Other fixes: 
- Center both texts in sub-label (text under Need More Help?) for matching and better experience. 
- Make **Join Discord** font size smaller. 
 

