### PR TITLE
minor cypress test speedup

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,13 +35,8 @@ jobs:
           path: '/home/runner/.cache'
           key: nodeModules-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 
-      - uses: actions/cache@v2
-        with:
-          path: '**/hardhat/node_modules'
-          key: hardhatNodeModules-${{ runner.os }}-${{ hashFiles('**/hardhat/yarn.lock') }}
-
       - run: yarn --frozen-lockfile
-      - run: ./scripts/setup.sh
+      - run: ./scripts/link_hardhat.sh
       - run: yarn typecheck
       - run: yarn lint:check
       - run: yarn prettier:check

--- a/cypress/e2e/updateUser.cy.ts
+++ b/cypress/e2e/updateUser.cy.ts
@@ -61,33 +61,6 @@ context('Coordinape', () => {
     // Assert that the old address is there and correct
     assertAddr(oldAddress);
   });
-
-  it("can set user's fixed payment amount", () => {
-    cy.visit(`/circles/${circleId}/members`);
-    cy.login();
-
-    cy.contains('Kasey', { timeout: 120000 }).should('be.visible');
-
-    // Click on edit user
-    cy.contains('Kasey', { timeout: 120000 })
-      .parents('tr')
-      .within(() => {
-        cy.get('td').last().get('button:first').click();
-      });
-
-    // enter the fixed payment amount
-    cy.getInputByLabel('Fixed Payment Amount').clear().type('1200').blur();
-
-    cy.contains('Save').click();
-    cy.reload(true);
-    cy.contains('Kasey', { timeout: 120000 }).should('be.visible');
-    // Verify new value in contributors table
-    cy.contains('Kasey', { timeout: 120000 })
-      .parents('tr')
-      .within(() => {
-        cy.get('td').eq(7).should('have.text', '12000');
-      });
-  });
 });
 
 const assertAddr = (addr: string) => {

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -2,7 +2,7 @@
 set -e
 export CI=1
 
-EXECARGS=()
+OTHERARGS=()
 while [[ "$#" -gt 0 ]]; do case $1 in
   --cypress-only) CYPRESS_ONLY=1;;
   --local) LOCAL=1;;
@@ -61,7 +61,9 @@ yarn db-seed-fresh
 
 if [ -z "$CYPRESS_ONLY" ]; then
   craco test --runInBand --coverage
-  yarn --cwd hardhat test
+
+  # these are redundant with jest & cypress tests now
+  # yarn --cwd hardhat test
 fi
 
 if [ -z "$LOCAL" ]; then


### PR DESCRIPTION
remove unnecessary step from allocation test
remove a test from updateUser.cy.ts that is not so high-value

## Motivation and Context

make the Cypress tests faster