### PR TITLE
Bugfix: duplicated epoch entries in db

### DIFF
--- a/api-lib/gql/queries.ts
+++ b/api-lib/gql/queries.ts
@@ -292,10 +292,10 @@ export async function getOverlappingEpoch(
     _or: [
       {
         start_date: { _lt: end_date },
-        end_date: { _gt: end_date },
+        end_date: { _gte: end_date },
       },
       {
-        start_date: { _lt: start_date },
+        start_date: { _lte: start_date },
         end_date: { _gt: start_date },
       },
     ],


### PR DESCRIPTION
fixes #777

It's possible to create overlapping epoch right now if the start and end
ISO timestamps are _exactly_ equal to an existing epoch.

This change fixes the issue, by checking for equality while still
allowing for a new epoch to start at the exact same time as an epoch
ends.

test plan:

Find an existing epoch and grab the start_date and end_date.

The problem can be replicated by in GraphiQL (http://localhost:8080)
by plugging the start and end date in
here:
```gql
  epochs(where: {
       circle_id: { _eq: <circle_id> },
    _or: [
      {
        start_date: { _lt: <existing end_date> },
        end_date: { _gt: <existing end date> },
      },
      {
        start_date: { _lt: <existing start_date> },
        end_date: { _gt: <existing start_date> },
      },
    ],

    }) {
    	id
    	circle_id
    	start_date
    	end_date
  }
```

You'll notice that no overlapping epochs are returned by this query,
  which is obviously incorrect.

This query fixes it:
```gql
  epochs(where: {
       circle_id: { _eq: <circle_id> },
    _or: [
      {
        start_date: { _lt: <existing end_date> },
        end_date: { _gte: <existing end date> },
      },
      {
        start_date: { _lte: <existing start_date> },
        end_date: { _gt: <existing start_date> },
      },
    ],

    }) {
    	id
    	circle_id
    	start_date
    	end_date
  }
```
You'll notice that this returns the existing epoch the timestamps were
copied from.