### PR TITLE
moving typeform to an embedded form instead of a new tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@spruceid/siwe-parser": "^2.0.0",
     "@stitches/react": "1.2.6",
     "@storybook/react": "^6.4.19",
+    "@typeform/embed-react": "^1.18.0",
     "@web3-react/core": "6.1.9",
     "@web3-react/injected-connector": "6.0.7",
     "@web3-react/walletconnect-connector": "6.2.13",

--- a/src/components/HelpButton.tsx
+++ b/src/components/HelpButton.tsx
@@ -1,13 +1,13 @@
 import React, { useState } from 'react';
 
 import { styled } from '@stitches/react';
+import { PopupButton } from '@typeform/embed-react';
 
 import {
   EXTERNAL_URL_DISCORD,
   EXTERNAL_URL_DOCS,
   EXTERNAL_URL_MAILTO_SUPPORT,
   EXTERNAL_URL_SCHEDULE_WALKTHROUGH,
-  EXTERNAL_URL_TYPEFORM_FEEDBACK,
 } from '../routes/paths';
 import { Button, Flex } from '../ui';
 import { Box } from '../ui/Box/Box';
@@ -180,12 +180,28 @@ const HelpButton = () => {
         >
           Schedule a Walkthrough
         </HelpOption>
-        <HelpOption
-          href={EXTERNAL_URL_TYPEFORM_FEEDBACK}
-          icon={<GiveArrowsIcon size={'md'} color={'text'} />}
+        <Button
+          color={'transparent'}
+          fullWidth={true}
+          css={{ paddingLeft: '0px' }}
         >
-          Share Feedback
-        </HelpOption>
+          <PopupButton
+            id="nvOUfHKN"
+            className="my-button"
+            style={{ marginTop: 0 }}
+          >
+            <Flex
+              css={{
+                alignItems: 'center',
+              }}
+            >
+              <Flex css={{ mr: '$sm', alignItems: 'center', color: '$text' }}>
+                <GiveArrowsIcon size={'md'} color={'text'} />
+              </Flex>
+              Share Feedback
+            </Flex>
+          </PopupButton>
+        </Button>
         <Box css={{ borderTop: '0.5px solid $borderMedium', mt: '$sm' }}>
           <HelpOption
             href={EXTERNAL_URL_DOCS}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5948,6 +5948,19 @@
   resolved "https://registry.yarnpkg.com/@tweenjs/tween.js/-/tween.js-18.6.4.tgz#40a3d0a93647124872dec8e0fd1bd5926695b6ca"
   integrity sha512-lB9lMjuqjtuJrx7/kOkqQBtllspPIN+96OvTCeJ2j5FEzinoAXTdAMFnDAQT1KVPRlnYfBrqxtqP66vDM40xxQ==
 
+"@typeform/embed-react@^1.18.0":
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/@typeform/embed-react/-/embed-react-1.18.0.tgz#a89da5e3920a42bb802e7b6feac9685aa2783096"
+  integrity sha512-MUbTGoAUX2T8G/tOkhuAOBEPKsOROg/M16MK/5lPQj9a6auh9aJdVFbWRwXZx9U0M7ApG4u7BpNNCTj86sklxA==
+  dependencies:
+    "@typeform/embed" "1.36.1"
+    fast-deep-equal "^3.1.3"
+
+"@typeform/embed@1.36.1":
+  version "1.36.1"
+  resolved "https://registry.yarnpkg.com/@typeform/embed/-/embed-1.36.1.tgz#43dddcacbfc0fbb7efbe0b73c4e6bcbb0e0bd353"
+  integrity sha512-5Oll+EFT6UcU0oWA4n5ZwkXy+8KI4SwOIDMi3F8LMTEvoo4A7oeGtMi7MD2O+uuhgNTMcNFeBe6B8ovW83swAA==
+
 "@types/aria-query@^4.2.0":
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.2.tgz#ed4e0ad92306a704f9fb132a0cfcf77486dbe2bc"


### PR DESCRIPTION
## Motivation and Context

Fixes #1193  This is a cleaner workflow than adding a new tab and was requested by @ivyquinzel 

## Description

The Help button "Share Feedback" link was opening a new tab, now it opens a typeform native sort of embed thing. 

## Test and Deployment Plan

Try helpButton->Share feedback on desktop and mobile 