### PR TITLE
make pending_gifts.epoch_id non-nullable

### DIFF
--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -12055,7 +12055,7 @@ columns and relationships of "distributions" */
     dts_created: ModelTypes['timestamp'];
     /** An object relationship */
     epoch?: ModelTypes['epochs'];
-    epoch_id?: number;
+    epoch_id: number;
     /** An object relationship */
     gift_private?: ModelTypes['pending_gift_private'];
     id: ModelTypes['bigint'];
@@ -17940,7 +17940,7 @@ columns and relationships of "distributions" */
     dts_created: GraphQLTypes['timestamp'];
     /** An object relationship */
     epoch?: GraphQLTypes['epochs'];
-    epoch_id?: number;
+    epoch_id: number;
     /** An object relationship */
     gift_private?: GraphQLTypes['pending_gift_private'];
     id: GraphQLTypes['bigint'];

--- a/hasura/migrations/default/1648856418818_alter_table_public_pending_token_gifts_alter_column_epoch_id/down.sql
+++ b/hasura/migrations/default/1648856418818_alter_table_public_pending_token_gifts_alter_column_epoch_id/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."pending_token_gifts" alter column "epoch_id" drop not null;

--- a/hasura/migrations/default/1648856418818_alter_table_public_pending_token_gifts_alter_column_epoch_id/up.sql
+++ b/hasura/migrations/default/1648856418818_alter_table_public_pending_token_gifts_alter_column_epoch_id/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."pending_token_gifts" alter column "epoch_id" set not null;

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -4949,7 +4949,7 @@ columns and relationships of "distributions" */
     dts_created: ModelTypes['timestamp'];
     /** An object relationship */
     epoch?: ModelTypes['epochs'];
-    epoch_id?: number;
+    epoch_id: number;
     /** An object relationship */
     gift_private?: ModelTypes['pending_gift_private'];
     id: ModelTypes['bigint'];
@@ -7402,7 +7402,7 @@ columns and relationships of "distributions" */
     dts_created: GraphQLTypes['timestamp'];
     /** An object relationship */
     epoch?: GraphQLTypes['epochs'];
-    epoch_id?: number;
+    epoch_id: number;
     /** An object relationship */
     gift_private?: GraphQLTypes['pending_gift_private'];
     id: GraphQLTypes['bigint'];


### PR DESCRIPTION
Checked on prod that this will be ok by running this mutation:

```
query MyQuery {
  pending_token_gifts_aggregate(where: {epoch_id: {_is_null: true}}) {
    aggregate {
      count
    }
  }
}
```

and got this result:

```
{
  "data": {
    "pending_token_gifts_aggregate": {
      "aggregate": {
        "count": 0
      }
    }
  }
}
```