### PR TITLE
Create/update token & note allocations

### DIFF
--- a/api-lib/gql/__generated__/zeus/const.ts
+++ b/api-lib/gql/__generated__/zeus/const.ts
@@ -57,6 +57,40 @@ export const AllTypesProps: Record<string, any> = {
       required: false,
     },
   },
+  Allocation: {
+    note: {
+      type: 'String',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+    recipient_id: {
+      type: 'Int',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+    tokens: {
+      type: 'Int',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+  },
+  Allocations: {
+    allocations: {
+      type: 'Allocation',
+      array: true,
+      arrayRequired: false,
+      required: true,
+    },
+    circle_id: {
+      type: 'Int',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+  },
   Boolean_comparison_exp: {
     _eq: {
       type: 'Boolean',
@@ -9119,6 +9153,14 @@ export const AllTypesProps: Record<string, any> = {
         array: false,
         arrayRequired: false,
         required: false,
+      },
+    },
+    updateAllocations: {
+      payload: {
+        type: 'Allocations',
+        array: false,
+        arrayRequired: false,
+        required: true,
       },
     },
     updateCircle: {
@@ -21771,6 +21813,10 @@ export const ReturnTypes: Record<string, any> = {
     ttl: 'Int',
     refresh: 'Boolean',
   },
+  AllocationsResponse: {
+    user: 'users',
+    user_id: 'Int',
+  },
   ConfirmationResponse: {
     success: 'Boolean',
   },
@@ -22976,6 +23022,7 @@ export const ReturnTypes: Record<string, any> = {
     insert_vouches: 'vouches_mutation_response',
     insert_vouches_one: 'vouches',
     logoutUser: 'LogoutResponse',
+    updateAllocations: 'AllocationsResponse',
     updateCircle: 'UpdateCircleOutput',
     updateEpoch: 'EpochResponse',
     updateTeammates: 'UpdateTeammatesResponse',

--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -16,6 +16,21 @@ export type ValueTypes = {
     role?: number | null;
     starting_tokens?: number | null;
   };
+  ['Allocation']: {
+    note: string;
+    recipient_id: number;
+    tokens: number;
+  };
+  ['Allocations']: {
+    allocations?: ValueTypes['Allocation'][];
+    circle_id: number;
+  };
+  ['AllocationsResponse']: AliasType<{
+    /** An object relationship */
+    user?: ValueTypes['users'];
+    user_id?: boolean;
+    __typename?: boolean;
+  }>;
   /** Boolean expression to compare columns of type "Boolean". All fields are combined with logical 'AND'. */
   ['Boolean_comparison_exp']: {
     _eq?: boolean | null;
@@ -4130,6 +4145,10 @@ columns and relationships of "distributions" */
       ValueTypes['vouches']
     ];
     logoutUser?: ValueTypes['LogoutResponse'];
+    updateAllocations?: [
+      { payload: ValueTypes['Allocations'] },
+      ValueTypes['AllocationsResponse']
+    ];
     updateCircle?: [
       { payload: ValueTypes['UpdateCircleInput'] },
       ValueTypes['UpdateCircleOutput']
@@ -9707,6 +9726,13 @@ columns and relationships of "distributions" */
 
 export type ModelTypes = {
   ['AdminUpdateUserInput']: GraphQLTypes['AdminUpdateUserInput'];
+  ['Allocation']: GraphQLTypes['Allocation'];
+  ['Allocations']: GraphQLTypes['Allocations'];
+  ['AllocationsResponse']: {
+    /** An object relationship */
+    user: ModelTypes['users'];
+    user_id: number;
+  };
   /** Boolean expression to compare columns of type "Boolean". All fields are combined with logical 'AND'. */
   ['Boolean_comparison_exp']: GraphQLTypes['Boolean_comparison_exp'];
   ['ConfirmationResponse']: {
@@ -11583,6 +11609,7 @@ columns and relationships of "distributions" */
     /** insert a single row into the table: "vouches" */
     insert_vouches_one?: ModelTypes['vouches'];
     logoutUser?: ModelTypes['LogoutResponse'];
+    updateAllocations?: ModelTypes['AllocationsResponse'];
     updateCircle?: ModelTypes['UpdateCircleOutput'];
     updateEpoch?: ModelTypes['EpochResponse'];
     updateTeammates?: ModelTypes['UpdateTeammatesResponse'];
@@ -13858,6 +13885,21 @@ export type GraphQLTypes = {
     non_receiver?: boolean;
     role?: number;
     starting_tokens?: number;
+  };
+  ['Allocation']: {
+    note: string;
+    recipient_id: number;
+    tokens: number;
+  };
+  ['Allocations']: {
+    allocations?: Array<GraphQLTypes['Allocation']>;
+    circle_id: number;
+  };
+  ['AllocationsResponse']: {
+    __typename: 'AllocationsResponse';
+    /** An object relationship */
+    user: GraphQLTypes['users'];
+    user_id: number;
   };
   /** Boolean expression to compare columns of type "Boolean". All fields are combined with logical 'AND'. */
   ['Boolean_comparison_exp']: {
@@ -17190,6 +17232,7 @@ columns and relationships of "distributions" */
     /** insert a single row into the table: "vouches" */
     insert_vouches_one?: GraphQLTypes['vouches'];
     logoutUser?: GraphQLTypes['LogoutResponse'];
+    updateAllocations?: GraphQLTypes['AllocationsResponse'];
     updateCircle?: GraphQLTypes['UpdateCircleOutput'];
     updateEpoch?: GraphQLTypes['EpochResponse'];
     updateTeammates?: GraphQLTypes['UpdateTeammatesResponse'];
@@ -21379,6 +21422,7 @@ export const enum pending_gift_private_select_column {
 /** unique or primary key constraints on table "pending_token_gifts" */
 export const enum pending_token_gifts_constraint {
   pending_token_gifts_pkey = 'pending_token_gifts_pkey',
+  pending_token_gifts_sender_id_recipient_id_epoch_id_key = 'pending_token_gifts_sender_id_recipient_id_epoch_id_key',
 }
 /** select columns of table "pending_token_gifts" */
 export const enum pending_token_gifts_select_column {

--- a/api-lib/nominees.ts
+++ b/api-lib/nominees.ts
@@ -57,11 +57,40 @@ export const getUserFromProfileIdWithCircle = async (
             },
           },
           {
+            pending_sent_gifts: [
+              {},
+              {
+                id: true,
+                recipient_id: true,
+                recipient_address: true,
+                note: true,
+                tokens: true,
+              },
+            ],
             circle: {
               nomination_days_limit: true,
               min_vouches: true,
+              epochs: [
+                {
+                  where: {
+                    _and: [
+                      { end_date: { _gt: 'now()' } },
+                      { start_date: { _lt: 'now()' } },
+                    ],
+                  },
+                },
+                {
+                  start_date: true,
+                  end_date: true,
+                  id: true,
+                },
+              ],
             },
             id: true,
+            address: true,
+            give_token_remaining: true,
+            starting_tokens: true,
+            non_giver: true,
           },
         ],
       },

--- a/api/hasura/actions/updateAllocations.ts
+++ b/api/hasura/actions/updateAllocations.ts
@@ -1,0 +1,193 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+import { getUsersFromUserIds } from '../../../api-lib/findUser';
+import {
+  ValueTypes,
+  pending_token_gifts_constraint,
+  pending_token_gifts_update_column,
+} from '../../../api-lib/gql/__generated__/zeus';
+import { adminClient } from '../../../api-lib/gql/adminClient';
+import { errorResponseWithStatusCode } from '../../../api-lib/HttpError';
+import { getUserFromProfileIdWithCircle } from '../../../api-lib/nominees';
+import { verifyHasuraRequestMiddleware } from '../../../api-lib/validate';
+import {
+  updateAllocationsInput,
+  composeHasuraActionRequestBodyWithSession,
+  HasuraUserSessionVariables,
+} from '../../../src/lib/zod';
+
+async function handler(req: VercelRequest, res: VercelResponse) {
+  const {
+    input: { payload: input },
+    session_variables: sessionVariables,
+  } = composeHasuraActionRequestBodyWithSession(
+    updateAllocationsInput,
+    HasuraUserSessionVariables
+  ).parse(req.body);
+
+  const profileId = sessionVariables.hasuraProfileId;
+  const { circle_id, allocations } = input;
+
+  const user = await getUserFromProfileIdWithCircle(profileId, circle_id);
+  if (!user) {
+    return errorResponseWithStatusCode(
+      res,
+      { message: 'User does not belong to this circle' },
+      422
+    );
+  }
+  const currentEpoch = user.circle.epochs.pop();
+  if (!currentEpoch) {
+    return errorResponseWithStatusCode(
+      res,
+      { message: 'No Active Epoch' },
+      422
+    );
+  }
+
+  if (allocations.some(a => a.recipient_id === user.id)) {
+    return errorResponseWithStatusCode(
+      res,
+      { message: 'You cannot allocate to yourself' },
+      422
+    );
+  }
+
+  const uniqueValues = new Set(allocations.map(v => v.recipient_id));
+
+  if (uniqueValues.size < allocations.length) {
+    return errorResponseWithStatusCode(
+      res,
+      {
+        message:
+          'You cannot allocate to the same recipient twice in the same request',
+      },
+      422
+    );
+  }
+  // get eligible recipients that are in this circle
+  const eligibleRecipients = await getUsersFromUserIds(
+    allocations.map(a => a.recipient_id),
+    circle_id
+  );
+  if (!eligibleRecipients.length) {
+    return errorResponseWithStatusCode(
+      res,
+      { message: 'Recipient does not belong to this circle' },
+      422
+    );
+  }
+  const { pending_sent_gifts, starting_tokens } = user;
+
+  const newAllocations = allocations.filter(a =>
+    // filter and leave only those that are eligible
+    eligibleRecipients.some(u => u.id === a.recipient_id)
+  );
+
+  const existingAllocations = pending_sent_gifts.filter(
+    // filter away new allocations that intersects with existing allocations so we don't double count
+    g => !newAllocations.some(u => u.recipient_id === g.recipient_id)
+  );
+
+  // add up the tokens of existing allocations
+  let overallTokensUsed = existingAllocations.length
+    ? existingAllocations
+        .map(g => g.tokens)
+        .reduce((total, tokens) => tokens + total)
+    : 0;
+
+  const allocationMutations = newAllocations.reduce((ops, gift) => {
+    const recipient = eligibleRecipients.find(u => u.id === gift.recipient_id);
+    if (!recipient) return ops;
+
+    const giftTokens =
+      user.non_giver || recipient.non_receiver ? 0 : gift.tokens;
+    overallTokensUsed += giftTokens;
+    const existingGift = pending_sent_gifts.find(
+      g => g.recipient_id === gift.recipient_id
+    );
+    ops[gift.recipient_id + '_updateUser'] = {
+      update_users_by_pk: [
+        {
+          pk_columns: { id: gift.recipient_id },
+          _inc: {
+            give_token_received: existingGift
+              ? giftTokens - existingGift.tokens
+              : giftTokens,
+          },
+        },
+        { __typename: true },
+      ],
+    };
+    ops[gift.recipient_id + '_giftMutation'] =
+      giftTokens > 0 || gift.note
+        ? {
+            insert_pending_token_gifts_one: [
+              {
+                object: {
+                  ...gift,
+                  circle_id,
+                  epoch_id: currentEpoch.id,
+                  sender_id: user.id,
+                  sender_address: user.address,
+                  recipient_address: recipient.address,
+                  tokens: giftTokens,
+                },
+                on_conflict: {
+                  constraint:
+                    pending_token_gifts_constraint.pending_token_gifts_sender_id_recipient_id_epoch_id_key,
+                  update_columns: [
+                    pending_token_gifts_update_column.tokens,
+                    pending_token_gifts_update_column.note,
+                    pending_token_gifts_update_column.sender_address,
+                    pending_token_gifts_update_column.recipient_address,
+                  ],
+                },
+              },
+              { __typename: true },
+            ],
+          }
+        : {
+            delete_pending_token_gifts: [
+              {
+                where: {
+                  epoch_id: { _eq: currentEpoch.id },
+                  sender_id: { _eq: user.id },
+                  recipient_id: { _eq: gift.recipient_id },
+                  circle_id: { _eq: circle_id },
+                },
+              },
+              { __typename: true },
+            ],
+          };
+
+    return ops;
+  }, {} as { [aliasKey: string]: ValueTypes['mutation_root'] });
+
+  if (starting_tokens < overallTokensUsed) {
+    return errorResponseWithStatusCode(
+      res,
+      { message: 'You cannot allocate more than your total starting tokens' },
+      422
+    );
+  }
+
+  await adminClient.mutate({
+    update_users_by_pk: [
+      {
+        pk_columns: { id: user.id },
+        _set: {
+          give_token_remaining: starting_tokens - overallTokensUsed,
+        },
+      },
+      { __typename: true },
+    ],
+    __alias: {
+      ...allocationMutations,
+    },
+  });
+
+  return res.status(200).json({ user_id: user.id });
+}
+
+export default verifyHasuraRequestMiddleware(handler);

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -31,6 +31,10 @@ type Mutation {
 }
 
 type Mutation {
+  updateAllocations(payload: Allocations!): AllocationsResponse
+}
+
+type Mutation {
   updateCircle(payload: UpdateCircleInput!): UpdateCircleOutput
 }
 
@@ -171,6 +175,17 @@ input UpdateEpochInput {
   grant: Float
 }
 
+input Allocation {
+  recipient_id: Int!
+  tokens: Int!
+  note: String!
+}
+
+input Allocations {
+  allocations: [Allocation!]
+  circle_id: Int!
+}
+
 type CreateCircleResponse {
   id: Int!
 }
@@ -217,4 +232,8 @@ type ConfirmationResponse {
 
 type UpdateCircleOutput {
   id: Int!
+}
+
+type AllocationsResponse {
+  user_id: Int!
 }

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -82,6 +82,16 @@ actions:
   permissions:
   - role: superadmin
   - role: user
+- name: updateAllocations
+  definition:
+    kind: synchronous
+    handler: '{{HASURA_API_BASE_URL}}/actions/updateAllocations'
+    headers:
+    - name: verification_key
+      value_from_env: HASURA_EVENT_SECRET
+  permissions:
+  - role: user
+  - role: superadmin
 - name: updateCircle
   definition:
     kind: synchronous
@@ -183,6 +193,8 @@ custom_types:
   - name: DeleteUserInput
   - name: UpdateCircleInput
   - name: UpdateEpochInput
+  - name: Allocation
+  - name: Allocations
   objects:
   - name: CreateCircleResponse
     relationships:
@@ -294,4 +306,14 @@ custom_types:
       type: object
       field_mapping:
         id: id
+  - name: AllocationsResponse
+    relationships:
+    - remote_table:
+        schema: public
+        name: users
+      name: user
+      source: default
+      type: object
+      field_mapping:
+        user_id: id
   scalars: []

--- a/hasura/migrations/default/1649169600501_alter_table_public_pending_token_gifts_add_unique_sender_id_recipient_id_epoch_id/down.sql
+++ b/hasura/migrations/default/1649169600501_alter_table_public_pending_token_gifts_add_unique_sender_id_recipient_id_epoch_id/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."pending_token_gifts" drop constraint "pending_token_gifts_sender_id_recipient_id_epoch_id_key";

--- a/hasura/migrations/default/1649169600501_alter_table_public_pending_token_gifts_add_unique_sender_id_recipient_id_epoch_id/down.sql
+++ b/hasura/migrations/default/1649169600501_alter_table_public_pending_token_gifts_add_unique_sender_id_recipient_id_epoch_id/down.sql
@@ -1,1 +1,1 @@
-alter table "public"."pending_token_gifts" drop constraint "pending_token_gifts_sender_id_recipient_id_epoch_id_key";
+alter table "public"."pending_token_gifts" drop constraint if exists "pending_token_gifts_sender_id_recipient_id_epoch_id_key";

--- a/hasura/migrations/default/1649169600501_alter_table_public_pending_token_gifts_add_unique_sender_id_recipient_id_epoch_id/up.sql
+++ b/hasura/migrations/default/1649169600501_alter_table_public_pending_token_gifts_add_unique_sender_id_recipient_id_epoch_id/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."pending_token_gifts" add constraint "pending_token_gifts_sender_id_recipient_id_epoch_id_key" unique ("sender_id", "recipient_id", "epoch_id");

--- a/src/lib/gql/__generated__/zeus/const.ts
+++ b/src/lib/gql/__generated__/zeus/const.ts
@@ -57,6 +57,40 @@ export const AllTypesProps: Record<string, any> = {
       required: false,
     },
   },
+  Allocation: {
+    note: {
+      type: 'String',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+    recipient_id: {
+      type: 'Int',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+    tokens: {
+      type: 'Int',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+  },
+  Allocations: {
+    allocations: {
+      type: 'Allocation',
+      array: true,
+      arrayRequired: false,
+      required: true,
+    },
+    circle_id: {
+      type: 'Int',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+  },
   Boolean_comparison_exp: {
     _eq: {
       type: 'Boolean',
@@ -5534,6 +5568,14 @@ export const AllTypesProps: Record<string, any> = {
     insert_vaults_one: {
       object: {
         type: 'vaults_insert_input',
+        array: false,
+        arrayRequired: false,
+        required: true,
+      },
+    },
+    updateAllocations: {
+      payload: {
+        type: 'Allocations',
         array: false,
         arrayRequired: false,
         required: true,
@@ -13042,6 +13084,10 @@ export const ReturnTypes: Record<string, any> = {
     ttl: 'Int',
     refresh: 'Boolean',
   },
+  AllocationsResponse: {
+    user: 'users',
+    user_id: 'Int',
+  },
   ConfirmationResponse: {
     success: 'Boolean',
   },
@@ -13244,6 +13290,7 @@ export const ReturnTypes: Record<string, any> = {
     insert_vaults: 'vaults_mutation_response',
     insert_vaults_one: 'vaults',
     logoutUser: 'LogoutResponse',
+    updateAllocations: 'AllocationsResponse',
     updateCircle: 'UpdateCircleOutput',
     updateEpoch: 'EpochResponse',
     updateTeammates: 'UpdateTeammatesResponse',

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -16,6 +16,21 @@ export type ValueTypes = {
     role?: number | null;
     starting_tokens?: number | null;
   };
+  ['Allocation']: {
+    note: string;
+    recipient_id: number;
+    tokens: number;
+  };
+  ['Allocations']: {
+    allocations?: ValueTypes['Allocation'][];
+    circle_id: number;
+  };
+  ['AllocationsResponse']: AliasType<{
+    /** An object relationship */
+    user?: ValueTypes['users'];
+    user_id?: boolean;
+    __typename?: boolean;
+  }>;
   /** Boolean expression to compare columns of type "Boolean". All fields are combined with logical 'AND'. */
   ['Boolean_comparison_exp']: {
     _eq?: boolean | null;
@@ -1680,6 +1695,10 @@ columns and relationships of "distributions" */
       ValueTypes['vaults']
     ];
     logoutUser?: ValueTypes['LogoutResponse'];
+    updateAllocations?: [
+      { payload: ValueTypes['Allocations'] },
+      ValueTypes['AllocationsResponse']
+    ];
     updateCircle?: [
       { payload: ValueTypes['UpdateCircleInput'] },
       ValueTypes['UpdateCircleOutput']
@@ -4259,6 +4278,13 @@ columns and relationships of "distributions" */
 
 export type ModelTypes = {
   ['AdminUpdateUserInput']: GraphQLTypes['AdminUpdateUserInput'];
+  ['Allocation']: GraphQLTypes['Allocation'];
+  ['Allocations']: GraphQLTypes['Allocations'];
+  ['AllocationsResponse']: {
+    /** An object relationship */
+    user: ModelTypes['users'];
+    user_id: number;
+  };
   /** Boolean expression to compare columns of type "Boolean". All fields are combined with logical 'AND'. */
   ['Boolean_comparison_exp']: GraphQLTypes['Boolean_comparison_exp'];
   ['ConfirmationResponse']: {
@@ -4760,6 +4786,7 @@ columns and relationships of "distributions" */
     /** insert a single row into the table: "vaults" */
     insert_vaults_one?: ModelTypes['vaults'];
     logoutUser?: ModelTypes['LogoutResponse'];
+    updateAllocations?: ModelTypes['AllocationsResponse'];
     updateCircle?: ModelTypes['UpdateCircleOutput'];
     updateEpoch?: ModelTypes['EpochResponse'];
     updateTeammates?: ModelTypes['UpdateTeammatesResponse'];
@@ -5656,6 +5683,21 @@ export type GraphQLTypes = {
     non_receiver?: boolean;
     role?: number;
     starting_tokens?: number;
+  };
+  ['Allocation']: {
+    note: string;
+    recipient_id: number;
+    tokens: number;
+  };
+  ['Allocations']: {
+    allocations?: Array<GraphQLTypes['Allocation']>;
+    circle_id: number;
+  };
+  ['AllocationsResponse']: {
+    __typename: 'AllocationsResponse';
+    /** An object relationship */
+    user: GraphQLTypes['users'];
+    user_id: number;
   };
   /** Boolean expression to compare columns of type "Boolean". All fields are combined with logical 'AND'. */
   ['Boolean_comparison_exp']: {
@@ -7063,6 +7105,7 @@ columns and relationships of "distributions" */
     /** insert a single row into the table: "vaults" */
     insert_vaults_one?: GraphQLTypes['vaults'];
     logoutUser?: GraphQLTypes['LogoutResponse'];
+    updateAllocations?: GraphQLTypes['AllocationsResponse'];
     updateCircle?: GraphQLTypes['UpdateCircleOutput'];
     updateEpoch?: GraphQLTypes['EpochResponse'];
     updateTeammates?: GraphQLTypes['UpdateTeammatesResponse'];

--- a/src/lib/zod/index.ts
+++ b/src/lib/zod/index.ts
@@ -211,6 +211,17 @@ export const updateCircleInput = z
   })
   .strict();
 
+export const updateAllocationsInput = z.object({
+  allocations: z
+    .object({
+      recipient_id: z.number().int().positive(),
+      tokens: z.number().int().min(0),
+      note: z.string().max(5000).optional(),
+    })
+    .array(),
+  circle_id: z.number().int().positive(),
+});
+
 export const HasuraAdminSessionVariables = z
   .object({
     'x-hasura-role': z.literal('admin'),


### PR DESCRIPTION
fixes #568 
### Test Plan

1. run `yarn hasura console`
2. Choose a circle with multiple users. Make sure you have an active epoch or else create one. Purge all the `pending_gift_token` dummy data for the circle. (this may cause lag as event triggers may fire off)
3. Run this mutation to test, change the allocation array as desired
```gql
mutation MyMutation {
  updateAllocations(payload: {circle_id: <circle>, allocations: 
    [{note: "thank you", recipient_id: <id>, tokens: 42},
     {note: "no thanks", recipient_id: <id>, tokens: 15},
      {note: "", recipient_id: <id>, tokens: 43},
      {note: "hmmm", recipient_id: <id>, tokens: 11},
    ]
  
  }) {
    user {
      id
      give_token_remaining
      pending_sent_gifts{
        recipient_id
        tokens
        gift_private {
          note
        }
      }
    }
  }
}
``` 
4. After allocating check the `users` and `pending_token_gifts` tables to make sure the accounting logic is done right.
5. You should not be able to:
- Allocate to anyone outside of your circle
- Allocate to yourself
- Allocate to the same recipient more than once in the same request
- Allocate when there is no active epoch
- Allocate away more tokens than your `starting_tokens` value
6. Note that:
- Updating an allocation to empty `note` & 0 `tokens` should delete the record
- Allocating to a `non_receiver` will reduce the `token` value to 0
- Allocating as a `non_giver` will reduce the `token` values to 0
- Updating an allocation token amount should update the recipient's `give_token_received` correctly

A new DB unique constraint is added for `pending_token_gifts` for `sender_id`, `recipient_id`, `epoch_id`
to validate there is no constraint violation run
```sql
SELECT sender_id, recipient_id, epoch_id
FROM public.pending_token_gifts
group by sender_id, recipient_id, epoch_id having count(*) > 1;
```