### PR TITLE
Fix: topocount reviews on api and hasura PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,14 +1,11 @@
-/api/       @topocount
-/api-lib/   @topocount
 /docker/    @topocount
-/hasura/    @topocount
 /scripts/   @topocount
 
 /src/       @teeolendo
 /hardhat/   @teeolendo
 
-/api/       @zashton
-/api-lib/   @zashton
-/hasura/    @zashton
+/api/       @zashton @topocount
+/api-lib/   @zashton @topocount
+/hasura/    @zashton @topocount
 
 /src/       @levity


### PR DESCRIPTION
In the prior config, zashton's assignments to the same folders overwrote my assignments
on prior lines. This allows both of us to be assigned on all changes to the applicable
folders.