### PR TITLE
trim name strings before checking the length

### DIFF
--- a/src/forms/AdminUserForm.tsx
+++ b/src/forms/AdminUserForm.tsx
@@ -14,7 +14,9 @@ interface IUserAndCircle {
 
 const schema = z
   .object({
-    name: z.string().min(3, 'Name must be at least 3 characters long.'),
+    name: z.string().refine(val => val.trim().length >= 3, {
+      message: 'Name must be at least 3 characters long.',
+    }),
     address: zEthAddress,
     non_giver: z.boolean(),
     fixed_non_receiver: z.boolean(),

--- a/src/forms/CreateCircleForm.tsx
+++ b/src/forms/CreateCircleForm.tsx
@@ -4,17 +4,19 @@ import { createForm } from './createForm';
 
 const schema = z
   .object({
-    user_name: z
-      .string()
-      .min(3, 'User name must be at least 3 characters long.'),
-    circle_name: z
-      .string()
-      .min(3, 'Circle name must be at least 3 characters long.'),
-    protocol_name: z
-      .string()
-      .min(3, 'Org name must be at least 3 characters long.'),
+    user_name: z.string().refine(val => val.trim().length >= 3, {
+      message: 'Name must be at least 3 characters long.',
+    }),
+    circle_name: z.string().refine(val => val.trim().length >= 3, {
+      message: 'Circle name must be at least 3 characters long.',
+    }),
+    protocol_name: z.string().refine(val => val.trim().length >= 3, {
+      message: 'Org name must be at least 3 characters long.',
+    }),
     protocol_id: z.number().optional(),
-    contact: z.string().min(4, 'Circle Point of Contact is Required.'),
+    contact: z.string().refine(val => val.trim().length >= 4, {
+      message: 'Circle Point of Contact is Required.',
+    }),
   })
   .strict();
 

--- a/src/lib/zod/index.ts
+++ b/src/lib/zod/index.ts
@@ -216,7 +216,11 @@ export const updateCircleInput = z
 
   .object({
     circle_id: z.number().positive(),
-    name: z.string().min(3).max(255).optional(),
+    name: z
+      .string()
+      .max(255)
+      .refine(val => val.trim().length >= 3)
+      .optional(),
     alloc_text: z.string().max(5000).optional(),
     auto_opt_out: z.boolean().optional(),
     default_opt_in: z.boolean().optional(),
@@ -226,7 +230,11 @@ export const updateCircleInput = z
     only_giver_vouch: z.boolean().optional(),
     team_sel_text: z.string().optional(),
     team_selection: z.boolean().optional(),
-    token_name: z.string().max(255).optional(),
+    token_name: z
+      .string()
+      .max(255)
+      .refine(val => val.trim().length >= 3)
+      .optional(),
     update_webhook: z.boolean().optional(),
     vouching: z.boolean().optional(),
     vouching_text: z.string().max(5000).optional(),

--- a/src/pages/VouchingPage/NewNominationModal.tsx
+++ b/src/pages/VouchingPage/NewNominationModal.tsx
@@ -21,7 +21,9 @@ import {
 
 const schema = z
   .object({
-    name: z.string().min(3, 'Name must be at least 3 characters long.'),
+    name: z.string().refine(val => val.trim().length >= 3, {
+      message: 'Name must be at least 3 characters long.',
+    }),
     address: zEthAddress,
     description: z
       .string()


### PR DESCRIPTION
## Motivation and Context

fixes #944

## Description

Trim names strings before comparing the length.
For edit circle Modal the validation is done at src/lib/zod/index.ts because there is no validation at the modal.

## Test and Deployment Plan

### Scenario 1

1- Go To Vouching Page
2- Nominate A new user
3- Enter a nominee name that has only white-spaces or white-spaces around one or two letters.

the name shouldn't be accepted 
![image](https://user-images.githubusercontent.com/34943689/170336982-44f7e588-e54d-4a7b-9fec-bc6e4ec16b08.png)


### Scenario 2
1- Go To Admin Page
2- Add a new contributer
3- Enter a user name that has only white-spaces or white-spaces around one or two letters.

the name shouldn't be accepted 
![image](https://user-images.githubusercontent.com/34943689/170337374-60104558-b752-4dc3-a85a-05174c8784b4.png)

### Scenario 3 
1- Go to Admin Page
2- Edit the circle
3- Replace the circle name with empty spaces

The name shouldn't be accepted
![image](https://user-images.githubusercontent.com/34943689/170341028-03510c4a-5e35-42b7-9261-86a38fd05829.png)

### Scenario 4 
1- Go to Admin Page
2- Create a new circle with white space names
![image](https://user-images.githubusercontent.com/34943689/170342043-48e05fe3-35a7-4ab3-aa8f-2b850692ff52.png)

## Reviewers
@levity @CryptoGraffe @topocount 

## Related Issue

#944 
