### PR TITLE
Fix/741/epoch creating loading

### DIFF
--- a/src/hooks/useApiAdminCircle.ts
+++ b/src/hooks/useApiAdminCircle.ts
@@ -39,7 +39,7 @@ export const useApiAdminCircle = (circleId: number) => {
       await fetchManifest();
     },
     [circleId],
-    { hideLoading: true }
+    { hideLoading: false }
   );
 
   const updateEpoch = useRecoilLoadCatch(
@@ -48,7 +48,7 @@ export const useApiAdminCircle = (circleId: number) => {
       await fetchManifest();
     },
     [circleId],
-    { hideLoading: true }
+    { hideLoading: false }
   );
 
   const deleteEpoch = useRecoilLoadCatch(

--- a/src/pages/AdminPage/AdminEpochModal.tsx
+++ b/src/pages/AdminPage/AdminEpochModal.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 import { makeStyles } from '@material-ui/core';
 
@@ -88,6 +88,8 @@ export const AdminEpochModal = ({
 }) => {
   const classes = useStyles();
 
+  const [saving, setSaving] = useState(false);
+
   const { createEpoch, updateEpoch } = useApiAdminCircle(circleId);
 
   const source = useMemo(
@@ -101,11 +103,15 @@ export const AdminEpochModal = ({
   return (
     <EpochForm.FormController
       source={source}
-      submit={params =>
+      submit={params => {
+        setSaving(true);
         (epoch ? updateEpoch(epoch.id, params) : createEpoch(params))
           .then(() => onClose())
-          .catch(console.warn)
-      }
+          .then(() => {
+            setSaving(false);
+          })
+          .catch(console.warn);
+      }}
     >
       {({ fields, errors, changedOutput, value, handleSubmit }) => (
         <FormModal
@@ -113,7 +119,7 @@ export const AdminEpochModal = ({
           open={open}
           title={epoch ? `Edit Epoch ${epoch.number}` : 'Create Epoch'}
           onSubmit={handleSubmit}
-          submitDisabled={!changedOutput}
+          submitDisabled={!changedOutput || saving}
           errors={errors}
         >
           <div className={classes.modalDescription}>

--- a/src/pages/AdminPage/AdminEpochModal.tsx
+++ b/src/pages/AdminPage/AdminEpochModal.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 import { makeStyles } from '@material-ui/core';
 
@@ -88,8 +88,6 @@ export const AdminEpochModal = ({
 }) => {
   const classes = useStyles();
 
-  const [saving, setSaving] = useState(false);
-
   const { createEpoch, updateEpoch } = useApiAdminCircle(circleId);
 
   const source = useMemo(
@@ -103,15 +101,11 @@ export const AdminEpochModal = ({
   return (
     <EpochForm.FormController
       source={source}
-      submit={params => {
-        setSaving(true);
+      submit={params =>
         (epoch ? updateEpoch(epoch.id, params) : createEpoch(params))
           .then(() => onClose())
-          .then(() => {
-            setSaving(false);
-          })
-          .catch(console.warn);
-      }}
+          .catch(console.warn)
+      }
     >
       {({ fields, errors, changedOutput, value, handleSubmit }) => (
         <FormModal
@@ -119,7 +113,7 @@ export const AdminEpochModal = ({
           open={open}
           title={epoch ? `Edit Epoch ${epoch.number}` : 'Create Epoch'}
           onSubmit={handleSubmit}
-          submitDisabled={!changedOutput || saving}
+          submitDisabled={!changedOutput}
           errors={errors}
         >
           <div className={classes.modalDescription}>


### PR DESCRIPTION
## Summary
fix #741 by enable loading Modal
## Describtion
-Enable loading Modal on Create or Update Epoch to prevent the user from clicking the save button multiple times
## Test Plan
1- Go to Admin Page
2- Click Create Epoch or edit one of the existing Epochs
3- Update the Modal with correct values and click Save
Expected:
Loading Spinner should appear and prevent further clicking on Save button