### PR TITLE
Padding refactor 👎12px ... 👍16px

### DIFF
--- a/src/components/MyAvatarMenu/MyAvatarMenu.tsx
+++ b/src/components/MyAvatarMenu/MyAvatarMenu.tsx
@@ -82,7 +82,7 @@ export const MyAvatarMenu = () => {
                 flexDirection: 'column',
                 textAlign: 'right',
                 alignItems: 'end',
-                p: '$2sm',
+                p: '$md',
               }}
             >
               <PopoverClose asChild>

--- a/src/components/OverviewMenu/OverviewMenu.tsx
+++ b/src/components/OverviewMenu/OverviewMenu.tsx
@@ -107,7 +107,7 @@ export const OverviewMenu = () => {
               css={{
                 display: 'flex',
                 flexDirection: 'column',
-                p: '$2sm',
+                p: '$md',
               }}
             >
               <PopoverClose asChild>

--- a/src/stitches.config.ts
+++ b/src/stitches.config.ts
@@ -55,8 +55,7 @@ export const SvgIconConfig = {
 const spaces = {
   xs: '4px',
   sm: '8px',
-  md: '12px',
-  '2sm': '16px',
+  md: '16px',
   lg: '24px',
   xl: '32px',
   '1xl': '40px',

--- a/src/ui/Panel/Panel.tsx
+++ b/src/ui/Panel/Panel.tsx
@@ -13,7 +13,7 @@ export const Panel = styled('div', {
   borderRadius: '$3',
   backgroundColor: '$surface',
   border: '1px solid transparent',
-  padding: '$2sm',
+  padding: '$md',
 
   variants: {
     stack: {


### PR DESCRIPTION
* goodbye 12px padding/margin, long live 16px
* Remove `$2sm` implementation of 16px in favor of `$md`, which was previously 12px

## Motivation and Context

Figma is basically only using 4, 8, 16, 24, 32, 40, so I'm removing the 12px option that was set for $md.  I think there were some 12px margins in Figma at one time, but not currently, it seems.

Here's our key:
```
const spaces = {
  xs: '4px',
  sm: '8px',
  md: '16px',
  lg: '24px',
  xl: '32px',
  '1xl': '40px',
  '2xl': '48px',
  '3xl': '60px',
};
```
