### PR TITLE
fixes #642 by integrating deleteUser graphql into FE

### DIFF
--- a/src/hooks/useApiAdminCircle.ts
+++ b/src/hooks/useApiAdminCircle.ts
@@ -77,7 +77,7 @@ export const useApiAdminCircle = (circleId: number) => {
 
   const deleteUser = useRecoilLoadCatch(
     () => async (userAddress: string) => {
-      await getApiService().deleteUser(circleId, userAddress);
+      await mutations.deleteUser(circleId, userAddress);
       await fetchManifest();
     },
     [circleId]

--- a/src/lib/gql/mutations.ts
+++ b/src/lib/gql/mutations.ts
@@ -320,3 +320,20 @@ export async function updateTeammates(circleId: number, teammates: number[]) {
   });
   return updateTeammates;
 }
+
+export async function deleteUser(circleId: number, address: string) {
+  const { deleteUser } = await client.mutate({
+    deleteUser: [
+      {
+        payload: {
+          circle_id: circleId,
+          address: address,
+        },
+      },
+      {
+        success: true,
+      },
+    ],
+  });
+  return deleteUser;
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -132,13 +132,6 @@ export class APIService {
     return response.data;
   };
 
-  deleteUser = async (circleId: number, address: string): Promise<IApiUser> => {
-    const response = await this.axios.delete(
-      `/v2/${circleId}/admin/users/${address}`
-    );
-    return response.data;
-  };
-
   postTokenGifts = async (
     circleId: number,
     params: PostTokenGiftsParam[]


### PR DESCRIPTION
Fixes #642 

Test plan:

1. Visit a circle admin page. I used Health in Conn - Friesen because it has a lot of users. 
2. Open up the ol' network tab in the develop console
3. delete a user. I deleted Diego, because they were first.
4. note the network call is graphql, not laravel
5. note that the user goes away. 