### PR TITLE
Implement disable_cron script

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "setup": "./scripts/setup.sh",
     "db-seed-fresh": "scripts/seed_hasura.sh --clean",
     "db-seed": "scripts/seed_hasura.sh",
+    "db-disable-cron": "scripts/disable_cron.sh",
     "generate": "./scripts/generate-zeus.sh",
     "hasura": "hasura --skip-update-check --envfile ../.env --project ./hasura",
     "docker:start": "docker-compose up -d",

--- a/scripts/disable_cron.sh
+++ b/scripts/disable_cron.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# This script disables cron tasks in your local dev environment while
+# resetting the metadata after execution.
+# This means that re-enabling cron tasks is as simple as running
+# `yarn hasura metadata apply`
+#
+# This is done with the intention that most developers do not care about
+# cron tasks running automatically, but also don't want to manage anything
+# related to cron tasks in their git diffs, and potentially push a change
+# that could disable cron tasks up to remote
+
+CRON_FILE=./hasura/metadata/cron_triggers.yaml
+BACKUP=$CRON_FILE.bak
+
+function toggle_cron () {
+  if [[ -e $BACKUP ]]
+  then
+    mv $BACKUP $CRON_FILE
+  else
+    sed -i'.bak' -e s/^/#/ "$CRON_FILE"
+  fi
+}
+
+toggle_cron
+
+yarn hasura metadata apply
+
+toggle_cron

--- a/scripts/seed_hasura.sh
+++ b/scripts/seed_hasura.sh
@@ -13,3 +13,6 @@ ts-node ./scripts/db-add-me.ts
 
 # Re-enable event triggers post-seeding
 ./scripts/enable-triggers.sh
+
+# disable cron tasks to minimize unexpected CPU spikes
+./scripts/disable_cron.sh


### PR DESCRIPTION
This script is intended for testing and development environments. It
disables cron tasks in a local hasura docker container without modifying
the repo metadata, which makes it sort of fix-and-forget. This has pros
and cons, but I don't think most devs want to be bothered with what's
happening with cron triggers when working locally anyhow.

This script has been inserted into package.json and the seed script as a
convenience.

test plan:

`yarn db-disable-cron`

@levity please ensure this works on macs