### PR TITLE
Setup Dev Portal page to document GraphQL API access

### DIFF
--- a/src/hooks/useAuthToken.tsx
+++ b/src/hooks/useAuthToken.tsx
@@ -1,0 +1,15 @@
+import { useMemo } from 'react';
+
+import { getAuthToken } from '../services/api';
+
+import useConnectedAddress from './useConnectedAddress';
+
+export const useCurrentUserAuthToken = () => {
+  const address = useConnectedAddress();
+
+  return useMemo(() => {
+    if (!address) return null;
+
+    return getAuthToken();
+  }, [address]);
+};

--- a/src/pages/DevPortalPage/DevPortalPage.tsx
+++ b/src/pages/DevPortalPage/DevPortalPage.tsx
@@ -46,10 +46,11 @@ export const DevPortalPage: React.FC = () => {
           use Coordinape&#39;s GraphQL API. Click the button below to visit our
           API Explorer where you will find the GraphQL API endpoint, the
           token/headers you can use to authenticate your request, and a live
-          console to construct queries.
+          console to construct queries. Note that your auth token will be
+          invalidated upon logout from the Coordinape website.
         </Box>
         <Box css={{ pt: '$md', color: '$text', fontStyle: 'italic' }}>
-          NOTE: This API is subject to change as we improve our data model.
+          This API is subject to change as we improve our data model.
         </Box>
         <Box
           css={{

--- a/src/pages/DevPortalPage/DevPortalPage.tsx
+++ b/src/pages/DevPortalPage/DevPortalPage.tsx
@@ -4,10 +4,13 @@ import { REACT_APP_HASURA_URL } from '../../config/env';
 import { useCurrentUserAuthToken } from '../../hooks/useAuthToken';
 import { Box, Panel, Button } from '../../ui';
 
+const EXAMPLE_QUERY =
+  'query+MyCircles+%7B%0A++circles%28limit%3A+3%29+%7B%0A++++name%0A++++organization+%7B%0A++++++name%0A++++%7D%0A++++epochs%28limit%3A+3%2C+where%3A+%7Bended%3A+%7B_eq%3A+true%7D%7D%29+%7B%0A++++++id%0A++++++end_date%0A++++++start_date%0A++++%7D%0A++++users%28limit%3A+5%2C+order_by%3A+%7Bcreated_at%3A+asc%7D%29+%7B%0A++++++id%0A++++++name%0A++++++give_token_received%0A++++++give_token_remaining%0A++++++profile+%7B%0A++++++++twitter_username%0A++++++%7D%0A++++%7D%0A++%7D%0A%7D%0A';
+
 const getConsoleUrl = (authToken: string) => {
   return `https://cloud.hasura.io/public/graphiql?endpoint=${REACT_APP_HASURA_URL}&header=Authorization:${encodeURIComponent(
     `Bearer ${authToken}`
-  )}`;
+  )}&query=${EXAMPLE_QUERY}`;
 };
 
 /**
@@ -38,12 +41,15 @@ export const DevPortalPage: React.FC = () => {
         >
           Developer Portal
         </Box>
-        <Box css={{ pt: '$md', color: '$text', maxWidth: '70ch' }}>
+        <Box css={{ pt: '$md', color: '$text' }}>
           If you would like to access your circle data programmatically, you can
           use Coordinape&#39;s GraphQL API. Click the button below to visit our
           API Explorer where you will find the GraphQL API endpoint, the
           token/headers you can use to authenticate your request, and a live
           console to construct queries.
+        </Box>
+        <Box css={{ pt: '$md', color: '$text', fontStyle: 'italic' }}>
+          NOTE: This API is subject to change as we improve our data model.
         </Box>
         <Box
           css={{

--- a/src/pages/DevPortalPage/DevPortalPage.tsx
+++ b/src/pages/DevPortalPage/DevPortalPage.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+
+import { REACT_APP_HASURA_URL } from '../../config/env';
+import { useCurrentUserAuthToken } from '../../hooks/useAuthToken';
+import { Box, Panel, Button } from '../../ui';
+
+const getConsoleUrl = (authToken: string) => {
+  return `https://cloud.hasura.io/public/graphiql?endpoint=${REACT_APP_HASURA_URL}&header=Authorization:${encodeURIComponent(
+    `Bearer ${authToken}`
+  )}`;
+};
+
+/**
+ * Links the user to a GraphQL explorer for the Hasura API preconfigured with their API credentials
+ * @returns JSX.Element
+ */
+export const DevPortalPage: React.FC = () => {
+  const authToken = useCurrentUserAuthToken();
+
+  const consoleUrl = authToken ? getConsoleUrl(authToken) : '';
+
+  return (
+    <Box
+      css={{
+        margin: '$lg auto',
+        maxWidth: '$smallScreen',
+      }}
+    >
+      <Panel css={{ mx: '$lg' }}>
+        <Box
+          css={{
+            textTransform: 'capitalize',
+            fontSize: '$9',
+            lineHeight: '$shorter',
+            fontWeight: '$bold',
+            color: '$text',
+          }}
+        >
+          Developer Portal
+        </Box>
+        <Box css={{ pt: '$md', color: '$text', maxWidth: '70ch' }}>
+          If you would like to access your circle data programmatically, you can
+          use Coordinape&#39;s GraphQL API. Click the button below to visit our
+          API Explorer where you will find the GraphQL API endpoint, the
+          token/headers you can use to authenticate your request, and a live
+          console to construct queries.
+        </Box>
+        <Box
+          css={{
+            pt: '$md',
+          }}
+        >
+          <a
+            href={consoleUrl}
+            rel="noreferrer"
+            target="_blank"
+            style={{ textDecoration: 'none' }}
+          >
+            <Button size="large" color={'red'}>
+              Open API Explorer
+            </Button>
+          </a>
+        </Box>
+      </Panel>
+    </Box>
+  );
+};

--- a/src/pages/DevPortalPage/index.ts
+++ b/src/pages/DevPortalPage/index.ts
@@ -1,0 +1,2 @@
+import { DevPortalPage } from './DevPortalPage';
+export default DevPortalPage;

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -40,6 +40,7 @@ export const paths = {
   epoch: '/epoch',
   give: '/give',
   vouching: '/vouching',
+  devPortal: '/devPortal',
   history: '/history',
   admin: '/admin',
   vaults: '/admin/vaults',

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -40,7 +40,7 @@ export const paths = {
   epoch: '/epoch',
   give: '/give',
   vouching: '/vouching',
-  devPortal: '/devPortal',
+  developers: '/developers',
   history: '/history',
   admin: '/admin',
   vaults: '/admin/vaults',

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -2,6 +2,7 @@ import React, { lazy } from 'react';
 
 import { Routes, Route, Navigate } from 'react-router-dom';
 
+import DevPortalPage from '../pages/DevPortalPage';
 import AdminPage from 'pages/AdminPage';
 import AllocationPage from 'pages/AllocationPage';
 import CreateCirclePage from 'pages/CreateCirclePage';
@@ -88,6 +89,8 @@ const LoggedInRoutes = () => {
         path={paths.connectIntegration}
         element={<IntegrationCallbackPage />}
       />
+      <Route path={paths.devPortal} element={<DevPortalPage />} />
+
       <Route
         path={getDistributePath(':epochId')}
         element={<DistributePage />}

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -89,7 +89,7 @@ const LoggedInRoutes = () => {
         path={paths.connectIntegration}
         element={<IntegrationCallbackPage />}
       />
-      <Route path={paths.devPortal} element={<DevPortalPage />} />
+      <Route path={paths.developers} element={<DevPortalPage />} />
 
       <Route
         path={getDistributePath(':epochId')}

--- a/src/stitches.config.ts
+++ b/src/stitches.config.ts
@@ -106,6 +106,7 @@ export const {
       max: 'max-content',
       min: 'min-content',
       full: '100%',
+      smallScreen: '900px',
       mediumScreen: '1280px',
       ...spaces,
     },

--- a/src/ui/Button/Button.tsx
+++ b/src/ui/Button/Button.tsx
@@ -33,6 +33,9 @@ export const Button = styled('button', {
         '&:hover': {
           backgroundColor: '$lightText',
         },
+        '&[disabled]': {
+          opacity: 0.5,
+        },
       },
       transparent: {
         padding: '$xs',


### PR DESCRIPTION
Page is not accessible to general users from the main site navigation, you can only reach it by going to the /devPortal endpoint.

![image](https://user-images.githubusercontent.com/7143583/160222637-4da0e8c9-9906-4a46-83d9-a6571ada61f7.png)

Clicking the link will take the users to a live GraphQL console where they can get their auth tokens and browse the schema / build queries and mutations + comes prefilled with an example query.