### PR TITLE
Add CryptoGraffe to Co-owners for /src/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,11 @@
 /docker/    @topocount
 /scripts/   @topocount
 
-/src/       @teeolendo
-/hardhat/   @teeolendo
+/src/       @levity @teeolendo @cryptograffe
+/hardhat/   @teeolendo @topocount
 
 /api/       @zashton @topocount
 /api-lib/   @zashton @topocount
 /hasura/    @zashton @topocount
 
-/src/       @levity
 /cypress/   @topocount


### PR DESCRIPTION
Also fixed an issue where all `/src/` PRs were assigned to @levity and added myself to hardhat