### PR TITLE
migrate postTokenGifts / updateAllocations to use hasura in frontend

### DIFF
--- a/src/hooks/useAllocation.ts
+++ b/src/hooks/useAllocation.ts
@@ -14,7 +14,6 @@ import {
   rBaseTeammates,
 } from 'recoilState/allocation';
 import { rUsersMap, useCircle } from 'recoilState/app';
-import { getApiService } from 'services/api';
 
 import { useDeepChangeEffect } from './useDeepChangeEffect';
 import { useRecoilLoadCatch } from './useRecoilLoadCatch';
@@ -166,7 +165,7 @@ export const useAllocation = (circleId: number) => {
         }))
         .toArray();
 
-      await getApiService().postTokenGifts(myUser.circle_id, params);
+      await mutations.updateAllocations(myUser.circle_id, params);
       await fetchCircle({ circleId: myUser.circle_id });
     },
     [myUser, pendingGifts, localGifts],

--- a/src/lib/gql/mutations.ts
+++ b/src/lib/gql/mutations.ts
@@ -5,6 +5,7 @@ import {
   NominateUserParam,
   UpdateUsersParam,
   UpdateCreateEpochParam,
+  PostTokenGiftsParam,
 } from '../../types';
 
 import { $, ValueTypes } from './__generated__/zeus';
@@ -309,6 +310,32 @@ export async function updateTeammates(circleId: number, teammates: number[]) {
     ],
   });
   return updateTeammates;
+}
+
+export async function updateAllocations(
+  circleId: number,
+  params: PostTokenGiftsParam[]
+) {
+  await client.mutate({
+    updateAllocations: [
+      {
+        payload: {
+          circle_id: circleId,
+          allocations: params.map(a => {
+            const withPatchedNote: Omit<typeof a, 'note'> & { note: string } = {
+              ...a,
+              note: a.note ? a.note : '',
+            };
+            return withPatchedNote;
+          }),
+        },
+      },
+      {
+        user_id: true,
+      },
+    ],
+  });
+  return;
 }
 
 export async function deleteUser(circleId: number, address: string) {

--- a/src/lib/gql/mutations.ts
+++ b/src/lib/gql/mutations.ts
@@ -1,11 +1,11 @@
 import {
   CreateCircleParam,
   IApiCircle,
-  PostUsersParam,
   NominateUserParam,
-  UpdateUsersParam,
-  UpdateCreateEpochParam,
   PostTokenGiftsParam,
+  PostUsersParam,
+  UpdateCreateEpochParam,
+  UpdateUsersParam,
 } from '../../types';
 
 import { $, ValueTypes } from './__generated__/zeus';
@@ -322,11 +322,10 @@ export async function updateAllocations(
         payload: {
           circle_id: circleId,
           allocations: params.map(a => {
-            const withPatchedNote: Omit<typeof a, 'note'> & { note: string } = {
+            return {
               ...a,
               note: a.note ? a.note : '',
             };
-            return withPatchedNote;
           }),
         },
       },

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -4,15 +4,7 @@ import axios from 'axios';
 import { API_URL } from 'config/env';
 import { getSignature } from 'utils/provider';
 
-import {
-  IApiTokenGift,
-  IApiProfile,
-  IApiUser,
-  IApiLogin,
-  IApiManifest,
-  PostTokenGiftsParam,
-  IApiFullCircle,
-} from 'types';
+import { IApiProfile, IApiLogin, IApiManifest, IApiFullCircle } from 'types';
 
 axios.defaults.baseURL = API_URL;
 
@@ -83,16 +75,6 @@ export class APIService {
 
   getProfile = async (address: string): Promise<IApiProfile> => {
     return (await this.axios.get(`/v2/profile/${address}`)).data;
-  };
-
-  postTokenGifts = async (
-    circleId: number,
-    params: PostTokenGiftsParam[]
-  ): Promise<IApiUser & { pending_sent_gifts: IApiTokenGift[] }> => {
-    const response = await this.axios.post(`/v2/${circleId}/token-gifts`, {
-      data: JSON.stringify(params),
-    });
-    return response.data;
   };
 
   downloadCSV = async (circleId: number, epoch: number): Promise<any> => {


### PR DESCRIPTION
Fixes #637 

To test:
1. visit the allocation page for an open epoch
2. open the network tab up
3. make some allocations and write some notes
4. /graphql should be hit but not laravel
5. stuff should work ok and update ok

Note you can't clear out a note to test deletion of the gift entirely because of #753 