### PR TITLE
Epoch Update Hasura feature 

### DIFF
--- a/api-lib/dateTimeHelpers.ts
+++ b/api-lib/dateTimeHelpers.ts
@@ -1,13 +1,15 @@
-import { DateTime } from 'luxon';
+import { DateTime, Settings } from 'luxon';
+
+Settings.defaultZone = 'utc';
 
 export const formatShortDateTime = (dateTime: string | DateTime) => {
   let dateTimeString;
   if (typeof dateTime === 'string') {
     dateTimeString = DateTime.fromISO(dateTime).toLocaleString(
-      DateTime.DATETIME_SHORT
+      DateTime.DATETIME_FULL
     );
   } else {
-    dateTimeString = dateTime.toLocaleString(DateTime.DATETIME_SHORT);
+    dateTimeString = dateTime.toLocaleString(DateTime.DATETIME_FULL);
   }
   // Format : 8/27/2021, 6:00 PM
   return dateTimeString;

--- a/api-lib/dateTimeHelpers.ts
+++ b/api-lib/dateTimeHelpers.ts
@@ -3,14 +3,8 @@ import { DateTime, Settings } from 'luxon';
 Settings.defaultZone = 'utc';
 
 export const formatShortDateTime = (dateTime: string | DateTime) => {
-  let dateTimeString;
   if (typeof dateTime === 'string') {
-    dateTimeString = DateTime.fromISO(dateTime).toLocaleString(
-      DateTime.DATETIME_FULL
-    );
-  } else {
-    dateTimeString = dateTime.toLocaleString(DateTime.DATETIME_FULL);
+    return DateTime.fromISO(dateTime).toLocaleString(DateTime.DATETIME_FULL);
   }
-  // Format : 8/27/2021, 6:00 PM
-  return dateTimeString;
+  return dateTime.toLocaleString(DateTime.DATETIME_FULL);
 };

--- a/api-lib/gql/__generated__/zeus/const.ts
+++ b/api-lib/gql/__generated__/zeus/const.ts
@@ -611,6 +611,44 @@ export const AllTypesProps: Record<string, any> = {
       required: false,
     },
   },
