### PR TITLE
Navbar bugfixes

### DIFF
--- a/src/ui/Button/Button.tsx
+++ b/src/ui/Button/Button.tsx
@@ -116,6 +116,10 @@ export const Button = styled('button', {
         fontWeight: '$medium',
         lineHeight: 'none',
         borderRadius: '$3',
+        padding: 0,
+        '& svg': {
+          margin: 0,
+        },
       },
     },
     variant: {


### PR DESCRIPTION
Issue: Icon for upload new org image was "missing"
Fix: adjust padding/margin that was pushing the icon off the background.

<img width="527" alt="Screen Shot 2022-06-06 at 6 54 58 PM" src="https://user-images.githubusercontent.com/100873710/172279069-0b245704-8bc0-4dea-9bb8-943b2fb8840e.png">