### PR TITLE
Dework integration: only query tasks from specific workspaces

### DIFF
--- a/src/hooks/useContributions.ts
+++ b/src/hooks/useContributions.ts
@@ -33,7 +33,7 @@ export function useContributionUsers(): ContributionUser[] {
             queryKey: `circle-integration-contributions-${i.id}-${epoch.id}`,
             queryFn: () =>
               fetch(
-                `https://api.demo.dework.xyz/integrations/coordinape/${
+                `https://api.deworkxyz.com/integrations/coordinape/${
                   i.data.organizationId
                 }?epoch_start=${epoch.start_date}&epoch_end=${
                   epoch.end_date

--- a/src/hooks/useContributions.ts
+++ b/src/hooks/useContributions.ts
@@ -33,7 +33,13 @@ export function useContributionUsers(): ContributionUser[] {
             queryKey: `circle-integration-contributions-${i.id}-${epoch.id}`,
             queryFn: () =>
               fetch(
-                `https://api.deworkxyz.com/integrations/coordinape/${i.data.organizationId}?epoch_start=${epoch.start_date}&epoch_end=${epoch.end_date}`
+                `https://api.demo.dework.xyz/integrations/coordinape/${
+                  i.data.organizationId
+                }?epoch_start=${epoch.start_date}&epoch_end=${
+                  epoch.end_date
+                }&workspace_ids=${encodeURIComponent(
+                  i.data.workspaceIds?.join(',') || ''
+                )}`
               )
                 .then(res => res.json())
                 .then(res => res as Response),

--- a/src/pages/IntegrationCallbackPage/IntegrationCallbackPage.tsx
+++ b/src/pages/IntegrationCallbackPage/IntegrationCallbackPage.tsx
@@ -28,15 +28,12 @@ const integrationConfigs: ConnectIntegrationConfig[] = [
     create(params) {
       const organizationId = params.get('dework_organization_id');
       const organizationName = params.get('dework_organization_name');
-      const workspaceIds = params.get('dework_workspace_ids');
+      const workspaceIds = params.get('dework_workspace_ids')?.split(',');
       return {
         integrationName:
           `${organizationName} on Dework` +
           (workspaceIds?.length ? ` (${workspaceIds.length} spaces)` : ''),
-        integrationConfig: {
-          organizationId,
-          workspaceIds: workspaceIds?.split(','),
-        },
+        integrationConfig: { organizationId, workspaceIds },
       };
     },
   },

--- a/src/pages/IntegrationCallbackPage/IntegrationCallbackPage.tsx
+++ b/src/pages/IntegrationCallbackPage/IntegrationCallbackPage.tsx
@@ -28,9 +28,15 @@ const integrationConfigs: ConnectIntegrationConfig[] = [
     create(params) {
       const organizationId = params.get('dework_organization_id');
       const organizationName = params.get('dework_organization_name');
+      const workspaceIds = params.get('dework_workspace_ids');
       return {
-        integrationName: `${organizationName} on Dework`,
-        integrationConfig: { organizationId },
+        integrationName:
+          `${organizationName} on Dework` +
+          (workspaceIds?.length ? ` (${workspaceIds.length} spaces)` : ''),
+        integrationConfig: {
+          organizationId,
+          workspaceIds: workspaceIds?.split(','),
+        },
       };
     },
   },

--- a/src/pages/IntegrationCallbackPage/IntegrationCallbackPage.tsx
+++ b/src/pages/IntegrationCallbackPage/IntegrationCallbackPage.tsx
@@ -28,7 +28,10 @@ const integrationConfigs: ConnectIntegrationConfig[] = [
     create(params) {
       const organizationId = params.get('dework_organization_id');
       const organizationName = params.get('dework_organization_name');
-      const workspaceIds = params.get('dework_workspace_ids')?.split(',');
+      const workspaceIdsString = params.get('dework_workspace_ids');
+      const workspaceIds = workspaceIdsString
+        ? workspaceIdsString.split(',')
+        : undefined;
       return {
         integrationName:
           `${organizationName} on Dework` +


### PR DESCRIPTION
## Motivation and Context

Multiple DAOs, incl Aragon, have asked for only showing Dework tasks from a specific space in Coordinape. For example, some DAOs use Dework for multiple guilds but have a guild specific Coordinape circle. Then it wouldn't make sense to pull in tasks from all guilds, but rather only for the specific guild that the circle is about.

## Description

This PR adds config to save Dework `workspaceIds` as part of the Dework integration. For existing integrations, or DAOs that don't want to only sync specific spaces, the integration will keep working as it does now.

## Test and Deployment Plan

No breaking change, so should be able to just deploy. Please let us know when deployed so that we can inform DAOs that have asked for this and roll out our frontend changes related to exposing this in the Coordinape/Dework connection UI on our end

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/17096641/178472607-3421e93b-d5d0-4302-8a4d-7fe08ab3eb00.png)

![image](https://user-images.githubusercontent.com/17096641/178473710-b9ade674-1c63-4c94-ba2d-a0d6dae6296f.png)


## Reviewers

N/A

## Related Issue

N/A
