### PR TITLE
createCircle Allows both protocol id and name inputs

### DIFF
--- a/api-lib/gql/queries.ts
+++ b/api-lib/gql/queries.ts
@@ -229,7 +229,8 @@ export async function getExpiredNominees() {
 
 export async function checkAddressAdminInOrg(
   address: string,
-  protocol_id: number
+  protocol_id: number,
+  protocol_name = '%%'
 ) {
   const { profiles } = await adminClient.query({
     profiles: [
@@ -238,7 +239,10 @@ export async function checkAddressAdminInOrg(
           address: { _ilike: address },
           users: {
             role: { _eq: 1 },
-            circle: { protocol_id: { _eq: protocol_id } },
+            circle: {
+              protocol_id: { _eq: protocol_id },
+              organization: { name: { _ilike: protocol_name } },
+            },
           },
         },
       },

--- a/api/hasura/actions/createCircle.ts
+++ b/api/hasura/actions/createCircle.ts
@@ -21,13 +21,17 @@ async function handler(req: VercelRequest, res: VercelResponse) {
       if (input.protocol_id) {
         const isAdmin = await queries.checkAddressAdminInOrg(
           sessionVariables.hasuraAddress,
-          input.protocol_id
+          input.protocol_id,
+          input.protocol_name || '%%'
         );
         if (!isAdmin) {
           return res.status(422).json({
             extensions: [],
-            message:
-              'Address is not an admin of any circles under this protocol',
+            message: `Address is not an admin of any circles under protocol with id ${
+              input.protocol_id
+            }${
+              input.protocol_name ? ` and name '${input.protocol_name}'` : ''
+            }`,
             code: '422',
           });
         }

--- a/src/lib/zod/index.ts
+++ b/src/lib/zod/index.ts
@@ -11,9 +11,7 @@ export const createCircleSchemaInput = z
   })
   .strict()
   .refine(
-    data =>
-      (data.protocol_name || data.protocol_id) &&
-      !(data.protocol_name && data.protocol_id),
+    data => data.protocol_name || data.protocol_id,
     'Either Protocol name should be filled in or a Protocol should be selected.'
   );
 


### PR DESCRIPTION
Laravel currently allows both parameters in the createCircle REST
endpoint and ignores the protocol name in the case where both are
present.

Our frontend currently supplies all parameters, even if no change has
been made. This change allows for compat with frontend behavior while
behaving more soundly if the name does not match the name of the
protocol id supplied. I've also updated the error message to be more
contextually helpful in this case.

test plan:
test cases where
1. no name is suppled: the endpoint should behave as before, and create
   the circle if the protocol id points to and existing protocol
2. both are supplied and the name matches the existing protocol name:
   the new circle should point to the existing protocol
3. both are supplied and the protocol name does not match the existing
   name: The error message should inform the user that the user is not
   an admin of the protocol with id _and_ name instead of just id. It's
   not great ergonomics but it's better than just name.