### PR TITLE
Exclude non receivers from auto reblancer

### DIFF
--- a/src/hooks/useAllocation.ts
+++ b/src/hooks/useAllocation.ts
@@ -121,10 +121,13 @@ export const useAllocation = (circleId: number) => {
     if (tokenAllocated === 0) {
       setLocalGifts(
         localGifts.slice().map(g => {
-          return {
-            ...g,
-            tokens: Math.floor(tokenStarting / teammateReceiverCount),
-          };
+          if (!g.user.non_receiver) {
+            return {
+              ...g,
+              tokens: Math.floor(tokenStarting / teammateReceiverCount),
+            };
+          }
+          return g;
         })
       );
     } else {


### PR DESCRIPTION
Bug #463 fix: If opted out from give members are added to allocation team they will received give if auto redistribute button is clicked and the remaining gives will be negative.
fix:
Add a condition to rebalanceGifts to check if the user is opted in for receiving or not before distributing the balance if there is no weight is assigned to the receiver