### PR TITLE
adding a trigger to make sure that profile exists before user is updated

### DIFF
--- a/hasura/migrations/default/1650588140371_add_users_profile_exists_trigger/down.sql
+++ b/hasura/migrations/default/1650588140371_add_users_profile_exists_trigger/down.sql
@@ -1,0 +1,2 @@
+DROP TRIGGER IF EXISTS users_insert_trigger on "users";
+DROP FUNCTION IF EXISTS function_ensure_profile_exists();

--- a/hasura/migrations/default/1650588140371_add_users_profile_exists_trigger/up.sql
+++ b/hasura/migrations/default/1650588140371_add_users_profile_exists_trigger/up.sql
@@ -1,0 +1,16 @@
+CREATE OR REPLACE FUNCTION function_ensure_profile_exists() RETURNS TRIGGER AS
+$BODY$
+  BEGIN
+      INSERT INTO "profiles"(address) VALUES(new.address) ON CONFLICT DO NOTHING;
+      RETURN new;
+  END;
+$BODY$
+language plpgsql;
+
+DO $$
+BEGIN
+    CREATE TRIGGER users_insert_trigger BEFORE INSERT OR UPDATE on "users" FOR EACH ROW EXECUTE PROCEDURE function_ensure_profile_exists();
+EXCEPTION
+    WHEN duplicate_object THEN
+        RAISE NOTICE 'Trigger already exists. Ignoring...';
+END$$;


### PR DESCRIPTION
to test:

1. most cases have this handled in code, but vouching does not
2. vouch for a nominee with enough vouches that it converts to a user and doesn't throw a graphql error
3. also also adding a contributor to a circle doesnt throw an error 