### PR TITLE
Implement createUsers in bulk Hasura action

### DIFF
--- a/api-lib/gql/__generated__/zeus/const.ts
+++ b/api-lib/gql/__generated__/zeus/const.ts
@@ -379,6 +379,20 @@ export const AllTypesProps: Record<string, any> = {
       required: false,
     },
   },
+  CreateUsersInput: {
+    circle_id: {
+      type: 'Int',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+    users: {
+      type: 'UserObj',
+      array: true,
+      arrayRequired: false,
+      required: true,
+    },
+  },
   DeleteEpochInput: {
     circle_id: {
       type: 'Int',
@@ -769,6 +783,50 @@ export const AllTypesProps: Record<string, any> = {
       array: false,
       arrayRequired: false,
       required: true,
+    },
+  },
+  UserObj: {
+    address: {
+      type: 'String',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+    fixed_non_receiver: {
+      type: 'Boolean',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    name: {
+      type: 'String',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+    non_giver: {
+      type: 'Boolean',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    non_receiver: {
+      type: 'Boolean',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    role: {
+      type: 'Int',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    starting_tokens: {
+      type: 'Int',
+      array: false,
+      arrayRequired: false,
+      required: false,
     },
   },
   VouchInput: {
@@ -8533,6 +8591,14 @@ export const AllTypesProps: Record<string, any> = {
     createUser: {
       payload: {
         type: 'CreateUserInput',
+        array: false,
+        arrayRequired: false,
+        required: true,
+      },
+    },
+    createUsers: {
+      payload: {
+        type: 'CreateUsersInput',
         array: false,
         arrayRequired: false,
         required: true,
@@ -22229,7 +22295,15 @@ export const ReturnTypes: Record<string, any> = {
   },
   UserResponse: {
     UserResponse: 'users',
+    address: 'String',
+    circle_id: 'Int',
+    fixed_non_receiver: 'Boolean',
     id: 'ID',
+    name: 'String',
+    non_giver: 'Boolean',
+    non_receiver: 'Boolean',
+    role: 'Int',
+    starting_tokens: 'Int',
   },
   VouchOutput: {
     id: 'Int',
@@ -23328,6 +23402,7 @@ export const ReturnTypes: Record<string, any> = {
     createEpoch: 'EpochResponse',
     createNominee: 'CreateNomineeResponse',
     createUser: 'UserResponse',
+    createUsers: 'UserResponse',
     deleteEpoch: 'DeleteEpochResponse',
     deleteUser: 'ConfirmationResponse',
     delete_burns: 'burns_mutation_response',

--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -127,6 +127,10 @@ export type ValueTypes = {
     role?: number | null;
     starting_tokens?: number | null;
   };
+  ['CreateUsersInput']: {
+    circle_id: number;
+    users?: ValueTypes['UserObj'][];
+  };
   ['DeleteEpochInput']: {
     circle_id: number;
     id: number;
@@ -261,10 +265,27 @@ export type ValueTypes = {
   ['UploadImageInput']: {
     image_data_base64: string;
   };
+  ['UserObj']: {
+    address: string;
+    fixed_non_receiver?: boolean | null;
+    name: string;
+    non_giver?: boolean | null;
+    non_receiver?: boolean | null;
+    role?: number | null;
+    starting_tokens?: number | null;
+  };
   ['UserResponse']: AliasType<{
     /** An object relationship */
     UserResponse?: ValueTypes['users'];
+    address?: boolean;
+    circle_id?: boolean;
+    fixed_non_receiver?: boolean;
     id?: boolean;
+    name?: boolean;
+    non_giver?: boolean;
+    non_receiver?: boolean;
+    role?: boolean;
+    starting_tokens?: boolean;
     __typename?: boolean;
   }>;
   ['VouchInput']: {
@@ -3683,6 +3704,10 @@ columns and relationships of "distributions" */
     ];
     createUser?: [
       { payload: ValueTypes['CreateUserInput'] },
+      ValueTypes['UserResponse']
+    ];
+    createUsers?: [
+      { payload: ValueTypes['CreateUsersInput'] },
       ValueTypes['UserResponse']
     ];
     deleteEpoch?: [
@@ -9900,6 +9925,7 @@ export type ModelTypes = {
     nominee: ModelTypes['nominees'];
   };
   ['CreateUserInput']: GraphQLTypes['CreateUserInput'];
+  ['CreateUsersInput']: GraphQLTypes['CreateUsersInput'];
   ['DeleteEpochInput']: GraphQLTypes['DeleteEpochInput'];
   ['DeleteEpochResponse']: {
     success: boolean;
@@ -9945,10 +9971,19 @@ export type ModelTypes = {
   ['UpdateUserInput']: GraphQLTypes['UpdateUserInput'];
   ['UploadCircleImageInput']: GraphQLTypes['UploadCircleImageInput'];
   ['UploadImageInput']: GraphQLTypes['UploadImageInput'];
+  ['UserObj']: GraphQLTypes['UserObj'];
   ['UserResponse']: {
     /** An object relationship */
     UserResponse: ModelTypes['users'];
+    address: string;
+    circle_id: number;
+    fixed_non_receiver?: boolean;
     id: string;
+    name: string;
+    non_giver?: boolean;
+    non_receiver?: boolean;
+    role?: number;
+    starting_tokens?: number;
   };
   ['VouchInput']: GraphQLTypes['VouchInput'];
   ['VouchOutput']: {
@@ -11617,6 +11652,7 @@ columns and relationships of "distributions" */
     createEpoch?: ModelTypes['EpochResponse'];
     createNominee?: ModelTypes['CreateNomineeResponse'];
     createUser?: ModelTypes['UserResponse'];
+    createUsers?: (ModelTypes['UserResponse'] | undefined)[];
     deleteEpoch?: ModelTypes['DeleteEpochResponse'];
     deleteUser?: ModelTypes['ConfirmationResponse'];
     /** delete data from the table: "burns" */
@@ -14154,6 +14190,10 @@ export type GraphQLTypes = {
     role?: number;
     starting_tokens?: number;
   };
+  ['CreateUsersInput']: {
+    circle_id: number;
+    users?: Array<GraphQLTypes['UserObj']>;
+  };
   ['DeleteEpochInput']: {
     circle_id: number;
     id: number;
@@ -14288,11 +14328,28 @@ export type GraphQLTypes = {
   ['UploadImageInput']: {
     image_data_base64: string;
   };
+  ['UserObj']: {
+    address: string;
+    fixed_non_receiver?: boolean;
+    name: string;
+    non_giver?: boolean;
+    non_receiver?: boolean;
+    role?: number;
+    starting_tokens?: number;
+  };
   ['UserResponse']: {
     __typename: 'UserResponse';
     /** An object relationship */
     UserResponse: GraphQLTypes['users'];
+    address: string;
+    circle_id: number;
+    fixed_non_receiver?: boolean;
     id: string;
+    name: string;
+    non_giver?: boolean;
+    non_receiver?: boolean;
+    role?: number;
+    starting_tokens?: number;
   };
   ['VouchInput']: {
     nominee_id: number;
@@ -17340,6 +17397,7 @@ columns and relationships of "distributions" */
     createEpoch?: GraphQLTypes['EpochResponse'];
     createNominee?: GraphQLTypes['CreateNomineeResponse'];
     createUser?: GraphQLTypes['UserResponse'];
+    createUsers?: Array<GraphQLTypes['UserResponse'] | undefined>;
     deleteEpoch?: GraphQLTypes['DeleteEpochResponse'];
     deleteUser?: GraphQLTypes['ConfirmationResponse'];
     /** delete data from the table: "burns" */

--- a/api/hasura/actions/createUsers.ts
+++ b/api/hasura/actions/createUsers.ts
@@ -1,0 +1,164 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+import { authCircleAdminMiddleware } from '../../../api-lib/circleAdmin';
+import { ValueTypes } from '../../../api-lib/gql/__generated__/zeus';
+import { adminClient } from '../../../api-lib/gql/adminClient';
+import { errorResponseWithStatusCode } from '../../../api-lib/HttpError';
+import {
+  composeHasuraActionRequestBody,
+  createUsersBulkSchemaInput,
+} from '../../../src/lib/zod';
+
+async function handler(req: VercelRequest, res: VercelResponse) {
+  const {
+    input: { payload: input },
+  } = composeHasuraActionRequestBody(createUsersBulkSchemaInput).parse(
+    req.body
+  );
+
+  const { circle_id, users } = input;
+
+  const uniqueAddresses = [...new Set(users.map(u => u.address.toLowerCase()))];
+
+  // Check if bulk contains duplicates.
+  if (uniqueAddresses.length < users.length) {
+    return errorResponseWithStatusCode(
+      res,
+      {
+        message: `Users list contains duplicate address.`,
+      },
+      422
+    );
+  }
+
+  // Load all members of the provided circle with duplicate addresses.
+  const { users: existingUsers } = await adminClient.query({
+    users: [
+      {
+        where: {
+          circle_id: { _eq: circle_id },
+          _or: uniqueAddresses.map(add => {
+            return { address: { _ilike: add } };
+          }),
+        },
+      },
+      {
+        id: true,
+        address: true,
+        deleted_at: true,
+        starting_tokens: true,
+      },
+    ],
+  });
+
+  const usersToUpdate = existingUsers.map(eu => {
+    const updatedUser = users.find(
+      u => u.address.toLowerCase() === eu.address.toLowerCase()
+    );
+    return {
+      ...eu,
+      ...updatedUser,
+      give_token_remaining: updatedUser?.starting_tokens,
+    };
+  });
+
+  // Check if a user exists without a soft deletion conflicts with the new bulk.
+  const conflict = usersToUpdate.filter(u => !u.deleted_at);
+  if (conflict.length) {
+    return errorResponseWithStatusCode(
+      res,
+      {
+        message: `Users already exist: [${conflict
+          .map(e => e.address)
+          .join(', ')}]`,
+      },
+      422
+    );
+  }
+
+  const newUsers = users
+    .filter(u => {
+      return !existingUsers.some(
+        eu => eu.address.toLowerCase() === u.address.toLowerCase()
+      );
+    })
+    .map(u => ({ ...u, circle_id }));
+
+  const updateUsersMutation = usersToUpdate.reduce((opts, user) => {
+    opts[user.address] = {
+      update_users_by_pk: [
+        {
+          pk_columns: { id: user.id },
+          _set: {
+            ...user,
+            deleted_at: null,
+          },
+        },
+        {
+          id: true,
+          circle_id: true,
+          name: true,
+          address: true,
+          non_giver: true,
+          fixed_non_receiver: true,
+          non_receiver: true,
+          starting_tokens: true,
+          role: true,
+        },
+      ],
+    };
+
+    // End any active nomination
+    opts[user.address + '_update_nominee'] = {
+      update_nominees: [
+        {
+          _set: { ended: true },
+          where: {
+            circle_id: { _eq: circle_id },
+            address: { _ilike: user.address },
+            name: { _eq: user.name },
+            ended: { _eq: false },
+          },
+        },
+        {
+          returning: {
+            id: true,
+          },
+        },
+      ],
+    };
+    return opts;
+  }, {} as { [aliasKey: string]: ValueTypes['mutation_root'] });
+
+  // Update the state after all validations have passed
+  const mutationResult = await adminClient.mutate({
+    insert_users: [
+      {
+        objects: newUsers,
+      },
+      {
+        returning: {
+          id: true,
+          circle_id: true,
+          name: true,
+          address: true,
+          non_giver: true,
+          fixed_non_receiver: true,
+          non_receiver: true,
+          starting_tokens: true,
+          role: true,
+        },
+      },
+    ],
+    __alias: { ...updateUsersMutation },
+  });
+
+  // Get the returning values from each update-user aliases.
+  const results = usersToUpdate
+    .map(u => mutationResult[u.address].update_users_by_pk)
+    .concat(mutationResult.insert_users?.returning as []);
+
+  return res.status(200).json(results);
+}
+
+export default authCircleAdminMiddleware(handler);

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -1,5 +1,7 @@
 type Mutation {
-  adminUpdateUser(payload: AdminUpdateUserInput!): UserResponse
+  adminUpdateUser(
+    payload: AdminUpdateUserInput!
+  ): UserResponse
 }
 
 type Mutation {
@@ -11,23 +13,39 @@ type Mutation {
 }
 
 type Mutation {
-  createEpoch(payload: CreateEpochInput!): EpochResponse
+  createEpoch(
+    payload: CreateEpochInput!
+  ): EpochResponse
 }
 
 type Mutation {
-  createNominee(payload: CreateNomineeInput!): CreateNomineeResponse
+  createNominee(
+    payload: CreateNomineeInput!
+  ): CreateNomineeResponse
 }
 
 type Mutation {
-  createUser(payload: CreateUserInput!): UserResponse
+  createUser(
+    payload: CreateUserInput!
+  ): UserResponse
 }
 
 type Mutation {
-  deleteEpoch(payload: DeleteEpochInput!): DeleteEpochResponse
+  createUsers(
+    payload: CreateUsersInput!
+  ): [UserResponse]
 }
 
 type Mutation {
-  deleteUser(payload: DeleteUserInput!): ConfirmationResponse
+  deleteEpoch(
+    payload: DeleteEpochInput!
+  ): DeleteEpochResponse
+}
+
+type Mutation {
+  deleteUser(
+    payload: DeleteUserInput!
+  ): ConfirmationResponse
 }
 
 type Mutation {
@@ -35,39 +53,57 @@ type Mutation {
 }
 
 type Mutation {
-  updateAllocations(payload: Allocations!): AllocationsResponse
+  updateAllocations(
+    payload: Allocations!
+  ): AllocationsResponse
 }
 
 type Mutation {
-  updateCircle(payload: UpdateCircleInput!): UpdateCircleOutput
+  updateCircle(
+    payload: UpdateCircleInput!
+  ): UpdateCircleOutput
 }
 
 type Mutation {
-  updateEpoch(payload: UpdateEpochInput!): EpochResponse
+  updateEpoch(
+    payload: UpdateEpochInput!
+  ): EpochResponse
 }
 
 type Mutation {
-  updateTeammates(payload: UpdateTeammatesInput!): UpdateTeammatesResponse
+  updateTeammates(
+    payload: UpdateTeammatesInput!
+  ): UpdateTeammatesResponse
 }
 
 type Mutation {
-  updateUser(payload: UpdateUserInput!): UserResponse
+  updateUser(
+    payload: UpdateUserInput!
+  ): UserResponse
 }
 
 type Mutation {
-  uploadCircleLogo(payload: UploadCircleImageInput!): UpdateCircleResponse
+  uploadCircleLogo(
+    payload: UploadCircleImageInput!
+  ): UpdateCircleResponse
 }
 
 type Mutation {
-  uploadProfileAvatar(payload: UploadImageInput!): UpdateProfileResponse
+  uploadProfileAvatar(
+    payload: UploadImageInput!
+  ): UpdateProfileResponse
 }
 
 type Mutation {
-  uploadProfileBackground(payload: UploadImageInput!): UpdateProfileResponse
+  uploadProfileBackground(
+    payload: UploadImageInput!
+  ): UpdateProfileResponse
 }
 
 type Mutation {
-  vouch(payload: VouchInput!): VouchOutput
+  vouch(
+    payload: VouchInput!
+  ): VouchOutput
 }
 
 input CreateCircleInput {
@@ -189,6 +225,19 @@ input Allocations {
   circle_id: Int!
 }
 
+input CreateUsersInput {
+  circle_id: Int!
+  users: [UserObj]!
+}
+
+input UserObj {
+  name: String!
+  address: String!
+  non_giver: Boolean
+  fixed_non_receiver: Boolean
+  non_receiver: Boolean
+  starting_tokens: Int
+  role: Int
 input AllocationCsvInput {
   circle_id: Int!
   grant: Float
@@ -214,6 +263,14 @@ type LogoutResponse {
 
 type UserResponse {
   id: ID!
+  circle_id: Int!
+  name: String!
+  address: String!
+  non_giver: Boolean
+  fixed_non_receiver: Boolean
+  non_receiver: Boolean
+  starting_tokens: Int
+  role: Int
 }
 
 type DeleteEpochResponse {
@@ -246,6 +303,15 @@ type UpdateCircleOutput {
 
 type AllocationsResponse {
   user_id: Int!
+}
+
+type CreateUsersResponse {
+  responses: [ID]!
+}
+
+type UserOutput {
+  id: ID!
+  address: String!
 }
 
 type AllocationCsvResponse {

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -62,6 +62,17 @@ actions:
   permissions:
   - role: user
   - role: superadmin
+- name: createUsers
+  definition:
+    kind: synchronous
+    handler: '{{HASURA_API_BASE_URL}}/actions/createUsers'
+    forward_client_headers: true
+    headers:
+    - name: verification_key
+      value_from_env: HASURA_EVENT_SECRET
+  permissions:
+  - role: user
+  - role: superadmin
 - name: deleteEpoch
   definition:
     kind: synchronous
@@ -206,6 +217,8 @@ custom_types:
   - name: Allocation
   - name: Allocations
   - name: AllocationCsvInput
+  - name: CreateUsersInput
+  - name: UserObj
   objects:
   - name: CreateCircleResponse
     relationships:
@@ -328,4 +341,6 @@ custom_types:
       field_mapping:
         user_id: id
   - name: AllocationCsvResponse
+  - name: CreateUsersResponse
+  - name: UserOutput
   scalars: []

--- a/src/lib/gql/__generated__/zeus/const.ts
+++ b/src/lib/gql/__generated__/zeus/const.ts
@@ -347,6 +347,20 @@ export const AllTypesProps: Record<string, any> = {
       required: false,
     },
   },
+  CreateUsersInput: {
+    circle_id: {
+      type: 'Int',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+    users: {
+      type: 'UserObj',
+      array: true,
+      arrayRequired: false,
+      required: true,
+    },
+  },
   DeleteEpochInput: {
     circle_id: {
       type: 'Int',
@@ -737,6 +751,50 @@ export const AllTypesProps: Record<string, any> = {
       array: false,
       arrayRequired: false,
       required: true,
+    },
+  },
+  UserObj: {
+    address: {
+      type: 'String',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+    fixed_non_receiver: {
+      type: 'Boolean',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    name: {
+      type: 'String',
+      array: false,
+      arrayRequired: false,
+      required: true,
+    },
+    non_giver: {
+      type: 'Boolean',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    non_receiver: {
+      type: 'Boolean',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    role: {
+      type: 'Int',
+      array: false,
+      arrayRequired: false,
+      required: false,
+    },
+    starting_tokens: {
+      type: 'Int',
+      array: false,
+      arrayRequired: false,
+      required: false,
     },
   },
   VouchInput: {
@@ -5695,6 +5753,14 @@ export const AllTypesProps: Record<string, any> = {
     createUser: {
       payload: {
         type: 'CreateUserInput',
+        array: false,
+        arrayRequired: false,
+        required: true,
+      },
+    },
+    createUsers: {
+      payload: {
+        type: 'CreateUsersInput',
         array: false,
         arrayRequired: false,
         required: true,
@@ -13407,7 +13473,15 @@ export const ReturnTypes: Record<string, any> = {
   },
   UserResponse: {
     UserResponse: 'users',
+    address: 'String',
+    circle_id: 'Int',
+    fixed_non_receiver: 'Boolean',
     id: 'ID',
+    name: 'String',
+    non_giver: 'Boolean',
+    non_receiver: 'Boolean',
+    role: 'Int',
+    starting_tokens: 'Int',
   },
   VouchOutput: {
     id: 'Int',
@@ -13558,6 +13632,7 @@ export const ReturnTypes: Record<string, any> = {
     createEpoch: 'EpochResponse',
     createNominee: 'CreateNomineeResponse',
     createUser: 'UserResponse',
+    createUsers: 'UserResponse',
     deleteEpoch: 'DeleteEpochResponse',
     deleteUser: 'ConfirmationResponse',
     delete_circle_integrations: 'circle_integrations_mutation_response',

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -112,6 +112,10 @@ export type ValueTypes = {
     role?: number | null;
     starting_tokens?: number | null;
   };
+  ['CreateUsersInput']: {
+    circle_id: number;
+    users?: ValueTypes['UserObj'][];
+  };
   ['DeleteEpochInput']: {
     circle_id: number;
     id: number;
@@ -246,10 +250,27 @@ export type ValueTypes = {
   ['UploadImageInput']: {
     image_data_base64: string;
   };
+  ['UserObj']: {
+    address: string;
+    fixed_non_receiver?: boolean | null;
+    name: string;
+    non_giver?: boolean | null;
+    non_receiver?: boolean | null;
+    role?: number | null;
+    starting_tokens?: number | null;
+  };
   ['UserResponse']: AliasType<{
     /** An object relationship */
     UserResponse?: ValueTypes['users'];
+    address?: boolean;
+    circle_id?: boolean;
+    fixed_non_receiver?: boolean;
     id?: boolean;
+    name?: boolean;
+    non_giver?: boolean;
+    non_receiver?: boolean;
+    role?: boolean;
+    starting_tokens?: boolean;
     __typename?: boolean;
   }>;
   ['VouchInput']: {
@@ -1671,6 +1692,10 @@ columns and relationships of "distributions" */
     ];
     createUser?: [
       { payload: ValueTypes['CreateUserInput'] },
+      ValueTypes['UserResponse']
+    ];
+    createUsers?: [
+      { payload: ValueTypes['CreateUsersInput'] },
       ValueTypes['UserResponse']
     ];
     deleteEpoch?: [
@@ -4387,6 +4412,7 @@ export type ModelTypes = {
     nominee: ModelTypes['nominees'];
   };
   ['CreateUserInput']: GraphQLTypes['CreateUserInput'];
+  ['CreateUsersInput']: GraphQLTypes['CreateUsersInput'];
   ['DeleteEpochInput']: GraphQLTypes['DeleteEpochInput'];
   ['DeleteEpochResponse']: {
     success: boolean;
@@ -4432,10 +4458,19 @@ export type ModelTypes = {
   ['UpdateUserInput']: GraphQLTypes['UpdateUserInput'];
   ['UploadCircleImageInput']: GraphQLTypes['UploadCircleImageInput'];
   ['UploadImageInput']: GraphQLTypes['UploadImageInput'];
+  ['UserObj']: GraphQLTypes['UserObj'];
   ['UserResponse']: {
     /** An object relationship */
     UserResponse: ModelTypes['users'];
+    address: string;
+    circle_id: number;
+    fixed_non_receiver?: boolean;
     id: string;
+    name: string;
+    non_giver?: boolean;
+    non_receiver?: boolean;
+    role?: number;
+    starting_tokens?: number;
   };
   ['VouchInput']: GraphQLTypes['VouchInput'];
   ['VouchOutput']: {
@@ -4850,6 +4885,7 @@ columns and relationships of "distributions" */
     createEpoch?: ModelTypes['EpochResponse'];
     createNominee?: ModelTypes['CreateNomineeResponse'];
     createUser?: ModelTypes['UserResponse'];
+    createUsers?: (ModelTypes['UserResponse'] | undefined)[];
     deleteEpoch?: ModelTypes['DeleteEpochResponse'];
     deleteUser?: ModelTypes['ConfirmationResponse'];
     /** delete data from the table: "circle_integrations" */
@@ -5860,6 +5896,10 @@ export type GraphQLTypes = {
     role?: number;
     starting_tokens?: number;
   };
+  ['CreateUsersInput']: {
+    circle_id: number;
+    users?: Array<GraphQLTypes['UserObj']>;
+  };
   ['DeleteEpochInput']: {
     circle_id: number;
     id: number;
@@ -5994,11 +6034,28 @@ export type GraphQLTypes = {
   ['UploadImageInput']: {
     image_data_base64: string;
   };
+  ['UserObj']: {
+    address: string;
+    fixed_non_receiver?: boolean;
+    name: string;
+    non_giver?: boolean;
+    non_receiver?: boolean;
+    role?: number;
+    starting_tokens?: number;
+  };
   ['UserResponse']: {
     __typename: 'UserResponse';
     /** An object relationship */
     UserResponse: GraphQLTypes['users'];
+    address: string;
+    circle_id: number;
+    fixed_non_receiver?: boolean;
     id: string;
+    name: string;
+    non_giver?: boolean;
+    non_receiver?: boolean;
+    role?: number;
+    starting_tokens?: number;
   };
   ['VouchInput']: {
     nominee_id: number;
@@ -7232,6 +7289,7 @@ columns and relationships of "distributions" */
     createEpoch?: GraphQLTypes['EpochResponse'];
     createNominee?: GraphQLTypes['CreateNomineeResponse'];
     createUser?: GraphQLTypes['UserResponse'];
+    createUsers?: Array<GraphQLTypes['UserResponse'] | undefined>;
     deleteEpoch?: GraphQLTypes['DeleteEpochResponse'];
     deleteUser?: GraphQLTypes['ConfirmationResponse'];
     /** delete data from the table: "circle_integrations" */

--- a/src/lib/zod/index.ts
+++ b/src/lib/zod/index.ts
@@ -91,6 +91,13 @@ export const createUserSchemaInput = z
   })
   .strict();
 
+export const createUsersBulkSchemaInput = z
+  .object({
+    circle_id: z.number(),
+    users: createUserSchemaInput.omit({ circle_id: true }).array().min(1),
+  })
+  .strict();
+
 export const circleIdInput = z
   .object({
     circle_id: z.number(),


### PR DESCRIPTION
Resolves #775
related: #708 #508 
____ 
### Summary
It's similar to #508 in logic but in bulk action: new users will be inserted and soft-deleted users will be restored. 

### Test Plan
1. Prepare a list of new users you want to add. 
2. Soft delete single/some users and add them to the list. 
3. Try the following,
```gql
mutation {
  createUsers(payload: {circle_id: 6, users: [
    {address: "0xac0D5FD72BD52B55Fb559eee0Fb3A0638f73AdaD", name: "New User 01"},
    {address: "0x7FEA962EC07B7beA2c94672C8DA7ece097a2Af0a", name: "New User 02"}
  ]}) {
    name
    id
    fixed_non_receiver
    circle_id
    starting_tokens
  }
}
```
4. verify that new users is added and existing users is restored again, also nomination is ended & 'give_token_remaining` is updated if provided.
