### PR TITLE
Opt In Quality of Life Improvements

### DIFF
--- a/hasura/migrations/default/1658458629766_alter_table_public_users_alter_column_non_receiver/down.sql
+++ b/hasura/migrations/default/1658458629766_alter_table_public_users_alter_column_non_receiver/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."users" alter column "non_receiver" set default 'true';

--- a/hasura/migrations/default/1658458629766_alter_table_public_users_alter_column_non_receiver/up.sql
+++ b/hasura/migrations/default/1658458629766_alter_table_public_users_alter_column_non_receiver/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."users" alter column "non_receiver" set default 'false';

--- a/src/pages/AllocationPage/AllocationEpoch.tsx
+++ b/src/pages/AllocationPage/AllocationEpoch.tsx
@@ -133,7 +133,6 @@ const AllocationEpoch = ({
   useEffect(() => {
     if (myUser) {
       setEpochBio(myUser?.bio ?? '');
-      setNonReceiver(myUser.non_receiver);
     }
   }, [myUser]);
 
@@ -204,6 +203,14 @@ const AllocationEpoch = ({
             <hr className={classes.optHr} />
             <div className={classes.optInputContainer}>
               <OptInput
+                isChecked={!nonReceiver}
+                subTitle={`I want to be eligible to receive ${
+                  selectedCircle?.token_name || 'GIVE'
+                }`}
+                title="Opt In"
+                updateOpt={() => setNonReceiver(false)}
+              />
+              <OptInput
                 isChecked={nonReceiver}
                 subTitle="I am paid sufficiently via other channels"
                 title="Opt Out"
@@ -214,14 +221,6 @@ const AllocationEpoch = ({
                     setNonReceiver(true);
                   }
                 }}
-              />
-              <OptInput
-                isChecked={!nonReceiver}
-                subTitle={`I want to be eligible to receive ${
-                  selectedCircle?.token_name || 'GIVE'
-                }`}
-                title="Opt In"
-                updateOpt={() => setNonReceiver(false)}
               />
               <ActionDialog
                 open={optOutOpen}


### PR DESCRIPTION
These changes make it easier for users to opt in and for circle creators
to onboard a circle faster.

First, created users used to be opted out upon creation, and had to opt
in during their first epoch to begin receiving GIVE. Now they are
opted in by default in our app, and there is no longer this chicken and
egg issue of users opting in and having no one to GIVE to because others
are not opted in.

Second, the UI now has the Opt-in radio button selected on every page
load. This makes it easier to opt in, and the user is now required to
explicitly opt out before receiving give.

Test plan:

E2E tests should still pass and unit tests still pass

Related Issue:
closes #1162 
