### PR TITLE
Make edge thickness a factor of node diameter

### DIFF
--- a/src/pages/AssetMapPage/AMForceGraph.tsx
+++ b/src/pages/AssetMapPage/AMForceGraph.tsx
@@ -46,7 +46,7 @@ const COLOR_LINK_DIM = '#00000008';
 
 const MIN_ZOOM = 3;
 
-const edgeWidthScaler = (f: number) => f * MIN_ZOOM + 1;
+const edgeWidthScaler = (f: number) => f * MIN_ZOOM + MIN_ZOOM;
 // const nodeSizeScaler = (f: number) => NODE_R + f * 8;
 const nodeBorderScaler = (f: number) => 0.7 + f * 2.5;
 // const edgeForceScaler = (f: number) => 0.1 * f;

--- a/src/pages/AssetMapPage/AMForceGraph.tsx
+++ b/src/pages/AssetMapPage/AMForceGraph.tsx
@@ -46,6 +46,7 @@ const COLOR_LINK_DIM = '#00000008';
 
 const MIN_ZOOM = 3;
 
+const NODE_R = 5;
 // const nodeSizeScaler = (f: number) => NODE_R + f * 8;
 const nodeBorderScaler = (f: number) => 0.7 + f * 2.5;
 // const edgeForceScaler = (f: number) => 0.1 * f;
