### PR TITLE
Handle circle API keys in auth handler

### DIFF
--- a/api-lib/authHelpers.ts
+++ b/api-lib/authHelpers.ts
@@ -1,5 +1,7 @@
 import { createHash, randomBytes } from 'crypto';
 
+export type AuthHeaderPrefix = 'api' | number;
+
 export function generateTokenString(len = 40): string {
   const bufSize = len * 2;
   if (bufSize > 65536) {
@@ -19,17 +21,23 @@ export function hashTokenString(tokenString: string): string {
   return createHash('sha256').update(tokenString).digest('hex');
 }
 
-export function formatAuthHeader(prefix: string, tokenString: string): string {
+export function formatAuthHeader(
+  prefix: AuthHeaderPrefix,
+  tokenString: string
+): string {
   return `${prefix}|${tokenString}`;
 }
 
 export function parseAuthHeader(header: string): {
-  prefix: string;
+  prefix: AuthHeaderPrefix;
   tokenHash: string;
 } {
   const [prefix, tokenString] = header.replace('Bearer ', '').split('|');
 
   const tokenHash = hashTokenString(tokenString);
 
-  return { prefix, tokenHash };
+  return {
+    prefix: prefix === 'api' ? prefix : Number.parseInt(prefix, 10),
+    tokenHash,
+  };
 }

--- a/api/hasura/actions/generateApiKey.ts
+++ b/api/hasura/actions/generateApiKey.ts
@@ -1,6 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
 import {
+  formatAuthHeader,
   generateTokenString,
   hashTokenString,
 } from '../../../api-lib/authHelpers';
@@ -46,7 +47,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
   );
 
   return res.status(200).json({
-    api_key: apiKey,
+    api_key: formatAuthHeader('api', apiKey),
     hash,
   });
 }

--- a/api/hasura/auth.ts
+++ b/api/hasura/auth.ts
@@ -19,13 +19,41 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     assert(req.headers?.authorization, 'No token was provided');
     const { prefix, tokenHash } = parseAuthHeader(req.headers.authorization);
 
+    if (prefix === 'api') {
+      const apiKeyRes = await adminClient.query(
+        {
+          circle_api_keys_by_pk: [
+            {
+              hash: tokenHash,
+            },
+            {
+              hash: true,
+              circle_id: true,
+            },
+          ],
+        },
+        { operationName: 'auth_getApiKey @cached(ttl: 30)' }
+      );
+
+      const { hash, circle_id } = apiKeyRes.circle_api_keys_by_pk || {};
+      assert(hash && circle_id, 'The API key provided is not valid');
+
+      res.status(200).json({
+        'X-Hasura-Role': 'api-user',
+        'X-Hasura-Api-Key-Hash': hash,
+        'X-Hasura-Circle-Id': circle_id.toString(),
+      });
+      return;
+    }
+
+    // handle personal access tokens
     const tokenRow = await adminClient.query(
       {
         personal_access_tokens: [
           {
             where: {
               tokenable_type: { _eq: 'App\\Models\\Profile' },
-              id: { _eq: Number.parseInt(prefix, 10) },
+              id: { _eq: prefix },
               token: { _eq: tokenHash },
             },
           },
@@ -36,7 +64,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             },
           },
         ],
-        // cache query with ttl of 30s
       },
       { operationName: 'auth_getToken @cached(ttl: 30)' }
     );

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -236,8 +236,8 @@ input GenerateApiKeyInput {
   update_circle: Boolean
   read_nominees: Boolean
   create_vouches: Boolean
-  read_allocations: Boolean
-  update_allocations: Boolean
+  read_pending_token_gifts: Boolean
+  update_pending_token_gifts: Boolean
   read_member_profiles: Boolean
   read_epochs: Boolean
 }


### PR DESCRIPTION
## Motivation and Context

Allows requests with circle API keys to be authenticated by the Hasura auth handler

## Description

Assign api-user role in Hasura auth handler if an API key is passed in

## Test and Deployment Plan

1. Generate an API key by calling the generateApiKey action
2. Make a request to the `/api/hasura/auth` endpoint with the Authorization header set to `Bearer <apiKey>`
3. Ensure it returns `api-key` for the role and the correct circleId

## Reviewers
@topocount @zashton 

## Related Issue

#887 
