### PR TITLE
fix: Change styling only when is select

### DIFF
--- a/src/components/ApeAutocomplete/ApeAutocomplete.tsx
+++ b/src/components/ApeAutocomplete/ApeAutocomplete.tsx
@@ -38,6 +38,7 @@ export const ApeAutocomplete = ({
   placeholder,
   helperText,
   label,
+  isSelect,
   ...props
 }: Omit<
   React.ComponentProps<typeof Autocomplete>,
@@ -53,6 +54,7 @@ export const ApeAutocomplete = ({
   helperText?: string;
   error?: boolean;
   label?: string;
+  isSelect?: boolean;
 }) => {
   const classes = useStyles();
 
@@ -101,7 +103,7 @@ export const ApeAutocomplete = ({
             placeholder={placeholder}
             helperText={helperText}
             error={error}
-            apeVariant="select"
+            apeVariant={isSelect ? 'select' : undefined}
           />
         );
       }}


### PR DESCRIPTION
## Motivation and Context

<!-- Why is this change required? What problem does it solve? This can be omitted if a linked issue is provided
-->

Organization Name is missing the grey background for it's text box when creating a circle, this was introduced as part of the work for https://github.com/coordinape/coordinape/pull/914 which required a new styling for the `ApeAutocomplete`

## Description

<!-- Describe your changes -->

Only change the `ApeAutocomplete` styling when it's a select (in the map) 

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->

Ran locally and saw the correct style being applied

## Screenshots (if appropriate):

<img width="1792" alt="Screen Shot 2022-06-13 at 4 52 31 pm" src="https://user-images.githubusercontent.com/78794805/173369043-cede5bd0-a924-4fc5-9603-9cbe8b0dce62.png">

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

@levity @crabsinger 

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

Closes https://github.com/coordinape/coordinape/issues/1019

<!-- Please link to the issue here -->
