### PR TITLE
Fix edge cases for distribution page button state

### DIFF
--- a/src/pages/DistributionsPage/AllocationsTable.tsx
+++ b/src/pages/DistributionsPage/AllocationsTable.tsx
@@ -76,6 +76,7 @@ export const AllocationsTable = ({
         css={{
           justifyContent: 'space-between',
           mb: '$lg',
+          alignItems: 'center',
         }}
       >
         <Text h3 css={{ fontWeight: '$semibold', color: '$headingText' }}>

--- a/src/pages/DistributionsPage/DistributionForm.tsx
+++ b/src/pages/DistributionsPage/DistributionForm.tsx
@@ -318,27 +318,26 @@ export function DistributionForm({
       // check if a non combined distribution is selected
       ((!fixedDist && !circleDist) || (circleDist && fixedDist));
     const totalAmt = isCombinedDist ? amountSet + totalFixedPayment : amountSet;
+
     if (isCombinedDist) {
       setMaxGiftTokens(tokenBalance);
       setMaxFixedPaymentTokens(tokenBalance);
       setSufficientFixPaymentTokens(tokenBalance >= totalAmt && totalAmt > 0);
+    } else if (formType === 'gift') {
+      setSufficientGiftTokens(tokenBalance >= totalAmt && totalAmt > 0);
+      setMaxGiftTokens(tokenBalance);
+      // if switching from combined dist selection to non combined
+      // we need to recheck if the fixed payment have sufficient tokens
+      if (
+        fixedPaymentTokenSel[0] &&
+        fixedPaymentTokenSel[0].symbol === giftVaultSymbol
+      )
+        setSufficientFixPaymentTokens(
+          maxFixedPaymentTokens >= totalFixedPayment && totalFixedPayment > 0
+        );
     } else {
-      if (formType === 'gift') {
-        setSufficientGiftTokens(tokenBalance >= totalAmt && totalAmt > 0);
-        setMaxGiftTokens(tokenBalance);
-        // if switching from combined dist selection to non combined
-        // we need to recheck if the fixed payment have sufficient tokens
-        if (
-          fixedPaymentTokenSel[0] &&
-          fixedPaymentTokenSel[0].symbol === giftVaultSymbol
-        )
-          setSufficientFixPaymentTokens(
-            maxFixedPaymentTokens >= totalFixedPayment && totalFixedPayment > 0
-          );
-      } else {
-        setSufficientFixPaymentTokens(tokenBalance >= totalAmt && totalAmt > 0);
-        setMaxFixedPaymentTokens(tokenBalance);
-      }
+      setSufficientFixPaymentTokens(tokenBalance >= totalAmt && totalAmt > 0);
+      setMaxFixedPaymentTokens(tokenBalance);
     }
   };
 

--- a/src/pages/DistributionsPage/DistributionForm.tsx
+++ b/src/pages/DistributionsPage/DistributionForm.tsx
@@ -112,11 +112,11 @@ export function DistributionForm({
 
   useEffect(() => {
     if (fixedPaymentTokenSel[0])
-    updateBalanceState(
-      fixedPaymentTokenSel[0].symbol,
-      totalFixedPayment,
-      'fixed'
-    );
+      updateBalanceState(
+        fixedPaymentTokenSel[0].symbol,
+        totalFixedPayment,
+        'fixed'
+      );
   }, [fixed_payment_token_type, totalFixedPayment]);
 
   const onFixedFormSubmit: SubmitHandler<TDistributionForm> = async (
@@ -281,8 +281,7 @@ export function DistributionForm({
     symbol: string,
     amount: number
   ): string => {
-
-    if(amount === 0) {
+    if (amount === 0) {
       return `Please input a token amount`;
     }
     if (sufficientTokens) {
@@ -318,12 +317,12 @@ export function DistributionForm({
           .toNumber()
       : 0;
     const isCombinedDist =
-        // check if the two symbols are the same
+      // check if the two symbols are the same
       ((formType === 'gift' &&
         fixedPaymentTokenSel[0] &&
         fixedPaymentTokenSel[0].symbol === symbol) ||
         (formType === 'fixed' && giftVaultSymbol === symbol)) &&
-        // check if a non combined distribution is selected
+      // check if a non combined distribution is selected
       ((!fixedDist && !circleDist) || (circleDist && fixedDist));
     const totalAmt = isCombinedDist ? amountSet + totalFixedPayment : amountSet;
     if (isCombinedDist) {
@@ -336,8 +335,13 @@ export function DistributionForm({
         setMaxGiftTokens(tokenBalance);
         // if switching from combined dist selection to non combined
         // we need to recheck if the fixed payment have sufficient tokens
-        if(fixedPaymentTokenSel[0] && fixedPaymentTokenSel[0].symbol === giftVaultSymbol)
-          setSufficientFixPaymentTokens(maxFixedPaymentTokens >= totalFixedPayment && totalFixedPayment > 0);
+        if (
+          fixedPaymentTokenSel[0] &&
+          fixedPaymentTokenSel[0].symbol === giftVaultSymbol
+        )
+          setSufficientFixPaymentTokens(
+            maxFixedPaymentTokens >= totalFixedPayment && totalFixedPayment > 0
+          );
       } else {
         setSufficientFixPaymentTokens(tokenBalance >= totalAmt && totalAmt > 0);
         setMaxFixedPaymentTokens(tokenBalance);

--- a/src/pages/DistributionsPage/DistributionForm.tsx
+++ b/src/pages/DistributionsPage/DistributionForm.tsx
@@ -281,17 +281,10 @@ export function DistributionForm({
     symbol: string,
     amount: number
   ): string => {
-    if (amount === 0) {
-      return `Please input a token amount`;
-    }
-    if (sufficientTokens) {
-      if (submitting) {
-        return 'Submitting...';
-      }
-
-      return `Submit ${symbol} Vault Distribution`;
-    }
-    return 'Insufficient Tokens';
+    if (amount === 0) return `Please input a token amount`;
+    if (!sufficientTokens) return 'Insufficient Tokens';
+    if (submitting) return 'Submitting...';
+    return `Submit ${symbol} Vault Distribution`;
   };
 
   const isCombinedDistribution = () => {

--- a/src/pages/DistributionsPage/DistributionForm.tsx
+++ b/src/pages/DistributionsPage/DistributionForm.tsx
@@ -80,13 +80,13 @@ export function DistributionForm({
   const contracts = useContracts();
   const circle = epoch.circle;
   assert(circle);
-  const fixed_payment_token_type = circle.fixed_payment_token_type;
+  const fixedPaymentTokenType = circle.fixed_payment_token_type;
   const totalFixedPayment = circleUsers
     .map(g => g.fixed_payment_amount ?? 0)
     .reduce((total, tokens) => tokens + total);
-  const fixedPaymentTokenSel = fixed_payment_token_type
+  const fixedPaymentTokenSel = fixedPaymentTokenType
     ? vaults.filter(
-        v => v.symbol.toLowerCase() === fixed_payment_token_type.toLowerCase()
+        v => v.symbol.toLowerCase() === fixedPaymentTokenType.toLowerCase()
       )
     : [];
   const { handleSubmit, control } = useForm<TDistributionForm>({
@@ -117,7 +117,7 @@ export function DistributionForm({
         totalFixedPayment,
         'fixed'
       );
-  }, [fixed_payment_token_type, totalFixedPayment]);
+  }, [fixedPaymentTokenType, totalFixedPayment]);
 
   const onFixedFormSubmit: SubmitHandler<TDistributionForm> = async (
     value: TDistributionForm
@@ -500,7 +500,7 @@ export function DistributionForm({
             </Box>
           </Flex>
 
-          {!fixed_payment_token_type ? (
+          {!fixedPaymentTokenType ? (
             <Box
               css={{
                 pt: '$lg',

--- a/src/pages/DistributionsPage/DistributionsPage.test.tsx
+++ b/src/pages/DistributionsPage/DistributionsPage.test.tsx
@@ -91,7 +91,7 @@ test('render without a distribution', async () => {
     expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
   });
   expect(screen.getByText('Gift Circle')).toBeInTheDocument();
-  expect(screen.getByText('Insufficient Tokens')).toBeInTheDocument();
+  expect(screen.getByText('Please input a token amount')).toBeInTheDocument();
 });
 
 test('render with a distribution', async () => {

--- a/src/ui/Text/Text.tsx
+++ b/src/ui/Text/Text.tsx
@@ -55,7 +55,7 @@ export const Text = styled('span', {
     },
     p: {
       true: {
-        display: 'inline',
+        display: 'block',
         color: '$text',
         fontSize: '$medium',
         lineHeight: '$base',


### PR DESCRIPTION
1. Fixed distribution button state when toggling Fixed Payment token in Circle settings page without refreshing

2. Fixed distribution button state when changing fixed payment amounts for circle users in Admin page without refreshing.

3. Button now displays `Please input token amount` instead of `Insufficient Tokens` when the total is zero for a combined distribution or if the respective input is zero for a non combined distribution

Fixes 
https://www.notion.so/coordinape/VAULTS-QA-dd5a668750314cbc8f9a431fac1132a0?p=da39ef02747f4f2e8998941d27ccc029&pm=s