### PR TITLE
fix simple token distribution

### DIFF
--- a/src/hooks/useVaultRouter.ts
+++ b/src/hooks/useVaultRouter.ts
@@ -58,7 +58,7 @@ export function useVaultRouter(contracts?: Contracts) {
         isSimpleToken
           ? token.transfer(receiverAddress, amount)
           : contracts.router.delegateDeposit(
-              vault.vault_address as string,
+              vault.vault_address,
               tokenAddress,
               amount
             ),

--- a/src/lib/vaults/distributor.test.ts
+++ b/src/lib/vaults/distributor.test.ts
@@ -1,0 +1,98 @@
+import { AddressZero } from '@ethersproject/constants';
+import { parseUnits } from '@ethersproject/units';
+
+import fixtures from '../merkle-distributor/fixtures.json';
+import { mint, tokens } from 'utils/testing/mint';
+import { chainId, provider } from 'utils/testing/provider';
+
+import { Contracts, getWrappedAmount } from '.';
+import { uploadEpochRoot } from './distributor';
+
+const contracts = new Contracts(chainId, provider);
+
+describe('simple token', () => {
+  beforeEach(async () => {
+    await mint({ token: 'SHIB', amount: '1000' });
+  });
+
+  test('upload epoch root', async () => {
+    const tokenAddress = tokens.SHIB.addr;
+    const createVaultTx = await contracts.vaultFactory.createCoVault(
+      AddressZero,
+      tokenAddress
+    );
+    const receipt1 = await createVaultTx.wait();
+    const vaultAddress = receipt1.events?.find(e => e.event === 'VaultCreated')
+      ?.args?.vault;
+
+    const vault = {
+      vault_address: vaultAddress,
+      simple_token_address: tokenAddress,
+    };
+
+    const amount = parseUnits('1000', 18);
+    const token = contracts.getERC20(tokenAddress);
+    await token.transfer(vaultAddress, amount);
+
+    const distributeTx = await uploadEpochRoot(
+      contracts,
+      vault as typeof uploadEpochRoot.arguments.vault,
+      1,
+      fixtures.output.merkleRoot,
+      amount
+    );
+
+    const receipt2 = await distributeTx.wait();
+    const loggedVaultAddr = receipt2.events?.find(
+      e => e.event === 'EpochFunded'
+    )?.args?.vault;
+    expect(loggedVaultAddr).toEqual(vaultAddress);
+  });
+});
+
+describe('yearn token', () => {
+  beforeEach(async () => {
+    await mint({ token: 'DAI', amount: '1000' });
+  });
+
+  test('upload epoch root', async () => {
+    const tokenAddress = tokens.DAI.addr;
+    const createVaultTx = await contracts.vaultFactory.createCoVault(
+      tokenAddress,
+      AddressZero
+    );
+    const receipt1 = await createVaultTx.wait();
+    const vaultAddress = receipt1.events?.find(e => e.event === 'VaultCreated')
+      ?.args?.vault;
+
+    const token = contracts.getERC20(tokenAddress);
+    const vault = {
+      vault_address: vaultAddress,
+      token_address: tokenAddress,
+      simple_token_address: AddressZero,
+      decimals: await token.decimals(),
+    };
+
+    const amount = parseUnits('1000', vault.decimals);
+    await token.approve(contracts.router.address, amount);
+    await contracts.router.delegateDeposit(
+      vault.vault_address,
+      tokenAddress,
+      amount
+    );
+
+    const distributeTx = await uploadEpochRoot(
+      contracts,
+      vault as typeof uploadEpochRoot.arguments.vault,
+      1,
+      fixtures.output.merkleRoot,
+      await getWrappedAmount('1000', vault, contracts)
+    );
+
+    const receipt2 = await distributeTx.wait();
+    const loggedVaultAddr = receipt2.events?.find(
+      e => e.event === 'EpochFunded'
+    )?.args?.vault;
+    expect(loggedVaultAddr).toEqual(vaultAddress);
+  });
+});

--- a/src/lib/vaults/distributor.ts
+++ b/src/lib/vaults/distributor.ts
@@ -1,0 +1,30 @@
+import { BigNumber } from '@ethersproject/bignumber';
+import { utils } from 'ethers';
+import { GraphQLTypes } from 'lib/gql/__generated__/zeus';
+
+import { Contracts, encodeCircleId, hasSimpleToken } from '.';
+
+export async function uploadEpochRoot(
+  contracts: Contracts,
+  vault: Pick<GraphQLTypes['vaults'], 'simple_token_address' | 'vault_address'>,
+  circleId: number,
+  merkleRoot: string,
+  amount: BigNumber
+) {
+  const encodedCircleId = encodeCircleId(circleId);
+  const isSimpleToken = hasSimpleToken(vault);
+  const vaultContract = contracts.getVault(vault.vault_address);
+  const tokenAddress = isSimpleToken
+    ? vault.simple_token_address
+    : await vaultContract.vault();
+  const tapType = utils.hexlify(isSimpleToken ? 2 : 1);
+
+  return contracts.distributor.uploadEpochRoot(
+    vault.vault_address,
+    encodedCircleId,
+    tokenAddress,
+    merkleRoot,
+    amount,
+    tapType
+  );
+}

--- a/src/pages/DistributionsPage/useSubmitDistribution.test.tsx
+++ b/src/pages/DistributionsPage/useSubmitDistribution.test.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 import { act, render, waitFor } from '@testing-library/react';
 import { BigNumber, FixedNumber } from 'ethers';
 import { createDistribution } from 'lib/merkle-distributor';
-import { getWrappedAmount, Asset } from 'lib/vaults';
+import { getWrappedAmount, Asset, encodeCircleId } from 'lib/vaults';
 
 import { useContracts } from 'hooks';
 import { useVaultFactory } from 'hooks/useVaultFactory';
@@ -137,7 +137,7 @@ test('submit distribution', async () => {
 
         merkleRootFromDistributor = await contracts.distributor.epochRoots(
           vault.vault_address,
-          distro.encodedCircleId,
+          encodeCircleId(2),
           await contracts.getVault(vault.vault_address).vault(),
           distro.epochId
         );

--- a/src/utils/testing/mint.ts
+++ b/src/utils/testing/mint.ts
@@ -3,7 +3,7 @@ import { BigNumber, ethers, utils } from 'ethers';
 import { provider } from './provider';
 import { unlockSigner } from './unlockSigner';
 
-const tokens = {
+export const tokens = {
   DAI: {
     addr: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
     whale: '0x8d6f396d210d385033b348bcae9e4f9ea4e045bd',
@@ -11,6 +11,10 @@ const tokens = {
   USDC: {
     addr: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
     whale: '0x47ac0Fb4F2D84898e4D9E7b4DaB3C24507a6D503',
+  },
+  SHIB: {
+    addr: '0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE',
+    whale: '0xdead000000000000000042069420694206942069',
   },
 };
 
@@ -20,15 +24,15 @@ export async function mint({
   amount,
 }: {
   token: string;
-  address: string;
+  address?: string;
   amount: string;
 }) {
+  if (!address) address = (await provider.listAccounts())[0];
   switch (token) {
     case 'ETH':
       await mintEth(address, amount);
       break;
-    case 'USDC':
-    case 'DAI':
+    default:
       await mintToken(token, address, amount);
       break;
   }
@@ -43,11 +47,11 @@ export const mintEth = async (receiver: string, amount: string) => {
 };
 
 export const mintToken = async (
-  symbol: 'USDC' | 'DAI',
+  symbol: string,
   receiver: string,
   amount: string
 ) => {
-  const { whale, addr } = tokens[symbol];
+  const { whale, addr } = tokens[symbol as keyof typeof tokens];
   await mintEth(whale, '0.1');
   const sender = await unlockSigner(whale);
   const contract = new ethers.Contract(


### PR DESCRIPTION
Fixes [this QA report in Notion](https://www.notion.so/coordinape/226b9363ee0d45cead60e5365ae65d10?v=2137f63c15394b32b90fb80dd09a5244&p=456bcb22b03f4a148e6d1db45b01d376&pm=s)

we weren't setting tapType and tokenAddress correctly in the call to uploadEpochRoot

this fix also encapsulates that logic into lib/vaults/distributor & adds tests for simple token & yearn token distribution

those tests can serve as a nice reference for the basic JS API we've made for vault operations, sans all the React- & UX-related stuff
