### PR TITLE
move docs/feedback to help button and link to typeform

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@gqty/react": "2.1.0",
     "@hcaptcha/react-hcaptcha": "0.3.7",
     "@hookform/resolvers": "^2.8.8",
+    "@jridgewell/gen-mapping": "^0.3.2",
     "@material-ui/core": "4.11.3",
     "@material-ui/icons": "4.11.2",
     "@material-ui/lab": "4.0.0-alpha.58",

--- a/src/components/HelpButton.tsx
+++ b/src/components/HelpButton.tsx
@@ -2,6 +2,13 @@ import React, { useState } from 'react';
 
 import { styled } from '@stitches/react';
 
+import {
+  EXTERNAL_URL_DISCORD,
+  EXTERNAL_URL_DOCS,
+  EXTERNAL_URL_MAILTO_SUPPORT,
+  EXTERNAL_URL_SCHEDULE_WALKTHROUGH,
+  EXTERNAL_URL_TYPEFORM_FEEDBACK,
+} from '../routes/paths';
 import { Button, Flex } from '../ui';
 import { Box } from '../ui/Box/Box';
 import { ClockIcon } from '../ui/icons/ClockIcon';
@@ -28,7 +35,7 @@ const HelpButtonContainer = styled('div', {
   zIndex: 3,
   '&[data-open="true"]': {
     width: '270px', // magic number to make it look nice and not be crazy on mobile -g
-    height: '258px', // magic number, yep. If i do auto the animations are terrible -g
+    height: '298px', // magic number, yep. If i do auto the animations are terrible -g
     borderRadius: '$3',
     '.help-icon': {
       transition: null,
@@ -155,28 +162,32 @@ const HelpButton = () => {
           </Text>
         </div>
         <HelpOption
-          href={'https://discord.gg/pc7KFEdsSh'}
+          href={EXTERNAL_URL_DISCORD}
           icon={<DiscordIcon size={'md'} color={'text'} />}
         >
           Ask on Discord
         </HelpOption>
         <HelpOption
-          href={'mailto:support@coodinape.com'}
+          href={EXTERNAL_URL_MAILTO_SUPPORT}
           icon={<EnvelopeIcon size={'md'} color={'text'} />}
         >
           Email Us
         </HelpOption>
         <HelpOption
-          href={
-            'https://coordinape.com/schedule-a-walkthrough?utm_medium=helpbutton&utm_campaign=onboarding'
-          }
+          href={EXTERNAL_URL_SCHEDULE_WALKTHROUGH}
           icon={<ClockIcon size={'md'} color={'text'} />}
         >
           Schedule a Walkthrough
         </HelpOption>
+        <HelpOption
+          href={EXTERNAL_URL_TYPEFORM_FEEDBACK}
+          icon={<ClockIcon size={'md'} color={'text'} />}
+        >
+          Share Feedback
+        </HelpOption>
         <Box css={{ borderTop: '0.5px solid $borderMedium', mt: '$sm' }}>
           <HelpOption
-            href={'https://docs.coordinape.com/'}
+            href={EXTERNAL_URL_DOCS}
             icon={<DocumentIcon size={'md'} color={'text'} />}
           >
             Documentation

--- a/src/components/MainLayout/MainHeader.tsx
+++ b/src/components/MainLayout/MainHeader.tsx
@@ -21,7 +21,7 @@ import {
   useMyProfile,
   useSelectedCircle,
 } from 'recoilState/app';
-import { EXTERNAL_URL_DOCS, isCircleSpecificPath, paths } from 'routes/paths';
+import { isCircleSpecificPath, paths } from 'routes/paths';
 import { Box, IconButton, Link, Image } from 'ui';
 import { shortenAddress } from 'utils';
 
@@ -199,13 +199,6 @@ const MobileHeader = ({
                   },
                 }}
               >
-                <Link
-                  href={EXTERNAL_URL_DOCS}
-                  target="_blank"
-                  css={{ display: 'block' }}
-                >
-                  Docs
-                </Link>
                 <Link
                   as={NavLink}
                   to={paths.profile('me')}

--- a/src/components/MyAvatarMenu/MyAvatarMenu.tsx
+++ b/src/components/MyAvatarMenu/MyAvatarMenu.tsx
@@ -9,7 +9,7 @@ import { menuGroupStyle } from 'components/MainLayout/MainHeader';
 import isFeatureEnabled from 'config/features';
 import { useWalletStatus } from 'hooks/login';
 import { useMyProfile } from 'recoilState/app';
-import { EXTERNAL_URL_DOCS, paths } from 'routes/paths';
+import { paths } from 'routes/paths';
 import {
   Box,
   Link,
@@ -127,18 +127,6 @@ export const MyAvatarMenu = () => {
                 </Link>
                 <Link type="menu" as={NavLink} to={paths.circles}>
                   Circles
-                </Link>
-              </Box>
-              <Box css={menuGroupStyle}>
-                <Link type="menu" href={EXTERNAL_URL_DOCS}>
-                  Docs
-                </Link>
-                <Link
-                  type="menu"
-                  href="https://notionforms.io/forms/give-us-your-feedback-improve-coordinape"
-                  target="_blank"
-                >
-                  Give Feedback
                 </Link>
               </Box>
             </Box>

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -7,6 +7,8 @@ export const MAP_HIGHLIGHT_PARAM = 'highlight';
 export const EXTERNAL_URL_TYPEFORM =
   'https://yearnfinance.typeform.com/to/egGYEbrC';
 export const EXTERNAL_URL_DOCS = 'https://docs.coordinape.com';
+export const EXTERNAL_URL_SCHEDULE_WALKTHROUGH =
+  'https://coordinape.com/schedule-a-walkthrough?utm_medium=helpbutton&utm_campaign=onboarding';
 export const EXTERNAL_URL_LANDING_PAGE = 'https://coordinape.com';
 export const EXTERNAL_URL_DOCS_REGIFT = `${EXTERNAL_URL_DOCS}/welcome/new-feature-regift`;
 export const EXTERNAL_URL_TWITTER = 'https://twitter.com/coordinape';
@@ -18,6 +20,9 @@ export const EXTERNAL_URL_MEDIUM_ARTICLE =
 // TODO: Change this to something more specific to feedback.
 export const EXTERNAL_URL_FEEDBACK =
   'https://coordinape.notion.site/Why-is-Coordinape-in-my-Circle-fd17133a82ef4cbf84d4738311fb557a';
+export const EXTERNAL_URL_TYPEFORM_FEEDBACK =
+  'https://fe7gssn4rhy.typeform.com/to/nvOUfHKN';
+export const EXTERNAL_URL_MAILTO_SUPPORT = 'mailto:support@coordinape.com';
 
 const toSearchString = (params: Record<string, string | number>) =>
   Object.entries(params)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3501,6 +3501,38 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
+"@jridgewell/gen-mapping@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz#c1aedc61e853f2bb9f5dfe6d4442d3b565b253b9"
+  integrity sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==
+  dependencies:
+    "@jridgewell/set-array" "^1.0.1"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+    "@jridgewell/trace-mapping" "^0.3.9"
+
+"@jridgewell/resolve-uri@^3.0.3":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
+  integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
+
+"@jridgewell/set-array@^1.0.1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
+  integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
+
+"@jridgewell/sourcemap-codec@^1.4.10":
+  version "1.4.14"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
+  integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
+
+"@jridgewell/trace-mapping@^0.3.9":
+  version "0.3.14"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz#b231a081d8f66796e475ad588a1ef473112701ed"
+  integrity sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+
 "@json-rpc-tools/provider@^1.5.5":
   version "1.7.6"
   resolved "https://registry.yarnpkg.com/@json-rpc-tools/provider/-/provider-1.7.6.tgz#8a17c34c493fa892632e278fd9331104e8491ec6"


### PR DESCRIPTION
Fixes #1104 by moving Docs and Feedback links to help button and changing to typeform for feedback. 

Also cleans up links by using constants. 

Does not include embedding TypeForm in a modal as asked in original ticket. This should not be merged until that discussion is resolved. 