### PR TITLE
Claims Improvements

### DIFF
--- a/src/pages/ClaimsPage/ClaimsPage.tsx
+++ b/src/pages/ClaimsPage/ClaimsPage.tsx
@@ -1,5 +1,5 @@
 import { LoadingModal, makeTable } from 'components';
-import { Box, Panel, Flex, Text, Button } from 'ui';
+import { Avatar, Box, Panel, Flex, Text, Button } from 'ui';
 import { SingleColumnLayout } from 'ui/layouts';
 import { makeExplorerUrl } from 'utils/provider';
 
@@ -23,10 +23,17 @@ const ClaimsRow: React.FC<ClaimsRowData> = ({ claim, group, children }) => {
   return (
     <tr>
       <td>
-        <Text>{claim.distribution.epoch.circle?.organization?.name}</Text>
+        <Flex>
+          {claim.distribution.epoch.circle?.logo ? (
+            <Avatar small path={claim.distribution.epoch.circle?.logo} />
+          ) : (
+            ''
+          )}
+          <Text>{claim.distribution.epoch.circle?.organization?.name}</Text>
+        </Flex>
       </td>
       <td>
-        <Flex row css={{ gap: '$sm' }}>
+        <Flex css={{ gap: '$sm' }}>
           <Text>{claim.distribution.epoch.circle?.name}</Text>
         </Flex>
       </td>

--- a/src/pages/ClaimsPage/ClaimsPage.tsx
+++ b/src/pages/ClaimsPage/ClaimsPage.tsx
@@ -25,7 +25,11 @@ const ClaimsRow: React.FC<ClaimsRowData> = ({ claim, group, children }) => {
       <td>
         <Flex>
           {claim.distribution.epoch.circle?.logo ? (
-            <Avatar small path={claim.distribution.epoch.circle?.logo} />
+            <Avatar
+              small
+              path={claim.distribution.epoch.circle?.logo}
+              css={{ my: 0, ml: 0 }}
+            />
           ) : (
             ''
           )}

--- a/src/pages/ClaimsPage/mutations.ts
+++ b/src/pages/ClaimsPage/mutations.ts
@@ -4,10 +4,12 @@ import { useMutation } from 'react-query';
 export function useMarkClaimTaken() {
   return useMutation(
     ({
+      claimId,
       circleId,
       txHash,
       vaultAddress,
     }: {
+      claimId: number;
       circleId: number;
       txHash: string;
       vaultAddress: string;
@@ -21,6 +23,7 @@ export function useMarkClaimTaken() {
               },
               where: {
                 txHash: { _is_null: true },
+                id: { _lte: claimId },
                 distribution: {
                   vault: { vault_address: { _eq: vaultAddress } },
                   epoch: { circle: { id: { _eq: circleId } } },

--- a/src/pages/ClaimsPage/useClaimAllocation.ts
+++ b/src/pages/ClaimsPage/useClaimAllocation.ts
@@ -89,6 +89,7 @@ export function useClaimAllocation() {
 
       showInfo('Saving record of claim...');
       await markSaved({
+        claimId,
         circleId: circle.id,
         txHash,
         vaultAddress: vault.vault_address,

--- a/src/ui/Avatar/Avatar.tsx
+++ b/src/ui/Avatar/Avatar.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import * as AvatarPrimitive from '@radix-ui/react-avatar';
+import type * as Stitches from '@stitches/react';
 
 import { styled } from '../../stitches.config';
 import {
@@ -75,6 +76,7 @@ export const Avatar = ({
   name,
   onClick,
   small,
+  css,
   ...props
 }: {
   path?: string;
@@ -84,6 +86,7 @@ export const Avatar = ({
   /** represents avatar with smaller size `32x32` */
   small?: boolean;
   children?: React.ReactNode;
+  css?: Stitches.CSS;
 }) => {
   const avatarPath = getAvatarPathWithoutPlaceholder(path);
 
@@ -91,6 +94,7 @@ export const Avatar = ({
     <AvatarRoot
       onClick={() => onClick?.()}
       size={small ? 'small' : 'large'}
+      {...(css ? { css } : {})}
       {...props}
     >
       {avatarPath && <AvatarImage src={avatarPath} alt={name} />}


### PR DESCRIPTION
Claims Page Improvements
- add circle logo to UI

- edgecase-fix: only update older claims:

If you load the FE, and get claims 1,2,3. And then while on that page a claim 4 is created, claiming 3 would cause claim 4 to be marked as claimed erroneously. This fixes that edge case.
