### PR TITLE
fix: Value of `TELEGRAM_BOT_TOKEN` in `.env.example`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,7 +39,7 @@ REACT_APP_HASURA_URL=http://localhost:8080/v1/graphql
 REACT_APP_S3_BASE_URL=http://coordinape.s3-website.localhost.localstack.cloud:4566
 # NODE: Used for the node scripts and vercel serverless functions
 NODE_HASURA_URL=http://localhost:8080/v1/graphql
-TELEGRAM_BOT_TOKEN=<your Telegram testing bot token>
+TELEGRAM_BOT_TOKEN=your-telegramt-testing-bot-token
 IMAGES_AWS_ENDPOINT=http://s3.localhost.localstack.cloud:4566
 IMAGES_AWS_BUCKET=coordinape
 


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

When I was going through the [Quick Start](https://github.com/coordinape/coordinape#quick-start) there was the following error when running `yarn db-seed-fresh`:

```
➜  coordinape git:(main) ✗ yarn db-seed-fresh
yarn run v1.22.18
$ scripts/seed_hasura.sh --clean
scripts/seed_hasura.sh: line 11: export: `token>': not a valid identifier
error Command failed with exit code 1.
```

Change the value of `TELEGRAM_BOT_TOKEN` in `.env.example` so that the script `seed_hasura.sh` can run without parsing errors.

## Related Issue

<!--- Please link to the issue here -->

N/A

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Make the quick start smoother

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran `yarn db-seed-fresh` after the change and it works as expected.

## Screenshots (if appropriate):
