### PR TITLE
bugfix: createNominee

### DIFF
--- a/api-lib/nominees.ts
+++ b/api-lib/nominees.ts
@@ -124,14 +124,15 @@ export const insertNominee = async (params: {
   const today = new Date();
   const expiry = new Date();
   expiry.setDate(today.getDate() + params.nomination_days_limit);
+  const input = { ...params, nomination_days_limit: undefined };
   const { insert_nominees_one } = await adminClient.mutate(
     {
       insert_nominees_one: [
         {
           object: {
-            ...params,
-            nominated_date: today,
-            expiry_date: expiry,
+            ...input,
+            nominated_date: today.toISOString(),
+            expiry_date: expiry.toISOString(),
           },
         },
         {


### PR DESCRIPTION
CreateNominee had and invalid parameter and DateTimes were not
stringified

test plan:

attempt to create a nominee in the frontend, in the Vouching interface.