### PR TITLE
restoring deleteEpoch action that got lost in a bad merge

### DIFF
--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -19,6 +19,10 @@ type Mutation {
 }
 
 type Mutation {
+  deleteEpoch(payload: DeleteEpochInput!): DeleteEpochResponse
+}
+
+type Mutation {
   logoutUser: LogoutResponse
 }
 
@@ -82,6 +86,11 @@ input AdminUpdateUserInput {
   role: Int
 }
 
+input DeleteEpochInput {
+  id: Int!
+  circle_id: Int!
+}
+
 input CreateNomineeInput {
   name: String!
   circle_id: Int!
@@ -127,6 +136,10 @@ type LogoutResponse {
 
 type UserResponse {
   id: ID!
+}
+
+type DeleteEpochResponse {
+  success: Boolean!
 }
 
 type CreateNomineeResponse {

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -52,6 +52,16 @@ actions:
   permissions:
   - role: user
   - role: superadmin
+- name: deleteEpoch
+  definition:
+    kind: synchronous
+    handler: '{{HASURA_API_BASE_URL}}/actions/deleteEpoch'
+    headers:
+      - name: verification_key
+        value_from_env: HASURA_EVENT_SECRET
+  permissions:
+    - role: user
+    - role: superadmin
 - name: logoutUser
   definition:
     kind: synchronous
@@ -124,6 +134,7 @@ custom_types:
   - name: UploadImageInput
   - name: UploadCircleImageInput
   - name: AdminUpdateUserInput
+  - name: DeleteEpochInput
   - name: CreateNomineeInput
   - name: UpdateUserInput
   - name: VouchInput
@@ -187,6 +198,7 @@ custom_types:
       type: object
       field_mapping:
         id: id
+  - name: DeleteEpochResponse
   - name: CreateNomineeResponse
     relationships:
     - remote_table:


### PR DESCRIPTION
This got lost in this commit: https://github.com/coordinape/coordinape/commit/1e78d07105a923dcf56ca7c0ffb34378e62e049a


To test:
1. create a new epoch
2. go into hasura console and sort the epochs by highest id
3. note the id and circle_id
4. go to the API tab and run (substituting proper ids:

```
mutation MyMutation2 {
  deleteEpoch(payload: {circle_id: 1, id: 191}) {
    success
  }
}

5. refresh the web page and note that the epoch is gone
6. 
```
