### PR TITLE
allow admin buttons wrap

### DIFF
--- a/src/pages/AdminPage/AdminPage.tsx
+++ b/src/pages/AdminPage/AdminPage.tsx
@@ -77,16 +77,25 @@ const AdminPage = () => {
   return (
     <SingleColumnLayout>
       <Panel>
-        <Flex css={{ alignItems: 'center' }}>
+        <Flex css={{ alignItems: 'center', mb: '$sm' }}>
           <Text h2 css={{ my: '$xl' }}>
             {selectedCircle?.name}
           </Text>
           {!isMobile ? (
-            <Flex css={{ flexGrow: 1, justifyContent: 'flex-end', gap: '$md' }}>
+            <Flex
+              css={{
+                flexGrow: 1,
+                flexWrap: 'wrap',
+                justifyContent: 'flex-end',
+                gap: '$md',
+                mb: '$md',
+              }}
+            >
               <Button
                 color="primary"
                 outlined
                 onClick={() => setEditCircle(true)}
+                css={{ minWidth: '180px' }}
               >
                 <EditIcon />
                 Settings
@@ -104,6 +113,7 @@ const AdminPage = () => {
                 color="primary"
                 outlined
                 onClick={() => navigate(paths.createCircle)}
+                css={{ minWidth: '180px' }}
               >
                 <PlusCircleIcon />
                 Add Circle

--- a/src/pages/AdminPage/components.tsx
+++ b/src/pages/AdminPage/components.tsx
@@ -61,6 +61,7 @@ export const CreateEpochButton = ({
       outlined
       size={inline ? 'inline' : 'medium'}
       onClick={onClick}
+      css={{ minWidth: '180px' }}
     >
       Create Epoch
       <Tooltip
@@ -100,6 +101,7 @@ export const AddContributorButton = ({
       outlined
       size={inline ? 'inline' : 'medium'}
       onClick={onClick}
+      css={{ minWidth: '180px' }}
     >
       Add Contributor
       <Tooltip


### PR DESCRIPTION
## Motivation and Context
fixes #1011

## Description

1- Give adminPage button minWidth of 180px
2- allow button to wrap on narrow layout

## Test and Deployment Plan
1- Resize the browser window while on Admin Page 
Expected:
The button should wrap and remain inside the window.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/34943689/173892226-244437fc-37be-4970-8ac8-cb937f556da8.png)
![image](https://user-images.githubusercontent.com/34943689/173892421-f0589886-f42e-419b-8da7-4fd4ff162d0f.png)

