### PR TITLE
Handle bad image upload errors on OrgLogoUploader

### DIFF
--- a/src/components/OrgLogoUpload/OrgLogoUpload.tsx
+++ b/src/components/OrgLogoUpload/OrgLogoUpload.tsx
@@ -10,6 +10,7 @@ import { useImageUploader, useApeSnackbar } from 'hooks';
 import { UploadIcon, EditIcon } from 'icons';
 import { Avatar, Box, Button } from 'ui';
 import { getAvatarPathWithFallback } from 'utils/domain';
+import { normalizeError } from 'utils/reporting';
 
 const VALID_FILE_TYPES = ['image/jpg', 'image/jpeg', 'image/png'];
 
@@ -62,7 +63,15 @@ export const OrgLogoUpload = ({
       setIsUploadingLogo(false);
       return;
     }
-    const response = await uploadLogo(id, formFileUploadProps.value);
+    let response = undefined;
+    try {
+      response = await uploadLogo(id, formFileUploadProps.value);
+    } catch (e: any) {
+      setIsUploadingLogo(false);
+      showError(normalizeError(e).message);
+      formFileUploadProps.onChange(undefined);
+      return;
+    }
     setIsUploadingLogo(false);
     setUploadedLogoUrl(response.uploadOrgLogo?.org.logo);
     formFileUploadProps.onChange(undefined);


### PR DESCRIPTION
fixes #990

## Description

throw an error in ImageUpater.ts if an invalid format is provided.
Add a snackbar to show the error in OrgLogoUpload.tsx
Stop the loading modal and revert to the previous image

## Test Plan
1- create a text file and change the format to jpg or png
2- choose the file and try to upload it to hasura

Expected:
A snackbar should be displayed and the previous image should be redisplayed

## Screenshots (if appropriate):

![Screenshot from 2022-06-04 03-35-51](https://user-images.githubusercontent.com/34943689/171971993-8aaf7c98-29b4-4b9c-86ee-f17944826d36.png)

