### PR TITLE
fix: 1180 - fixes the calendly link for schedule a walkthrough to use the hosted page

### DIFF
--- a/src/components/HelpButton.tsx
+++ b/src/components/HelpButton.tsx
@@ -167,7 +167,9 @@ const HelpButton = () => {
           Email Us
         </HelpOption>
         <HelpOption
-          href={'https://calendly.com/zakku/coordinape-call'}
+          href={
+            'https://coordinape.com/schedule-a-walkthrough?utm_medium=helpbutton&utm_campaign=onboarding'
+          }
           icon={<ClockIcon size={'md'} color={'text'} />}
         >
           Schedule a Walkthrough


### PR DESCRIPTION
Fixes #1180 by using updated link from @ivyquinzel 