### PR TITLE
fixes #638 by integrating updateUser graphql into frontend

### DIFF
--- a/src/hooks/useApiWithSelectedCircle.ts
+++ b/src/hooks/useApiWithSelectedCircle.ts
@@ -2,7 +2,6 @@ import * as mutations from 'lib/gql/mutations';
 
 import { useApiBase } from 'hooks';
 import { useSelectedCircle } from 'recoilState/app';
-import { getApiService } from 'services/api';
 
 import { useRecoilLoadCatch } from './useRecoilLoadCatch';
 
@@ -16,12 +15,9 @@ export const useApiWithSelectedCircle = () => {
 
   const updateMyUser = useRecoilLoadCatch(
     () => async (params: PutUsersParam) => {
-      await getApiService().updateMyUser(circleId, {
-        name: myUser.name,
-        bio: myUser.bio,
-        non_receiver: myUser.non_receiver,
-        non_giver: myUser.non_giver,
-        epoch_first_visit: myUser.epoch_first_visit,
+      await mutations.updateUser({
+        // TODO: this was using the local fields from myUser AND the params, but I have no idea why
+        circle_id: circleId,
         ...params,
       });
       await fetchManifest();

--- a/src/lib/gql/mutations.ts
+++ b/src/lib/gql/mutations.ts
@@ -333,9 +333,7 @@ export async function updateProfile(params: ValueTypes['profiles_set_input']) {
       {
         // This uses the hasura permissions / preloaded column to set the where
         where: {},
-        _set: {
-          ...params,
-        },
+        _set: { ...params },
       },
       {
         affected_rows: true,
@@ -343,4 +341,20 @@ export async function updateProfile(params: ValueTypes['profiles_set_input']) {
     ],
   });
   return update_profiles;
+}
+
+export async function updateUser(params: ValueTypes['UpdateUserInput']) {
+  const { updateUser } = await client.mutate({
+    updateUser: [
+      {
+        payload: {
+          ...params,
+        },
+      },
+      {
+        id: true,
+      },
+    ],
+  });
+  return updateUser;
 }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -12,7 +12,6 @@ import {
   IApiLogin,
   IApiManifest,
   PostTokenGiftsParam,
-  PutUsersParam,
   UpdateCreateEpochParam,
   IApiFullCircle,
 } from 'types';
@@ -111,16 +110,6 @@ export class APIService {
       }
     );
     return response.data as IApiEpoch;
-  };
-
-  updateMyUser = async (
-    circleId: number,
-    params: PutUsersParam
-  ): Promise<IApiUser> => {
-    const response = await this.axios.put(`/v2/${circleId}/users`, {
-      data: JSON.stringify(params),
-    });
-    return response.data;
   };
 
   postTokenGifts = async (


### PR DESCRIPTION
Fixes #638 

Some notes here:
* the rest api was using some local state from `useApiWithSelectedCircle` to set the name, bio, etc, before applying the params. This resulted in setting the name to `Me` which doesn't make any sense, and breaks the server side validation rules of name being >3 chars. I'm not really sure what the intent was here but everything seems to work ok with removing this this stuff. 
* I don't know why name is in the params, its not really used for anything in the UI , so I'm not sure how to test it, and what the relation to `Me` is 

Test Plan:

1. Visit the My Epoch page for a circle 
2.  flip the opt-in settings and change your bio
3.  make sure settings are saved
4. make sure network request is to /graphql instead of laravel