### PR TITLE
Fix for duplicate address issue

### DIFF
--- a/api/hasura/actions/adminUpdateUser.ts
+++ b/api/hasura/actions/adminUpdateUser.ts
@@ -91,6 +91,21 @@ async function handler(req: VercelRequest, res: VercelResponse) {
         },
       },
     ],
+    update_nominees: [
+      {
+        _set: { ended: true },
+        where: {
+          circle_id: { _eq: circle_id },
+          address: { _ilike: input.new_address },
+          ended: { _eq: false },
+        },
+      },
+      {
+        returning: {
+          id: true,
+        },
+      },
+    ],
   });
 
   const returnResult = mutationResult.update_users?.returning.pop();

--- a/api/hasura/actions/createUser.ts
+++ b/api/hasura/actions/createUser.ts
@@ -15,7 +15,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
 
   // External Constraint Validation
   // It might be preferable to add this uniqueness constraint into the database
-  const { circle_id, address, name } = input;
+  const { circle_id, address } = input;
 
   const { users: existingUsers } = await adminClient.query({
     users: [
@@ -99,7 +99,6 @@ async function handler(req: VercelRequest, res: VercelResponse) {
         where: {
           circle_id: { _eq: circle_id },
           address: { _ilike: address },
-          name: { _eq: name },
           ended: { _eq: false },
         },
       },

--- a/api/hasura/actions/createUsers.ts
+++ b/api/hasura/actions/createUsers.ts
@@ -108,7 +108,6 @@ async function handler(req: VercelRequest, res: VercelResponse) {
           where: {
             circle_id: { _eq: circle_id },
             address: { _ilike: user.address },
-            name: { _eq: user.name },
             ended: { _eq: false },
           },
         },

--- a/api/hasura/actions/vouch.ts
+++ b/api/hasura/actions/vouch.ts
@@ -1,6 +1,9 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
-import { getUserFromProfileId } from '../../../api-lib/findUser';
+import {
+  getUserFromAddress,
+  getUserFromProfileId,
+} from '../../../api-lib/findUser';
 import * as mutations from '../../../api-lib/gql/mutations';
 import * as queries from '../../../api-lib/gql/queries';
 import {
@@ -80,6 +83,11 @@ async function validate(nomineeId: number, voucherProfileId: number) {
     throw new ForbiddenError(
       "voucher nominated this nominee so can't additionally vouch"
     );
+  }
+
+  const user = await getUserFromAddress(nominee.address, nominee.circle_id);
+  if (user) {
+    throw new ForbiddenError('User with this address already exists');
   }
 
   const { vouches } = await queries.getExistingVouch(nomineeId, voucher.id);

--- a/hasura/metadata/cron_triggers.yaml
+++ b/hasura/metadata/cron_triggers.yaml
@@ -1,5 +1,5 @@
 - name: check-nominee
-  webhook: '{{HASURA_API_BASE_URL}}/cron/check-nominee'
+  webhook: '{{HASURA_API_BASE_URL}}/cron/checkNominee'
   schedule: 1 0 * * *
   include_in_metadata: true
   payload: {}

--- a/hasura/migrations/default/1651000685281_alter_table_public_users_add_unique_address_circle_id_deleted_at/down.sql
+++ b/hasura/migrations/default/1651000685281_alter_table_public_users_add_unique_address_circle_id_deleted_at/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."users" drop constraint "users_address_circle_id_deleted_at_key";

--- a/hasura/migrations/default/1651000685281_alter_table_public_users_add_unique_address_circle_id_deleted_at/up.sql
+++ b/hasura/migrations/default/1651000685281_alter_table_public_users_add_unique_address_circle_id_deleted_at/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."users" add constraint "users_address_circle_id_deleted_at_key" unique ("address", "circle_id", "deleted_at");


### PR DESCRIPTION
Fixes #833

### Test Plan
1. Create a nominee
2. Create a user with the same address but different name (or update a user to the same address)
3. Make sure nomination has ended and you cannot vouch for the user anymore
4. Ensure `checkNominee` cron job is running
5. Check for DB conflicts run:

```sql 
SELECT address, circle_id, deleted_at
FROM public.users
group by address, circle_id, deleted_at having  count(*) > 1;
```