### PR TITLE
Update Claim perms

### DIFF
--- a/hasura/metadata/databases/default/tables/public_claims.yaml
+++ b/hasura/metadata/databases/default/tables/public_claims.yaml
@@ -19,15 +19,8 @@ insert_permissions:
     backend_only: false
     check:
       distribution:
-        epoch:
-          circle:
-            users:
-              _and:
-              - deleted_at:
-                  _is_null: true
-              - profile:
-                  id:
-                    _eq: X-Hasura-User-Id
+        created_by:
+          _eq: X-Hasura-User-Id
     columns:
     - address
     - amount
@@ -70,14 +63,6 @@ update_permissions:
     columns:
     - txHash
     filter:
-      distribution:
-        epoch:
-          circle:
-            users:
-              _and:
-              - deleted_at:
-                  _is_null: true
-              - profile:
-                  id:
-                    _eq: X-Hasura-User-Id
+      profile_id:
+        _eq: X-Hasura-User-Id
   role: user


### PR DESCRIPTION
Insert: Should only be able to create a claim of a given distribution ID if you are the owner (creator) of that distribution.

Update: you can only update your own claims.
