### PR TITLE
Withdraw fixes

### DIFF
--- a/hardhat/deploymentInfo.json
+++ b/hardhat/deploymentInfo.json
@@ -68,13 +68,13 @@
       "address": "0x81f3A59B9e262e27B9c7717e7002d82c2bccDa27"
     },
     "MockRegistry": {
-      "address": "0xe8a0721aF820630398994127C5592d41bB939689"
+      "address": "0xa64014AdF0E28a4c3f464e1Ebfccc0edAee0E559"
     },
     "MockVaultFactory": {
-      "address": "0xf968AF55F713BA8284f24c37de8636529b3F9425"
+      "address": "0x5066CF36107E1f9B64A860dBEef3A1ba9E68a971"
     },
     "MockUSDCVaultFactory": {
-      "address": "0x3f49F1D1Eb9b85305A9DA6A131200458B262ddF6"
+      "address": "0x375aaF80E40b95fC7984b2fc3e5c6974A11f7679"
     },
     "USDC": {
       "address": "0xC478a48520005bF9C97b145dE2D8DD2b54Ba4abC"

--- a/hardhat/dist/deploymentInfo.json
+++ b/hardhat/dist/deploymentInfo.json
@@ -68,13 +68,13 @@
             "address": "0x81f3A59B9e262e27B9c7717e7002d82c2bccDa27"
         },
         "MockRegistry": {
-            "address": "0xe8a0721aF820630398994127C5592d41bB939689"
+            "address": "0xa64014AdF0E28a4c3f464e1Ebfccc0edAee0E559"
         },
         "MockVaultFactory": {
-            "address": "0xf968AF55F713BA8284f24c37de8636529b3F9425"
+            "address": "0x5066CF36107E1f9B64A860dBEef3A1ba9E68a971"
         },
         "MockUSDCVaultFactory": {
-            "address": "0x3f49F1D1Eb9b85305A9DA6A131200458B262ddF6"
+            "address": "0x375aaF80E40b95fC7984b2fc3e5c6974A11f7679"
         },
         "USDC": {
             "address": "0xC478a48520005bF9C97b145dE2D8DD2b54Ba4abC"

--- a/src/lib/vaults/tokens.ts
+++ b/src/lib/vaults/tokens.ts
@@ -57,7 +57,8 @@ export const getWrappedAmount = async (
   if (newTotalAmount.lte(vaultBalance)) return newTotalAmount;
 
   // this is acceptable rounding error
-  if (newTotalAmount.lt(vaultBalance.add(100))) return vaultBalance;
+  const acceptableError = BigNumber.from(10).pow(vault.decimals - 4);
+  if (newTotalAmount.lt(vaultBalance.add(acceptableError))) return vaultBalance;
 
   throw new Error(
     `Trying to tap ${newTotalAmount} but vault has only ${vaultBalance}.`

--- a/src/pages/VaultsPage/WithdrawModal.tsx
+++ b/src/pages/VaultsPage/WithdrawModal.tsx
@@ -22,7 +22,9 @@ export default function WithdrawModal({
   vault,
   balance,
 }: WithdrawModalProps) {
-  const schema = z.object({ amount: z.number().min(0).max(balance) }).strict();
+  const schema = z
+    .object({ amount: z.number().positive().max(balance) })
+    .strict();
   type WithdrawFormSchema = z.infer<typeof schema>;
   const contracts = useContracts();
   const [submitting, setSubmitting] = useState(false);


### PR DESCRIPTION
# Genericize Rounding error calcs
    
This initially only worked soundly for USDC (6 decimals) and now works
soundly for ERC20s of any decimal amount by rounding up by 0.0001 to
check if the total balance is meant to be withdrawn

# Disallow submitting a withdrawal of zero amount

The submit button is now disabled when input contains a zero value

# Update deployment Info
    
This fixes the MockVault issue where they become underfunded as deposits
roll in because they aren't minting enough yv tokens to CoVaults upon
deposit, causing the deposited DAI/USDC to become unrecoverable
