### PR TITLE
removing name from updateUser input

### DIFF
--- a/api-lib/gql/__generated__/zeus/const.ts
+++ b/api-lib/gql/__generated__/zeus/const.ts
@@ -716,12 +716,6 @@ export const AllTypesProps: Record<string, any> = {
       arrayRequired: false,
       required: false,
     },
-    name: {
-      type: 'String',
-      array: false,
-      arrayRequired: false,
-      required: false,
-    },
     non_receiver: {
       type: 'Boolean',
       array: false,

--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -242,7 +242,6 @@ export type ValueTypes = {
     bio?: string | null;
     circle_id: number;
     epoch_first_visit?: boolean | null;
-    name?: string | null;
     non_receiver?: boolean | null;
   };
   ['UploadCircleImageInput']: {
@@ -14090,7 +14089,6 @@ export type GraphQLTypes = {
     bio?: string;
     circle_id: number;
     epoch_first_visit?: boolean;
-    name?: string;
     non_receiver?: boolean;
   };
   ['UploadCircleImageInput']: {

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -120,7 +120,6 @@ input CreateNomineeInput {
 
 input UpdateUserInput {
   circle_id: Int!
-  name: String
   non_receiver: Boolean
   epoch_first_visit: Boolean
   bio: String

--- a/src/lib/gql/__generated__/zeus/const.ts
+++ b/src/lib/gql/__generated__/zeus/const.ts
@@ -684,12 +684,6 @@ export const AllTypesProps: Record<string, any> = {
       arrayRequired: false,
       required: false,
     },
-    name: {
-      type: 'String',
-      array: false,
-      arrayRequired: false,
-      required: false,
-    },
     non_receiver: {
       type: 'Boolean',
       array: false,

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -227,7 +227,6 @@ export type ValueTypes = {
     bio?: string | null;
     circle_id: number;
     epoch_first_visit?: boolean | null;
-    name?: string | null;
     non_receiver?: boolean | null;
   };
   ['UploadCircleImageInput']: {
@@ -5884,7 +5883,6 @@ export type GraphQLTypes = {
     bio?: string;
     circle_id: number;
     epoch_first_visit?: boolean;
-    name?: string;
     non_receiver?: boolean;
   };
   ['UploadCircleImageInput']: {

--- a/src/lib/zod/index.ts
+++ b/src/lib/zod/index.ts
@@ -72,7 +72,6 @@ export const createNomineeInputSchema = z
 export const updateUserSchemaInput = z
   .object({
     circle_id: z.number(),
-    name: z.string().min(3).max(255).optional(),
     non_receiver: z.boolean().optional(),
     epoch_first_visit: z.boolean().optional(),
     bio: z.string().optional(),


### PR DESCRIPTION
Fixes #725 

To test:

1. restart docker after updating
2. go to the hasura console
3. Run an updateUser mutation such as this and see that you can no longer specify name
```
mutation MyMutation {
  updateUser(payload: {circle_id: 6}) {
    UserResponse {
      name
      id
    }
  }
}
```
4. test update User ("my epoch" page) in the UI and make sure it still works 