### PR TITLE
feat: Update the expiry-date with a new value if the an expired nominee is re-nominated

### DIFF
--- a/api-lib/nominees.ts
+++ b/api-lib/nominees.ts
@@ -179,3 +179,32 @@ export const insertNominee = async (params: {
 
   return insert_nominees_one;
 };
+
+export const updateNominee = async (params: {
+  address: string;
+  circle_id: number;
+  nomination_days_limit: number;
+}) => {
+  const today = new Date();
+  const expiry = new Date();
+  expiry.setDate(today.getDate() + params.nomination_days_limit);
+  const input = { ...params, nomination_days_limit: undefined };
+
+  const update_nominees_one = await adminClient.mutate(
+    {
+      update_nominees_one: [
+        {
+          object: {
+            ...input,
+            nominated_date: today.toISOString(),
+            expiry_date: expiry.toISOString(),
+          },
+        },
+        { id: true },
+      ],
+    },
+    { operationName: 'updateNominee' }
+  );
+
+  return update_nominees_one;
+};

--- a/api/hasura/actions/_handlers/createNominee.ts
+++ b/api/hasura/actions/_handlers/createNominee.ts
@@ -6,6 +6,7 @@ import {
   insertNominee,
   getUserFromProfileIdWithCircle,
   getNomineeFromAddress,
+  updateNominee,
 } from '../../../../api-lib/nominees';
 import { verifyHasuraRequestMiddleware } from '../../../../api-lib/validate';
 import {
@@ -52,26 +53,40 @@ async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   // check if user exists in nominee table same circle and not ended
-  const checkAddressExists = await getNomineeFromAddress(address, circle_id);
-  if (checkAddressExists) {
-    return errorResponseWithStatusCode(
-      res,
-      { message: 'User with address already exists as a nominee' },
-      422
-    );
+  const existingNominee = await getNomineeFromAddress(address, circle_id);
+
+  if (!existingNominee) {
+    // add an event trigger to check if vouches are enough and insert an user/profile
+    const nominee = await insertNominee({
+      nominated_by_user_id,
+      circle_id,
+      address,
+      name,
+      description,
+      nomination_days_limit,
+      vouches_required,
+    });
+
+    return res.status(200).json(nominee);
   }
 
-  // add an event trigger to check if vouches are enough and insert an uesr/profile
-  const nominee = await insertNominee({
-    nominated_by_user_id,
-    circle_id,
-    address,
-    name,
-    description,
-    nomination_days_limit,
-    vouches_required,
-  });
-  return res.status(200).json(nominee);
+  const isPastNominee = new Date(existingNominee.expiry_date) < new Date();
+
+  if (isPastNominee) {
+    const updatedNominee = await updateNominee({
+      circle_id,
+      address,
+      nomination_days_limit,
+    });
+
+    return res.status(200).json(updatedNominee);
+  }
+
+  return errorResponseWithStatusCode(
+    res,
+    { message: 'User with address already exists as a nominee' },
+    422
+  );
 }
 
 export default verifyHasuraRequestMiddleware(handler);


### PR DESCRIPTION
## Motivation and Context

<!-- Why is this change required? What problem does it solve? This can be omitted if a linked issue is provided
-->

If nomination period ended, it is not possible to re-add a nominee.

## Description

<!-- Describe your changes -->

Update the expiry-date with a new value if the an expired nominee is re-nominated

## Related Issue

https://github.com/coordinape/coordinape/issues/789
<!-- Please link to the issue here -->
