### PR TITLE
🪲 Bugfix for Undelete-able zero in input field

### DIFF
--- a/cypress/e2e/createUser.cy.ts
+++ b/cypress/e2e/createUser.cy.ts
@@ -33,7 +33,7 @@ context('Coordinape', () => {
     cy.contains('A Test User', { timeout: 120000 })
       .parents('tr')
       .within(() => {
-        cy.get('td').eq(7).should('have.text', '12000');
+        cy.get('td').eq(7).should('have.text', '1200');
       });
   });
 });

--- a/cypress/e2e/updateUser.cy.ts
+++ b/cypress/e2e/updateUser.cy.ts
@@ -76,9 +76,9 @@ context('Coordinape', () => {
       });
 
     // enter the fixed payment amount
-    cy.getInputByLabel('Fixed Payment Amount').clear().type('1200').blur();
+    cy.getInputByLabel('Fixed Payment Amount').clear().type('12000').blur();
 
-    cy.contains('Save').click();
+    cy.contains('Save').click({force: true});
     cy.reload(true);
     cy.contains('Kasey', { timeout: 120000 }).should('be.visible');
     // Verify new value in contributors table

--- a/cypress/e2e/updateUser.cy.ts
+++ b/cypress/e2e/updateUser.cy.ts
@@ -78,7 +78,7 @@ context('Coordinape', () => {
     // enter the fixed payment amount
     cy.getInputByLabel('Fixed Payment Amount').clear().type('12000').blur();
 
-    cy.contains('Save').click({force: true});
+    cy.contains('Save').click({ force: true });
     cy.reload(true);
     cy.contains('Kasey', { timeout: 120000 }).should('be.visible');
     // Verify new value in contributors table

--- a/src/components/DeprecatedFormTextField/DeprecatedFormTextField.tsx
+++ b/src/components/DeprecatedFormTextField/DeprecatedFormTextField.tsx
@@ -15,7 +15,7 @@ export const DeprecatedFormTextField = ({
 }) => {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     onChange(
-      typeof value === 'number' ? Number(e.target.value) : e.target.value
+      typeof value === 'number' ? parseFloat(e.target.value) : e.target.value
     );
   };
 

--- a/src/components/FormTokenField/FormTokenField.tsx
+++ b/src/components/FormTokenField/FormTokenField.tsx
@@ -49,6 +49,7 @@ export const FormTokenField = ({
       value={value}
       onChange={handleChange}
       type="number"
+      placeholder="0"
       onFocus={event => (event.currentTarget as HTMLInputElement).select()}
     />
   );

--- a/src/pages/AdminPage/AdminUserModal.tsx
+++ b/src/pages/AdminPage/AdminUserModal.tsx
@@ -166,6 +166,7 @@ export const AdminUserModal = ({
                 ) : (
                   <DeprecatedFormTextField
                     fullWidth
+                    type="number"
                     onChange={() => {}}
                     label="Fixed Payment Amount"
                     disabled={true}

--- a/src/pages/AdminPage/AdminUserModal.tsx
+++ b/src/pages/AdminPage/AdminUserModal.tsx
@@ -141,6 +141,7 @@ export const AdminUserModal = ({
               <DeprecatedFormTextField
                 {...fields.starting_tokens}
                 type="number"
+                placeholder="0"
                 infoTooltip={
                   <>
                     The maximum amount of giving a user can allocate in an epoch{' '}
@@ -159,6 +160,7 @@ export const AdminUserModal = ({
                     {...fields.fixed_payment_amount}
                     label="Fixed Payment Amount"
                     type="number"
+                    placeholder="0"
                     fullWidth
                   />
                 ) : (

--- a/src/pages/CircleAdminPage/CircleAdminPage.tsx
+++ b/src/pages/CircleAdminPage/CircleAdminPage.tsx
@@ -11,6 +11,7 @@ import { makeStyles } from '@material-ui/core';
 import {
   ApeAvatar,
   DeprecatedApeTextField,
+  DeprecatedFormTextField,
   ApeToggle,
   FormAutocomplete,
 } from 'components';
@@ -423,7 +424,7 @@ export const CircleAdminPage = () => {
         <div
           className={clsx(classes.vouchingItem, !vouching.value && 'disabled')}
         >
-          <DeprecatedApeTextField
+          <DeprecatedFormTextField
             label="Minimum vouches to add member"
             type="number"
             placeholder="0"
@@ -445,7 +446,7 @@ export const CircleAdminPage = () => {
         <div
           className={clsx(classes.vouchingItem, !vouching.value && 'disabled')}
         >
-          <DeprecatedApeTextField
+          <DeprecatedFormTextField
             label="Length of nomination period"
             type="number"
             placeholder="0"

--- a/src/pages/CircleAdminPage/CircleAdminPage.tsx
+++ b/src/pages/CircleAdminPage/CircleAdminPage.tsx
@@ -425,8 +425,8 @@ export const CircleAdminPage = () => {
         >
           <DeprecatedApeTextField
             label="Minimum vouches to add member"
-            // type="number"
-            // placeholder="0"
+            type="number"
+            placeholder="0"
             {...minVouches}
             fullWidth
             disabled={!vouching.value}
@@ -447,8 +447,8 @@ export const CircleAdminPage = () => {
         >
           <DeprecatedApeTextField
             label="Length of nomination period"
-            // type="number"
-            // placeholder="0"
+            type="number"
+            placeholder="0"
             {...nominationDaysLimit}
             helperText="(# of days)"
             fullWidth

--- a/src/pages/CircleAdminPage/CircleAdminPage.tsx
+++ b/src/pages/CircleAdminPage/CircleAdminPage.tsx
@@ -424,7 +424,9 @@ export const CircleAdminPage = () => {
           className={clsx(classes.vouchingItem, !vouching.value && 'disabled')}
         >
           <DeprecatedApeTextField
-            label="Mininum vouches to add member"
+            label="Minimum vouches to add member"
+            // type="number"
+            // placeholder="0"
             {...minVouches}
             fullWidth
             disabled={!vouching.value}
@@ -445,6 +447,8 @@ export const CircleAdminPage = () => {
         >
           <DeprecatedApeTextField
             label="Length of nomination period"
+            // type="number"
+            // placeholder="0"
             {...nominationDaysLimit}
             helperText="(# of days)"
             fullWidth

--- a/src/pages/DistributionsPage/DistributionForm.tsx
+++ b/src/pages/DistributionsPage/DistributionForm.tsx
@@ -404,6 +404,7 @@ export function DistributionForm({
                       symbol: giftVaultSymbol,
                     })}
                     type="number"
+                    placeholder="0"
                     error={!!error}
                     value={circleDist ? circleDist.gift_amount : value}
                     disabled={submitting || !!circleDist || vaults.length === 0}
@@ -530,6 +531,7 @@ export function DistributionForm({
                           symbol: fpTokenSymbol,
                         })}
                         type="number"
+                        placeholder="0"
                         error={!!error}
                         value={
                           fixedDist ? fixedDist.fixed_amount : totalFixedPayment


### PR DESCRIPTION
Number form fields that use `<DeprecatedApeTextField` faced an issue where the initial input value of `0` could not easily be deleted.  
* Fix leading-zero bug
* Set some number only fields to `type="number"`
* Fix vouching input field bug