### PR TITLE
Bugfix: stringify luxon datetimes

### DIFF
--- a/api-lib/gql/queries.ts
+++ b/api-lib/gql/queries.ts
@@ -410,12 +410,12 @@ export async function getOverlappingEpoch(
     circle_id: { _eq: circle_id },
     _or: [
       {
-        start_date: { _lt: end_date },
-        end_date: { _gte: end_date },
+        start_date: { _lt: end_date.toISO() },
+        end_date: { _gte: end_date.toISO() },
       },
       {
-        start_date: { _lte: start_date },
-        end_date: { _gt: start_date },
+        start_date: { _lte: start_date.toISO() },
+        end_date: { _gt: start_date.toISO() },
       },
     ],
   };

--- a/api/hasura/actions/createEpoch.ts
+++ b/api/hasura/actions/createEpoch.ts
@@ -83,7 +83,8 @@ async function handler(request: VercelRequest, response: VercelResponse) {
         {
           object: {
             ...input,
-            end_date,
+            start_date: start_date.toISO(),
+            end_date: end_date.toISO(),
             repeat_day_of_month,
           },
         },


### PR DESCRIPTION
With the update to Zeus, luxon datetimes are no longer stringified
automatically.

I combed the repo for places where datetimes aren't stringified but it
might be worth another look from @zashton

test plan:

1. `vercel dev` on a seeded DB
2. browse to http://localhost:3000/admin/circles
3. click create epoch and attempt to submit a valid, non-overlapping
   epoch. It should submit successfully, without error.