### PR TITLE
Dework integration: tightened up ProfileCard styling

### DIFF
--- a/src/components/ProfileCard/ContributionSummary.tsx
+++ b/src/components/ProfileCard/ContributionSummary.tsx
@@ -30,7 +30,7 @@ const useStyles = makeStyles(theme => ({
     alignItems: 'center',
     boxShadow: '0px 1px 10px rgba(0, 0, 0, 0.05)',
     padding: theme.spacing(0.25, 1),
-    marginBottom: theme.spacing(1),
+    marginBottom: theme.spacing(0.5),
     borderRadius: 4,
     backgroundColor: theme.colors.white,
     color: theme.colors.text,
@@ -69,7 +69,7 @@ export const ContributionSummary: FC<Props> = ({ contributions }) => {
           className={classes.row}
         >
           <DeworkLogo size="md" />
-          <Typography variant="body1" className={classes.rowTitle}>
+          <Typography variant="body2" className={classes.rowTitle}>
             {contribution.title}
           </Typography>
           <RightArrowIcon size="md" className={classes.moreIcon} />

--- a/src/components/ProfileCard/GiftInput.tsx
+++ b/src/components/ProfileCard/GiftInput.tsx
@@ -17,13 +17,22 @@ const useStyles = makeStyles(theme => ({
     padding: theme.spacing(0, 0.5),
   },
   textField: {
-    marginTop: theme.spacing(1.5),
     '& label': {
       height: 14,
-      margin: theme.spacing(0, 0, 0.5),
       fontSize: 12,
       fontWeight: 'bold',
+      marginTop: theme.spacing(0.5),
       color: 'rgba(81, 99, 105, 0.7)',
+    },
+  },
+  noteTextField: {
+    '& > div': {
+      marginTop: theme.spacing(0.5),
+      marginBottom: 0,
+    },
+    '& textarea': {
+      paddingTop: 0,
+      paddingBottom: 0,
     },
   },
   tokenInputContainer: {
@@ -140,7 +149,7 @@ export const GiftInput = ({
       )}
       <ApeTextField
         label="Leave a Note"
-        className={classes.textField}
+        className={[classes.textField, classes.noteTextField].join(' ')}
         onChange={onChangeNote}
         placeholder="Thank you for..."
         value={note}

--- a/src/components/ProfileCard/ProfileCard.tsx
+++ b/src/components/ProfileCard/ProfileCard.tsx
@@ -89,7 +89,6 @@ const useStyles = makeStyles(theme => ({
   },
   bio: {
     flexGrow: 1,
-    margin: theme.spacing(1.5, 0, 0),
     fontSize: 14,
     fontWeight: 600,
     color: 'rgba(81, 99, 105, 0.5)',

--- a/src/components/ProfileSkills/ProfileSkills.tsx
+++ b/src/components/ProfileSkills/ProfileSkills.tsx
@@ -4,7 +4,7 @@ import { makeStyles } from '@material-ui/core';
 
 const useStyles = makeStyles(theme => ({
   skillItem: {
-    margin: theme.spacing(0.5),
+    margin: theme.spacing(0.2),
     padding: theme.spacing(0.2, 1.7),
     background: theme.colors.lightBlue,
     textAlign: 'center',

--- a/src/hooks/useContributions.ts
+++ b/src/hooks/useContributions.ts
@@ -33,7 +33,7 @@ export function useContributionUsers(): ContributionUser[] {
             queryKey: `circle-integration-contributions-${i.id}-${epoch.id}`,
             queryFn: () =>
               fetch(
-                `https://api.dework.xyz/integrations/coordinape/${i.data.organizationId}?epoch_start=${epoch.start_date}&epoch_end=${epoch.end_date}`
+                `https://api.deworkxyz.com/integrations/coordinape/${i.data.organizationId}?epoch_start=${epoch.start_date}&epoch_end=${epoch.end_date}`
               )
                 .then(res => res.json())
                 .then(res => res as Response),


### PR DESCRIPTION
Problem:
![image](https://user-images.githubusercontent.com/17096641/160666266-ecc8c0cf-9247-4ec5-93fc-c6d3fb2d2b57.png)

Users can't see the contribution summary/Dework tasks in Coordinape profile cards