### PR TITLE
store distribution_json properly

### DIFF
--- a/hasura/migrations/default/1659968853380_fix_distribution_json/up.sql
+++ b/hasura/migrations/default/1659968853380_fix_distribution_json/up.sql
@@ -1,0 +1,2 @@
+update distributions 
+set distribution_json = (distribution_json #>> '{}')::jsonb;

--- a/src/pages/ClaimsPage/hooks.ts
+++ b/src/pages/ClaimsPage/hooks.ts
@@ -52,7 +52,7 @@ export const useClaimsTableData = () => {
     assert(claim && address);
     const { index, proof, distribution } = claim;
 
-    const { claims: jsonClaims } = JSON.parse(distribution.distribution_json);
+    const { claims: jsonClaims } = distribution.distribution_json;
 
     // we use this value instead of the column on the claims row because it is
     // more precise

--- a/src/pages/ClaimsPage/useClaimAllocation.test.tsx
+++ b/src/pages/ClaimsPage/useClaimAllocation.test.tsx
@@ -146,7 +146,7 @@ test('claim single successfully', async () => {
           address: address1,
           distribution: {
             id: 1,
-            distribution_json: '',
+            distribution_json: {},
             distribution_epoch_id: event?.args?.epochId,
             epoch: {
               id: 1,

--- a/src/pages/DistributionsPage/mutations.ts
+++ b/src/pages/DistributionsPage/mutations.ts
@@ -1,18 +1,32 @@
-import { ValueTypes } from 'lib/gql/__generated__/zeus';
+import { ValueTypes, useZeusVariables } from 'lib/gql/__generated__/zeus';
 import { client } from 'lib/gql/client';
 import { useMutation } from 'react-query';
 
 export function useSaveDistribution() {
   return useMutation(
     async (distribution?: ValueTypes['distributions_insert_input']) => {
+      // this is not a hook
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      const variables = useZeusVariables({ json: 'jsonb' })({
+        json: distribution?.distribution_json,
+      });
+
       const { insert_distributions_one } = await client.mutate(
         {
           insert_distributions_one: [
-            { object: { ...distribution } },
+            {
+              object: {
+                ...distribution,
+                distribution_json: variables.$('json'),
+              },
+            },
             { id: true },
           ],
         },
-        { operationName: 'saveDistribution' }
+        {
+          operationName: 'saveDistribution',
+          variables,
+        }
       );
       return insert_distributions_one;
     }

--- a/src/pages/DistributionsPage/useSubmitDistribution.test.tsx
+++ b/src/pages/DistributionsPage/useSubmitDistribution.test.tsx
@@ -165,7 +165,7 @@ test('submit distribution', async () => {
 
   // did we store values in the db?
   const args1 = save1calls[0][0];
-  const distJson = JSON.parse(args1.distribution_json);
+  const distJson = args1.distribution_json;
   expect(args1.claims.data.length).toBe(3);
   const savedTotal = FixedNumber.from(args1.total_amount);
   const distJsonTotal = FixedNumber.from(distJson.tokenTotal);
@@ -221,7 +221,7 @@ test('previous distribution', async () => {
           previousDistribution: {
             id: 1,
             vault_id: 1,
-            distribution_json: JSON.stringify(previousDistribution),
+            distribution_json: previousDistribution,
           },
           fixedAmount: '0',
           giftAmount: '100',

--- a/src/pages/DistributionsPage/useSubmitDistribution.ts
+++ b/src/pages/DistributionsPage/useSubmitDistribution.ts
@@ -88,10 +88,7 @@ export function useSubmitDistribution() {
         vault,
         contracts
       );
-      const prev =
-        previousDistribution &&
-        JSON.parse(previousDistribution.distribution_json);
-
+      const prev = previousDistribution?.distribution_json;
       const distribution = createDistribution(
         gifts,
         fixedGifts,
@@ -133,7 +130,7 @@ export function useSubmitDistribution() {
         merkle_root: distribution.merkleRoot,
         claims: { data: claims },
         vault_id: Number(vault.id),
-        distribution_json: JSON.stringify(distribution),
+        distribution_json: distribution,
         fixed_amount: Number(FixedNumber.from(fixedAmount, 'fixed128x18')),
         gift_amount: Number(FixedNumber.from(giftAmount, 'fixed128x18')),
         distribution_type: type,


### PR DESCRIPTION
## Motivation and Context

The `distributions.distribution_json` column is being stored as a giant plain-text string instead of JSON, even though the database table type is already `jsonb`.

This was a compromise when the feature was initially implemented due to lack of support from Zeus, but Zeus's support improved.

## Description

- store and read the `distribution_json` column as JSON
- add a migration to convert existing column values

----

This is based off of `recover-distributions` because that has lots of related changes; will rebase once #1232 is merged.