### PR TITLE
Compare contributors names by English locale

### DIFF
--- a/src/pages/AdminPage/AdminPage.tsx
+++ b/src/pages/AdminPage/AdminPage.tsx
@@ -202,6 +202,8 @@ const epochDetail = (e: IEpoch) => {
       }`;
 };
 
+const englishCollator = new Intl.Collator('en-u-kf-upper');
+
 const AdminPage = ({ legacy }: { legacy?: boolean }) => {
   const classes = useStyles();
   const [keyword, setKeyword] = useState<string>('');
@@ -369,7 +371,7 @@ const AdminPage = ({ legacy }: { legacy?: boolean }) => {
               </div>
             );
           },
-          sortFunc:(a: string, b: string) =>  new Intl.Collator('en-u-kf-upper').compare(a, b),
+          sortFunc: (a: string, b: string) => englishCollator.compare(a, b),
           wide: true,
           leftAlign: true,
         },

--- a/src/pages/AdminPage/AdminPage.tsx
+++ b/src/pages/AdminPage/AdminPage.tsx
@@ -369,6 +369,7 @@ const AdminPage = ({ legacy }: { legacy?: boolean }) => {
               </div>
             );
           },
+          sortFunc:(a: string, b: string) =>  new Intl.Collator('en-u-kf-upper').compare(a, b),
           wide: true,
           leftAlign: true,
         },


### PR DESCRIPTION
fixes #673
**Summary**
use  Intl.Collator('en-u-kf-upper') to compare the contributors names strings by English locale so that only strings that differ in base letters compare as unequal.
kf-upper: to sort upper case letters first