### PR TITLE
CI cache fix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,3 +43,8 @@ jobs:
           curl -Os https://uploader.codecov.io/latest/linux/codecov 
           chmod +x codecov 
           ./codecov
+
+      # remove symlink to prevent redundant caching
+      - name: Cleanup
+        run: |
+          rm node_modules/@coordinape/hardhat


### PR DESCRIPTION
fix for an issue where the cache gets created with files in `node_modules/@coordinape/hardhat`, but then this directory doesn't exist when the cache is unpacked in the next run (probably because it's a symlink), so there are lots of errors logged. harmless but annoying