### PR TITLE
Move hardhat account in cypress to a variable

### DIFF
--- a/cypress/integration/createVault.ts
+++ b/cypress/integration/createVault.ts
@@ -1,13 +1,14 @@
-import { gqlQuery, injectWeb3 } from '../util';
+import { gqlQuery, injectWeb3, deriveAccount } from '../util';
 
 let circleId;
 
 context('Coordinape', () => {
   before(() => {
     const providerPort = Cypress.env('HARDHAT_GANACHE_PORT');
+    const userAccount = deriveAccount().address;
     Cypress.on('window:before:load', injectWeb3(providerPort));
     return cy
-      .mintErc20('USDC', '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', '20000')
+      .mintErc20('USDC', userAccount, '20000')
       .then(() =>
         gqlQuery({
           circles: [{ where: { name: { _eq: 'Sports' } } }, { id: true }],

--- a/cypress/util/index.ts
+++ b/cypress/util/index.ts
@@ -21,9 +21,9 @@ import {
 export class TestProvider {
   engine: ProviderEngine;
   constructor(url: string, accountIndex = 0, seed: string = DEFAULT_SEED) {
-    const privateKey = HDNode.fromMnemonic(seed)
-      .derivePath(getAccountPath(accountIndex))
-      .privateKey.substring(2);
+    const privateKey = deriveAccount(accountIndex, seed).privateKey.substring(
+      2
+    );
 
     this.engine = new ProviderEngine();
     this.engine.addProvider(new FiltersSubprovider());
@@ -66,6 +66,9 @@ export const injectWeb3 = (providerPort: string) => (win: any) => {
     console.warn('ethereum already enabled: ', win.ethereum);
   }
 };
+
+export const deriveAccount = (index = 0, seed: string = DEFAULT_SEED) =>
+  HDNode.fromMnemonic(seed).derivePath(getAccountPath(index));
 
 export const gqlQuery = makeThunder(
   Cypress.env('NODE_HASURA_URL'),


### PR DESCRIPTION
## Background and Motivation

We want to avoid hard-coded ethereum accounts wherever possible to
make tests more resilient and agile. This also makes it easier to
access other accounts from the seed phrase when needed.

## Test plan

cypress e2e tests should pass