### PR TITLE
Fix adding a new circle as a new user

### DIFF
--- a/src/pages/CreateCirclePage/CreateCirclePage.tsx
+++ b/src/pages/CreateCirclePage/CreateCirclePage.tsx
@@ -9,7 +9,7 @@ import CreateCircleForm from 'forms/CreateCircleForm';
 import { useApiWithProfile } from 'hooks';
 import { useMyProfile } from 'recoilState/app';
 import * as paths from 'routes/paths';
-import { Box, Button, Panel, Text, TextField, Tooltip } from 'ui';
+import { Box, Button, Panel, Text, Tooltip } from 'ui';
 import { SingleColumnLayout } from 'ui/layouts';
 
 export const SummonCirclePage = () => {
@@ -141,9 +141,10 @@ export const SummonCirclePage = () => {
                           <InfoCircledIcon />
                         </Tooltip>
                       </Text>
-                      <TextField
+                      <FormTextField
+                        {...fields.protocol_name}
                         placeholder="Organization Name"
-                        css={{ width: '100%' }}
+                        fullWidth
                       />
                     </div>
                   )}


### PR DESCRIPTION
## Motivation and Context

When a user who is not a part of a circle tries to create a new circle, they create button is not responsive

## Description

There was an issue regarding the input field of protocol(org) name
![image](https://user-images.githubusercontent.com/34943689/179302162-683580a9-c4e8-4058-9125-31fed649fbdc.png)
The control props was not added to the input field in the condition of a user is not part of an org.
![image](https://user-images.githubusercontent.com/34943689/179302295-4849aaf9-89ff-4831-ad11-7d37c7c3648a.png)


## Test and Deployment Plan
Use a new wallet and try to add a circle

## Additional info
The form should be done by react hook-form but this is a quick fix for a current issue