### PR TITLE
Vercel fixes for serverless

### DIFF
--- a/api-lib/config.ts
+++ b/api-lib/config.ts
@@ -53,7 +53,9 @@ export const INFURA_PROJECT_ID = getEnvValue(
   'missing-infura-id'
 );
 
-export const HARDHAT_GANACHE_PORT = getEnvValue('HARDHAT_GANACHE_PORT');
+export const HARDHAT_GANACHE_PORT: number = getEnvValue(
+  'HARDHAT_GANACHE_PORT' || 8546
+);
 
 export const ETHEREUM_RPC_URL: string = getEnvValue('ETHEREUM_RPC_URL');
 

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "lint": "eslint",
     "lint:check": "eslint \"{api,api-lib,hasura,src}/**/*.{js,ts,tsx,graphql}\"",
     "lint:fix": "yarn lint:check --fix",
+    "postinstall": "./scripts/link_hardhat.sh",
     "prettier": "prettier \"{api,src}/**/*.{js,ts,tsx}\"",
     "prettier:check": "yarn prettier --check",
     "prettier:fix": "yarn prettier --write",


### PR DESCRIPTION
Vercel doesn't utilize the project's configured "build command" for
serverless functions, and the backend now needs access to the
deployment.json file. The postinstall script is a lightweight way to
address this. It also potentially allows us to simplify the build command
in vercel to dedup the effort of linking to the protocol repo.

test plan:

```sh
rm -rf node_modules
git submodule deinit --all
yarn --frozen-lockfile

yarn docker:start
vercel dev
```

browse to http://localhost:8080
Run the following mutation:
```gql
mutation MyMutation {
  createVault(payload: {chain_id: 10, org_id: 10, vault_address: "0x0"}){
    id
  }
}
```

If you get a zod error, that means the deployment.json file resolved
correctly