### PR TITLE
moving getDiscordWebhook to use graphql instead of laravel

### DIFF
--- a/src/hooks/useApiAdminCircle.ts
+++ b/src/hooks/useApiAdminCircle.ts
@@ -1,4 +1,5 @@
 import * as mutations from 'lib/gql/mutations';
+import * as queries from 'lib/gql/queries';
 
 import { fileToBase64 } from '../lib/base64';
 import { ValueTypes } from '../lib/gql/__generated__/zeus';
@@ -85,7 +86,7 @@ export const useApiAdminCircle = (circleId: number) => {
 
   const getDiscordWebhook = useRecoilLoadCatch(
     () => async () => {
-      return await getApiService().getDiscordWebhook(circleId);
+      return (await queries.getDiscordWebhook(circleId)) || '';
     },
     [circleId]
   );

--- a/src/lib/gql/queries.ts
+++ b/src/lib/gql/queries.ts
@@ -19,3 +19,21 @@ export const getCurrentEpoch = async (
   });
   return currentEpoch;
 };
+
+export const getDiscordWebhook = async (circleId: number) => {
+  const { circle_private } = await client.query({
+    circle_private: [
+      {
+        where: {
+          circle_id: {
+            _eq: circleId,
+          },
+        },
+      },
+      {
+        discord_webhook: true,
+      },
+    ],
+  });
+  return circle_private.pop()?.discord_webhook;
+};

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -111,11 +111,6 @@ export class APIService {
     return response.data;
   };
 
-  getDiscordWebhook = async (circleId: number): Promise<any> => {
-    const response = await this.axios.get(`/v2/${circleId}/admin/webhook`);
-    return response.data;
-  };
-
   downloadCSV = async (circleId: number, epoch: number): Promise<any> => {
     return this.axios.get(`/v2/${circleId}/csv?epoch=${epoch}`);
   };


### PR DESCRIPTION
Fixes #757 

To test:

1. Go to admin page for a circle
2. open the settings modal
3. open the developer console network tab of browser
4. tap Edit Discord Webhook, verify that network hit is /graphql instead of laravel
5. save and change the webhook
6. refresh the page and reload and visit the edit webhook input again
7.  see that it loads the correct value
8. try changing it and reloading and such