### PR TITLE
Fix get wrapped amount with decimals

### DIFF
--- a/src/lib/vaults/tokens.ts
+++ b/src/lib/vaults/tokens.ts
@@ -44,8 +44,7 @@ export const getWrappedAmount = async (
   >,
   contracts: Contracts
 ): Promise<BigNumber> => {
-  const shifter = BigNumber.from(10).pow(vault.decimals);
-  const weiAmount = BigNumber.from(amount).mul(shifter);
+  const weiAmount = utils.parseUnits(amount, vault.decimals);
   if (hasSimpleToken(vault)) return weiAmount;
 
   const vaultContract = contracts.getVault(vault.vault_address);


### PR DESCRIPTION
`getWrappedAmount` can't handle decimal amounts , which causes errors for various flows in the app.

fixes
https://www.notion.so/coordinape/VAULTS-QA-dd5a668750314cbc8f9a431fac1132a0?p=50e754b48e3f45fdbf46f50888baee6c&pm=s