### PR TITLE
Remove capitalization from AllocationEpoch component

### DIFF
--- a/src/pages/AllocationPage/AllocationEpoch.tsx
+++ b/src/pages/AllocationPage/AllocationEpoch.tsx
@@ -161,9 +161,7 @@ const AllocationEpoch = ({
         className={classes.bioTextarea}
         maxLength={MAX_BIO_LENGTH}
         onChange={onChangeBio}
-        placeholder={`Tell us about your contributions in the ${capitalize(
-          selectedCircle?.name
-        )} Circle this epoch...`}
+        placeholder={`Tell us about your contributions in the ${selectedCircle?.name} Circle this epoch...`}
         value={epochBio}
       />
       {!fixedNonReceiver ? (


### PR DESCRIPTION
The capitalization in the AllocationEpoch component should match the data source so I removed the capitalization of the string.

fixes #747 