### PR TITLE
bugfix: new users cannot be created from a vouch

### DIFF
--- a/api-lib/gql/mutations.ts
+++ b/api-lib/gql/mutations.ts
@@ -1,4 +1,8 @@
-import { order_by, ValueTypes } from './__generated__/zeus';
+import {
+  profiles_constraint,
+  order_by,
+  ValueTypes,
+} from './__generated__/zeus';
 import { adminClient } from './adminClient';
 
 export async function insertProfiles(
@@ -302,6 +306,23 @@ export async function insertUser(
   circleId: number
 ) {
   const { insert_users_one } = await adminClient.mutate({
+    insert_profiles_one: [
+      {
+        object: { address },
+        // This clause allows gql to catch the conflict and do nothing
+        // hasura calls this an "upsert"
+        on_conflict: {
+          constraint: profiles_constraint.profiles_address_key,
+          // Don't update the entry at all if a profile exists
+          // Don't want to touch the timestamp if we aren't actually
+          // modifying anything
+          update_columns: [],
+        },
+      },
+      {
+        address: true,
+      },
+    ],
     insert_users_one: [
       {
         object: {


### PR DESCRIPTION
Currently, vouched users who don't already have a profile are failing to
be created due to the new fk contraint on addresses between profiles and
vouches. This fixes that problem by optionally creating a profile if one
doesn't exist in the same TX the user is created in.

test plan:

Run this in your local hasura console at http://localhost:8080:
```gql
mutation testCreateUser {
  insert_profiles_one(
    object: {
    address: "0x88dCC3A3c55DD18D09aE7572424d22763f60B241"
  	}
    on_conflict: {
      constraint: profiles_address_key
      update_columns: []
    }
  ) {
    __typename
  }
  insert_users_one(object: {
    name: "Bobby",
    address: "0x88dCC3A3c55DD18D09aE7572424d22763f60B241"
    circle_id: 21 # or some circle_id that is valid
  }){
    __typename
  }
}
```
Verify that the user is created and the profile is created.
Run it again with a different circle id and verify that the user is
created but the response for the profile creation mutation is `null`.