### PR TITLE
delete api key table when seeding fresh

### DIFF
--- a/scripts/db_clean.ts
+++ b/scripts/db_clean.ts
@@ -14,6 +14,7 @@ type MutationName = keyof ValueTypes['mutation_root'];
     'delete_teammates',
     'delete_vouches',
     'delete_nominees',
+    'delete_circle_api_keys',
     'delete_users',
     'delete_epochs',
     'delete_circle_integrations',


### PR DESCRIPTION
## Motivation and Context

this was just an oversight in the db_clean script when this new table was added

