### PR TITLE
fix: add explicit timestamptz type to actions.graphql

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,17 +4,9 @@
       "pragma": "React",
       "version": "detect"
     },
-    "import/extensions": [
-      ".js",
-      ".jsx",
-      ".ts",
-      ".tsx"
-    ],
+    "import/extensions": [".js", ".jsx", ".ts", ".tsx"],
     "import/parsers": {
-      "@typescript-eslint/parser": [
-        ".ts",
-        ".tsx"
-      ]
+      "@typescript-eslint/parser": [".ts", ".tsx"]
     }
   },
   "parser": "@typescript-eslint/parser",
@@ -56,20 +48,12 @@
     "no-console": [
       "warn",
       {
-        "allow": [
-          "warn",
-          "error"
-        ]
+        "allow": ["warn", "error"]
       }
     ],
-    "semi": [
-      "error",
-      "always"
-    ],
+    "semi": ["error", "always"],
     "no-warning-comments": "off",
-    "@typescript-eslint/no-unused-vars": [
-      "error"
-    ],
+    "@typescript-eslint/no-unused-vars": ["error"],
     "import/extensions": 0,
     "import/no-unresolved": 0,
     "import/no-extraneous-dependencies": [
@@ -87,10 +71,7 @@
           "external",
           "internal",
           "parent",
-          [
-            "sibling",
-            "index"
-          ]
+          ["sibling", "index"]
         ],
         // define material-ui group that will appear separately after other main externals
         "pathGroups": [
@@ -124,12 +105,7 @@
     "react/jsx-filename-extension": [
       1,
       {
-        "extensions": [
-          ".js",
-          ".jsx",
-          ".ts",
-          ".tsx"
-        ]
+        "extensions": [".js", ".jsx", ".ts", ".tsx"]
       }
     ],
     "react-hooks/rules-of-hooks": "error",
@@ -171,6 +147,7 @@
           {
             "types": "PascalCase",
             "InputValueDefinition": "snake_case",
+            "ScalarTypeDefinition": "snake_case",
             "Argument": "snake_case",
             "FieldDefinition[parent.name.value!=Mutation]": "snake_case",
             "FieldDefinition[parent.name.value=Mutation]": "camelCase"

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -270,3 +270,5 @@ type AllocationsResponse {
 type AllocationCsvResponse {
   file: String!
 }
+
+scalar timestamptz

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -216,9 +216,9 @@ custom_types:
   - name: UpdateEpochInput
   - name: Allocation
   - name: Allocations
-  - name: AllocationCsvInput
   - name: CreateUsersInput
   - name: UserObj
+  - name: AllocationCsvInput
   objects:
   - name: CreateCircleResponse
     relationships:
@@ -341,4 +341,5 @@ custom_types:
       field_mapping:
         user_id: id
   - name: AllocationCsvResponse
-  scalars: []
+  scalars:
+  - name: timestamptz


### PR DESCRIPTION
timestamptz is a builting scalar type in hasura. However, it is not a
builtin in graphql, so our linter fails to parse the file. Explicitly
declaring it allows for the file to be parsed, linted, and fixed again.

Unfortunately, it's not capital-cased type, so I've had to add a rule to
the .eslintrc config file to prevent it from throwing a lint error.

test plan:
- yarn lint:check
- yarn hasura metadata apply
- yarn hasura metadata export
- ensure gql queries using the timestamptz type continue to behave as
  expected.