### PR TITLE
change teammates permissions so you can only see your own teammates

### DIFF
--- a/hasura/metadata/databases/default/tables/public_teammates.yaml
+++ b/hasura/metadata/databases/default/tables/public_teammates.yaml
@@ -29,12 +29,8 @@ select_permissions:
     - created_at
     - updated_at
     filter:
-      user:
-        circle:
-          users:
-            profile:
-              id:
-                _eq: X-Hasura-User-Id
+      user_id:
+        _eq: X-Hasura-User-Id
   role: user
 event_triggers:
 - definition:


### PR DESCRIPTION
this dramatically improves the perf of the getFullCircle query for large circles