### PR TITLE
Goerli prep and Vaults endpoint bugfix

### DIFF
--- a/api-lib/config.ts
+++ b/api-lib/config.ts
@@ -61,6 +61,8 @@ export const HARDHAT_GANACHE_PORT: number = getEnvValue(
 
 export const ETHEREUM_RPC_URL: string = getEnvValue('ETHEREUM_RPC_URL');
 
+export const GOERLI_RPC_URL: string = getEnvValue('GOERLI_RPC_URL');
+
 // This is only set to 'production' when deployed from main branch
 export const VERCEL_ENV: string = getEnvValue('VERCEL_ENV', 'development');
 export const IMAGE_DIR: string = getEnvValue('IMAGE_DIR', '');

--- a/api-lib/contracts.ts
+++ b/api-lib/contracts.ts
@@ -1,4 +1,13 @@
-import deploymentInfo from '@coordinape/hardhat/dist/deploymentInfo.json';
+import type { JsonRpcProvider } from '@ethersproject/providers';
+
+import deploymentInfo from '../hardhat/dist/deploymentInfo.json';
+import type {
+  ApeDistributor,
+  ApeRouter,
+  ApeVaultFactoryBeacon,
+  ApeVaultWrapperImplementation,
+  ERC20,
+} from '../hardhat/dist/typechain';
 import {
   ApeDistributor__factory,
   ApeRouter__factory,
@@ -6,15 +15,7 @@ import {
   ApeVaultWrapperImplementation__factory,
   ERC20__factory,
   VaultAPI__factory,
-} from '@coordinape/hardhat/dist/typechain';
-import type {
-  ApeDistributor,
-  ApeRouter,
-  ApeVaultFactoryBeacon,
-  ApeVaultWrapperImplementation,
-  ERC20,
-} from '@coordinape/hardhat/dist/typechain';
-import type { JsonRpcProvider } from '@ethersproject/providers';
+} from '../hardhat/dist/typechain';
 
 export type {
   ApeDistributor,
@@ -22,7 +23,7 @@ export type {
   ApeVaultFactoryBeacon,
   ApeVaultWrapperImplementation,
   ERC20,
-} from '@coordinape/hardhat/dist/typechain';
+} from '../hardhat/dist/typechain';
 
 const requiredContracts = [
   'ApeVaultFactoryBeacon',

--- a/api-lib/provider.ts
+++ b/api-lib/provider.ts
@@ -1,13 +1,18 @@
 import { JsonRpcProvider } from '@ethersproject/providers';
 
-import { ETHEREUM_RPC_URL, HARDHAT_GANACHE_PORT } from './config';
+import {
+  ETHEREUM_RPC_URL,
+  GOERLI_RPC_URL,
+  HARDHAT_GANACHE_PORT,
+} from './config';
 
 export function getProvider(chainId: number) {
   switch (chainId) {
     // TODO: return different providers for different production chains
     case 1: // mainnet
-    case 4: // rinkeby
       return new JsonRpcProvider(ETHEREUM_RPC_URL);
+    case 5: // Goerli
+      return new JsonRpcProvider(GOERLI_RPC_URL);
     case 1337:
     case 1338:
       return new JsonRpcProvider('http://localhost:' + HARDHAT_GANACHE_PORT);


### PR DESCRIPTION
## Motivation and Context

Using hardhat dependencies via npm link or npm imports in our backend as local dependencies doesn't work in the vercel serverless environment.

## Description

<!-- Describe your changes -->

This changes those imports to a relative path, which is a bit course and inelegant, but bypasses the complexity of configuring a local npm dependency. This can be reverted if/when we publish our hardhat dep on the registry or migrate to a monorepo.

## Test and Deployment Plan

Make sure vault deployments work in staging!

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->
