### PR TITLE
making updated_at and start_date non-nullable on epoch

### DIFF
--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -10916,7 +10916,7 @@ columns and relationships of "distributions" */
     /** An object relationship */
     circle?: ModelTypes['circles'];
     circle_id: number;
-    created_at?: ModelTypes['timestamp'];
+    created_at: ModelTypes['timestamp'];
     days?: number;
     end_date: ModelTypes['timestamptz'];
     ended: boolean;
@@ -10933,12 +10933,12 @@ columns and relationships of "distributions" */
     regift_days: number;
     repeat: number;
     repeat_day_of_month: number;
-    start_date?: ModelTypes['timestamptz'];
+    start_date: ModelTypes['timestamptz'];
     /** An array relationship */
     token_gifts: ModelTypes['token_gifts'][];
     /** An aggregate relationship */
     token_gifts_aggregate: ModelTypes['token_gifts_aggregate'];
-    updated_at?: ModelTypes['timestamp'];
+    updated_at: ModelTypes['timestamp'];
   };
   /** aggregated selection of "epoches" */
   ['epochs_aggregate']: {
@@ -16150,7 +16150,7 @@ columns and relationships of "distributions" */
     /** An object relationship */
     circle?: GraphQLTypes['circles'];
     circle_id: number;
-    created_at?: GraphQLTypes['timestamp'];
+    created_at: GraphQLTypes['timestamp'];
     days?: number;
     end_date: GraphQLTypes['timestamptz'];
     ended: boolean;
@@ -16167,12 +16167,12 @@ columns and relationships of "distributions" */
     regift_days: number;
     repeat: number;
     repeat_day_of_month: number;
-    start_date?: GraphQLTypes['timestamptz'];
+    start_date: GraphQLTypes['timestamptz'];
     /** An array relationship */
     token_gifts: Array<GraphQLTypes['token_gifts']>;
     /** An aggregate relationship */
     token_gifts_aggregate: GraphQLTypes['token_gifts_aggregate'];
-    updated_at?: GraphQLTypes['timestamp'];
+    updated_at: GraphQLTypes['timestamp'];
   };
   /** aggregated selection of "epoches" */
   ['epochs_aggregate']: {

--- a/hasura/migrations/default/1649222699929_alter_table_public_epoches_alter_column_updated_at/down.sql
+++ b/hasura/migrations/default/1649222699929_alter_table_public_epoches_alter_column_updated_at/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."epoches" alter column "updated_at" drop not null;

--- a/hasura/migrations/default/1649222699929_alter_table_public_epoches_alter_column_updated_at/up.sql
+++ b/hasura/migrations/default/1649222699929_alter_table_public_epoches_alter_column_updated_at/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."epoches" alter column "updated_at" set not null;

--- a/hasura/migrations/default/1649222711646_alter_table_public_epoches_alter_column_start_date/down.sql
+++ b/hasura/migrations/default/1649222711646_alter_table_public_epoches_alter_column_start_date/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."epoches" alter column "start_date" drop not null;

--- a/hasura/migrations/default/1649222711646_alter_table_public_epoches_alter_column_start_date/up.sql
+++ b/hasura/migrations/default/1649222711646_alter_table_public_epoches_alter_column_start_date/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."epoches" alter column "start_date" set not null;

--- a/hasura/migrations/default/1649222967344_fix_null_epoch_created_at/down.sql
+++ b/hasura/migrations/default/1649222967344_fix_null_epoch_created_at/down.sql
@@ -1,0 +1,3 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- UPDATE "public"."epoches" set created_at=start_date where created_at is null;

--- a/hasura/migrations/default/1649222967344_fix_null_epoch_created_at/up.sql
+++ b/hasura/migrations/default/1649222967344_fix_null_epoch_created_at/up.sql
@@ -1,0 +1,1 @@
+UPDATE "public"."epoches" set created_at=start_date where created_at is null;

--- a/hasura/migrations/default/1649223006624_alter_table_public_epoches_alter_column_created_at/down.sql
+++ b/hasura/migrations/default/1649223006624_alter_table_public_epoches_alter_column_created_at/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."epoches" alter column "created_at" drop not null;

--- a/hasura/migrations/default/1649223006624_alter_table_public_epoches_alter_column_created_at/up.sql
+++ b/hasura/migrations/default/1649223006624_alter_table_public_epoches_alter_column_created_at/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."epoches" alter column "created_at" set not null;

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -4644,7 +4644,7 @@ columns and relationships of "distributions" */
     /** An object relationship */
     circle?: ModelTypes['circles'];
     circle_id: number;
-    created_at?: ModelTypes['timestamp'];
+    created_at: ModelTypes['timestamp'];
     days?: number;
     end_date: ModelTypes['timestamptz'];
     ended: boolean;
@@ -4658,12 +4658,12 @@ columns and relationships of "distributions" */
     number?: number;
     repeat: number;
     repeat_day_of_month: number;
-    start_date?: ModelTypes['timestamptz'];
+    start_date: ModelTypes['timestamptz'];
     /** An array relationship */
     token_gifts: ModelTypes['token_gifts'][];
     /** An aggregate relationship */
     token_gifts_aggregate: ModelTypes['token_gifts_aggregate'];
-    updated_at?: ModelTypes['timestamp'];
+    updated_at: ModelTypes['timestamp'];
   };
   /** order by aggregate values of table "epoches" */
   ['epochs_aggregate_order_by']: GraphQLTypes['epochs_aggregate_order_by'];
@@ -6760,7 +6760,7 @@ columns and relationships of "distributions" */
     /** An object relationship */
     circle?: GraphQLTypes['circles'];
     circle_id: number;
-    created_at?: GraphQLTypes['timestamp'];
+    created_at: GraphQLTypes['timestamp'];
     days?: number;
     end_date: GraphQLTypes['timestamptz'];
     ended: boolean;
@@ -6774,12 +6774,12 @@ columns and relationships of "distributions" */
     number?: number;
     repeat: number;
     repeat_day_of_month: number;
-    start_date?: GraphQLTypes['timestamptz'];
+    start_date: GraphQLTypes['timestamptz'];
     /** An array relationship */
     token_gifts: Array<GraphQLTypes['token_gifts']>;
     /** An aggregate relationship */
     token_gifts_aggregate: GraphQLTypes['token_gifts_aggregate'];
-    updated_at?: GraphQLTypes['timestamp'];
+    updated_at: GraphQLTypes['timestamp'];
   };
   /** order by aggregate values of table "epoches" */
   ['epochs_aggregate_order_by']: {


### PR DESCRIPTION
This makes the zeus typing a lot nicer in the FE. I verified this was ok in the prod data, except for 7 rows that are covered by the UPDATE in this migration. 