### PR TITLE
Bugfix: allow for falsy core contracts in History

### DIFF
--- a/src/hooks/useContracts.ts
+++ b/src/hooks/useContracts.ts
@@ -11,7 +11,8 @@ export function useContracts(): Contracts | undefined {
 
   return useMemo((): Contracts | undefined => {
     if (!library || !chainId) return undefined;
-    if (!supportedChainIds.includes(chainId)) {
+    const isSupportedChainId = supportedChainIds.includes(chainId.toString());
+    if (!isSupportedChainId) {
       logOnce(`Contracts do not support chain ${chainId}`);
       return undefined;
     }

--- a/src/lib/vaults/contracts.ts
+++ b/src/lib/vaults/contracts.ts
@@ -40,20 +40,20 @@ const requiredContracts = [
   'ApeDistributor',
 ];
 
-export const supportedChainIds: number[] = Object.entries(deploymentInfo)
+export const supportedChainIds: string[] = Object.entries(deploymentInfo)
   .filter(([, contracts]) => requiredContracts.every(c => c in contracts))
-  .map(x => Number(x[0]));
+  .map(x => x[0].toString());
 
 export class Contracts {
   vaultFactory: ApeVaultFactoryBeacon;
   router: ApeRouter;
   distributor: ApeDistributor;
-  chainId: number;
+  chainId: string;
   provider: JsonRpcProvider;
   signer: Signer;
 
-  constructor(chainId: number, provider: JsonRpcProvider) {
-    this.chainId = chainId;
+  constructor(chainId: number | string, provider: JsonRpcProvider) {
+    this.chainId = chainId.toString();
     this.provider = provider;
     this.signer = provider.getSigner();
 
@@ -111,7 +111,10 @@ export class Contracts {
     // workaround for mainnet-forked testchains
     if (
       !address &&
-      [HARDHAT_CHAIN_ID, HARDHAT_GANACHE_CHAIN_ID].includes(this.chainId)
+      [
+        HARDHAT_CHAIN_ID.toString(),
+        HARDHAT_GANACHE_CHAIN_ID.toString(),
+      ].includes(this.chainId)
     ) {
       address = (deploymentInfo as any)[1][symbol]?.address;
       if (!address) return undefined;

--- a/src/pages/HistoryPage/HistoryPage.tsx
+++ b/src/pages/HistoryPage/HistoryPage.tsx
@@ -28,7 +28,7 @@ export const HistoryPage = () => {
   const query = useQuery(
     ['history', circleId],
     () => getHistoryData(circleId, userId, contracts),
-    { enabled: !!userId && !!circleId && !!contracts }
+    { enabled: !!userId && !!circleId }
   );
 
   const circle = query.data;

--- a/src/pages/HistoryPage/getHistoryData.ts
+++ b/src/pages/HistoryPage/getHistoryData.ts
@@ -1,6 +1,4 @@
-import assert from 'assert';
-
-import type { FixedNumber } from 'ethers';
+import { FixedNumber } from 'ethers';
 import { order_by } from 'lib/gql/__generated__/zeus';
 import { client } from 'lib/gql/client';
 import type { Contracts } from 'lib/vaults';
@@ -12,7 +10,6 @@ export const getHistoryData = async (
   userId: number,
   contracts?: Contracts
 ) => {
-  assert(contracts);
   const gq = await client.query(
     {
       circles_by_pk: [
@@ -112,6 +109,8 @@ export const getHistoryData = async (
   );
 
   const circle = gq.circles_by_pk;
+
+  if (!contracts) return circle;
 
   type DistributionWithPrice = Exclude<
     typeof circle,

--- a/src/utils/connectors.ts
+++ b/src/utils/connectors.ts
@@ -10,7 +10,13 @@ import { INFURA_PROJECT_ID } from 'config/env';
 export const MAINNET_RPC_URL = `https://mainnet.infura.io/v3/${INFURA_PROJECT_ID}`;
 
 const injected = new InjectedConnector({
-  supportedChainIds: [...supportedChainIds, 1],
+  supportedChainIds: [...supportedChainIds, 1].map(n =>
+    // This is the most type-safe way
+    // way to handle this conversion to Numbers that the InjectedConnector
+    // is expecting, since String.prototype.toString() is idempotent
+    // (yay, something in javascript works the way you'd expect!)
+    Number.parseInt(n.toString())
+  ),
 });
 
 export const makeWalletConnectConnector = () =>


### PR DESCRIPTION
The Vaults aren't on mainnet yet, so we need to support the history view without them. I also added some code to index and lookup chainIds as strings, since a supported chainId of String type would fail to resolve a successful lookup.

test plan:

set your network to mainnet and browse to http://localhost:3000/history after authenticating and seeding the database.

I also ensure my changes typecheck and unit tests pass.