### PR TITLE
Allow Editing Current Epoch

### DIFF
--- a/src/pages/HistoryPage/CurrentEpochPanel.tsx
+++ b/src/pages/HistoryPage/CurrentEpochPanel.tsx
@@ -3,7 +3,7 @@ import { NavLink } from 'react-router-dom';
 import { CSS } from 'stitches.config';
 
 import { paths } from 'routes/paths';
-import { Box, Panel, Text, Button } from 'ui';
+import { Box, Panel, Text, Button, Flex } from 'ui';
 import Medal from 'ui/icons/Medal.svg';
 import PlusInCircle from 'ui/icons/PlusInCircle.svg';
 
@@ -14,6 +14,9 @@ type Props = {
   vouching: boolean;
   circleId: number;
   tokenName?: string;
+  editCurrentEpoch: () => void;
+  isEditing: boolean;
+  isAdmin: boolean;
   css?: CSS;
 };
 export const CurrentEpochPanel = ({
@@ -23,6 +26,9 @@ export const CurrentEpochPanel = ({
   unallocated,
   circleId,
   tokenName = 'GIVE',
+  editCurrentEpoch,
+  isEditing,
+  isAdmin,
   css = {},
 }: Props) => {
   const startDate = DateTime.fromISO(epoch.start_date);
@@ -52,40 +58,49 @@ export const CurrentEpochPanel = ({
           {startDate.toFormat('d')} - {endDate.toFormat(endDateFormat)}
         </Text>
       </Box>
-      <Box
-        css={{
-          display: 'flex',
-          gap: '$md',
-          '@sm': { flexDirection: 'column' },
-        }}
-      >
-        {vouching && (
+      <Flex column css={{ gap: '$md' }}>
+        <Flex css={{ justifyContent: 'flex-end' }}>
+          {!isEditing && isAdmin && (
+            <Button color="primary" outlined onClick={() => editCurrentEpoch()}>
+              Edit
+            </Button>
+          )}
+        </Flex>
+        <Box
+          css={{
+            display: 'flex',
+            gap: '$md',
+            '@sm': { flexDirection: 'column' },
+          }}
+        >
+          {vouching && (
+            <Minicard
+              icon={Medal}
+              title="Nominations"
+              alert={nominees > 0}
+              content={
+                nominees > 0
+                  ? `${nominees} nomination${nominees > 1 ? 's' : ''}`
+                  : 'None yet. Nominate someone?'
+              }
+              path={paths.vouching(circleId)}
+              linkLabel="Go to Vouching"
+            />
+          )}
           <Minicard
-            icon={Medal}
-            title="Nominations"
-            alert={nominees > 0}
+            icon={PlusInCircle}
+            title="Allocations"
+            alert={unallocated > 0}
             content={
-              nominees > 0
-                ? `${nominees} nomination${nominees > 1 ? 's' : ''}`
-                : 'None yet. Nominate someone?'
+              unallocated > 0
+                ? `Allocate Your Remaining ${unallocated} ${tokenName}`
+                : `No More ${tokenName} to Allocate`
             }
-            path={paths.vouching(circleId)}
-            linkLabel="Go to Vouching"
+            path={paths.allocation(circleId)}
+            linkLabel="Allocate to Teammates"
           />
-        )}
-        <Minicard
-          icon={PlusInCircle}
-          title="Allocations"
-          alert={unallocated > 0}
-          content={
-            unallocated > 0
-              ? `Allocate Your Remaining ${unallocated} ${tokenName}`
-              : `No More ${tokenName} to Allocate`
-          }
-          path={paths.allocation(circleId)}
-          linkLabel="Allocate to Teammates"
-        />
-      </Box>
+        </Box>
+      </Flex>
     </Panel>
   );
 };

--- a/src/pages/HistoryPage/HistoryPage.tsx
+++ b/src/pages/HistoryPage/HistoryPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 
 import { isUserAdmin } from 'lib/users';
 import { useQuery } from 'react-query';
@@ -88,6 +88,11 @@ export const HistoryPage = () => {
     }
     query.refetch();
   };
+
+  useEffect(() => {
+    setEditEpoch(undefined);
+    setNewEpoch(false);
+  }, [circleId]);
 
   if (query.isLoading || query.isIdle)
     return <LoadingModal visible note="HistoryPage" />;

--- a/src/pages/HistoryPage/HistoryPage.tsx
+++ b/src/pages/HistoryPage/HistoryPage.tsx
@@ -178,6 +178,11 @@ export const HistoryPage = () => {
             nominees={nominees}
             unallocated={unallocated}
             tokenName={circle?.token_name}
+            isAdmin={isAdmin}
+            isEditing={editEpoch || newEpoch ? true : false}
+            editCurrentEpoch={() => {
+              setEditEpoch(currentEpoch);
+            }}
           />
         </>
       )}


### PR DESCRIPTION
## Motivation and Context

implements #1138 - Fixes an issue regarding the Editing Form where the form remains open if the user switched to another circle.

## Description
1- Add Edit button to current Epoch if the user is Admin.
2- Disable editing start date and start time in EpochForm for current Epoch.
3- The validation is between current epoch and future epochs if not empty
3- Bypass comparing between start date and current time for current epoch.

## Test and Deployment Plan
1- Tested editing current epoch with and without Available upcoming epochs.
2- Retested adding new epochs and editing next epochs.

## Screenshots (if appropriate):
Admin
![image](https://user-images.githubusercontent.com/34943689/179075803-fdea8ae0-bfc0-4e05-a1e8-f850ed3aa8b4.png)
![image](https://user-images.githubusercontent.com/34943689/179075862-0671bc5a-b93a-4de1-bc97-f477db1d4343.png)

Regular user
![image](https://user-images.githubusercontent.com/34943689/179075974-97aed6e3-640b-4c7d-baa7-5776bffd1c10.png)


