### PR TITLE
fixes #636 by integrating update teammates graphql into FE

### DIFF
--- a/src/hooks/useAllocation.ts
+++ b/src/hooks/useAllocation.ts
@@ -1,4 +1,5 @@
 import iti from 'itiriri';
+import * as mutations from 'lib/gql/mutations';
 import isEqual from 'lodash/isEqual';
 import { useRecoilValue, useRecoilState, useSetRecoilState } from 'recoil';
 
@@ -138,7 +139,7 @@ export const useAllocation = (circleId: number) => {
 
   const saveTeammates = useRecoilLoadCatch(
     () => async () => {
-      await getApiService().postTeammates(
+      await mutations.updateTeammates(
         myUser.circle_id,
         localTeammates.map(u => u.id)
       );

--- a/src/lib/gql/mutations.ts
+++ b/src/lib/gql/mutations.ts
@@ -292,3 +292,17 @@ export async function deleteEpoch(circleId: number, epochId: number) {
   });
   return deleteEpoch;
 }
+
+export async function updateTeammates(circleId: number, teammates: number[]) {
+  const { updateTeammates } = await client.mutate({
+    updateTeammates: [
+      {
+        payload: { circle_id: circleId, teammates: teammates },
+      },
+      {
+        user_id: true,
+      },
+    ],
+  });
+  return updateTeammates;
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -155,16 +155,6 @@ export class APIService {
     return response.data;
   };
 
-  postTeammates = async (
-    circleId: number,
-    teammates: number[]
-  ): Promise<IApiUser & { pending_sent_gifts: IApiTokenGift[] }> => {
-    const response = await this.axios.post(`/v2/${circleId}/teammates`, {
-      data: JSON.stringify({ teammates: teammates }),
-    });
-    return response.data;
-  };
-
   postTokenGifts = async (
     circleId: number,
     params: PostTokenGiftsParam[]


### PR DESCRIPTION
Fixes #636 

To test,

1. Visit the Allocation page for a circle with lots of members
2. open the network tab
3. add some teammates and save
4. validate that the request goes to graphql instead of laravel endpoint
5. make sure it all works ok by adding and removing members