### PR TITLE
feat: Add "Pay with Parcel" Button setting under Integrations

### DIFF
--- a/src/icons/ParcelIcon.tsx
+++ b/src/icons/ParcelIcon.tsx
@@ -1,0 +1,46 @@
+/* eslint-disable react/display-name */
+import * as React from 'react';
+
+import { styled, SvgIconConfig } from 'stitches.config';
+
+import { IconProps } from 'types';
+
+export const ParcelIcon = styled(
+  React.forwardRef<SVGSVGElement, IconProps>(
+    ({ color = 'currentColor', ...props }, forwardedRef) => {
+      return (
+        <svg
+          width="28"
+          height="28"
+          viewBox="0 0 28 28"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          {...props}
+          ref={forwardedRef}
+        >
+          <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M22.454 5.71722V12.8443L14.2266 17.8534V0L22.454 5.71722Z"
+            fill={color}
+          />
+          <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M14.2274 17.853V27.9999L6 22.8601L14.2274 17.853Z"
+            fill={color}
+          />
+          <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M14.2274 0V17.8534L6 22.8583V5.71511L14.2274 0Z"
+            fill={color}
+          />
+        </svg>
+      );
+    }
+  ),
+  SvgIconConfig
+);
+
+export default ParcelIcon;

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -31,6 +31,7 @@ export * from './InfoIcon';
 export * from './LinkIcon';
 export * from './MediumIcon';
 export * from './MinusCircleIcon';
+export * from './ParcelIcon';
 export * from './PlusCircleIcon';
 export * from './RightArrowIcon';
 export * from './SaveIcon';

--- a/src/pages/AdminPage/AdminIntegrations.tsx
+++ b/src/pages/AdminPage/AdminIntegrations.tsx
@@ -6,7 +6,7 @@ import { makeStyles, IconButton } from '@material-ui/core';
 
 import { ActionDialog } from 'components';
 import { useCurrentCircleIntegrations } from 'hooks/gql/useCurrentCircleIntegrations';
-import { DeleteIcon, DeworkIcon, DeworkLogo } from 'icons';
+import { DeleteIcon, DeworkIcon, DeworkLogo, ParcelIcon } from 'icons';
 import { paths } from 'routes/paths';
 import { Flex, Button } from 'ui';
 
@@ -71,18 +71,34 @@ export const AdminIntegrations = () => {
           </div>
         ))}
       </div>
-      <Button
-        as="a"
-        color="neutral"
-        size="medium"
-        outlined
-        href={`https://app.dework.xyz/apps/install/coordinape?redirect=${window.location.origin}${paths.connectIntegration}`}
-      >
-        <Flex css={{ mr: '$sm' }}>
-          <DeworkIcon size="md" />
-        </Flex>
-        Connect Dework
-      </Button>
+      <Flex css={{ mr: '$sm' }} className={classes.integrationRow}>
+        <Button
+          as="a"
+          color="neutral"
+          size="medium"
+          outlined
+          href={`https://app.dework.xyz/apps/install/coordinape?redirect=${window.location.origin}${paths.connectIntegration}`}
+        >
+          <Flex css={{ mr: '$sm' }}>
+            <DeworkIcon size="md" />
+          </Flex>
+          Connect Dework
+        </Button>
+        <Button
+          as="a"
+          color="neutral"
+          size="medium"
+          outlined
+          href={
+            'https://docs.coordinape.com/get-started/compensation/paying-your-team'
+          }
+        >
+          <Flex css={{ mr: '$sm' }}>
+            <ParcelIcon size="md" />
+          </Flex>
+          Pay with Parcel
+        </Button>
+      </Flex>
 
       <ActionDialog
         open={!!deleteIntegration}

--- a/src/pages/AdminPage/AdminIntegrations.tsx
+++ b/src/pages/AdminPage/AdminIntegrations.tsx
@@ -90,7 +90,7 @@ export const AdminIntegrations = () => {
           size="medium"
           outlined
           href={
-            'https://docs.coordinape.com/get-started/compensation/paying-your-team'
+            'https://docs.coordinape.com/get-started/compensation/paying-your-team/parcel'
           }
         >
           <Flex css={{ mr: '$sm' }}>


### PR DESCRIPTION
## Motivation and Context

<!-- Why is this change required? What problem does it solve? This can be omitted if a linked issue is provided
-->

Add a "Pay with Parcel" button to the site under the integrations section so users can know we support an integration with Parcel.

## Description

<!-- Describe your changes -->

Added a button that links to our Docs page for the Parcel Integration.

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->

Ran locally, observed the button and clicked on it

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

<img width="1792" alt="Screen Shot 2022-06-07 at 11 31 25 am" src="https://user-images.githubusercontent.com/78794805/172289909-dd0d64da-c8b1-4d6f-8778-fbca4f0e23bc.png">

## Related Issue

<!-- Please link to the issue here -->

https://github.com/coordinape/coordinape/issues/985
