### PR TITLE
fixes #1010 - sort overview by [membership, alphanumeric]

### DIFF
--- a/src/pages/CirclesPage/CirclesPage.tsx
+++ b/src/pages/CirclesPage/CirclesPage.tsx
@@ -71,7 +71,7 @@ export const CirclesPage = () => {
             )}
           </Box>
           <Box css={{ display: 'flex', flexDirection: 'column', gap: '$md' }}>
-            {sortBy(org.circles, c => -c.users.length).map(circle => (
+            {sortBy(org.circles, c => [-c.users.length, c.name]).map(circle => (
               <CircleRow
                 circle={circle}
                 key={circle.id}


### PR DESCRIPTION
resolves #1010 

Sort circles by membership (am I in the circle, and then alphanumerically.

### screenshot

<img width="821" alt="Screen Shot 2022-07-15 at 4 26 29 PM" src="https://user-images.githubusercontent.com/83605543/179323900-b16cd5d4-bf82-4f6c-a2f5-bcb23ecdc36c.png">

