### PR TITLE
Fix `DateTime` format in receive Info summary

### DIFF
--- a/src/components/ReceiveInfo/ReceiveInfo.tsx
+++ b/src/components/ReceiveInfo/ReceiveInfo.tsx
@@ -160,7 +160,7 @@ export const ReceiveInfo = () => {
                   {tokenGift.sender?.name}
                 </div>
                 <div className={classes.noteDate}>
-                  {DateTime.fromSQL(tokenGift.dts_created).toLocaleString(
+                  {DateTime.fromISO(tokenGift.dts_created).toLocaleString(
                     DateTime.DATETIME_MED
                   )}
                 </div>


### PR DESCRIPTION
closes: #835
____
The received dates from the database values are ISO 8601 format
example: `2022-04-26T12:13:25.976896`.

when using `DateTime.fromSQL()` the luxon library gives this explanation: 
```
  reason: 'unparsable',
  explanation: `the input "2022-04-26T12:13:25.976896" can't be parsed as SQL
```