@@ -125,14 +126,14 @@ export const AMForceGraph = () => {
   const linkDirectionalParticleWidth = useCallback((edge: IMapEdgeFG) => {
     const { getEdgeMeasure, isEgoEdge } = mapCtxRef.current;
     if (isEgoEdge(edge, 'gives') || isEgoEdge(edge, 'receives')) {
-      return getEdgeMeasure(edge) * MIN_ZOOM * 10;
+      return getEdgeMeasure(edge) * MIN_ZOOM * NODE_R * 2;
     }
     return 0;
   }, []);
 
   const getWidth = useCallback((edge: IMapEdgeFG) => {
     const { getEdgeMeasure } = mapCtxRef.current;
-    return getEdgeMeasure(edge) * MIN_ZOOM * 10;
+    return getEdgeMeasure(edge) * MIN_ZOOM * NODE_R * 2;
   }, []);
 
   const getCurvature = useCallback((edge: IMapEdgeFG) => {
@@ -155,7 +156,7 @@ export const AMForceGraph = () => {
         mapCtxRef.current;
       const nid = node.id;
 
-      const radius = 5;
+      const radius = NODE_R;
       const width = getNodeMeasure(node, nodeBorderScaler);
       const isInBag = bag.has(nid);
 
@@ -230,7 +231,7 @@ export const AMForceGraph = () => {
             graphData={mapGraphData}
             height={height}
             width={width}
-            nodeRelSize={5}
+            nodeRelSize={NODE_R}
             nodeCanvasObject={nodeCanvasObject as (n: NodeObject) => number}
             onNodeClick={onNodeClick as (n: NodeObject) => void}
             onBackgroundClick={onBackgroundClick}

--- a/src/pages/AssetMapPage/AMForceGraph.tsx
+++ b/src/pages/AssetMapPage/AMForceGraph.tsx
@@ -46,7 +46,6 @@ const COLOR_LINK_DIM = '#00000008';
 
 const MIN_ZOOM = 3;
 
-const edgeWidthScaler = (f: number) => f * MIN_ZOOM + MIN_ZOOM;
 // const nodeSizeScaler = (f: number) => NODE_R + f * 8;
 const nodeBorderScaler = (f: number) => 0.7 + f * 2.5;
 // const edgeForceScaler = (f: number) => 0.1 * f;
@@ -126,14 +125,14 @@ export const AMForceGraph = () => {
   const linkDirectionalParticleWidth = useCallback((edge: IMapEdgeFG) => {
     const { getEdgeMeasure, isEgoEdge } = mapCtxRef.current;
     if (isEgoEdge(edge, 'gives') || isEgoEdge(edge, 'receives')) {
-      return getEdgeMeasure(edge, edgeWidthScaler);
+      return getEdgeMeasure(edge) * MIN_ZOOM * 10;
     }
     return 0;
   }, []);
 
   const getWidth = useCallback((edge: IMapEdgeFG) => {
     const { getEdgeMeasure } = mapCtxRef.current;
-    return getEdgeMeasure(edge, edgeWidthScaler);
+    return getEdgeMeasure(edge) * MIN_ZOOM * 10;
   }, []);
 
   const getCurvature = useCallback((edge: IMapEdgeFG) => {
@@ -231,6 +230,7 @@ export const AMForceGraph = () => {
             graphData={mapGraphData}
             height={height}
             width={width}
+            nodeRelSize={5}
             nodeCanvasObject={nodeCanvasObject as (n: NodeObject) => number}
             onNodeClick={onNodeClick as (n: NodeObject) => void}
             onBackgroundClick={onBackgroundClick}

--- a/src/pages/AssetMapPage/AMForceGraph.tsx
+++ b/src/pages/AssetMapPage/AMForceGraph.tsx
@@ -44,9 +44,9 @@ const COLOR_RECEIVE_LINK = '#d3860d80';
 const COLOR_LINK = '#00000015';
 const COLOR_LINK_DIM = '#00000008';
 
-const NODE_R = 5;
+const MIN_ZOOM = 3;
 
-const edgeWidthScaler = (f: number) => f * 25 + 1;
+const edgeWidthScaler = (f: number) => f * MIN_ZOOM + 1;
 // const nodeSizeScaler = (f: number) => NODE_R + f * 8;
 const nodeBorderScaler = (f: number) => 0.7 + f * 2.5;
 // const edgeForceScaler = (f: number) => 0.1 * f;
@@ -231,7 +231,6 @@ export const AMForceGraph = () => {
             graphData={mapGraphData}
             height={height}
             width={width}
-            nodeRelSize={NODE_R}
             nodeCanvasObject={nodeCanvasObject as (n: NodeObject) => number}
             onNodeClick={onNodeClick as (n: NodeObject) => void}
             onBackgroundClick={onBackgroundClick}
@@ -245,6 +244,7 @@ export const AMForceGraph = () => {
             linkWidth={getWidth as (l: LinkObject) => number}
             linkCurvature={getCurvature as (l: LinkObject) => number}
             linkDirectionalParticles={4}
+            minZoom={MIN_ZOOM}
           />
         )}
       </AutoSizer>

--- a/src/recoilState/map.ts
+++ b/src/recoilState/map.ts
@@ -557,7 +557,12 @@ export const rMapContext = selector<IMapContext>({
     };
 
     const getEdgeMeasure = (edge: IMapEdgeFG, scaler?: TScaler): number => {
-      return scaler ? scaler(edge.tokens / 100) : edge.tokens;
+      //if tokens > 100 the width will be 90% node diameter
+      if (edge.tokens > 100) {
+        return scaler ? scaler(8) : edge.tokens;
+      }
+      //if tokens <= 100 the width will be a factor of 80% node diameter
+      return scaler ? scaler((edge.tokens * 7) / 100) : edge.tokens;
     };
 
     const getNodeMeasure = (node: IMapNodeFG, scaler?: TScaler): number => {

--- a/src/recoilState/map.ts
+++ b/src/recoilState/map.ts
@@ -556,13 +556,17 @@ export const rMapContext = selector<IMapContext>({
       }
     };
 
-    const getEdgeMeasure = (edge: IMapEdgeFG, scaler?: TScaler): number => {
-      //if tokens > 100 the width will be 90% node diameter
-      if (edge.tokens > 100) {
-        return scaler ? scaler(8) : edge.tokens;
-      }
-      //if tokens <= 100 the width will be a factor of 80% node diameter
-      return scaler ? scaler((edge.tokens * 7) / 100) : edge.tokens;
+    // return the ratio between the value of this edge, and the total amount
+    // that a single person received. set a lower bound so edges don't become
+    // too thin when there's a skewed distribution.
+    //
+    // so an edge will be max-width when the person who received the most in the
+    // group got it all from a single other person.
+    //
+    // this works correctly only when metric == 'give'... but the option to
+    // change metric to anything else is hidden, so... "this is fine"
+    const getEdgeMeasure = (edge: IMapEdgeFG): number => {
+      return Math.max(0.1, edge.tokens / max);
     };
 
     const getNodeMeasure = (node: IMapNodeFG, scaler?: TScaler): number => {

--- a/src/types/graph.d.ts
+++ b/src/types/graph.d.ts
@@ -49,7 +49,7 @@ interface IMapContext {
   isEgoEdge: (edge: IMapEdgeFG, direction: TDirection = 'both') => boolean;
   isBagEdge: (edge: IMapEdgeFG, direction: TDirection = 'both') => boolean;
   isBetweenBagEdge: (edge: IMapEdgeFG) => boolean;
-  getEdgeMeasure: (edge: IMapEdgeFG, scaler?: TScaler) => number;
+  getEdgeMeasure: (edge: IMapEdgeFG) => number;
   getNodeMeasure: (node: IMapNodeFG, scaler?: TScaler) => number;
   getCurvature: (edge: IMapEdgeFG) => number;
 }


### PR DESCRIPTION
## Summary
fixes #733 
Make edge thickness a factor of node diameter
add `minZoom` to `ForceGraph2D`
remove unnecessary `nodeRelSize` 

## Description
Accoriding to `force-graph` `linkWidth` [docs](https://github.com/vasturiano/force-graph) : _link widths remain visually constant through various zoom levels, where as node sizes scale relatively._
so it is not possible to make the link width resisable as the nodes diameter

My suggested solution made link width a factor of 80% of the node diameter multiplied by 3 and minZoom is set to 3 so that users can't zoom out until link width is greater than circle width.

## Test Plan
### Preconditions:
1- Active Epoch with multiple opt-in users
2- Set yourself 1000  gives
### Test scenario
1- allocate to a user 500 and distribute the rest to the other users
### Expected:
Node edges width should be visible correctly and max width shouldn't exceed the circles diameters
![image](https://user-images.githubusercontent.com/34943689/165504179-0cf10a36-4461-4ce1-9c49-3d90073b9d0e.png)


