### PR TITLE
fix hasSimpleToken

### DIFF
--- a/src/lib/vaults/contracts.test.ts
+++ b/src/lib/vaults/contracts.test.ts
@@ -14,6 +14,29 @@ test('getPricePerShare', async () => {
   const event = receipt.events?.find(e => e.event === 'VaultCreated');
   const vaultAddress = event?.args?.vault;
 
-  const price = await contracts.getPricePerShare(vaultAddress, 'DAI', 18);
+  const price = await contracts.getPricePerShare(
+    vaultAddress,
+    ZERO_ADDRESS,
+    18
+  );
   expect(price.toUnsafeFloat()).toBeGreaterThan(1);
+});
+
+test('getPricePerShare with simple token', async () => {
+  const contracts = new Contracts(chainId, provider);
+  const tokenAddress = contracts.getToken('DAI').address;
+  const tx = await contracts.vaultFactory.createApeVault(
+    ZERO_ADDRESS,
+    tokenAddress
+  );
+  const receipt = await tx.wait();
+  const event = receipt.events?.find(e => e.event === 'VaultCreated');
+  const vaultAddress = event?.args?.vault;
+
+  const price = await contracts.getPricePerShare(
+    vaultAddress,
+    tokenAddress,
+    18
+  );
+  expect(price.toUnsafeFloat()).toEqual(1);
 });

--- a/src/lib/vaults/contracts.ts
+++ b/src/lib/vaults/contracts.ts
@@ -91,10 +91,10 @@ export class Contracts {
   // returns value ready to be converted to float, i.e. 1.5, not 1500000
   async getPricePerShare(
     vaultAddress: string,
-    symbol: string,
+    simple_token_address: string,
     decimals: number
   ) {
-    if (hasSimpleToken({ symbol })) return FixedNumber.from(1);
+    if (hasSimpleToken({ simple_token_address })) return FixedNumber.from(1);
     const pps = await (await this.getYVault(vaultAddress)).pricePerShare();
     const shifter = FixedNumber.from(BigNumber.from(10).pow(decimals));
     return FixedNumber.from(pps).divUnsafe(shifter);

--- a/src/lib/vaults/tokens.ts
+++ b/src/lib/vaults/tokens.ts
@@ -3,11 +3,14 @@ import assert from 'assert';
 import { BigNumber, FixedNumber } from 'ethers';
 import { GraphQLTypes } from 'lib/gql/__generated__/zeus';
 
-import { Asset } from './';
+import { ZERO_ADDRESS } from 'config/constants';
+
 import type { Contracts } from './contracts';
 
-export const hasSimpleToken = (vault: Pick<GraphQLTypes['vaults'], 'symbol'>) =>
-  !Object.values(Asset).includes(vault.symbol as Asset);
+export const hasSimpleToken = ({
+  simple_token_address,
+}: Pick<GraphQLTypes['vaults'], 'simple_token_address'>) =>
+  simple_token_address && simple_token_address !== ZERO_ADDRESS;
 
 export const getTokenAddress = (
   vault: Pick<
@@ -18,7 +21,7 @@ export const getTokenAddress = (
   const address = hasSimpleToken(vault)
     ? vault.simple_token_address
     : vault.token_address;
-  assert(address, 'Vault is missing token address');
+  assert(address && address !== ZERO_ADDRESS, 'Vault is missing token address');
   return address;
 };
 
@@ -29,7 +32,10 @@ export const getTokenAddress = (
 // arguments are very different
 export const getWrappedAmount = async (
   amount: string,
-  vault: Pick<GraphQLTypes['vaults'], 'decimals' | 'vault_address' | 'symbol'>,
+  vault: Pick<
+    GraphQLTypes['vaults'],
+    'decimals' | 'vault_address' | 'simple_token_address'
+  >,
   contracts: Contracts
 ) => {
   const shifter = BigNumber.from(10).pow(vault.decimals);

--- a/src/pages/HistoryPage/getHistoryData.ts
+++ b/src/pages/HistoryPage/getHistoryData.ts
@@ -4,6 +4,7 @@ import { client } from 'lib/gql/client';
 import type { Contracts } from 'lib/vaults';
 
 import { Awaited } from '../../types/shim';
+import { ZERO_ADDRESS } from 'config/constants';
 
 export const getHistoryData = async (
   circleId: number,
@@ -93,6 +94,7 @@ export const getHistoryData = async (
                         decimals: true,
                         symbol: true,
                         vault_address: true,
+                        simple_token_address: true,
                       },
                     },
                   ],
@@ -125,7 +127,7 @@ export const getHistoryData = async (
       (dist as DistributionWithPrice).pricePerShare =
         await contracts.getPricePerShare(
           dist.vault.vault_address,
-          dist.vault.symbol,
+          dist.vault.simple_token_address || ZERO_ADDRESS,
           dist.vault.decimals
         );
     }


### PR DESCRIPTION
can't determine this by the token symbol, because a user could use e.g. USDC as a simple token by putting in the token address directly
