### PR TITLE
Circle API Keys and api-user role

### DIFF
--- a/hasura/metadata/databases/default/tables/public_circle_api_keys.yaml
+++ b/hasura/metadata/databases/default/tables/public_circle_api_keys.yaml
@@ -1,0 +1,3 @@
+table:
+  name: circle_api_keys
+  schema: public

--- a/hasura/metadata/databases/default/tables/public_circle_api_keys.yaml
+++ b/hasura/metadata/databases/default/tables/public_circle_api_keys.yaml
@@ -1,3 +1,7 @@
 table:
   name: circle_api_keys
   schema: public
+object_relationships:
+- name: createdByUser
+  using:
+    foreign_key_constraint_on: created_by

--- a/hasura/metadata/databases/default/tables/public_circles.yaml
+++ b/hasura/metadata/databases/default/tables/public_circles.yaml
@@ -15,6 +15,13 @@ object_relationships:
   using:
     foreign_key_constraint_on: protocol_id
 array_relationships:
+- name: api_keys
+  using:
+    foreign_key_constraint_on:
+      column: circle_id
+      table:
+        name: circle_api_keys
+        schema: public
 - name: burns
   using:
     foreign_key_constraint_on:
@@ -77,6 +84,30 @@ select_permissions:
 - permission:
     columns:
     - alloc_text
+    - default_opt_in
+    - id
+    - is_verified
+    - logo
+    - min_vouches
+    - name
+    - nomination_days_limit
+    - team_sel_text
+    - team_selection
+    - token_name
+    - vouching
+    - vouching_text
+    filter:
+      api_keys:
+        _and:
+        - hash:
+            _eq: X-Hasura-Api-Key-Hash
+        - read_circle:
+            _eq: true
+    limit: 5
+  role: api-user
+- permission:
+    columns:
+    - alloc_text
     - auto_opt_out
     - created_at
     - default_opt_in
@@ -107,6 +138,28 @@ select_permissions:
                 _is_null: true
   role: user
 update_permissions:
+- permission:
+    check: null
+    columns:
+    - alloc_text
+    - discord_webhook
+    - logo
+    - min_vouches
+    - name
+    - nomination_days_limit
+    - team_sel_text
+    - team_selection
+    - token_name
+    - vouching
+    - vouching_text
+    filter:
+      api_keys:
+        _and:
+        - hash:
+            _eq: X-Hasura-Api-Key-Hash
+        - update_circle:
+            _eq: true
+  role: api-user
 - permission:
     check: null
     columns:

--- a/hasura/metadata/databases/default/tables/public_epoches.yaml
+++ b/hasura/metadata/databases/default/tables/public_epoches.yaml
@@ -56,6 +56,31 @@ select_permissions:
     - ended
     - grant
     - id
+    - number
+    - regift_days
+    - repeat
+    - repeat_day_of_month
+    - start_date
+    - updated_at
+    filter:
+      circle:
+        api_keys:
+          _and:
+          - hash:
+              _eq: X-Hasura-Api-Key-Hash
+          - read_epochs:
+              _eq: true
+    limit: 10
+  role: api-user
+- permission:
+    columns:
+    - circle_id
+    - created_at
+    - days
+    - end_date
+    - ended
+    - grant
+    - id
     - notified_before_end
     - notified_end
     - notified_start

--- a/hasura/metadata/databases/default/tables/public_nominees.yaml
+++ b/hasura/metadata/databases/default/tables/public_nominees.yaml
@@ -41,6 +41,28 @@ array_relationships:
         schema: public
 select_permissions:
 - permission:
+    columns:
+    - circle_id
+    - description
+    - ended
+    - expiry_date
+    - id
+    - name
+    - nominated_by_user_id
+    - nominated_date
+    - user_id
+    - vouches_required
+    filter:
+      circle:
+        api_keys:
+          _and:
+          - hash:
+              _eq: X-Hasura-Api-Key-Hash
+          - read_nominees:
+              _eq: true
+    limit: 20
+  role: api-user
+- permission:
     allow_aggregations: true
     columns:
     - address

--- a/hasura/metadata/databases/default/tables/public_pending_token_gifts.yaml
+++ b/hasura/metadata/databases/default/tables/public_pending_token_gifts.yaml
@@ -31,6 +31,28 @@ object_relationships:
     foreign_key_constraint_on: sender_id
 select_permissions:
 - permission:
+    allow_aggregations: true
+    columns:
+    - circle_id
+    - created_at
+    - dts_created
+    - epoch_id
+    - id
+    - recipient_id
+    - sender_id
+    - tokens
+    - updated_at
+    filter:
+      circle:
+        api_keys:
+          _and:
+          - hash:
+              _eq: X-Hasura-Api-Key-Hash
+          - read_pending_token_gifts:
+              _eq: true
+    limit: 100
+  role: api-user
+- permission:
     columns:
     - circle_id
     - created_at

--- a/hasura/metadata/databases/default/tables/public_profiles.yaml
+++ b/hasura/metadata/databases/default/tables/public_profiles.yaml
@@ -14,6 +14,33 @@ array_relationships:
 select_permissions:
 - permission:
     columns:
+      - address
+      - avatar
+      - background
+      - bio
+      - created_at
+      - discord_username
+      - github_username
+      - id
+      - medium_username
+      - skills
+      - telegram_username
+      - twitter_username
+      - updated_at
+      - website
+    filter:
+      users:
+        circle:
+          api_keys:
+            _and:
+              - hash:
+                  _eq: X-Hasura-Api-Key-Hash
+              - read_member_profiles:
+                  _eq: true
+    limit: 50
+  role: api-user
+- permission:
+    columns:
     - address
     - avatar
     - background

