### PR TITLE
Login before overview data fetch

### DIFF
--- a/src/components/MainLayout/MainHeader.tsx
+++ b/src/components/MainLayout/MainHeader.tsx
@@ -11,9 +11,9 @@ import {
   NewApeAvatar,
   OverviewMenu,
 } from 'components';
-import { useWalletStatus } from 'components/MyAvatarMenu/MyAvatarMenu';
 import isFeatureEnabled from 'config/features';
 import { useMediaQuery } from 'hooks';
+import { useWalletStatus } from 'hooks/login';
 import { HamburgerIcon, CloseIcon } from 'icons';
 import {
   rSelectedCircle,

--- a/src/components/MainLayout/MainLayout.tsx
+++ b/src/components/MainLayout/MainLayout.tsx
@@ -12,6 +12,8 @@ import {
   WalletAuthModal,
 } from 'components';
 import { useApiBase } from 'hooks';
+import { AuthContext, useAuthStep } from 'hooks/login';
+import type { AuthStep } from 'hooks/login';
 import { useWalletAuth } from 'recoilState';
 import { AppRoutes } from 'routes/routes';
 import { Box } from 'ui';
@@ -20,7 +22,10 @@ import { MainHeader } from './MainHeader';
 
 // this component sets up the top navigation bar to stay fixed on-screen and
 // have content scroll underneath it
+
 export const MainLayout = () => {
+  const authStepState = useState<AuthStep>('connect');
+
   return (
     <Box
       css={{
@@ -35,23 +40,25 @@ export const MainLayout = () => {
         '& > main': { flex: 1 },
       }}
     >
-      <MainHeader />
-      <RequireAuth>
-        <Suspense fallback={<LinearProgress />}>
-          <Box
-            as="main"
-            css={{
-              overflowY: 'auto',
-              '@sm': { zIndex: 1 }, // for hamburger menu
-            }}
-          >
-            <GlobalUi />
-            <SentryScopeController />
-            <AppRoutes />
-          </Box>
-          <HelpButton />
-        </Suspense>
-      </RequireAuth>
+      <AuthContext.Provider value={authStepState}>
+        <MainHeader />
+        <RequireAuth>
+          <Suspense fallback={<LinearProgress />}>
+            <Box
+              as="main"
+              css={{
+                overflowY: 'auto',
+                '@sm': { zIndex: 1 }, // for hamburger menu
+              }}
+            >
+              <GlobalUi />
+              <SentryScopeController />
+              <AppRoutes />
+            </Box>
+            <HelpButton />
+          </Suspense>
+        </RequireAuth>
+      </AuthContext.Provider>
     </Box>
   );
 };
@@ -63,13 +70,11 @@ export const scrollToTop = () => {
   document.getElementsByTagName('main')[0].scrollTop = 0;
 };
 
-type AuthSteps = 'connect' | 'sign' | 'done';
-
 const RequireAuth = (props: { children: ReactElement }) => {
   const address = useWalletAuth().address;
   const web3Context = useWeb3React();
   const { finishAuth } = useApiBase();
-  const [authStep, setAuthStep] = useState<AuthSteps>('connect');
+  const [authStep, setAuthStep] = useAuthStep();
 
   useEffect(() => {
     // reset after logging out or signature error

--- a/src/components/MyAvatarMenu/MyAvatarMenu.tsx
+++ b/src/components/MyAvatarMenu/MyAvatarMenu.tsx
@@ -45,11 +45,14 @@ export const MyAvatarMenu = () => {
   const [showTxModal, setShowTxModal] = useState(false);
 
   const [popoverClicked, setPopoverClicked] = useState(false);
-  const ref = useRef<HTMLButtonElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const clickPopover = () => {
     if (popoverClicked) return;
-    ref.current?.click();
+    triggerRef.current?.click();
     setPopoverClicked(true);
+  };
+  const closePopover = () => {
+    setTimeout(() => triggerRef.current?.click());
   };
 
   return (
@@ -61,7 +64,7 @@ export const MyAvatarMenu = () => {
         <Popover>
           <PopoverTrigger
             asChild
-            ref={ref}
+            ref={triggerRef}
             onMouseEnter={clickPopover}
             onMouseLeave={() => setPopoverClicked(false)}
           >
@@ -73,7 +76,8 @@ export const MyAvatarMenu = () => {
             // These offset values must be dialed in browser.  CSS values/strings cannot be used, only numbers.
             sideOffset={-67}
             alignOffset={-16}
-            css={{ background: '$surface' }}
+            css={{ background: '$surface', outline: 'none' }}
+            onClick={closePopover}
           >
             <Box
               css={{

--- a/src/components/MyAvatarMenu/MyAvatarMenu.tsx
+++ b/src/components/MyAvatarMenu/MyAvatarMenu.tsx
@@ -1,19 +1,13 @@
-import React, { useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 
-import { useWeb3React } from '@web3-react/core';
 import { NavLink } from 'react-router-dom';
 
 import { makeStyles, Hidden } from '@material-ui/core';
 
-import { ReactComponent as CoinbaseSVG } from 'assets/svgs/wallet/coinbase.svg';
-import { ReactComponent as MetaMaskSVG } from 'assets/svgs/wallet/metamask-color.svg';
-import { ReactComponent as WalletConnectSVG } from 'assets/svgs/wallet/wallet-connect.svg';
 import { ApeAvatar } from 'components';
 import { menuGroupStyle } from 'components/MainLayout/MainHeader';
-import { EConnectorNames } from 'config/constants';
 import isFeatureEnabled from 'config/features';
-import { useApiBase } from 'hooks';
-import useConnectedAddress from 'hooks/useConnectedAddress';
+import { useWalletStatus } from 'hooks/login';
 import { useMyProfile } from 'recoilState/app';
 import { EXTERNAL_URL_DOCS, paths } from 'routes/paths';
 import {
@@ -25,7 +19,6 @@ import {
   PopoverClose,
 } from 'ui';
 import { shortenAddress } from 'utils';
-import { connectors } from 'utils/connectors';
 
 import { RecentTransactionsModal } from './RecentTransactionsModal';
 
@@ -150,46 +143,4 @@ export const MyAvatarMenu = () => {
       </Hidden>
     </>
   );
-};
-
-type Connector = Exclude<
-  ReturnType<typeof useWeb3React>['connector'],
-  undefined
->;
-
-const connectorIcon = (connector: Connector | undefined) => {
-  if (!connector) return null;
-
-  const name = Object.entries(connectors).find(
-    ([, ctr]) => connector.constructor === ctr.constructor
-  )?.[0];
-
-  switch (name) {
-    case EConnectorNames.Injected:
-      return <MetaMaskSVG />;
-    case EConnectorNames.WalletConnect:
-      return <WalletConnectSVG />;
-    case EConnectorNames.WalletLink:
-      return <CoinbaseSVG />;
-  }
-  return null;
-};
-
-export const useWalletStatus = () => {
-  const { connector, deactivate } = useWeb3React();
-  const address = useConnectedAddress();
-  const { logout } = useApiBase(); // eslint-disable-line
-
-  return {
-    icon: connectorIcon(connector),
-    address,
-    logout: () => {
-      logout();
-
-      // this is wrapped in setTimeout to make sure the Recoil state changes
-      // from logout() above are applied before we re-render RequireAuth.
-      // otherwise, after logging out, you immediately see a signature prompt
-      setTimeout(deactivate);
-    },
-  };
 };

--- a/src/components/OverviewMenu/OverviewMenu.tsx
+++ b/src/components/OverviewMenu/OverviewMenu.tsx
@@ -46,6 +46,7 @@ export const OverviewMenu = () => {
   const hasCircles = useHasCircles();
 
   const goToCircle = (id: number, path: string) => {
+    closePopover();
     scrollToTop();
     navigate(path);
   };
@@ -78,11 +79,14 @@ export const OverviewMenu = () => {
   );
 
   const [popoverClicked, setPopoverClicked] = useState(false);
-  const ref = useRef<HTMLButtonElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const clickPopover = () => {
     if (popoverClicked) return;
-    ref.current?.click();
+    triggerRef.current?.click();
     setPopoverClicked(true);
+  };
+  const closePopover = () => {
+    setTimeout(() => triggerRef.current?.click());
   };
 
   return (
@@ -91,7 +95,7 @@ export const OverviewMenu = () => {
         <Popover>
           <PopoverTrigger
             asChild
-            ref={ref}
+            ref={triggerRef}
             onMouseEnter={clickPopover}
             onMouseLeave={() => setPopoverClicked(false)}
           >
@@ -134,7 +138,9 @@ export const OverviewMenu = () => {
                   marginTop: '$sm',
                 }}
               >
-                {hasCircles && <TopLevelLinks links={mainLinks} />}
+                {hasCircles && (
+                  <TopLevelLinks links={mainLinks} onClick={closePopover} />
+                )}
               </Box>
               {orgs?.map(org => (
                 <Box key={org.id} css={menuGroupStyle}>
@@ -169,8 +175,10 @@ type CircleItemProps = {
 
 export const TopLevelLinks = ({
   links,
+  onClick,
 }: {
   links: [string, string, string[]?][];
+  onClick?: () => void;
 }) => {
   const location = useLocation();
 
@@ -183,6 +191,7 @@ export const TopLevelLinks = ({
           as={NavLink}
           key={path}
           to={path}
+          onClick={onClick}
           className={matchPaths?.includes(location.pathname) ? 'active' : ''}
         >
           {label}

--- a/src/components/OverviewMenu/getOverviewMenuData.ts
+++ b/src/components/OverviewMenu/getOverviewMenuData.ts
@@ -1,6 +1,7 @@
 import { client } from 'lib/gql/client';
 import { useQuery } from 'react-query';
 
+import { useAuthStep } from 'hooks/login';
 import useConnectedAddress from 'hooks/useConnectedAddress';
 
 export const getOverviewMenuData = (address: string) =>
@@ -36,11 +37,12 @@ export const getOverviewMenuData = (address: string) =>
 // we can reuse it
 export const useOverviewMenuQuery = () => {
   const address = useConnectedAddress();
+  const [authStep] = useAuthStep();
   return useQuery(
     ['OverviewMenu', address],
     () => getOverviewMenuData(address as string),
     {
-      enabled: !!address,
+      enabled: !!address && authStep === 'done',
       staleTime: Infinity,
     }
   );

--- a/src/hooks/login.tsx
+++ b/src/hooks/login.tsx
@@ -1,0 +1,64 @@
+import { createContext, useContext } from 'react';
+
+import { useWeb3React } from '@web3-react/core';
+
+import { ReactComponent as CoinbaseSVG } from 'assets/svgs/wallet/coinbase.svg';
+import { ReactComponent as MetaMaskSVG } from 'assets/svgs/wallet/metamask-color.svg';
+import { ReactComponent as WalletConnectSVG } from 'assets/svgs/wallet/wallet-connect.svg';
+import { EConnectorNames } from 'config/constants';
+import { useApiBase } from 'hooks';
+import useConnectedAddress from 'hooks/useConnectedAddress';
+import { connectors } from 'utils/connectors';
+
+const connectorIcon = (
+  connector: ReturnType<typeof useWeb3React>['connector']
+) => {
+  if (!connector) return null;
+
+  const name = Object.entries(connectors).find(
+    ([, ctr]) => connector.constructor === ctr.constructor
+  )?.[0];
+
+  switch (name) {
+    case EConnectorNames.Injected:
+      return <MetaMaskSVG />;
+    case EConnectorNames.WalletConnect:
+      return <WalletConnectSVG />;
+    case EConnectorNames.WalletLink:
+      return <CoinbaseSVG />;
+  }
+  return null;
+};
+
+export const useWalletStatus = () => {
+  const { connector, deactivate } = useWeb3React();
+  const address = useConnectedAddress();
+  const { logout } = useApiBase();
+
+  return {
+    icon: connectorIcon(connector),
+    address,
+    logout: () => {
+      logout();
+
+      // this is wrapped in setTimeout to make sure the Recoil state changes
+      // from logout() above are applied before we re-render RequireAuth.
+      // otherwise, after logging out, you immediately see a signature prompt
+      setTimeout(deactivate);
+    },
+  };
+};
+
+export type AuthStep = 'connect' | 'sign' | 'done';
+
+type AuthContextType = [
+  AuthStep,
+  React.Dispatch<React.SetStateAction<AuthStep>>
+];
+
+export const AuthContext = createContext<AuthContextType>([
+  'connect',
+  () => {},
+]);
+
+export const useAuthStep = () => useContext(AuthContext);


### PR DESCRIPTION
## Motivation and Context

The query to fetch data for the overview menu was running before login was completed.

## Description

The key piece of state determining when a user has logged in (i.e. has submitted a valid signature & gotten an auth token) was in the RequireAuth component in MainLayout. This piece of state was hoisted into a Context and a hook was created so that it could be read in `useOverviewMenuQuery`

## Test and Deployment Plan

- Confirm that the login flow still functions by logging in and out, canceling signature, etc.
- After logging out, reload the browser. You should not see any "auth token not set" messages in the console, and after logging in, the overview menu should be populated with your circles.
