### PR TITLE
fix: Use circle token name instead of hardcoded GIVE

### DIFF
--- a/api-lib/gql/queries.ts
+++ b/api-lib/gql/queries.ts
@@ -16,6 +16,7 @@ export async function getCircle(id: number) {
           team_sel_text: true,
           discord_webhook: true,
           telegram_id: true,
+          token_name: true,
           organization: {
             telegram_id: true,
           },

--- a/api-lib/handleOptOutMsg.ts
+++ b/api-lib/handleOptOutMsg.ts
@@ -12,6 +12,9 @@ export default async function handleOptOutMsg(
 
   if (data.old.non_receiver === false && data.new.non_receiver === true) {
     const currentEpoch = await queries.getCurrentEpoch(data.new.circle_id);
+    const { circles_by_pk: circle } = await queries.getCircle(
+      data.new.circle_id
+    );
 
     if (currentEpoch) {
       await sendSocialMessage({
@@ -20,7 +23,9 @@ export default async function handleOptOutMsg(
         // is removed
         message:
           `${data.new.name} has opted out of the current epoch.\n` +
-          `A Total of ${data.old.give_token_received} GIVE was refunded`,
+          `A Total of ${data.old.give_token_received} ${
+            circle?.token_name || 'GIVE'
+          } was refunded`,
         circleId: data.new.circle_id,
         channels,
       });
@@ -29,6 +34,9 @@ export default async function handleOptOutMsg(
   }
   if (data.old.non_giver === false && data.new.non_giver === true) {
     const currentEpoch = await queries.getCurrentEpoch(data.new.circle_id);
+    const { circles_by_pk: circle } = await queries.getCircle(
+      data.new.circle_id
+    );
 
     if (currentEpoch) {
       await sendSocialMessage({
@@ -39,7 +47,7 @@ export default async function handleOptOutMsg(
           `${data.new.name} can no longer allocate GIVE during the current epoch.\n` +
           `A Total of ${
             data.old.starting_tokens - data.old.give_token_remaining
-          } GIVE was refunded`,
+          } ${circle?.token_name || 'GIVE'} was refunded`,
         circleId: data.new.circle_id,
         channels,
       });

--- a/api-lib/handleRefundGiveMsg.ts
+++ b/api-lib/handleRefundGiveMsg.ts
@@ -19,6 +19,8 @@ export default async function handleRefundGiveMsg(
     return false;
   }
 
+  const { circles_by_pk: circle } = await queries.getCircle(data.old.circle_id);
+
   const currentEpoch = await queries.getCurrentEpoch(data.old.circle_id);
   if (currentEpoch) {
     const { users_by_pk: sender } = await adminClient.query(
@@ -51,8 +53,9 @@ export default async function handleRefundGiveMsg(
         // and will be deprecated. This total will be removed when the column
         // is removed
         message:
-          `${sender.name} has been refunded ${data.old.tokens} GIVE ` +
-          `from ${recipient.name}`,
+          `${sender.name} has been refunded ${data.old.tokens} ${
+            circle?.token_name || 'GIVE'
+          } ` + `from ${recipient.name}`,
         circleId: data.old.circle_id,
         channels,
       });

--- a/api/hasura/cron/epochs.ts
+++ b/api/hasura/cron/epochs.ts
@@ -91,6 +91,7 @@ async function getEpochsToNotify() {
                 id: true,
                 name: true,
                 telegram_id: true,
+                token_name: true,
                 discord_webhook: true,
                 organization: { name: true },
                 users: [
@@ -240,7 +241,9 @@ export async function notifyEpochEnd({
       ${circle.organization?.name}/${
         circle.name
       } epoch ends in less than 24 hours!
-      Users that have yet to fully allocate their GIVE:
+      Users that have yet to fully allocate their ${
+        circle.token_name || 'GIVE'
+      }:
       ${usersHodlingGive.join(', ')}
     `;
 

--- a/src/pages/AdminPage/AdminCircleModal.tsx
+++ b/src/pages/AdminPage/AdminCircleModal.tsx
@@ -377,8 +377,12 @@ export const AdminCircleModal = ({
           label="Default Opt In?"
           infoTooltip={
             <YesNoTooltip
-              yes="All new members are eligible to receive GIVE"
-              no="New members need to log into Coordinape and opt in to receiving GIVE"
+              yes={`All new members are eligible to receive ${
+                circle.tokenName || 'GIVE'
+              }`}
+              no={`New members need to log into Coordinape and opt in to receiving ${
+                circle.tokenName || 'GIVE'
+              }`}
               href={DOCS_HREF}
               anchorText={DOCS_TEXT}
             />
@@ -391,7 +395,9 @@ export const AdminCircleModal = ({
           label="Only Givers can vouch"
           infoTooltip={
             <YesNoTooltip
-              yes="Only members who are eligible to send GIVE can vouch for new members"
+              yes={`Only members who are eligible to send ${
+                circle.tokenName || 'GIVE'
+              } can vouch for new members`}
               no="Anyone in the circle can vouch for new members"
               href={DOCS_HREF}
               anchorText={DOCS_TEXT}

--- a/src/pages/AdminPage/AdminEpochModal.tsx
+++ b/src/pages/AdminPage/AdminEpochModal.tsx
@@ -11,6 +11,7 @@ import {
 } from 'components';
 import EpochForm, { summarizeEpoch } from 'forms/AdminEpochForm';
 import { useApiAdminCircle } from 'hooks';
+import { useSelectedCircle } from 'recoilState/app';
 
 import { IEpoch } from 'types';
 
@@ -90,6 +91,8 @@ export const AdminEpochModal = ({
 
   const { createEpoch, updateEpoch } = useApiAdminCircle(circleId);
 
+  const { circle } = useSelectedCircle();
+
   const source = useMemo(
     () => ({
       epoch: epoch,
@@ -118,7 +121,7 @@ export const AdminEpochModal = ({
         >
           <div className={classes.modalDescription}>
             An Epoch is a period of time where circle members contribute value &
-            allocate GIVE tokens to one another.{' '}
+            allocate {circle.tokenName || 'GIVE'} tokens to one another.{' '}
             <span>
               <a
                 className={classes.modalExternalLink}

--- a/src/pages/AdminPage/AdminUserModal.tsx
+++ b/src/pages/AdminPage/AdminUserModal.tsx
@@ -173,7 +173,9 @@ export const AdminUserModal = ({
               {...fixed_non_receiver}
               value={!fixedNonReceiverValue}
               onChange={v => fixedNonReceiverOnChange(!v)}
-              label={`Allow contributor to receive ${selectedCircle.tokenName}`}
+              label={`Allow contributor to receive ${
+                selectedCircle.tokenName || 'GIVE'
+              }`}
               infoTooltip={
                 <>
                   Allows the Contributor to get paid based on the amount of
@@ -188,14 +190,17 @@ export const AdminUserModal = ({
 
           <ActionDialog
             open={!hasAcceptedOptOutWarning && showOptOutChangeWarning}
-            title="This user has GIVE allocated."
+            title={`This user has ${
+              selectedCircle.tokenName || 'GIVE'
+            } allocated.`}
             onPrimary={() => {
               setHasAcceptedOptOutWarning(true);
               setShowOptOutChangeWarning(false);
             }}
           >
-            Changing their opt-in status will remove all GIVE allocated to them.
-            This cannot be undone.
+            Changing their opt-in status will remove all{' '}
+            {selectedCircle.tokenName || 'GIVE'} allocated to them. This cannot
+            be undone.
           </ActionDialog>
         </FormModal>
       )}

--- a/src/pages/AllocationPage/AllocationEpoch.tsx
+++ b/src/pages/AllocationPage/AllocationEpoch.tsx
@@ -185,7 +185,9 @@ const AllocationEpoch = ({
             />
             <ActionDialog
               open={optOutOpen}
-              title={`If you Opt Out you will lose your ${myUser.give_token_received} GIVE`}
+              title={`If you Opt Out you will lose your ${
+                myUser.give_token_received
+              } ${selectedCircle?.token_name || 'GIVE'}`}
               onClose={() => setOptOutOpen(false)}
               onPrimary={() => {
                 setNonReceiver(true);
@@ -193,9 +195,10 @@ const AllocationEpoch = ({
               }}
               primaryText="Proceed to Opt Out"
             >
-              Opting out during an in-progress epoch will result in any GIVE you
-              have received being returned to senders. Are you sure you wish to
-              proceed? This cannot be undone.
+              Opting out during an in-progress epoch will result in any{' '}
+              {selectedCircle?.token_name || 'GIVE'} you have received being
+              returned to senders. Are you sure you wish to proceed? This cannot
+              be undone.
             </ActionDialog>
           </div>
         </>

--- a/src/pages/DistributionsPage/AllocationsTable.tsx
+++ b/src/pages/DistributionsPage/AllocationsTable.tsx
@@ -32,7 +32,7 @@ export const AllocationsTable = ({
       headers={[
         'Name',
         'ETH Wallet',
-        'GIVE Received',
+        `${tokenName || 'GIVE'} Received`,
         '% of Epoch',
         'Vault Funds Allocated',
       ]}


### PR DESCRIPTION
## Motivation and Context

<!-- Why is this change required? What problem does it solve? This can be omitted if a linked issue is provided
-->

When a user changes the GIVE token name there were a few places were we were hardcoding "GIVE", it should be dynamically set depending on the circle's token name.

## Description

<!-- Describe your changes -->

Change the places where "GIVE" was hardcoded to use the token name from the circle.

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->

Ran the app locally and saw the change for most of them, not totally sure how to test the following:

* api-lib/handleRefundGiveMsg.ts
* api-lib/handleOptOutMsg.ts
* api/hasura/cron/epochs.ts

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

Before
<img width="1792" alt="Screen Shot 2022-05-28 at 1 15 28 pm" src="https://user-images.githubusercontent.com/78794805/170810085-44cc73ba-40eb-4aa6-878c-cb1949d0129b.png">
After
<img width="1792" alt="Screen Shot 2022-05-28 at 1 21 51 pm" src="https://user-images.githubusercontent.com/78794805/170810087-4ce33937-236b-4113-b7a4-6c9b8a9e1faa.png">

Before
<img width="1792" alt="Screen Shot 2022-05-28 at 1 30 20 pm" src="https://user-images.githubusercontent.com/78794805/170810090-d4c576d6-4d87-4f19-89a9-dbd022b1bcd4.png">
After
<img width="1792" alt="Screen Shot 2022-05-28 at 1 35 44 pm" src="https://user-images.githubusercontent.com/78794805/170810094-c5b72bc5-cbe3-4391-a014-3f2dfdc4783b.png">

After
<img width="1792" alt="Screen Shot 2022-05-28 at 1 22 39 pm" src="https://user-images.githubusercontent.com/78794805/170810089-1663b395-5092-46b0-8ce8-f6c98b2551ae.png">
After
<img width="1792" alt="Screen Shot 2022-05-28 at 1 22 22 pm" src="https://user-images.githubusercontent.com/78794805/170810088-9137c8c3-53ad-488f-bd34-2709892f7d34.png">
After
<img width="1792" alt="Screen Shot 2022-05-28 at 1 40 20 pm" src="https://user-images.githubusercontent.com/78794805/170810099-08802730-e394-4ed4-984f-01c675927a7b.png">

## Related Issue

<!-- Please link to the issue here -->

Closes https://github.com/coordinape/coordinape/issues/924
