### PR TITLE
Fixes the refunding issue #829

### DIFF
--- a/api-lib/event_triggers/refundPendingGift.ts
+++ b/api-lib/event_triggers/refundPendingGift.ts
@@ -4,7 +4,7 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 
 import { ValueTypes } from '../gql/__generated__/zeus';
 import { adminClient } from '../gql/adminClient';
-import * as queries from '../gql/queries';
+import { getUserByIdAndCurrentEpoch } from '../gql/queries';
 import { errorResponse } from '../HttpError';
 import { EventTriggerPayload } from '../types';
 
@@ -15,7 +15,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     event: { data },
   }: EventTriggerPayload<'users', 'UPDATE'> = req.body;
 
-  const { address, circle_id } = data.new;
+  const { circle_id, id } = data.new;
 
   const userDeleted = !data.old.deleted_at && data.new.deleted_at;
 
@@ -26,7 +26,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   const results = [];
   try {
-    const user = await queries.getUserAndCurrentEpoch(address, circle_id);
+    const user = await getUserByIdAndCurrentEpoch(id, circle_id);
     assert(user, 'panic: user must exist');
 
     const { pending_sent_gifts, pending_received_gifts, id: userId } = user;

--- a/api-lib/gql/queries.ts
+++ b/api-lib/gql/queries.ts
@@ -148,6 +148,80 @@ export async function getUserAndCurrentEpoch(
   return user;
 }
 
+export async function getUserByIdAndCurrentEpoch(
+  id: number,
+  circleId: number
+): Promise<typeof user | undefined> {
+  const {
+    users: [user],
+  } = await adminClient.query({
+    users: [
+      {
+        limit: 1,
+        where: {
+          id: { _eq: id },
+          circle_id: { _eq: circleId },
+        },
+      },
+      {
+        id: true,
+        fixed_non_receiver: true,
+        non_giver: true,
+        non_receiver: true,
+        starting_tokens: true,
+        give_token_received: true,
+        give_token_remaining: true,
+        pending_sent_gifts: [
+          // the join filters down to only gifts to the user
+          {},
+          {
+            id: true,
+            epoch_id: true,
+            sender_id: true,
+            sender_address: true,
+            recipient_id: true,
+            recipient_address: true,
+            note: true,
+            tokens: true,
+          },
+        ],
+        pending_received_gifts: [
+          // the join filters down to only gifts to the user
+          {},
+          {
+            id: true,
+            epoch_id: true,
+            sender_id: true,
+            sender_address: true,
+            recipient_id: true,
+            recipient_address: true,
+            note: true,
+            tokens: true,
+          },
+        ],
+        circle: {
+          epochs: [
+            {
+              where: {
+                _and: [
+                  { end_date: { _gt: 'now()' } },
+                  { start_date: { _lt: 'now()' } },
+                ],
+              },
+            },
+            {
+              start_date: true,
+              end_date: true,
+              id: true,
+            },
+          ],
+        },
+      },
+    ],
+  });
+  return user;
+}
+
 // TODO: This is a big problem if we can't trust the type checker.
 // Why is the type inference wrong here,
 // It could be undefined


### PR DESCRIPTION
Fixes #829 
Fixes #817 

issue was `getUserByIdAndCurrentEpoch` was not fetching deleted users
changed to `getUserByIdAndCurrentEpoch` so it would target the right user regardless if its deleted or not.

this issue is leaving quite a bit of bad data that i had to manually fix. you won't be able to access your page if the deleted user sent to you or you received gives from him.