### PR TITLE
check constraint on profiles.website

### DIFF
--- a/hasura/migrations/default/1648096542742_alter_table_public_profiles_add_check_constraint_valid_website/down.sql
+++ b/hasura/migrations/default/1648096542742_alter_table_public_profiles_add_check_constraint_valid_website/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."profiles" drop constraint "valid_website";

--- a/hasura/migrations/default/1648096542742_alter_table_public_profiles_add_check_constraint_valid_website/up.sql
+++ b/hasura/migrations/default/1648096542742_alter_table_public_profiles_add_check_constraint_valid_website/up.sql
@@ -1,1 +1,3 @@
+update "public"."profiles" set website = CONCAT('https://',website) where website not ilike 'https://%' and website not ilike 'http://%' and website is not null;
+
 alter table "public"."profiles" add constraint "valid_website" check (website::text ~* 'https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,255}\.[a-z]{2,9}\y([-a-zA-Z0-9@:%_\+.,~#?!&>//=]*)$'::text);

--- a/hasura/migrations/default/1648096542742_alter_table_public_profiles_add_check_constraint_valid_website/up.sql
+++ b/hasura/migrations/default/1648096542742_alter_table_public_profiles_add_check_constraint_valid_website/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."profiles" add constraint "valid_website" check (website::text ~* 'https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,255}\.[a-z]{2,9}\y([-a-zA-Z0-9@:%_\+.,~#?!&>//=]*)$'::text);

--- a/hasura/migrations/default/1648096542742_alter_table_public_profiles_add_check_constraint_valid_website/up.sql
+++ b/hasura/migrations/default/1648096542742_alter_table_public_profiles_add_check_constraint_valid_website/up.sql
@@ -1,4 +1,8 @@
 update "public"."profiles" set website = CONCAT('https://',website) where website not ilike 'https://%' and website not ilike 'http://%' and website is not null;
 -- update these three specific users, making sure they have these y.at addresses
-update "public"."profiles" set website=null where id in(3117,7056,566) AND website ilike 'https://y.at%';
-alter table "public"."profiles" add constraint "valid_website" check (website::text ~* 'https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,255}\.[a-z]{2,9}\y([-a-zA-Z0-9@:%_\+.,~#?!&>//=]*)$'::text);
+update "public"."profiles" set website = RTRIM(website) where website is not null;
+update "public"."profiles" set website='https://y.at/mountain.crown.mountain' where id=7056 AND website ilike 'https://y.at%';
+update "public"."profiles" set website='https://y.at/fox.rocket.rainbow' where id=3117 AND website ilike 'https://y.at%';
+update "public"."profiles" set website='https://y.at/teacup.ocean.sparkles.half-moon' where id=566 AND website ilike 'https://y.at%';
+update "public"."profiles" set website=NULL where id=706;
+alter table "public"."profiles" add constraint "valid_website" check (website::text ~* 'https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,255}\.[a-z]{2,9}\y([-a-zA-Z0-9@:%_\+.,~#?!&>//=]*)$'::text OR website IS NULL);

--- a/hasura/migrations/default/1648096542742_alter_table_public_profiles_add_check_constraint_valid_website/up.sql
+++ b/hasura/migrations/default/1648096542742_alter_table_public_profiles_add_check_constraint_valid_website/up.sql
@@ -1,3 +1,4 @@
 update "public"."profiles" set website = CONCAT('https://',website) where website not ilike 'https://%' and website not ilike 'http://%' and website is not null;
-
-alter table "public"."profiles" add constraint "valid_website" check (website::text ~* 'https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,255}\.[a-z]{2,9}\y([-a-zA-Z0-9@:%_\+.,~#?!&>//=]*)$'::text);
+-- update these three specific users, making sure they have these y.at addresses
+update "public"."profiles" set website=null where id in(3117,7056,566) AND website ilike 'https://y.at%';
+alter table "public"."profiles" add constraint "valid_website" check (website::text ~* 'https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,255}\.[a-z]{2,9}\y([-a-zA-Z0-9@:%_\+.,~#?!&>//=]*)$'::text);


### PR DESCRIPTION
This fixes #441 by obviating the need for a custom validation action. 

This includes migrations that fix existing rows that don't match this pattern. One side effect is the y.at emoji urls don't work. There were only 3 of them that weren't properly URL encoded, so they are cleaned up in this change explicitly. 

I tested this by importing a facsimile of the production data and running this migration. 

To test, run some mutations in the console that play around with variations on valid and invalid websites, e.g. 
```
mutation MyMutation {
  update_profiles_by_pk(
  pk_columns: {id: 2218},
 _set: {website: "http://slurp.next.mock.google.com?moo#jack"}) {
    id
    website
  }
}
```