### PR TITLE
Implement Tooltip link to Feedback Guide

### DIFF
--- a/src/components/ProfileCard/GiftInput.tsx
+++ b/src/components/ProfileCard/GiftInput.tsx
@@ -2,6 +2,7 @@ import { IconButton, makeStyles } from '@material-ui/core';
 
 import { ApeTextField } from 'components';
 import { PlusCircleIcon, DeprecatedMinusCircleIcon } from 'icons';
+import { Link } from 'ui';
 
 import { CardInfoText } from './CardInfoText';
 
@@ -147,6 +148,17 @@ export const GiftInput = ({
       )}
       <ApeTextField
         label="Leave a Note"
+        infoTooltip={
+          <>
+            What contributions earned your GIVE? Be specific, give examples!{' '}
+            <Link
+              target="_blank"
+              href="https://coordinape.com/post/giving-feedback-in-web3?utm_source=coordinape-app&utm_medium=tooltip&utm_campaign=givingfeedback"
+            >
+              Learn more about feedback here
+            </Link>
+          </>
+        }
         className={[classes.textField, classes.noteTextField].join(' ')}
         onChange={onChangeNote}
         placeholder="Thank you for..."


### PR DESCRIPTION

## Motivation and Context

<!-- Why is this change required? What problem does it solve? This can be omitted if a linked issue is provided
-->
As the beginning of building feedback tooling into our product, the first
change entails a link to our Guide to Giving feedback in Web3

## Description

<!-- Describe your changes -->
It's just a static tooltip that links to our blog. I've left the opener and
referrer rel setting as the default in case webflow utilizes that in its
tracking info. Glad to set rel="noopener noreferrer" if that is safer for folks.

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
Review the screenshot, ensure all tests pass. This is a really simple change.

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

![2022-07-05_16-46](https://user-images.githubusercontent.com/17910833/177423103-a136c05a-0f2d-459a-a237-d40d675c3c10.png)

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->
@AlexDistill

## Related Issue

<!-- Please link to the issue here -->
