### PR TITLE
Claims page UI Improvements (tooltip and rename)

### DIFF
--- a/src/pages/ClaimsPage/ClaimsPage.tsx
+++ b/src/pages/ClaimsPage/ClaimsPage.tsx
@@ -1,10 +1,16 @@
-import { LoadingModal, makeTable } from 'components';
+import { ApeInfoTooltip, LoadingModal, makeTable } from 'components';
+import { DISTRIBUTION_TYPE } from 'config/constants';
 import { Avatar, Box, Panel, Flex, Text, Button } from 'ui';
 import { SingleColumnLayout } from 'ui/layouts';
 import { makeExplorerUrl } from 'utils/provider';
 
 import { useClaimsTableData, ClaimsRowData } from './hooks';
-import { formatEpochDates, formatClaimAmount } from './utils';
+import { QueryClaim } from './queries';
+import {
+  formatDistributionDates,
+  formatClaimAmount,
+  formatAmount,
+} from './utils';
 
 const styles = {
   th: { whiteSpace: 'nowrap', textAlign: 'left' },
@@ -17,6 +23,30 @@ const buttonStyles = {
   px: '$sm',
   minWidth: '11vw',
   borderRadius: '$2',
+};
+
+const displayDistributionType = (
+  type: QueryClaim['distribution']['distribution_type']
+): string => {
+  if (type == DISTRIBUTION_TYPE['GIFT']) {
+    return 'Gift Circle';
+  } else if (type == DISTRIBUTION_TYPE['FIXED']) {
+    return 'Fixed Payment';
+  } else if (type == DISTRIBUTION_TYPE['COMBINED']) {
+    return 'Gift Circle + Fixed Payment';
+  } else {
+    return 'Unknown';
+  }
+};
+const groupTooltipInfo = (group: QueryClaim[]) => {
+  const detailsList = group.map(claim => (
+    <Flex key={claim.id}>
+      Epoch {claim.distribution.epoch.number} -{' '}
+      {displayDistributionType(claim.distribution.distribution_type)}:{' '}
+      {formatAmount(claim.new_amount)}
+    </Flex>
+  ));
+  return <Box>{detailsList}</Box>;
 };
 
 const ClaimsRow: React.FC<ClaimsRowData> = ({ claim, group, children }) => {
@@ -42,7 +72,10 @@ const ClaimsRow: React.FC<ClaimsRowData> = ({ claim, group, children }) => {
         </Flex>
       </td>
       <td>
-        <Text>{formatEpochDates(group)}</Text>
+        <Text>
+          <ApeInfoTooltip>{groupTooltipInfo(group)}</ApeInfoTooltip>
+          <Text>{formatDistributionDates(group)}</Text>
+        </Text>
       </td>
       <td>
         <Flex css={{ justifyContent: 'flex-end' }}>
@@ -106,7 +139,7 @@ export default function ClaimsPage() {
           headers={[
             { title: 'Organization', css: styles.th },
             { title: 'Circle', css: styles.th },
-            { title: 'Epochs', css: styles.th },
+            { title: 'Distributions', css: styles.th },
             { title: 'Rewards', css: styles.thLast },
           ]}
           data={unclaimedClaimsRows}

--- a/src/pages/ClaimsPage/queries.ts
+++ b/src/pages/ClaimsPage/queries.ts
@@ -32,6 +32,7 @@ export const getClaims = async (
             distribution_json: [{}, true],
             merkle_root: true,
             tx_hash: true,
+            distribution_type: true,
             vault: {
               id: true,
               chain_id: true,

--- a/src/pages/ClaimsPage/useClaimAllocation.test.tsx
+++ b/src/pages/ClaimsPage/useClaimAllocation.test.tsx
@@ -147,6 +147,7 @@ test('claim single successfully', async () => {
           distribution: {
             id: 1,
             distribution_json: {},
+            distribution_type: 1,
             distribution_epoch_id: event?.args?.epochId,
             epoch: {
               id: 1,

--- a/src/pages/ClaimsPage/utils.ts
+++ b/src/pages/ClaimsPage/utils.ts
@@ -6,7 +6,7 @@ import { QueryClaim } from './queries';
 
 // Takes a group of claims, and generates a Epoch Date representation showing
 // the date range and number of epochs in group.
-export function formatEpochDates(claims: QueryClaim[]) {
+export function formatDistributionDates(claims: QueryClaim[]) {
   claims = sortBy(claims, c =>
     new Date(c.distribution.epoch.start_date).getTime()
   );
@@ -15,7 +15,7 @@ export function formatEpochDates(claims: QueryClaim[]) {
   const endDate = new Date(
     claims[claims.length - 1].distribution.epoch.end_date
   );
-  const epochsPlural = claims.length > 1 ? 'Epochs:' : 'Epoch:';
+  const epochsPlural = claims.length > 1 ? 'Distributions:' : 'Distribution:';
 
   const monthName = (_date: Date) =>
     _date.toLocaleString('default', { month: 'long' });
@@ -33,9 +33,11 @@ export function formatClaimAmount(claims: QueryClaim[]): string {
   const totalAmount = claims.reduce((accumulator, curr) => {
     return accumulator + (curr.unwrappedNewAmount || 0);
   }, 0);
-  return `${parseFloat(totalAmount.toString()).toFixed(2)} ${
-    claims[0].distribution.vault.symbol
-  }`;
+  return `${formatAmount(totalAmount)} ${claims[0].distribution.vault.symbol}`;
+}
+
+export function formatAmount(amount: number): string {
+  return parseFloat(amount.toString()).toFixed(2);
 }
 
 const claimsRowKey = ({ distribution: { vault, epoch }, txHash }: QueryClaim) =>

--- a/src/pages/ClaimsPage/utils.ts
+++ b/src/pages/ClaimsPage/utils.ts
@@ -4,8 +4,11 @@ import sortBy from 'lodash/sortBy';
 
 import { QueryClaim } from './queries';
 
-// Takes a group of claims, and generates a Epoch Date representation showing
-// the date range and number of epochs in group.
+/**
+ * Generates a text representation showing the date range and number of
+ * distributions in the claims group.
+ * @param claims - a group of claims that can be claimed togoether in one tx.
+ */
 export function formatDistributionDates(claims: QueryClaim[]) {
   claims = sortBy(claims, c =>
     new Date(c.distribution.epoch.start_date).getTime()
@@ -27,8 +30,11 @@ export function formatDistributionDates(claims: QueryClaim[]) {
   )} ${endDate.getDate()} ${endDate.getFullYear()}`;
 }
 
-// Takes a group of claims and reduces to a summed value for that group for
-// display
+/**
+ * Takes a group of claims and reduces to a summed value for that group for
+ * display
+ * @param claims - a group of claims.
+ */
 export function formatClaimAmount(claims: QueryClaim[]): string {
   const totalAmount = claims.reduce((accumulator, curr) => {
     return accumulator + (curr.unwrappedNewAmount || 0);
@@ -43,14 +49,17 @@ export function formatAmount(amount: number): string {
 const claimsRowKey = ({ distribution: { vault, epoch }, txHash }: QueryClaim) =>
   `${vault.vault_address}-${epoch.circle?.id}-${txHash || ''}`;
 
-// reduceClaims: reduce all claims into one row per group of {vault, circle,
-// txHash}, for representing a group of claims into one row per set
-// of batch claimable claims. If you can claim them all together, display
-// them all together. If they were claimed in same tx, display them as one row
-// with link to the claim on etherscan)
-//
-// note that the "representative claim" for its set is determined by the order
-// of the input, so the input must be sorted if you want sorted output.
+/**
+ * reduceClaims: reduce all claims into one row per group of {vault, circle,
+ * txHash}, for representing a group of claims into one row per set
+ * of batch claimable claims. If you can claim them all together, display
+ * them all together. If they were claimed in same tx, display them as one row
+ * with link to the claim on etherscan)
+ *
+ * note that the "representative claim" for its set is determined by the order
+ * of the input, so the input must be sorted if you want sorted output.
+ * @param claims - a array of claims.
+ */
 const reduceClaims = (claims: QueryClaim[]) =>
   claims.reduce(
     (finalClaims, curr) =>


### PR DESCRIPTION
# Claims Page UI Improvements

- Add tooltips with details of underlying distributions grouped into a claim
screenshots:

<img width="459" alt="Screen Shot 2022-08-10 at 11 31 17 AM" src="https://user-images.githubusercontent.com/83605543/183992221-5db47602-8667-4953-8d64-9043b206f598.png">
<img width="509" alt="Screen Shot 2022-08-10 at 11 31 14 AM" src="https://user-images.githubusercontent.com/83605543/183992309-b789f364-7e93-4a34-b72b-c52bb8992ace.png">

- Rename "Epochs" to "Distributions" in the table.
<img width="386" alt="Screen Shot 2022-08-10 at 11 45 36 AM" src="https://user-images.githubusercontent.com/83605543/183992570-c3962126-b650-44c8-ae41-8cf416511cd8.png">

