### PR TITLE
feat: Add PR Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Description
+
+<!--- Describe your changes -->
+
+## Related Issue
+
+<!--- Please link to the issue here -->
+
+## Motivation and Context
+
+<!--- Why is this change required? What problem does it solve? -->
+
+## How Has This Been Tested?
+
+<!--- Please describe in detail how you tested your changes. -->
+
+## Screenshots (if appropriate):

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@
 
 <!--- Why is this change required? What problem does it solve? -->
 
-## How Has This Been Tested?
+## Test Plan
 
 <!--- Please describe in detail how you tested your changes. -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@
 
 <!-- Describe your changes -->
 
-## Test Plan
+## Test and Deployment Plan
 
 <!-- Please describe in detail how you tested your changes. -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 <!--
   Why is this change required? What problem does it solve?
-  This can be omitted if a linked issue is provided 
+  This can be omitted if a linked issue is provided
 -->
 
 ## Description
@@ -15,10 +15,14 @@
 
 ## Screenshots (if appropriate):
 
-<!-- 
-  This allows reviewers to begin reviewing your work 
+<!--
+  This allows reviewers to begin reviewing your work
   without checking out your branch locally
 -->
+
+## Reviewers
+
+<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->
 
 ## Related Issue
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,6 @@
 ## Motivation and Context
 
-<!--
-  Why is this change required? What problem does it solve?
-  This can be omitted if a linked issue is provided
+<!-- Why is this change required? What problem does it solve? This can be omitted if a linked issue is provided
 -->
 
 ## Description
@@ -11,14 +9,11 @@
 
 ## Test and Deployment Plan
 
-<!-- Please describe in detail how you tested your changes. -->
+<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
 
 ## Screenshots (if appropriate):
 
-<!--
-  This allows reviewers to begin reviewing your work
-  without checking out your branch locally
--->
+<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->
 
 ## Reviewers
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,17 +1,25 @@
-## Description
-
-<!--- Describe your changes -->
-
-## Related Issue
-
-<!--- Please link to the issue here -->
-
 ## Motivation and Context
 
-<!--- Why is this change required? What problem does it solve? -->
+<!--
+  Why is this change required? What problem does it solve?
+  This can be omitted if a linked issue is provided 
+-->
+
+## Description
+
+<!-- Describe your changes -->
 
 ## Test Plan
 
-<!--- Please describe in detail how you tested your changes. -->
+<!-- Please describe in detail how you tested your changes. -->
 
 ## Screenshots (if appropriate):
+
+<!-- 
+  This allows reviewers to begin reviewing your work 
+  without checking out your branch locally
+-->
+
+## Related Issue
+
+<!-- Please link to the issue here -->


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Add a PR template

## Related Issue

<!--- Please link to the issue here -->

N/A

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

When contributors create a PR, it would be very helpful to have a starting point when creating the PR description. It's also extremely valuable for future reviewers to have some context on the PR so that it's easier for them to review. Furthermore, the call for screenshots is nice when there are UI changes so that the reviewer can see the result of the changes without having to run the app.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

In all the projects and companies that I have worked with, and it has been extremely useful.

## Screenshots (if appropriate):
