### PR TITLE
bugfix: add default number to deployment_block column

### DIFF
--- a/hasura/migrations/default/1656710520327_vault_tx_types/up.sql
+++ b/hasura/migrations/default/1656710520327_vault_tx_types/up.sql
@@ -1,5 +1,6 @@
 -- add deployment_block column
-alter table "public"."vaults" add column "deployment_block" bigint
+alter table "public"."vaults" add column if not exists "deployment_block" bigint
+ default 6800000 -- a pre-testing block on goerli; still valid on mainnet
  not null;
 
 -- It's easier to drop and recreate the table wholesale


### PR DESCRIPTION
The chosen number is a pre-app testing block on goerli In order
to accomodate existing vaults in our backends.

This schema will be fully baked on mainnet and this default should be
removed after we go live.

Test Plan

The hasura migration should apply successfully in prod and staging