### PR TITLE
Enable plausible vercel proxy

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -41,7 +41,12 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Coordinape</title>
-    <script defer data-domain="coordinape.com" src="https://plausible.io/js/plausible.js"></script>
+    <script
+      defer
+      data-api="/stats/api/event"
+      data-domain="coordinape.com"
+      src="/stats/js/script.js"
+    ></script>
   </head>
   <body>
     <div id="root"></div>

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+  "rewrites": [
+    {
+      "source": "/stats/js/script.js",
+      "destination": "https://plausible.io/js/script.outbound-links.js"
+    },
+    {
+      "source": "/stats/api/event",
+      "destination": "https://plausible.io/api/event"
+    }
+  ]
+}


### PR DESCRIPTION
## Motivation and Context

Improve Plausible data accuracy by fetching JS through same domain instead of via external domain.

Uses Vercel rewrites. https://plausible.io/docs/proxy/introduction

## Description

* Setup Vercel proxy rewrites
* Fetch Plausbile JS through new rewrites path
* Update Plausible JS to fetch outbound-links tracking package
* 
## Test and Deployment Plan

Verify no console errors and Plausible analytics are working


## Reviewers

@CryptoGraffe 

