### PR TITLE
Remove MainHeader Popversmo trigger outline

### DIFF
--- a/src/components/MyAvatarMenu/MyAvatarMenu.tsx
+++ b/src/components/MyAvatarMenu/MyAvatarMenu.tsx
@@ -53,6 +53,7 @@ export const MyAvatarMenu = () => {
       <Hidden smDown>
         <Popover open={mouseEnterPopover || mouseEnterTrigger}>
           <PopoverTrigger
+            css={{ outline: 'none' }}
             asChild
             ref={triggerRef}
             onMouseEnter={() => setMouseEnterTrigger(true)}

--- a/src/components/OverviewMenu/OverviewMenu.tsx
+++ b/src/components/OverviewMenu/OverviewMenu.tsx
@@ -83,7 +83,7 @@ export const OverviewMenu = () => {
       <Hidden smDown>
         <Popover open={mouseEnterPopover || mouseEnterTrigger}>
           <PopoverTrigger
-            asChild
+            css={{ outline: 'none' }}
             ref={triggerRef}
             onMouseEnter={() => setMouseEnterTrigger(true)}
             onMouseLeave={() =>

--- a/src/ui/Popover.tsx
+++ b/src/ui/Popover.tsx
@@ -11,7 +11,7 @@ const StyledContent = styled(PopoverPrimitive.Content, {
 });
 
 export const Popover = PopoverPrimitive.Root;
-export const PopoverTrigger = PopoverPrimitive.Trigger;
+export const PopoverTrigger = styled(PopoverPrimitive.Trigger, {});
 export const PopoverContent = StyledContent;
 export const PopoverClose = PopoverPrimitive.Close;
 export const PopoverArrow = PopoverPrimitive.Arrow;


### PR DESCRIPTION
## Motivation and Context
 continues #1128 

## Description

remove the outlines that remains after closing the menu on the triggers

## Test and Deployment Plan
1- hover over the overview menu or profile menu then leave the menu
expected:
the menu should close without outline on the menu trigger
Before 

![Screenshot from 2022-07-13 17-16-52](https://user-images.githubusercontent.com/34943689/178807316-c14eb910-de8a-4597-a62f-a6cca25192ab.png)
after
![image](https://user-images.githubusercontent.com/34943689/178807398-0c9b7bbc-db84-4063-8e99-077077128b46.png)


## Related Issue

#1108
