### PR TITLE
Circle API key generation + management UI

### DIFF
--- a/api-lib/gql/__generated__/zeus/const.ts
+++ b/api-lib/gql/__generated__/zeus/const.ts
@@ -4799,7 +4799,7 @@ export const ReturnTypes: Record<string, any> = {
     id: 'ID',
   },
   GenerateApiKeyResponse: {
-    apiKey: 'String',
+    api_key: 'String',
     circleApiKey: 'circle_api_keys',
     hash: 'String',
   },

--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -619,6 +619,7 @@ export type ValueTypes = {
   ['Allocations']: {
     allocations?: Array<ValueTypes['Allocation']> | undefined | null;
     circle_id: number;
+    user_id?: number | undefined | null;
   };
   ['AllocationsResponse']: AliasType<{
     /** An object relationship */
@@ -761,16 +762,16 @@ export type ValueTypes = {
     circle_id: number;
     create_vouches?: boolean | undefined | null;
     name: string;
-    read_allocations?: boolean | undefined | null;
     read_circle?: boolean | undefined | null;
     read_epochs?: boolean | undefined | null;
     read_member_profiles?: boolean | undefined | null;
     read_nominees?: boolean | undefined | null;
-    update_allocations?: boolean | undefined | null;
+    read_pending_token_gifts?: boolean | undefined | null;
     update_circle?: boolean | undefined | null;
+    update_pending_token_gifts?: boolean | undefined | null;
   };
   ['GenerateApiKeyResponse']: AliasType<{
-    apiKey?: boolean | `@${string}`;
+    api_key?: boolean | `@${string}`;
     /** An object relationship */
     circleApiKey?: ValueTypes['circle_api_keys'];
     hash?: boolean | `@${string}`;
@@ -829,7 +830,6 @@ export type ValueTypes = {
   ['UpdateCircleInput']: {
     alloc_text?: string | undefined | null;
     auto_opt_out?: boolean | undefined | null;
-    chain_id?: number | undefined | null;
     circle_id: number;
     default_opt_in?: boolean | undefined | null;
     discord_webhook?: string | undefined | null;
@@ -13470,7 +13470,7 @@ export type ModelTypes = {
   };
   ['GenerateApiKeyInput']: GraphQLTypes['GenerateApiKeyInput'];
   ['GenerateApiKeyResponse']: {
-    apiKey: string;
+    api_key: string;
     /** An object relationship */
     circleApiKey: GraphQLTypes['circle_api_keys'];
     hash: string;
@@ -18168,6 +18168,7 @@ export type GraphQLTypes = {
   ['Allocations']: {
     allocations?: Array<GraphQLTypes['Allocation']> | undefined;
     circle_id: number;
+    user_id?: number | undefined;
   };
   ['AllocationsResponse']: {
     __typename: 'AllocationsResponse';
@@ -18268,17 +18269,17 @@ export type GraphQLTypes = {
     circle_id: number;
     create_vouches?: boolean | undefined;
     name: string;
-    read_allocations?: boolean | undefined;
     read_circle?: boolean | undefined;
     read_epochs?: boolean | undefined;
     read_member_profiles?: boolean | undefined;
     read_nominees?: boolean | undefined;
-    update_allocations?: boolean | undefined;
+    read_pending_token_gifts?: boolean | undefined;
     update_circle?: boolean | undefined;
+    update_pending_token_gifts?: boolean | undefined;
   };
   ['GenerateApiKeyResponse']: {
     __typename: 'GenerateApiKeyResponse';
-    apiKey: string;
+    api_key: string;
     /** An object relationship */
     circleApiKey: GraphQLTypes['circle_api_keys'];
     hash: string;
@@ -18336,7 +18337,6 @@ export type GraphQLTypes = {
   ['UpdateCircleInput']: {
     alloc_text?: string | undefined;
     auto_opt_out?: boolean | undefined;
-    chain_id?: number | undefined;
     circle_id: number;
     default_opt_in?: boolean | undefined;
     discord_webhook?: string | undefined;

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -246,8 +246,8 @@ input GenerateApiKeyInput {
   update_pending_token_gifts: Boolean
   read_member_profiles: Boolean
   read_epochs: Boolean
- }
-  
+}
+
 input UploadOrgImageInput {
   org_id: Int!
   image_data_base64: String!

--- a/hasura/metadata/databases/default/tables/public_profiles.yaml
+++ b/hasura/metadata/databases/default/tables/public_profiles.yaml
@@ -14,7 +14,6 @@ array_relationships:
 select_permissions:
 - permission:
     columns:
-    - address
     - avatar
     - background
     - bio

--- a/src/lib/gql/__generated__/zeus/const.ts
+++ b/src/lib/gql/__generated__/zeus/const.ts
@@ -27,6 +27,7 @@ export const AllTypesProps: Record<string, any> = {
   CreateVaultInput: {},
   DeleteEpochInput: {},
   DeleteUserInput: {},
+  GenerateApiKeyInput: {},
   Int_comparison_exp: {},
   String_comparison_exp: {},
   UpdateCircleInput: {},
@@ -1224,6 +1225,9 @@ export const AllTypesProps: Record<string, any> = {
     },
     delete_circle_integrations_by_pk: {
       id: 'bigint',
+    },
+    generateApiKey: {
+      payload: 'GenerateApiKeyInput',
     },
     insert_circle_integrations: {
       objects: 'circle_integrations_insert_input',
@@ -2937,6 +2941,11 @@ export const ReturnTypes: Record<string, any> = {
     epoch: 'epochs',
     id: 'ID',
   },
+  GenerateApiKeyResponse: {
+    api_key: 'String',
+    circleApiKey: 'circle_api_keys',
+    hash: 'String',
+  },
   LogoutResponse: {
     id: 'Int',
     profile: 'profiles',
@@ -3250,6 +3259,7 @@ export const ReturnTypes: Record<string, any> = {
     delete_circle_api_keys_by_pk: 'circle_api_keys',
     delete_circle_integrations: 'circle_integrations_mutation_response',
     delete_circle_integrations_by_pk: 'circle_integrations',
+    generateApiKey: 'GenerateApiKeyResponse',
     insert_circle_integrations: 'circle_integrations_mutation_response',
     insert_circle_integrations_one: 'circle_integrations',
     insert_claims: 'claims_mutation_response',

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -617,6 +617,7 @@ export type ValueTypes = {
   ['Allocations']: {
     allocations?: Array<ValueTypes['Allocation']> | undefined | null;
     circle_id: number;
+    user_id?: number | undefined | null;
   };
   ['AllocationsResponse']: AliasType<{
     /** An object relationship */
@@ -732,6 +733,25 @@ export type ValueTypes = {
     id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
+  ['GenerateApiKeyInput']: {
+    circle_id: number;
+    create_vouches?: boolean | undefined | null;
+    name: string;
+    read_circle?: boolean | undefined | null;
+    read_epochs?: boolean | undefined | null;
+    read_member_profiles?: boolean | undefined | null;
+    read_nominees?: boolean | undefined | null;
+    read_pending_token_gifts?: boolean | undefined | null;
+    update_circle?: boolean | undefined | null;
+    update_pending_token_gifts?: boolean | undefined | null;
+  };
+  ['GenerateApiKeyResponse']: AliasType<{
+    api_key?: boolean | `@${string}`;
+    /** An object relationship */
+    circleApiKey?: ValueTypes['circle_api_keys'];
+    hash?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
   /** Boolean expression to compare columns of type "Int". All fields are combined with logical 'AND'. */
   ['Int_comparison_exp']: {
     _eq?: number | undefined | null;
@@ -785,7 +805,6 @@ export type ValueTypes = {
   ['UpdateCircleInput']: {
     alloc_text?: string | undefined | null;
     auto_opt_out?: boolean | undefined | null;
-    chain_id?: number | undefined | null;
     circle_id: number;
     default_opt_in?: boolean | undefined | null;
     discord_webhook?: string | undefined | null;
@@ -3000,6 +3019,10 @@ columns and relationships of "distributions" */
     delete_circle_integrations_by_pk?: [
       { id: ValueTypes['bigint'] },
       ValueTypes['circle_integrations']
+    ];
+    generateApiKey?: [
+      { payload: ValueTypes['GenerateApiKeyInput'] },
+      ValueTypes['GenerateApiKeyResponse']
     ];
     insert_circle_integrations?: [
       {
@@ -6652,6 +6675,13 @@ export type ModelTypes = {
     epoch: GraphQLTypes['epochs'];
     id: string;
   };
+  ['GenerateApiKeyInput']: GraphQLTypes['GenerateApiKeyInput'];
+  ['GenerateApiKeyResponse']: {
+    api_key: string;
+    /** An object relationship */
+    circleApiKey: GraphQLTypes['circle_api_keys'];
+    hash: string;
+  };
   /** Boolean expression to compare columns of type "Int". All fields are combined with logical 'AND'. */
   ['Int_comparison_exp']: GraphQLTypes['Int_comparison_exp'];
   ['LogoutResponse']: {
@@ -7331,6 +7361,8 @@ columns and relationships of "distributions" */
     delete_circle_integrations_by_pk?:
       | GraphQLTypes['circle_integrations']
       | undefined;
+    /** Generates an API key for a circle */
+    generateApiKey?: GraphQLTypes['GenerateApiKeyResponse'] | undefined;
     /** insert data into the table: "circle_integrations" */
     insert_circle_integrations?:
       | GraphQLTypes['circle_integrations_mutation_response']
@@ -8335,6 +8367,7 @@ export type GraphQLTypes = {
   ['Allocations']: {
     allocations?: Array<GraphQLTypes['Allocation']> | undefined;
     circle_id: number;
+    user_id?: number | undefined;
   };
   ['AllocationsResponse']: {
     __typename: 'AllocationsResponse';
@@ -8429,6 +8462,25 @@ export type GraphQLTypes = {
     epoch: GraphQLTypes['epochs'];
     id: string;
   };
+  ['GenerateApiKeyInput']: {
+    circle_id: number;
+    create_vouches?: boolean | undefined;
+    name: string;
+    read_circle?: boolean | undefined;
+    read_epochs?: boolean | undefined;
+    read_member_profiles?: boolean | undefined;
+    read_nominees?: boolean | undefined;
+    read_pending_token_gifts?: boolean | undefined;
+    update_circle?: boolean | undefined;
+    update_pending_token_gifts?: boolean | undefined;
+  };
+  ['GenerateApiKeyResponse']: {
+    __typename: 'GenerateApiKeyResponse';
+    api_key: string;
+    /** An object relationship */
+    circleApiKey: GraphQLTypes['circle_api_keys'];
+    hash: string;
+  };
   /** Boolean expression to compare columns of type "Int". All fields are combined with logical 'AND'. */
   ['Int_comparison_exp']: {
     _eq?: number | undefined;
@@ -8482,7 +8534,6 @@ export type GraphQLTypes = {
   ['UpdateCircleInput']: {
     alloc_text?: string | undefined;
     auto_opt_out?: boolean | undefined;
-    chain_id?: number | undefined;
     circle_id: number;
     default_opt_in?: boolean | undefined;
     discord_webhook?: string | undefined;
@@ -10231,6 +10282,8 @@ columns and relationships of "distributions" */
     delete_circle_integrations_by_pk?:
       | GraphQLTypes['circle_integrations']
       | undefined;
+    /** Generates an API key for a circle */
+    generateApiKey?: GraphQLTypes['GenerateApiKeyResponse'] | undefined;
     /** insert data into the table: "circle_integrations" */
     insert_circle_integrations?:
       | GraphQLTypes['circle_integrations_mutation_response']

--- a/src/pages/AdminCircleApiPage/AdminCircleApiPage.tsx
+++ b/src/pages/AdminCircleApiPage/AdminCircleApiPage.tsx
@@ -1,0 +1,114 @@
+import { useState } from 'react';
+
+import { useMutation, useQueryClient } from 'react-query';
+
+import { useSelectedCircleId } from '../../recoilState';
+import { ActionDialog, LoadingModal } from 'components';
+import { Box, Button, Modal, Panel, Text } from 'ui';
+import { OrgLayout } from 'ui/layouts';
+
+import { ApiKeyDisplay } from './ApiKeyDisplay';
+import { ApiKeyForm } from './ApiKeyForm';
+import { ApiKeyRow } from './ApiKeyRow';
+import { deleteCircleApiKey } from './mutations';
+import { useCircleApiKeys } from './useCircleApiKeys';
+
+const AdminCircleApiPage = () => {
+  const [modal, setModal] = useState<'' | 'create' | 'display'>('');
+  const [keyToDelete, setKeyToDelete] = useState('');
+  const [displayedKey, setDisplayedKey] = useState('');
+
+  const queryClient = useQueryClient();
+
+  const circleId = useSelectedCircleId();
+  const { refetch, isLoading, data: apiKeys } = useCircleApiKeys(circleId);
+
+  const deleteKeyMutation = useMutation(deleteCircleApiKey, {
+    onSuccess: res => {
+      // immediately remove key from UI without needing to refetch
+      if (res) {
+        queryClient.setQueryData<typeof apiKeys>(
+          ['circle-api-keys', circleId],
+          oldKeys => {
+            return oldKeys?.filter(k => k.hash !== res.hash);
+          }
+        );
+      }
+    },
+    onSettled: () => {
+      setKeyToDelete('');
+      refetch();
+    },
+  });
+
+  const displayApiKey = (apiKey: string) => {
+    setDisplayedKey(apiKey);
+    setModal('display');
+  };
+
+  const handleDelete = async () => {
+    await deleteKeyMutation.mutate(keyToDelete);
+  };
+
+  const closeModal = () => {
+    setModal('');
+    setDisplayedKey('');
+  };
+
+  const closeDeleteDialog = () => {
+    setKeyToDelete('');
+  };
+
+  if (isLoading) return <LoadingModal visible />;
+
+  return (
+    <OrgLayout css={{ maxWidth: '$smallScreen' }}>
+      <Box css={{ display: 'flex' }}>
+        <Text h2 css={{ flexGrow: 1 }}>
+          Circle API Keys
+        </Text>
+        <Button color="primary" outlined onClick={() => setModal('create')}>
+          Create API Key
+        </Button>
+      </Box>
+      {apiKeys && apiKeys?.length > 0 ? (
+        apiKeys?.map(apiKey => (
+          <ApiKeyRow
+            key={apiKey.hash}
+            apiKey={apiKey}
+            onDelete={setKeyToDelete}
+          />
+        ))
+      ) : (
+        <Panel>
+          <Text color={'neutral'}>
+            There are no API keys for your circle yet.
+          </Text>
+        </Panel>
+      )}
+      {modal === 'create' && (
+        <Modal onClose={closeModal} title="Create a Circle API Key">
+          <ApiKeyForm onSuccess={displayApiKey} />
+        </Modal>
+      )}
+      {modal === 'display' && displayedKey && (
+        <Modal onClose={closeModal} title="API Key Created">
+          <ApiKeyDisplay apiKey={displayedKey} />
+        </Modal>
+      )}
+      <ActionDialog
+        open={!!keyToDelete}
+        title={`Delete API Key?`}
+        onPrimary={handleDelete}
+        primaryText={'Delete'}
+        onClose={closeDeleteDialog}
+      >
+        Any services using this API key will no longer have access to your
+        circle.
+      </ActionDialog>
+      <LoadingModal visible={deleteKeyMutation.isLoading} />
+    </OrgLayout>
+  );
+};
+
+export default AdminCircleApiPage;

--- a/src/pages/AdminCircleApiPage/ApiKeyDisplay.tsx
+++ b/src/pages/AdminCircleApiPage/ApiKeyDisplay.tsx
@@ -1,0 +1,41 @@
+import React, { FC } from 'react';
+
+// import { useFocus } from 'hooks/useFocus';
+import { Box, Button, Text, TextField } from 'ui';
+import { getConsoleUrl } from 'utils/apiKeyHelper';
+
+export const ApiKeyDisplay: FC<{ apiKey: string }> = ({ apiKey }) => {
+  const consoleUrl = apiKey ? getConsoleUrl(apiKey) : '';
+
+  return (
+    <Box
+      css={{ display: 'flex', alignItems: 'center', flexDirection: 'column' }}
+    >
+      <Text font="source" size="medium">
+        Make sure to copy your API key. You won’t be able to see it again!
+      </Text>
+      <TextField
+        ref={input => input && input.select()}
+        css={{ width: '100%', mt: '$md' }}
+        value={apiKey}
+        readOnly
+      />
+      <Box
+        css={{
+          pt: '$md',
+        }}
+      >
+        <a
+          href={consoleUrl}
+          rel="noreferrer"
+          target="_blank"
+          style={{ textDecoration: 'none' }}
+        >
+          <Button color="primary" outlined>
+            Open API Explorer
+          </Button>
+        </a>
+      </Box>
+    </Box>
+  );
+};

--- a/src/pages/AdminCircleApiPage/ApiKeyForm.tsx
+++ b/src/pages/AdminCircleApiPage/ApiKeyForm.tsx
@@ -1,0 +1,189 @@
+import { FC } from 'react';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import isEmpty from 'lodash/isEmpty';
+import { useController, useForm, SubmitHandler } from 'react-hook-form';
+import { useMutation, useQueryClient } from 'react-query';
+import { z } from 'zod';
+
+import { LoadingModal } from '../../components';
+import { useSelectedCircleId } from '../../recoilState';
+import { Box, Button, CheckBox, Form, FormLabel, Text, TextField } from 'ui';
+
+import { API_PERMISSION_LABELS } from './constants';
+import { generateCircleApiKey } from './mutations';
+import { CircleApiKeysResponse } from './useCircleApiKeys';
+
+const schema = z.object({
+  name: z.string().max(64).min(5),
+  read_circle: z.boolean(),
+  read_nominees: z.boolean(),
+  read_pending_token_gifts: z.boolean(),
+  read_member_profiles: z.boolean(),
+  read_epochs: z.boolean(),
+});
+
+type FormSchema = z.infer<typeof schema>;
+const resolver = zodResolver(schema);
+
+export const ApiKeyForm: FC<{ onSuccess: (apiKey: string) => void }> = ({
+  onSuccess,
+}) => {
+  const circleId = useSelectedCircleId();
+  const {
+    control,
+    formState: { errors, isValid },
+    handleSubmit,
+  } = useForm<FormSchema>({ resolver, mode: 'onBlur' });
+
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation(generateCircleApiKey, {
+    onSuccess: data => {
+      queryClient.invalidateQueries('circle-api-keys');
+      if (data) {
+        queryClient.setQueryData<CircleApiKeysResponse[]>(
+          ['circle-api-keys', circleId],
+          oldKeys => {
+            return [...(oldKeys || []), data.circleApiKey];
+          }
+        );
+        onSuccess(data.api_key);
+      }
+    },
+  });
+
+  const onSubmit: SubmitHandler<FormSchema> = data =>
+    mutation.mutate({
+      ...data,
+      circle_id: circleId,
+    });
+
+  const { field: name } = useController({
+    name: 'name',
+    control,
+    defaultValue: '',
+  });
+
+  const { field: readCircle } = useController({
+    name: 'read_circle',
+    control,
+    defaultValue: false,
+  });
+
+  const { field: readEpochs } = useController({
+    name: 'read_epochs',
+    control,
+    defaultValue: false,
+  });
+
+  const { field: readMemberProfiles } = useController({
+    name: 'read_member_profiles',
+    control,
+    defaultValue: false,
+  });
+  const { field: readPendingTokenGifts } = useController({
+    name: 'read_pending_token_gifts',
+    control,
+    defaultValue: false,
+  });
+  const { field: readNominees } = useController({
+    name: 'read_nominees',
+    control,
+    defaultValue: false,
+  });
+
+  return (
+    <Form
+      onSubmit={handleSubmit(onSubmit)}
+      css={{
+        width: '100%',
+        alignItems: 'center',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <Text font="source" size="medium">
+        Circle API keys allow for third party apps to read data from and
+        interact with your circle. You can configure specific permissions for
+        each key.
+      </Text>
+      <FormLabel htmlFor="name" type={'textField'} css={{ mt: '$lg' }}>
+        Label
+      </FormLabel>
+      <TextField
+        css={{ width: '100%' }}
+        id="name"
+        placeholder={'What is this API key for?'}
+        {...name}
+      />
+      <Box
+        css={{
+          display: 'flex',
+          gap: '$sm',
+          my: '$lg',
+          flexDirection: 'column',
+          width: '100%',
+        }}
+      >
+        <CheckBox
+          {...readCircle}
+          label={API_PERMISSION_LABELS['read_circle']}
+          infoTooltip={
+            <>Allows reading your circle name, logo, and configuration.</>
+          }
+        />
+        <CheckBox
+          {...readEpochs}
+          label={API_PERMISSION_LABELS['read_epochs']}
+          infoTooltip={<>Allows reading information about historical epochs.</>}
+        />
+        <CheckBox
+          {...readMemberProfiles}
+          label={API_PERMISSION_LABELS['read_member_profiles']}
+          infoTooltip={
+            <>
+              Allows reading member profiles (name, socials, avatars), excluding
+              wallet addresses.
+            </>
+          }
+        />
+        <CheckBox
+          {...readPendingTokenGifts}
+          label={API_PERMISSION_LABELS['read_pending_token_gifts']}
+          infoTooltip={
+            <>
+              Allows reading pending allocations in the current epoch (excluding
+              notes).
+            </>
+          }
+        />
+        <CheckBox
+          {...readNominees}
+          label={API_PERMISSION_LABELS['read_nominees']}
+          infoTooltip={<>Allows reading information about circle nominees.</>}
+        />
+      </Box>
+      <Button
+        color="primary"
+        css={{ mt: '$lg', width: '100%' }}
+        disabled={!isValid || mutation.isLoading}
+      >
+        Generate Key
+      </Button>
+      {!isEmpty(errors) && (
+        <Text color="alert" css={{ mt: '$sm' }}>
+          {Object.values(errors)
+            .map(e => e.message)
+            .join('. ')}
+        </Text>
+      )}
+      {mutation.isError && (
+        <Text color="alert" css={{ mt: '$sm' }}>
+          {(mutation.error as Error).message}
+        </Text>
+      )}
+      <LoadingModal visible={mutation.isLoading} />
+    </Form>
+  );
+};

--- a/src/pages/AdminCircleApiPage/ApiKeyRow.tsx
+++ b/src/pages/AdminCircleApiPage/ApiKeyRow.tsx
@@ -1,0 +1,52 @@
+import pickBy from 'lodash/pickBy';
+
+import { Box, Button, Panel, Text } from 'ui';
+
+import { API_PERMISSION_LABELS } from './constants';
+import {
+  CircleApiKeysResponse,
+  CircleApiPermissions,
+  circleApiPermissionsSelector,
+} from './useCircleApiKeys';
+
+export function ApiKeyRow({
+  apiKey,
+  onDelete,
+}: {
+  apiKey: CircleApiKeysResponse;
+  onDelete: (hash: string) => void;
+}) {
+  const permissions = pickBy(
+    apiKey,
+    (v, k) => v === true && k in circleApiPermissionsSelector
+  );
+
+  const permissionsString = Object.keys(permissions)
+    .map(p => API_PERMISSION_LABELS[p as keyof CircleApiPermissions])
+    .join(', ');
+
+  return (
+    <Panel>
+      <Box css={{ display: 'flex', alignItems: 'center', gap: '$md' }}>
+        <Box css={{ flexGrow: 1 }}>
+          <Text h3>{apiKey.name}</Text>
+          <Text size={'small'} color={'neutral'}>
+            Created by {apiKey.createdByUser.name}
+          </Text>
+          <Text variant={'label'} css={{ mt: '$sm' }}>
+            {permissionsString || 'No permissions given'}
+          </Text>
+        </Box>
+
+        <Button
+          color="destructive"
+          outlined
+          size="small"
+          onClick={() => onDelete(apiKey.hash)}
+        >
+          Delete
+        </Button>
+      </Box>
+    </Panel>
+  );
+}

--- a/src/pages/AdminCircleApiPage/constants.ts
+++ b/src/pages/AdminCircleApiPage/constants.ts
@@ -1,0 +1,15 @@
+import { circleApiPermissionsSelector } from './useCircleApiKeys';
+
+export const API_PERMISSION_LABELS: Record<
+  keyof typeof circleApiPermissionsSelector,
+  string
+> = {
+  read_circle: 'Read Circle Info',
+  read_nominees: 'Read Nominees',
+  read_pending_token_gifts: 'Read Allocations',
+  read_member_profiles: 'Read Member Profiles',
+  read_epochs: 'Read Epochs',
+  update_circle: 'Update Circle',
+  update_pending_token_gifts: 'Update Allocations',
+  create_vouches: 'Create Vouches',
+};

--- a/src/pages/AdminCircleApiPage/mutations.ts
+++ b/src/pages/AdminCircleApiPage/mutations.ts
@@ -1,0 +1,46 @@
+import { ValueTypes } from '../../lib/gql/__generated__/zeus';
+import { client } from '../../lib/gql/client';
+
+import { circleApiKeySelector } from './useCircleApiKeys';
+
+export async function generateCircleApiKey(
+  params: ValueTypes['GenerateApiKeyInput']
+) {
+  const { generateApiKey } = await client.mutate(
+    {
+      generateApiKey: [
+        {
+          payload: {
+            ...params,
+          },
+        },
+        {
+          api_key: true,
+          hash: true,
+          circleApiKey: circleApiKeySelector,
+        },
+      ],
+    },
+    {
+      operationName: 'generateApiKey',
+    }
+  );
+  return generateApiKey;
+}
+
+export async function deleteCircleApiKey(hash: string) {
+  const { delete_circle_api_keys_by_pk } = await client.mutate(
+    {
+      delete_circle_api_keys_by_pk: [
+        {
+          hash,
+        },
+        { hash: true },
+      ],
+    },
+    {
+      operationName: 'deleteApiKey',
+    }
+  );
+  return delete_circle_api_keys_by_pk;
+}

--- a/src/pages/AdminCircleApiPage/useCircleApiKeys.ts
+++ b/src/pages/AdminCircleApiPage/useCircleApiKeys.ts
@@ -1,0 +1,56 @@
+import { GraphQLTypes, InputType, Selector } from 'lib/gql/__generated__/zeus';
+import { client } from 'lib/gql/client';
+import { useQuery } from 'react-query';
+
+export const circleApiPermissionsSelector = Selector('circle_api_keys')({
+  read_circle: true,
+  read_nominees: true,
+  read_pending_token_gifts: true,
+  read_member_profiles: true,
+  read_epochs: true,
+  update_circle: true,
+  update_pending_token_gifts: true,
+  create_vouches: true,
+});
+
+export const circleApiKeySelector = Selector('circle_api_keys')({
+  hash: true,
+  name: true,
+  createdByUser: {
+    name: true,
+  },
+  ...circleApiPermissionsSelector,
+});
+
+export function useCircleApiKeys(circleId: number | undefined) {
+  return useQuery(
+    ['circle-api-keys', circleId],
+    async () => {
+      const { circle_api_keys } = await client.query(
+        {
+          circle_api_keys: [
+            {
+              where: { circle_id: { _eq: circleId } },
+            },
+            circleApiKeySelector,
+          ],
+        },
+        {
+          operationName: 'getCircleApiKeys',
+        }
+      );
+      return circle_api_keys;
+    },
+    { enabled: !!circleId }
+  );
+}
+
+export type CircleApiKeysResponse = InputType<
+  GraphQLTypes['circle_api_keys'],
+  typeof circleApiKeySelector
+>;
+
+export type CircleApiPermissions = InputType<
+  GraphQLTypes['circle_api_keys'],
+  typeof circleApiPermissionsSelector
+>;

--- a/src/pages/DevPortalPage/DevPortalPage.tsx
+++ b/src/pages/DevPortalPage/DevPortalPage.tsx
@@ -1,17 +1,8 @@
 import React from 'react';
 
-import { REACT_APP_HASURA_URL } from '../../config/env';
 import { useCurrentUserAuthToken } from '../../hooks/useAuthToken';
-import { Box, Panel, Button, Text } from '../../ui';
-
-const EXAMPLE_QUERY =
-  'query+MyCircles+%7B%0A++circles%28limit%3A+3%29+%7B%0A++++name%0A++++organization+%7B%0A++++++name%0A++++%7D%0A++++epochs%28limit%3A+3%2C+where%3A+%7Bended%3A+%7B_eq%3A+true%7D%7D%29+%7B%0A++++++id%0A++++++end_date%0A++++++start_date%0A++++%7D%0A++++users%28limit%3A+5%2C+order_by%3A+%7Bcreated_at%3A+asc%7D%29+%7B%0A++++++id%0A++++++name%0A++++++give_token_received%0A++++++give_token_remaining%0A++++++profile+%7B%0A++++++++twitter_username%0A++++++%7D%0A++++%7D%0A++%7D%0A%7D%0A';
-
-const getConsoleUrl = (authToken: string) => {
-  return `https://cloud.hasura.io/public/graphiql?endpoint=${REACT_APP_HASURA_URL}&header=Authorization:${encodeURIComponent(
-    `Bearer ${authToken}`
-  )}&query=${EXAMPLE_QUERY}`;
-};
+import { Box, Button, Panel, Text } from '../../ui';
+import { getConsoleUrl } from '../../utils/apiKeyHelper';
 
 /**
  * Links the user to a GraphQL explorer for the Hasura API preconfigured with their API credentials
@@ -20,7 +11,7 @@ const getConsoleUrl = (authToken: string) => {
 export const DevPortalPage: React.FC = () => {
   const authToken = useCurrentUserAuthToken();
 
-  const consoleUrl = authToken ? getConsoleUrl(authToken) : '';
+  const consoleUrl = authToken ? getConsoleUrl(authToken, true) : '';
 
   return (
     <Box

--- a/src/pages/VouchingPage/NewNominationModal.tsx
+++ b/src/pages/VouchingPage/NewNominationModal.tsx
@@ -33,16 +33,6 @@ const schema = z
 
 type NominateFormSchema = z.infer<typeof schema>;
 
-const labelStyles = {
-  lineHeight: '$short',
-  color: '$text',
-  fontSize: '$4',
-  fontFamily: 'Inter',
-  fontWeight: '$bold',
-  textAlign: 'center',
-  mb: '$sm',
-};
-
 interface errorObj {
   message: string;
 }
@@ -156,10 +146,10 @@ export const NewNominationModal = ({
             'column-gap': '$lg',
           }}
         >
-          <FormLabel htmlFor="name" css={labelStyles}>
+          <FormLabel htmlFor="name" type="textField">
             Name
           </FormLabel>
-          <FormLabel htmlFor="address" css={labelStyles}>
+          <FormLabel htmlFor="address" type="textField">
             ETH Address
           </FormLabel>
           <TextField
@@ -183,7 +173,7 @@ export const NewNominationModal = ({
               mt: '$1xl',
             }}
           >
-            <FormLabel htmlFor="description" css={labelStyles}>
+            <FormLabel htmlFor="description" type="textField">
               Why are you nominating this person?
             </FormLabel>
             <TextArea

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -37,6 +37,7 @@ const withSearchParams = (
 
 export const paths = {
   adminCircles: '/admin/circles',
+  adminApiKeys: '/admin/api',
   allocation: '/allocation',
   circles: '/circles',
   connectIntegration: '/connect-integration',
@@ -58,6 +59,7 @@ export const paths = {
 
 const circleSpecificPathKeys: (keyof typeof paths)[] = [
   'adminCircles',
+  'adminApiKeys',
   'allocation',
   'epoch',
   'give',

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -2,12 +2,13 @@ import React, { lazy } from 'react';
 
 import { Routes, Route, Navigate } from 'react-router-dom';
 
-import DevPortalPage from '../pages/DevPortalPage';
+import AdminCircleApiPage from 'pages/AdminCircleApiPage/AdminCircleApiPage';
 import AdminPage from 'pages/AdminPage';
 import AllocationPage from 'pages/AllocationPage';
 import CirclesPage from 'pages/CirclesPage';
 import CreateCirclePage from 'pages/CreateCirclePage';
 import DefaultPage from 'pages/DefaultPage';
+import DevPortalPage from 'pages/DevPortalPage';
 import DistributionsPage from 'pages/DistributionsPage';
 import HistoryPage from 'pages/HistoryPage';
 import IntegrationCallbackPage from 'pages/IntegrationCallbackPage';
@@ -64,6 +65,14 @@ const LoggedInRoutes = () => {
       <Route path={paths.give} element={<AllocationPage />} />
       <Route path={paths.circles} element={<CirclesPage />} />
       <Route path={paths.vaults} element={<VaultsPage />} />
+      <Route
+        path={paths.adminApiKeys}
+        element={
+          <RequireAdmin>
+            <AdminCircleApiPage />
+          </RequireAdmin>
+        }
+      />
       <Route path={paths.vaultTxs(':id')} element={<VaultTransactions />} />
       <Route
         path={paths.adminCircles}

--- a/src/ui/Button/Button.tsx
+++ b/src/ui/Button/Button.tsx
@@ -22,6 +22,9 @@ export const Button = styled('button', {
     // using saturate until hover colors are defined
     filter: 'saturate(1.4)',
   },
+  '&:focus': {
+    filter: 'saturate(1.4)',
+  },
   '&[disabled]': {
     opacity: 0.4,
     cursor: 'default',
@@ -50,6 +53,9 @@ export const Button = styled('button', {
         '&:hover': {
           filter: 'saturate(3)',
         },
+        '&:focus': {
+          filter: 'saturate(3)',
+        },
       },
       complete: {
         backgroundColor: '$complete',
@@ -60,6 +66,9 @@ export const Button = styled('button', {
         backgroundColor: 'transparent',
         color: '$text',
         '&:hover': {
+          backgroundColor: 'transparent',
+        },
+        '&:focus': {
           backgroundColor: 'transparent',
         },
       },
@@ -147,6 +156,10 @@ export const Button = styled('button', {
           color: '$secondary',
           background: '$surface',
         },
+        '&:focus': {
+          color: '$secondary',
+          background: '$surface',
+        },
         '&:disabled': {
           color: '$text',
         },
@@ -176,6 +189,11 @@ export const Button = styled('button', {
           filter: 'saturate(1)',
           backgroundColor: '$primary !important',
         },
+        '&:focus': {
+          color: '$white',
+          filter: 'saturate(1)',
+          backgroundColor: '$primary !important',
+        },
       },
     },
     {
@@ -185,6 +203,11 @@ export const Button = styled('button', {
         color: '$secondary',
         borderColor: '$secondary',
         '&:hover': {
+          color: '$white',
+          filter: 'saturate(1)',
+          backgroundColor: '$secondary !important',
+        },
+        '&:focus': {
           color: '$white',
           filter: 'saturate(1)',
           backgroundColor: '$secondary !important',
@@ -202,6 +225,11 @@ export const Button = styled('button', {
           filter: 'saturate(1)',
           backgroundColor: '$alert !important',
         },
+        '&:focus': {
+          color: '$white',
+          filter: 'saturate(1)',
+          backgroundColor: '$alert !important',
+        },
       },
     },
     {
@@ -215,6 +243,11 @@ export const Button = styled('button', {
           filter: 'saturate(1)',
           backgroundColor: '$neutral !important',
         },
+        '&:focus': {
+          color: '$white',
+          filter: 'saturate(1)',
+          backgroundColor: '$neutral !important',
+        },
       },
     },
     {
@@ -224,6 +257,11 @@ export const Button = styled('button', {
         color: '$complete',
         borderColor: '$complete',
         '&:hover': {
+          color: '$white',
+          filter: 'saturate(1)',
+          backgroundColor: '$complete !important',
+        },
+        '&:focus': {
           color: '$white',
           filter: 'saturate(1)',
           backgroundColor: '$complete !important',

--- a/src/ui/Checkbox/CheckBox.tsx
+++ b/src/ui/Checkbox/CheckBox.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
 import { CheckIcon, InfoCircledIcon } from '@radix-ui/react-icons';
 
@@ -16,6 +18,7 @@ const CheckboxRoot = styled(CheckboxPrimitive.Root, {
   alignItems: 'center',
   justifyContent: 'center',
   '&:hover': { borderColor: '$focusedBorder' },
+  '&:focus': { borderColor: '$focusedBorder' },
   variants: {
     border: {
       default: {
@@ -51,15 +54,7 @@ const Label = styled('label', {
   p: '$sm',
 });
 
-export const CheckBox = ({
-  value,
-  label,
-  error,
-  errorText,
-  disabled,
-  onChange,
-  infoTooltip,
-}: {
+type CheckBoxProps = {
   value: boolean;
   label: string;
   error?: boolean;
@@ -67,36 +62,46 @@ export const CheckBox = ({
   disabled?: boolean;
   onChange: (isChecked: boolean) => void;
   infoTooltip?: React.ReactNode;
-}) => (
-  <form>
-    <Flex
-      css={{
-        alignItems: 'center',
-        justifyContent: 'center',
-      }}
-    >
-      <CheckboxRoot
-        border={error ? 'error' : 'default'}
-        checked={value}
-        onCheckedChange={onChange}
-        disabled={disabled}
-        id={label}
+};
+
+export const CheckBox = React.forwardRef<HTMLButtonElement, CheckBoxProps>(
+  (
+    { value, label, error, errorText, disabled, onChange, infoTooltip },
+    ref
+  ) => (
+    <>
+      <Flex
+        css={{
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
       >
-        <CheckboxIndicator>
-          <CheckIcon />
-        </CheckboxIndicator>
-      </CheckboxRoot>
-      <Label htmlFor={label}>{label}</Label>
-      <Tooltip content={infoTooltip}>
-        <InfoCircledIcon />
-      </Tooltip>
-    </Flex>
-    {error && errorText && (
-      <Text color="alert" css={{ px: '$xl', fontSize: '$3' }}>
-        {errorText}
-      </Text>
-    )}
-  </form>
+        <CheckboxRoot
+          border={error ? 'error' : 'default'}
+          checked={value}
+          onCheckedChange={onChange}
+          disabled={disabled}
+          ref={ref}
+          id={label}
+        >
+          <CheckboxIndicator>
+            <CheckIcon />
+          </CheckboxIndicator>
+        </CheckboxRoot>
+        <Label htmlFor={label}>{label}</Label>
+        <Tooltip content={infoTooltip}>
+          <InfoCircledIcon />
+        </Tooltip>
+      </Flex>
+      {error && errorText && (
+        <Text color="alert" css={{ px: '$xl', fontSize: '$3' }}>
+          {errorText}
+        </Text>
+      )}
+    </>
+  )
 );
+
+CheckBox.displayName = 'CheckBox';
 
 export default CheckBox;

--- a/src/ui/FormLabel/FormLabel.tsx
+++ b/src/ui/FormLabel/FormLabel.tsx
@@ -1,5 +1,19 @@
 import { styled } from '../../stitches.config';
 
-export const FormLabel = styled('label', {});
+export const FormLabel = styled('label', {
+  variants: {
+    type: {
+      textField: {
+        lineHeight: '$short',
+        color: '$text',
+        fontSize: '$1',
+        fontFamily: 'Inter',
+        fontWeight: '$bold',
+        textAlign: 'center',
+        mb: '$sm',
+      },
+    },
+  },
+});
 
 export default FormLabel;

--- a/src/utils/apiKeyHelper.ts
+++ b/src/utils/apiKeyHelper.ts
@@ -1,0 +1,10 @@
+import { REACT_APP_HASURA_URL } from '../config/env';
+
+const EXAMPLE_QUERY =
+  'query+MyCircles+%7B%0A++circles%28limit%3A+3%29+%7B%0A++++name%0A++++organization+%7B%0A++++++name%0A++++%7D%0A++++epochs%28limit%3A+3%2C+where%3A+%7Bended%3A+%7B_eq%3A+true%7D%7D%29+%7B%0A++++++id%0A++++++end_date%0A++++++start_date%0A++++%7D%0A++++users%28limit%3A+5%2C+order_by%3A+%7Bcreated_at%3A+asc%7D%29+%7B%0A++++++id%0A++++++name%0A++++++give_token_received%0A++++++give_token_remaining%0A++++++profile+%7B%0A++++++++twitter_username%0A++++++%7D%0A++++%7D%0A++%7D%0A%7D%0A';
+
+export const getConsoleUrl = (authToken: string, withExample?: boolean) => {
+  return `https://cloud.hasura.io/public/graphiql?endpoint=${REACT_APP_HASURA_URL}&header=Authorization:${encodeURIComponent(
+    `Bearer ${authToken}`
+  )}${withExample ? `&query=${EXAMPLE_QUERY}` : ''}`;
+};


### PR DESCRIPTION
Currently available via URL only at `/admin/api`. Only allows setting up with read permissions for now.

## Test and Deployment Plan

Generate API keys with specific permissions and ensure that key can only fetch the data described in each permission and only for the circle it was generated for.

## Screenshots (if appropriate):

https://user-images.githubusercontent.com/7143583/173030826-29083bb5-999b-4046-8f4e-7ed78b12bbdb.mp4


## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

#887 