### PR TITLE
fix: Add isSelect prop to the select in map

### DIFF
--- a/src/pages/AssetMapPage/AMDrawer.tsx
+++ b/src/pages/AssetMapPage/AMDrawer.tsx
@@ -245,6 +245,7 @@ export const AMDrawer = () => {
             options={SKILLS}
             color="secondary"
             placeholder="Search"
+            isSelect
             InputProps={{
               endAdornment: (
                 <MagnifyingGlassIcon


### PR DESCRIPTION
Follow up on https://github.com/coordinape/coordinape/pull/1032

Add missing `isSelect` prop