### PR TITLE
Fix Epoch's day format in Epochs Table

### DIFF
--- a/src/pages/AdminPage/components.tsx
+++ b/src/pages/AdminPage/components.tsx
@@ -423,9 +423,9 @@ export const EpochsTable = ({
         : 'monthly';
     return e.ended
       ? e.labelActivity
-      : `${e.calculatedDays} ${e.calculatedDays > 1 ? 'days' : 'day'}${
-          e.repeat ? ` repeats ${r}` : ''
-        }`;
+      : `${e.calculatedDays.toFixed()} ${
+          e.calculatedDays > 1 ? 'days' : 'day'
+        }${e.repeat ? ` repeats ${r}` : ''}`;
   };
 
   // Epoch Columns


### PR DESCRIPTION
Epochs's `calculatedDays` wasn't perfectly rounded, ex:  `7.000000405092592`. 


<img width="659" alt="Screen Shot 2022-06-15 at 7 55 38 PM" src="https://user-images.githubusercontent.com/12991700/173893562-c3158cec-f9ba-4fd6-872b-76e1a58a66d0.png">
