### PR TITLE
Implement restore user hasura action

### DIFF
--- a/api/hasura/actions/restoreUser.ts
+++ b/api/hasura/actions/restoreUser.ts
@@ -1,0 +1,55 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+import { authCircleAdminMiddleware } from '../../../api-lib/circleAdmin';
+import { adminClient } from '../../../api-lib/gql/adminClient';
+import { errorResponseWithStatusCode } from '../../../api-lib/HttpError';
+import {
+  deleteUserInput,
+  composeHasuraActionRequestBody,
+} from '../../../src/lib/zod';
+
+async function handler(req: VercelRequest, res: VercelResponse) {
+  const {
+    input: { payload },
+  } = composeHasuraActionRequestBody(deleteUserInput).parse(req.body);
+
+  const { circle_id, address } = payload;
+
+  const {
+    users: [existingUser],
+  } = await adminClient.query({
+    users: [
+      {
+        limit: 1,
+        where: {
+          address: { _ilike: address },
+          circle_id: { _eq: circle_id },
+          // ignore soft_deleted users
+          deleted_at: { _is_null: false },
+        },
+      },
+      { id: true },
+    ],
+  });
+
+  if (!existingUser) {
+    errorResponseWithStatusCode(res, { message: 'user does not exist' }, 422);
+    return;
+  }
+
+  await adminClient.mutate({
+    update_users_by_pk: [
+      {
+        pk_columns: { id: existingUser.id },
+        _set: { deleted_at: null },
+      },
+      { __typename: true },
+    ],
+  });
+
+  res.status(200).json({
+    success: true,
+  });
+}
+
+export default authCircleAdminMiddleware(handler);

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -1,29 +1,43 @@
 type Mutation {
-  adminUpdateUser(payload: AdminUpdateUserInput!): UserResponse
+  adminUpdateUser(
+    payload: AdminUpdateUserInput!
+  ): UserResponse
 }
 
 type Mutation {
-  createCircle(payload: CreateCircleInput!): CreateCircleResponse
+  createCircle(
+    payload: CreateCircleInput!
+  ): CreateCircleResponse
 }
 
 type Mutation {
-  createEpoch(payload: CreateEpochInput!): EpochResponse
+  createEpoch(
+    payload: CreateEpochInput!
+  ): EpochResponse
 }
 
 type Mutation {
-  createNominee(payload: CreateNomineeInput!): CreateNomineeResponse
+  createNominee(
+    payload: CreateNomineeInput!
+  ): CreateNomineeResponse
 }
 
 type Mutation {
-  createUser(payload: CreateUserInput!): UserResponse
+  createUser(
+    payload: CreateUserInput!
+  ): UserResponse
 }
 
 type Mutation {
-  deleteEpoch(payload: DeleteEpochInput!): DeleteEpochResponse
+  deleteEpoch(
+    payload: DeleteEpochInput!
+  ): DeleteEpochResponse
 }
 
 type Mutation {
-  deleteUser(payload: DeleteUserInput!): ConfirmationResponse
+  deleteUser(
+    payload: DeleteUserInput!
+  ): ConfirmationResponse
 }
 
 type Mutation {
@@ -31,39 +45,63 @@ type Mutation {
 }
 
 type Mutation {
-  updateAllocations(payload: Allocations!): AllocationsResponse
+  restoreUser(
+    payload: DeletedUserInput!
+  ): ConfirmationResponse
 }
 
 type Mutation {
-  updateCircle(payload: UpdateCircleInput!): UpdateCircleOutput
+  updateAllocations(
+    payload: Allocations!
+  ): AllocationsResponse
 }
 
 type Mutation {
-  updateEpoch(payload: UpdateEpochInput!): EpochResponse
+  updateCircle(
+    payload: UpdateCircleInput!
+  ): UpdateCircleOutput
 }
 
 type Mutation {
-  updateTeammates(payload: UpdateTeammatesInput!): UpdateTeammatesResponse
+  updateEpoch(
+    payload: UpdateEpochInput!
+  ): EpochResponse
 }
 
 type Mutation {
-  updateUser(payload: UpdateUserInput!): UserResponse
+  updateTeammates(
+    payload: UpdateTeammatesInput!
+  ): UpdateTeammatesResponse
 }
 
 type Mutation {
-  uploadCircleLogo(payload: UploadCircleImageInput!): UpdateCircleResponse
+  updateUser(
+    payload: UpdateUserInput!
+  ): UserResponse
 }
 
 type Mutation {
-  uploadProfileAvatar(payload: UploadImageInput!): UpdateProfileResponse
+  uploadCircleLogo(
+    payload: UploadCircleImageInput!
+  ): UpdateCircleResponse
 }
 
 type Mutation {
-  uploadProfileBackground(payload: UploadImageInput!): UpdateProfileResponse
+  uploadProfileAvatar(
+    payload: UploadImageInput!
+  ): UpdateProfileResponse
 }
 
 type Mutation {
-  vouch(payload: VouchInput!): VouchOutput
+  uploadProfileBackground(
+    payload: UploadImageInput!
+  ): UpdateProfileResponse
+}
+
+type Mutation {
+  vouch(
+    payload: VouchInput!
+  ): VouchOutput
 }
 
 input CreateCircleInput {
@@ -185,6 +223,11 @@ input Allocations {
   circle_id: Int!
 }
 
+input DeletedUserInput {
+  circle_id: Int!
+  address: String!
+}
+
 type CreateCircleResponse {
   id: Int!
 }
@@ -236,3 +279,4 @@ type UpdateCircleOutput {
 type AllocationsResponse {
   user_id: Int!
 }
+

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -82,6 +82,13 @@ actions:
   permissions:
   - role: superadmin
   - role: user
+- name: restoreUser
+  definition:
+    kind: synchronous
+    handler: '{{HASURA_API_BASE_URL}}/actions/restoreUser'
+    headers:
+    - name: verification_key
+      value_from_env: HASURA_EVENT_SECRET
 - name: updateAllocations
   definition:
     kind: synchronous
@@ -195,6 +202,7 @@ custom_types:
   - name: UpdateEpochInput
   - name: Allocation
   - name: Allocations
+  - name: DeletedUserInput
   objects:
   - name: CreateCircleResponse
     relationships:


### PR DESCRIPTION
Part of #558
related: #701.
____
Test Plan:
1. Pick a previously deleted user to delete.
2. If there is no deleted user, follow #701.
2. run the following mutation:
```graphql
mutation {
  restoreUser(payload: {circle_id: <id>, address: <address>}) {
      success
  }
}
```

4. query the same user and make sure that `deleted_at` has become null:
```graphql
{
  users(where: {id: {_eq: <id>}}) {
    id
    deleted_at
  }
}
```