--- a/hasura/metadata/databases/default/tables/public_users.yaml
+++ b/hasura/metadata/databases/default/tables/public_users.yaml
@@ -65,6 +65,35 @@ array_relationships:
 select_permissions:
 - permission:
     columns:
+    - bio
+    - circle_id
+    - created_at
+    - fixed_non_receiver
+    - give_token_received
+    - give_token_remaining
+    - id
+    - name
+    - non_giver
+    - non_receiver
+    - starting_tokens
+    filter:
+      _and:
+      - deleted_at:
+          _is_null: true
+      - circle:
+          api_keys:
+            _and:
+            - hash:
+                _eq: X-Hasura-Api-Key-Hash
+            - _or:
+              - read_pending_token_gifts:
+                  _eq: true
+              - read_member_profiles:
+                  _eq: true
+    limit: 50
+  role: api-user
+- permission:
+    columns:
     - address
     - bio
     - circle_id

--- a/hasura/metadata/databases/default/tables/tables.yaml
+++ b/hasura/metadata/databases/default/tables/tables.yaml
@@ -1,4 +1,5 @@
 - "!include public_burns.yaml"
+- "!include public_circle_api_keys.yaml"
 - "!include public_circle_integrations.yaml"
 - "!include public_circle_metadata.yaml"
 - "!include public_circle_private.yaml"

--- a/hasura/migrations/default/1652767682611_create_circle_api_keys_table/down.sql
+++ b/hasura/migrations/default/1652767682611_create_circle_api_keys_table/down.sql
@@ -1,0 +1,42 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "public"."circle_api_keys" add column "read_epochs" boolean
+--  not null default 'false';
+
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "public"."circle_api_keys" add column "read_member_profiles" boolean
+--  not null default 'false';
+
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "public"."circle_api_keys" add column "update_pending_token_gifts" boolean
+--  not null default 'false';
+
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "public"."circle_api_keys" add column "read_pending_token_gifts" boolean
+--  not null default 'false';
+
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "public"."circle_api_keys" add column "create_vouches" boolean
+--  not null default 'false';
+
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "public"."circle_api_keys" add column "read_nominees" boolean
+--  not null default 'false';
+
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "public"."circle_api_keys" add column "update_circle" boolean
+--  not null default 'false';
+
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "public"."circle_api_keys" add column "read_circle" boolean
+--  not null default 'false';
+
+
+DROP TABLE "public"."circle_api_keys";

--- a/hasura/migrations/default/1652767682611_create_circle_api_keys_table/up.sql
+++ b/hasura/migrations/default/1652767682611_create_circle_api_keys_table/up.sql
@@ -1,0 +1,28 @@
+
+CREATE TABLE "public"."circle_api_keys" ("hash" text NOT NULL, "circle_id" int8 NOT NULL, "created_at" timestamptz NOT NULL DEFAULT now(), "created_by" int8 NOT NULL, "name" text NOT NULL, PRIMARY KEY ("hash") , UNIQUE ("hash"));COMMENT ON TABLE "public"."circle_api_keys" IS E'Circle-scoped API keys with user defined permissions to allow third parties to authenticate to Coordinape\'s GraphQL API.';
+
+
+alter table "public"."circle_api_keys" add column "read_circle" boolean
+ not null default 'false';
+
+alter table "public"."circle_api_keys" add column "update_circle" boolean
+ not null default 'false';
+
+alter table "public"."circle_api_keys" add column "read_nominees" boolean
+ not null default 'false';
+
+alter table "public"."circle_api_keys" add column "create_vouches" boolean
+ not null default 'false';
+
+alter table "public"."circle_api_keys" add column "read_pending_token_gifts" boolean
+ not null default 'false';
+
+alter table "public"."circle_api_keys" add column "update_pending_token_gifts" boolean
+ not null default 'false';
+
+alter table "public"."circle_api_keys" add column "read_member_profiles" boolean
+ not null default 'false';
+
+alter table "public"."circle_api_keys" add column "read_epochs" boolean
+ not null default 'false';
+

--- a/hasura/migrations/default/1653094730989_set_fk_public_circle_api_keys_circle_id/down.sql
+++ b/hasura/migrations/default/1653094730989_set_fk_public_circle_api_keys_circle_id/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."circle_api_keys" drop constraint "circle_api_keys_circle_id_fkey";

--- a/hasura/migrations/default/1653094730989_set_fk_public_circle_api_keys_circle_id/up.sql
+++ b/hasura/migrations/default/1653094730989_set_fk_public_circle_api_keys_circle_id/up.sql
@@ -1,0 +1,5 @@
+alter table "public"."circle_api_keys"
+  add constraint "circle_api_keys_circle_id_fkey"
+  foreign key ("circle_id")
+  references "public"."circles"
+  ("id") on update restrict on delete cascade;

--- a/hasura/migrations/default/1653094829404_set_fk_public_circle_api_keys_created_by/down.sql
+++ b/hasura/migrations/default/1653094829404_set_fk_public_circle_api_keys_created_by/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."circle_api_keys" drop constraint "circle_api_keys_created_by_fkey";

--- a/hasura/migrations/default/1653094829404_set_fk_public_circle_api_keys_created_by/up.sql
+++ b/hasura/migrations/default/1653094829404_set_fk_public_circle_api_keys_created_by/up.sql
@@ -1,0 +1,5 @@
+alter table "public"."circle_api_keys"
+  add constraint "circle_api_keys_created_by_fkey"
+  foreign key ("created_by")
+  references "public"."users"
+  ("id") on update restrict on delete restrict;


### PR DESCRIPTION
Sets up a new `circle_api_keys` table to store circle-scoped API keys with granular permissions + sets up relationships and permissions for the new `api-user` role.

For review, should ensure the configured permissions are appropriate for each given scope and that we aren't leaking anything critical.

related: #887 