### PR TITLE
bugfix: fix delete epoch in frontend

### DIFF
--- a/api-lib/gql/queries.ts
+++ b/api-lib/gql/queries.ts
@@ -327,7 +327,7 @@ export async function getExpiredNominees() {
             ended: {
               _eq: false,
             },
-            expiry_date: { _lte: new Date() },
+            expiry_date: { _lte: DateTime.now().toISO() },
           },
         },
         {

--- a/api/hasura/actions/deleteEpoch.ts
+++ b/api/hasura/actions/deleteEpoch.ts
@@ -1,6 +1,7 @@
 import assert from 'assert';
 
 import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { DateTime, Settings } from 'luxon';
 
 import { authCircleAdminMiddleware } from '../../../api-lib/circleAdmin';
 import { adminClient } from '../../../api-lib/gql/adminClient';
@@ -8,6 +9,8 @@ import {
   deleteEpochInput,
   composeHasuraActionRequestBody,
 } from '../../../src/lib/zod';
+
+Settings.defaultZone = 'utc';
 
 async function handler(req: VercelRequest, res: VercelResponse) {
   const {
@@ -23,7 +26,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
             // Check circle_id to ensure epoch is part of this circle
             circle_id: { _eq: circle_id },
             id: { _eq: id },
-            start_date: { _gt: new Date() },
+            start_date: { _gt: DateTime.now().toISO() },
             ended: { _eq: false },
           },
         },

--- a/src/hooks/useVaultFactory.test.tsx
+++ b/src/hooks/useVaultFactory.test.tsx
@@ -14,7 +14,7 @@ jest.mock('lib/gql/mutations', () => {
     addVault: jest.fn().mockReturnValue(
       Promise.resolve({
         insert_vaults_one: {
-          created_at: new Date(),
+          created_at: new Date().toISOString(),
           created_by: 21,
           decimals: 18,
           id: 2,
@@ -22,7 +22,7 @@ jest.mock('lib/gql/mutations', () => {
           simple_token_address: '0x0AaCfbeC6a24756c20D41914F2caba817C0d8521',
           symbol: 'DAI',
           token_address: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
-          updated_at: new Date(),
+          updated_at: new Date().toISOString(),
           vault_address: '0x0AaCfbeC6a24756c20D41914F2caba817C0d8521',
         },
       })

--- a/src/utils/testing/mocks.ts
+++ b/src/utils/testing/mocks.ts
@@ -1,5 +1,5 @@
 export const mockVault = {
-  created_at: new Date(),
+  created_at: new Date().toISOString(),
   created_by: 21,
   decimals: 18,
   id: 2,
@@ -7,7 +7,7 @@ export const mockVault = {
   simple_token_address: '0x0AaCfbeC6a24756c20D41914F2caba817C0d8521',
   symbol: 'DAI',
   token_address: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
-  updated_at: new Date(),
+  updated_at: new Date().toISOString(),
   vault_address: '0x0AaCfbeC6a24756c20D41914F2caba817C0d8521',
 };
 


### PR DESCRIPTION
this is the same problem as #893

I scanned for all Date() instantiations in our code and have stringified
them to ISO times where appropriate.

test plan:
1. vercel dev on a seeded DB
2. browse to http://localhost:3000/admin/circles
3. click create epoch and attempt to submit a valid, non-overlapping
    epoch.
4. delete the epoch and ensure it deletes properly