### PR TITLE
bugfix: input double padding removal on DeprecatedApeTextField

### DIFF
--- a/src/components/DeprecatedApeTextField/DeprecatedApeTextField.tsx
+++ b/src/components/DeprecatedApeTextField/DeprecatedApeTextField.tsx
@@ -180,11 +180,7 @@ const makeComponent =
         </Flex>
 
         {subtitle && <label className={classes.subLabel}>{subtitle}</label>}
-        <InputBase
-          className={classes.input}
-          {...(withRef ? { ref } : {})}
-          {...mergedInputProps}
-        />
+        <InputBase {...(withRef ? { ref } : {})} {...mergedInputProps} />
         <div className={classes.helperBox}>
           {helperText && (
             <span


### PR DESCRIPTION
![input-button-padding-bugfix](https://user-images.githubusercontent.com/100873710/184001766-8471d0e2-e18d-4574-8ae5-3bc88869719c.png)

* DeprecatedApeTextField: remove input class that is causing padding doubling `className={classes.input}`