### PR TITLE
Allow Circle API keys to call updateAllocations action

### DIFF
--- a/api-lib/authHelpers.ts
+++ b/api-lib/authHelpers.ts
@@ -1,5 +1,7 @@
 import { createHash, randomBytes } from 'crypto';
 
+import { adminClient } from './gql/adminClient';
+
 export type AuthHeaderPrefix = 'api' | number;
 
 export function generateTokenString(len = 40): string {
@@ -40,4 +42,32 @@ export function parseAuthHeader(header: string): {
     prefix: prefix === 'api' ? prefix : Number.parseInt(prefix, 10),
     tokenHash,
   };
+}
+
+export async function getCircleApiKey(hash: string) {
+  const apiKeyRes = await adminClient.query(
+    {
+      circle_api_keys_by_pk: [
+        {
+          hash,
+        },
+        {
+          hash: true,
+          circle_id: true,
+          name: true,
+          create_vouches: true,
+          read_pending_token_gifts: true,
+          read_nominees: true,
+          read_member_profiles: true,
+          read_epochs: true,
+          read_circle: true,
+          update_pending_token_gifts: true,
+          update_circle: true,
+        },
+      ],
+    },
+    { operationName: 'getCircleApiKey @cached(ttl: 60)' }
+  );
+
+  return apiKeyRes.circle_api_keys_by_pk;
 }

--- a/api-lib/findUser.ts
+++ b/api-lib/findUser.ts
@@ -1,6 +1,21 @@
 import assert from 'assert';
 
+import { Selector } from './gql/__generated__/zeus';
 import { adminClient } from './gql/adminClient';
+
+const userSelector = Selector('users')({
+  id: true,
+  role: true,
+  name: true,
+  address: true,
+  circle_id: true,
+  give_token_remaining: true,
+  give_token_received: true,
+  non_giver: true,
+  non_receiver: true,
+  fixed_non_receiver: true,
+  starting_tokens: true,
+});
 
 export const getUserFromProfileId = async (
   profileId: number,
@@ -19,19 +34,7 @@ export const getUserFromProfileId = async (
                 circle_id: { _eq: circleId },
               },
             },
-            {
-              id: true,
-              role: true,
-              name: true,
-              address: true,
-              circle_id: true,
-              give_token_remaining: true,
-              give_token_received: true,
-              non_giver: true,
-              non_receiver: true,
-              fixed_non_receiver: true,
-              starting_tokens: true,
-            },
+            userSelector,
           ],
         },
       ],
@@ -61,18 +64,7 @@ export const getUserFromAddress = async (address: string, circleId: number) => {
             ],
           },
         },
-        {
-          id: true,
-          role: true,
-          address: true,
-          circle_id: true,
-          give_token_remaining: true,
-          give_token_received: true,
-          non_giver: true,
-          non_receiver: true,
-          fixed_non_receiver: true,
-          starting_tokens: true,
-        },
+        userSelector,
       ],
     },
     {
@@ -97,18 +89,7 @@ export const getUsersFromUserIds = async (
             deleted_at: { _is_null: true },
           },
         },
-        {
-          id: true,
-          role: true,
-          address: true,
-          circle_id: true,
-          give_token_remaining: true,
-          give_token_received: true,
-          non_giver: true,
-          non_receiver: true,
-          fixed_non_receiver: true,
-          starting_tokens: true,
-        },
+        userSelector,
       ],
     },
     {

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -200,6 +200,7 @@ input Allocation {
 input Allocations {
   allocations: [Allocation!]
   circle_id: Int!
+  user_id: Int
 }
 
 input CreateUsersInput {

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -120,6 +120,7 @@ actions:
     - name: verification_key
       value_from_env: HASURA_EVENT_SECRET
   permissions:
+  - role: api-user
   - role: user
 - name: updateCircle
   definition:


### PR DESCRIPTION
## Motivation and Context

Since we use custom actions for updating user allocations, we need to adjust the auth and business logic in the action handler to account for API keys that have the `update_pending_token_gifts` permission.

## Description

Created a new action request body validator for testing if API keys have certain permissions in a standardized / explicit way.

## Test and Deployment Plan

1. Create a circle API key with the `update_pending_token_gifts` permission
2. Use the API key to call the `updateAllocations` mutation for that circle and ensure it succeeds
3. Call the same mutation but for a different circle and ensure it fails.
4. Create another circle API key without the `update_pending_token_gifts` permission
5. Use the API key to call the `updateAllocations` mutations and ensure it fails.

## Reviewers

@topocount 

## Related Issue

#887 