+  UpdateEpochInput: {
+    circle_id: {
+      type: 'Int',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+    days: {
+      type: 'Int',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+    grant: {
+      type: 'Float',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    id: {
+      type: 'Int',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+    repeat: {
+      type: 'Int',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+    start_date: {
+      type: 'timestamptz',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+  },
   UpdateTeammatesInput: {
     circle_id: {
       type: 'Int',
@@ -9086,6 +9124,14 @@ export const AllTypesProps: Record<string, any> = {
     updateCircle: {
       payload: {
         type: 'UpdateCircleInput',
+        array: false,
+        arrayRequired: false,
+        required: true,
+      },
+    },
+    updateEpoch: {
+      payload: {
+        type: 'UpdateEpochInput',
         array: false,
         arrayRequired: false,
         required: true,
@@ -22931,6 +22977,7 @@ export const ReturnTypes: Record<string, any> = {
     insert_vouches_one: 'vouches',
     logoutUser: 'LogoutResponse',
     updateCircle: 'UpdateCircleOutput',
+    updateEpoch: 'EpochResponse',
     updateTeammates: 'UpdateTeammatesResponse',
     updateUser: 'UserResponse',
     update_burns: 'burns_mutation_response',

--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -197,6 +197,14 @@ export type ValueTypes = {
     id?: boolean;
     __typename?: boolean;
   }>;
+  ['UpdateEpochInput']: {
+    circle_id: number;
+    days: number;
+    grant?: number | null;
+    id: number;
+    repeat: number;
+    start_date: ValueTypes['timestamptz'];
+  };
   ['UpdateProfileResponse']: AliasType<{
     id?: boolean;
     /** An object relationship */
@@ -4125,6 +4133,10 @@ columns and relationships of "distributions" */
     updateCircle?: [
       { payload: ValueTypes['UpdateCircleInput'] },
       ValueTypes['UpdateCircleOutput']
+    ];
+    updateEpoch?: [
+      { payload: ValueTypes['UpdateEpochInput'] },
+      ValueTypes['EpochResponse']
     ];
     updateTeammates?: [
       { payload: ValueTypes['UpdateTeammatesInput'] },
@@ -9748,6 +9760,7 @@ export type ModelTypes = {
     circle: ModelTypes['circles'];
     id: number;
   };
+  ['UpdateEpochInput']: GraphQLTypes['UpdateEpochInput'];
   ['UpdateProfileResponse']: {
     id: number;
     /** An object relationship */
@@ -11571,6 +11584,7 @@ columns and relationships of "distributions" */
     insert_vouches_one?: ModelTypes['vouches'];
     logoutUser?: ModelTypes['LogoutResponse'];
     updateCircle?: ModelTypes['UpdateCircleOutput'];
+    updateEpoch?: ModelTypes['EpochResponse'];
     updateTeammates?: ModelTypes['UpdateTeammatesResponse'];
     /** Update own user */
     updateUser?: ModelTypes['UserResponse'];
@@ -14003,6 +14017,14 @@ export type GraphQLTypes = {
     /** An object relationship */
     circle: GraphQLTypes['circles'];
     id: number;
+  };
+  ['UpdateEpochInput']: {
+    circle_id: number;
+    days: number;
+    grant?: number;
+    id: number;
+    repeat: number;
+    start_date: GraphQLTypes['timestamptz'];
   };
   ['UpdateProfileResponse']: {
     __typename: 'UpdateProfileResponse';
@@ -17169,6 +17191,7 @@ columns and relationships of "distributions" */
     insert_vouches_one?: GraphQLTypes['vouches'];
     logoutUser?: GraphQLTypes['LogoutResponse'];
     updateCircle?: GraphQLTypes['UpdateCircleOutput'];
+    updateEpoch?: GraphQLTypes['EpochResponse'];
     updateTeammates?: GraphQLTypes['UpdateTeammatesResponse'];
     /** Update own user */
     updateUser?: GraphQLTypes['UserResponse'];

--- a/api-lib/gql/queries.ts
+++ b/api-lib/gql/queries.ts
@@ -1,3 +1,7 @@
+import { DateTime } from 'luxon';
+
+import { EPOCH_REPEAT } from '../../api-lib/constants';
+
 import { adminClient } from './adminClient';
 
 export async function getCircle(id: number) {
@@ -274,4 +278,61 @@ export async function getExistingVouch(nomineeId: number, voucherId: number) {
       },
     ],
   });
+}
+
+export async function getOverlappingEpoch(
+  start_date: DateTime,
+  end_date: DateTime,
+  circle_id: number,
+  ignore_epoch_id?: number
+): Promise<typeof epoch | undefined> {
+  const whereCondition: any = {
+    start_date: { _lte: end_date },
+    circle_id: { _eq: circle_id },
+    end_date: { _gt: start_date },
+  };
+  if (ignore_epoch_id) {
+    whereCondition.id = { _neq: ignore_epoch_id };
+  }
+  const {
+    epochs: [epoch],
+  } = await adminClient.query({
+    epochs: [
+      {
+        limit: 1,
+        where: whereCondition,
+      },
+      {
+        id: true,
+        start_date: true,
+        end_date: true,
+      },
+    ],
+  });
+  return epoch;
+}
+
+export async function getRepeatingEpoch(
+  circle_id: number
+): Promise<typeof repeatingEpoch | undefined> {
+  const {
+    epochs: [repeatingEpoch],
+  } = await adminClient.query({
+    epochs: [
+      {
+        limit: 1,
+        where: {
+          ended: { _eq: false },
+          circle_id: { _eq: circle_id },
+          repeat: { _gte: EPOCH_REPEAT.WEEKLY },
+        },
+      },
+      {
+        id: true,
+        start_date: true,
+        end_date: true,
+      },
+    ],
+  });
+  return repeatingEpoch;
 }

--- a/api-lib/gql/queries.ts
+++ b/api-lib/gql/queries.ts
@@ -1,6 +1,7 @@
 import { DateTime } from 'luxon';
 
 import { EPOCH_REPEAT } from '../../api-lib/constants';
+import { ValueTypes } from '../../api-lib/gql/__generated__/zeus';
 
 import { adminClient } from './adminClient';
 
@@ -286,11 +287,20 @@ export async function getOverlappingEpoch(
   circle_id: number,
   ignore_epoch_id?: number
 ): Promise<typeof epoch | undefined> {
-  const whereCondition: any = {
-    start_date: { _lte: end_date },
+  const whereCondition: ValueTypes['epochs_bool_exp'] = {
     circle_id: { _eq: circle_id },
-    end_date: { _gt: start_date },
+    _or: [
+      {
+        start_date: { _lt: end_date },
+        end_date: { _gt: end_date },
+      },
+      {
+        start_date: { _lt: start_date },
+        end_date: { _gt: start_date },
+      },
+    ],
   };
+
   if (ignore_epoch_id) {
     whereCondition.id = { _neq: ignore_epoch_id };
   }

--- a/api/hasura/actions/updateEpoch.ts
+++ b/api/hasura/actions/updateEpoch.ts
@@ -11,31 +11,74 @@ import {
 } from '../../../api-lib/gql/queries';
 import { errorResponseWithStatusCode } from '../../../api-lib/HttpError';
 import {
-  createEpochInput,
+  updateEpochInput,
   composeHasuraActionRequestBody,
 } from '../../../src/lib/zod';
 
 Settings.defaultZone = 'utc';
 
 async function handler(request: VercelRequest, response: VercelResponse) {
+  const now = DateTime.now();
   const {
     input: { payload: input },
-  } = composeHasuraActionRequestBody(createEpochInput).parse(request.body);
-  const { circle_id, repeat, start_date, days } = input;
-  let repeat_day_of_month = 0;
+  } = composeHasuraActionRequestBody(updateEpochInput).parse(request.body);
+  const { circle_id, repeat, start_date, days, id, grant } = input;
   const end_date = start_date.plus({ days: days });
   if (DateTime.now() > end_date) {
     errorResponseWithStatusCode(
       response,
       {
-        message: `You cannot create an epoch that ends before now`,
+        message: `You cannot set an epoch that ends before now`,
+      },
+      422
+    );
+    return;
+  }
+  const {
+    epochs: [edittingEpoch],
+  } = await adminClient.query({
+    epochs: [
+      {
+        limit: 1,
+        where: {
+          circle_id: { _eq: circle_id },
+          id: { _eq: id },
+          ended: { _eq: false },
+        },
+      },
+      {
+        id: true,
+        start_date: true,
+        end_date: true,
+        repeat: true,
+        repeat_day_of_month: true,
+      },
+    ],
+  });
+
+  if (!edittingEpoch) {
+    errorResponseWithStatusCode(
+      response,
+      {
+        message: `Epoch not found`,
       },
       422
     );
     return;
   }
 
-  if (repeat > 0) {
+  if (now >= DateTime.fromISO(edittingEpoch.start_date) && start_date >= now) {
+    errorResponseWithStatusCode(
+      response,
+      {
+        message: `You cannot change the start date to later than now when epoch has already started`,
+      },
+      422
+    );
+    return;
+  }
+  let repeat_day_of_month = edittingEpoch.repeat_day_of_month;
+  if (repeat > 0 && edittingEpoch.repeat === 0) {
     const repeatingEpoch = await getRepeatingEpoch(circle_id);
     if (repeatingEpoch) {
       errorResponseWithStatusCode(
@@ -60,7 +103,8 @@ async function handler(request: VercelRequest, response: VercelResponse) {
   const overlappingEpoch = await getOverlappingEpoch(
     start_date,
     end_date,
-    circle_id
+    circle_id,
+    id
   );
   if (overlappingEpoch) {
     errorResponseWithStatusCode(
@@ -77,14 +121,18 @@ async function handler(request: VercelRequest, response: VercelResponse) {
     return;
   }
 
-  const { insert_epochs_one } = await adminClient.mutate({
-    insert_epochs_one: [
+  const { update_epochs_by_pk } = await adminClient.mutate({
+    update_epochs_by_pk: [
       {
-        object: {
-          ...input,
+        _set: {
+          start_date,
           end_date,
           repeat_day_of_month,
+          days,
+          repeat,
+          grant,
         },
+        pk_columns: { id },
       },
       {
         id: true,
@@ -92,7 +140,7 @@ async function handler(request: VercelRequest, response: VercelResponse) {
     ],
   });
 
-  response.status(200).json(insert_epochs_one);
+  response.status(200).json(update_epochs_by_pk);
 }
 
 export default authCircleAdminMiddleware(handler);

--- a/api/hasura/actions/updateEpoch.ts
+++ b/api/hasura/actions/updateEpoch.ts
@@ -22,9 +22,9 @@ async function handler(request: VercelRequest, response: VercelResponse) {
   const {
     input: { payload: input },
   } = composeHasuraActionRequestBody(updateEpochInput).parse(request.body);
-  const { circle_id, repeat, start_date, days, id, grant } = input;
+  const { circle_id, repeat, start_date, days, id } = input;
   const end_date = start_date.plus({ days: days });
-  if (DateTime.now() > end_date) {
+  if (now > end_date) {
     errorResponseWithStatusCode(
       response,
       {
@@ -125,12 +125,10 @@ async function handler(request: VercelRequest, response: VercelResponse) {
     update_epochs_by_pk: [
       {
         _set: {
-          start_date,
-          end_date,
+          ...edittingEpoch,
+          ...input,
           repeat_day_of_month,
-          days,
-          repeat,
-          grant,
+          end_date,
         },
         pk_columns: { id },
       },

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -35,6 +35,10 @@ type Mutation {
 }
 
 type Mutation {
+  updateEpoch(payload: UpdateEpochInput!): EpochResponse
+}
+
+type Mutation {
   updateTeammates(payload: UpdateTeammatesInput!): UpdateTeammatesResponse
 }
 
@@ -156,6 +160,15 @@ input UpdateCircleInput {
   only_giver_vouch: Boolean
   auto_opt_out: Boolean
   update_webhook: Boolean
+}
+
+input UpdateEpochInput {
+  id: Int!
+  circle_id: Int!
+  start_date: timestamptz!
+  days: Int!
+  repeat: Int!
+  grant: Float
 }
 
 type CreateCircleResponse {

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -92,6 +92,16 @@ actions:
   permissions:
   - role: superadmin
   - role: user
+- name: updateEpoch
+  definition:
+    kind: synchronous
+    handler: '{{HASURA_API_BASE_URL}}/actions/updateEpoch'
+    headers:
+    - name: verification_key
+      value_from_env: HASURA_EVENT_SECRET
+  permissions:
+  - role: user
+  - role: superadmin
 - name: updateTeammates
   definition:
     kind: synchronous
@@ -172,6 +182,7 @@ custom_types:
   - name: UpdateTeammatesInput
   - name: DeleteUserInput
   - name: UpdateCircleInput
+  - name: UpdateEpochInput
   objects:
   - name: CreateCircleResponse
     relationships:

--- a/src/lib/gql/__generated__/zeus/const.ts
+++ b/src/lib/gql/__generated__/zeus/const.ts
@@ -579,6 +579,44 @@ export const AllTypesProps: Record<string, any> = {
       required: false,
     },
   },
+  UpdateEpochInput: {
+    circle_id: {
+      type: 'Int',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+    days: {
+      type: 'Int',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+    grant: {
+      type: 'Float',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    id: {
+      type: 'Int',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+    repeat: {
+      type: 'Int',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+    start_date: {
+      type: 'timestamptz',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+  },
   UpdateTeammatesInput: {
     circle_id: {
       type: 'Int',
@@ -5504,6 +5542,14 @@ export const AllTypesProps: Record<string, any> = {
     updateCircle: {
       payload: {
         type: 'UpdateCircleInput',
+        array: false,
+        arrayRequired: false,
+        required: true,
+      },
+    },
+    updateEpoch: {
+      payload: {
+        type: 'UpdateEpochInput',
         array: false,
         arrayRequired: false,
         required: true,
@@ -13199,6 +13245,7 @@ export const ReturnTypes: Record<string, any> = {
     insert_vaults_one: 'vaults',
     logoutUser: 'LogoutResponse',
     updateCircle: 'UpdateCircleOutput',
+    updateEpoch: 'EpochResponse',
     updateTeammates: 'UpdateTeammatesResponse',
     updateUser: 'UserResponse',
     update_circles: 'circles_mutation_response',

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -184,6 +184,14 @@ export type ValueTypes = {
     id?: boolean;
     __typename?: boolean;
   }>;
+  ['UpdateEpochInput']: {
+    circle_id: number;
+    days: number;
+    grant?: number | null;
+    id: number;
+    repeat: number;
+    start_date: ValueTypes['timestamptz'];
+  };
   ['UpdateProfileResponse']: AliasType<{
     id?: boolean;
     /** An object relationship */
@@ -1675,6 +1683,10 @@ columns and relationships of "distributions" */
     updateCircle?: [
       { payload: ValueTypes['UpdateCircleInput'] },
       ValueTypes['UpdateCircleOutput']
+    ];
+    updateEpoch?: [
+      { payload: ValueTypes['UpdateEpochInput'] },
+      ValueTypes['EpochResponse']
     ];
     updateTeammates?: [
       { payload: ValueTypes['UpdateTeammatesInput'] },
@@ -4298,6 +4310,7 @@ export type ModelTypes = {
     circle: ModelTypes['circles'];
     id: number;
   };
+  ['UpdateEpochInput']: GraphQLTypes['UpdateEpochInput'];
   ['UpdateProfileResponse']: {
     id: number;
     /** An object relationship */
@@ -4748,6 +4761,7 @@ columns and relationships of "distributions" */
     insert_vaults_one?: ModelTypes['vaults'];
     logoutUser?: ModelTypes['LogoutResponse'];
     updateCircle?: ModelTypes['UpdateCircleOutput'];
+    updateEpoch?: ModelTypes['EpochResponse'];
     updateTeammates?: ModelTypes['UpdateTeammatesResponse'];
     /** Update own user */
     updateUser?: ModelTypes['UserResponse'];
@@ -5799,6 +5813,14 @@ export type GraphQLTypes = {
     /** An object relationship */
     circle: GraphQLTypes['circles'];
     id: number;
+  };
+  ['UpdateEpochInput']: {
+    circle_id: number;
+    days: number;
+    grant?: number;
+    id: number;
+    repeat: number;
+    start_date: GraphQLTypes['timestamptz'];
   };
   ['UpdateProfileResponse']: {
     __typename: 'UpdateProfileResponse';
@@ -7042,6 +7064,7 @@ columns and relationships of "distributions" */
     insert_vaults_one?: GraphQLTypes['vaults'];
     logoutUser?: GraphQLTypes['LogoutResponse'];
     updateCircle?: GraphQLTypes['UpdateCircleOutput'];
+    updateEpoch?: GraphQLTypes['EpochResponse'];
     updateTeammates?: GraphQLTypes['UpdateTeammatesResponse'];
     /** Update own user */
     updateUser?: GraphQLTypes['UserResponse'];

--- a/src/lib/zod/index.ts
+++ b/src/lib/zod/index.ts
@@ -132,6 +132,37 @@ export const createEpochInput = z
     }
   });
 
+export const updateEpochInput = z
+  .object({
+    id: z.number().int().positive(),
+    circle_id: z.number().int().positive(),
+    start_date: zStringISODateUTC,
+    repeat: z.number().int().min(0).max(2),
+    days: z
+      .number()
+      .min(1, 'Must be at least one day.')
+      .max(100, 'cant be more than 100 days'),
+    grant: z.number().positive().min(1).max(1000000000).optional(),
+  })
+  .strict()
+  .superRefine((val, ctx) => {
+    let message;
+    if (val.days > 7 && val.repeat === 1) {
+      message =
+        'You cannot have more than 7 days length for a weekly repeating epoch.';
+    } else if (val.days > 28 && val.repeat === 2) {
+      message =
+        'You cannot have more than 28 days length for a monthly repeating epoch.';
+    }
+
+    if (message) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message,
+      });
+    }
+  });
+
 export const updateTeammatesInput = z
   .object({
     teammates: z.number().int().positive().array(),


### PR DESCRIPTION
fixes #566 
and some refactoring of Create Epoch

### Test Plan
1. run `yarn hasura console`
2. create an epoch with the mutation
```gql
mutation MyMutation {
   createEpoch(payload: {circle_id: <circle_id>, days: <days>, repeat: 0, start_date: "2022-09-27T10:00:00"}) {
     epoch{
       id
       circle_id
       days
       start_date
       end_date
       repeat
     }
   }
}
```
3. With the epoch `id` use it to run the update mutation and set it to any new values
```gql
mutation MyMutation {
    updateEpoch(payload: {circle_id: <circle_id>, days: <days>, id:<id>, repeat: 0, start_date: "2022-08-27T10:00:00"}) {
    epoch {
      id
      start_date
      ended
      end_date
      days
      repeat
      repeat_day_of_month
    }
  }
}
```
4. Epoch now should be updated to the new values
5. You should not be able to
- overlap an existing epoch date
- have more than 1 repeating epoch that has not ended yet
- create/update an epoch to an end date that is earlier than now
