### PR TITLE
Fix FormTokenField Decimal Handling

### DIFF
--- a/cypress/e2e/createVault.cy.ts
+++ b/cypress/e2e/createVault.cy.ts
@@ -36,7 +36,7 @@ context('Coordinape', () => {
 
     // Deposit USDC into the vault
     cy.contains('Deposit').click();
-    cy.get('input[type=number]', { timeout: 90000 })
+    cy.get('input[type=text]', { timeout: 90000 })
       .click()
       .wait(1000)
       .type('5000');
@@ -51,7 +51,7 @@ context('Coordinape', () => {
 
     // Withdraw USDC from the Vault
     cy.contains('Withdraw').click();
-    cy.get('input[type=number]', { timeout: 120000 })
+    cy.get('input[type=text]', { timeout: 120000 })
       .click()
       .wait(1000)
       .type('100');
@@ -66,7 +66,7 @@ context('Coordinape', () => {
     // submit distribution onchain
     cy.visit(`/circles/${circleId}/history`);
     cy.contains('a', 'Review / Export', { timeout: 120000 }).click();
-    cy.get('input[type=number]:first', { timeout: 90000 }).click().type('4500');
+    cy.get('input[type=text]:last', { timeout: 90000 }).click().type('4500');
     cy.contains('button', 'Submit USDC Vault Distribution').click();
     cy.contains('Submitting', { timeout: 120000 });
     cy.contains('Please sign the transaction', { timeout: 120000 });

--- a/src/components/FormTokenField/FormTokenField.test.tsx
+++ b/src/components/FormTokenField/FormTokenField.test.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+
+import { render, screen, act, fireEvent } from '@testing-library/react';
+
+import { TestWrapper } from 'utils/testing';
+
+import { FormTokenField } from './FormTokenField';
+
+const handleChange = jest.fn();
+const mockProps = {
+  value: '2500',
+  symbol: 'MOCK',
+  decimals: 18,
+  max: '3700',
+  onChange: handleChange,
+  helperText: 'derp',
+};
+
+const MockTokenPage = () => {
+  const [value, setValue] = useState('');
+  return (
+    <TestWrapper>
+      <FormTokenField {...mockProps} value={value} onChange={setValue} />
+    </TestWrapper>
+  );
+};
+
+test('can render a valid token amount', () => {
+  act(() => {
+    render(<MockTokenPage />);
+  });
+  const input: HTMLInputElement = screen.getByTestId('FormTokenField');
+  fireEvent.change(input, { target: { value: '1.12' } });
+  expect(input.value).toBe('1.12');
+  fireEvent.change(input, { target: { value: '1' } });
+  expect(input.value).toBe('1');
+  fireEvent.change(input, { target: { value: '.12' } });
+  expect(input.value).toBe('.12');
+});
+test('can remove invalid characters', () => {
+  act(() => {
+    render(<MockTokenPage />);
+  });
+  const input: HTMLInputElement = screen.getByTestId('FormTokenField');
+  fireEvent.change(input, { target: { value: '1.12adfa' } });
+  expect(input.value).toBe('1.12');
+});
+test('can truncate excess decimals', () => {
+  act(() => {
+    render(<MockTokenPage />);
+  });
+  const input: HTMLInputElement = screen.getByTestId('FormTokenField');
+  fireEvent.change(input, { target: { value: '1.12345678901234567890' } });
+  expect(input.value).toBe('1.123456789012345678');
+});

--- a/src/components/FormTokenField/FormTokenField.tsx
+++ b/src/components/FormTokenField/FormTokenField.tsx
@@ -47,14 +47,16 @@ export const FormTokenField = React.forwardRef((props: Props, ref) => {
   } = props;
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    // only accept floating point inputs
+    const matches = e.target.value.match(/\d*\.?\d*/);
+    if (matches == null) {
+      onChange('');
+      return;
+    }
+    const nextValue = matches[0];
     try {
-      //console.info({ value, newvalue: e.target.value, decimals });
-      if (e.target.value === '') {
-        onChange('');
-        return;
-      }
-      parseUnits(e.target.value, decimals);
-      onChange(e.target.value);
+      parseUnits(nextValue, decimals);
+      onChange(nextValue);
     } catch (err: any) {
       // swallow the underflow error and just render the value with
       // a valid quantity of decimals
@@ -66,11 +68,11 @@ export const FormTokenField = React.forwardRef((props: Props, ref) => {
         err.code === 'NUMERIC_FAULT' &&
         err.fault === 'underflow'
       ) {
-        const [whole = '0', frac = '0'] = e.target.value.split('.');
+        const [whole = '0', frac = '0'] = nextValue.split('.');
         onChange(whole + '.' + frac.substring(0, decimals));
         return;
       } else {
-        onChange(e.target.value);
+        onChange(nextValue);
         throw err;
       }
     }
@@ -92,11 +94,12 @@ export const FormTokenField = React.forwardRef((props: Props, ref) => {
         endAdornment: symbol.toUpperCase(),
       }}
       apeVariant="token"
+      inputProps={{ 'data-testid': 'FormTokenField' }}
       error={error}
       helperText={!errorText ? helperText : errorText}
       value={value}
       onChange={handleChange}
-      type="number"
+      type="text"
       placeholder="0"
       onFocus={event => (event.currentTarget as HTMLInputElement).select()}
     />

--- a/src/pages/DistributionsPage/DistributionForm.tsx
+++ b/src/pages/DistributionsPage/DistributionForm.tsx
@@ -121,7 +121,7 @@ export function DistributionForm({
     if (circleDist) {
       updateBalanceState(
         circleDist.vault.symbol,
-        circleDist.gift_amount,
+        circleDist.gift_amount.toString(),
         'gift'
       );
     } else if (vaults[0] && !giftVaultSymbol) {
@@ -421,7 +421,7 @@ export function DistributionForm({
                   distribution: circleDist,
                   symbol: giftVaultSymbol,
                 })}
-                type="number"
+                type="text"
                 placeholder="0"
                 error={!!amountFieldState.error}
                 value={
@@ -561,7 +561,7 @@ export function DistributionForm({
                       distribution: fixedDist,
                       symbol: fpTokenSymbol,
                     })}
-                    type="number"
+                    type="text"
                     placeholder="0"
                     error={!!fixedAmountFieldState.error}
                     value={

--- a/src/pages/DistributionsPage/DistributionForm.tsx
+++ b/src/pages/DistributionsPage/DistributionForm.tsx
@@ -86,7 +86,7 @@ export function DistributionForm({
   const fixedPaymentTokenType = circle.fixed_payment_token_type;
   const totalFixedPayment = circleUsers
     .map(g => g.fixed_payment_amount ?? 0)
-    .reduce((total, tokens) => tokens + total)
+    .reduce((total, tokens) => tokens + total, 0)
     .toString();
   const fpTokenSymbol = fixedPaymentTokenType
     ? vaults.find(
@@ -305,7 +305,7 @@ export function DistributionForm({
     amount: string,
     type: string
   ): string => {
-    if (amount === '0') return `Please input a token amount`;
+    if (Number.parseFloat(amount) === 0) return `Please input a token amount`;
     if (!sufficientTokens) return 'Insufficient Tokens';
     if (
       (giftSubmitting && type === 'gift') ||
@@ -426,7 +426,7 @@ export function DistributionForm({
                 error={!!amountFieldState.error}
                 value={
                   circleDist
-                    ? circleDist.gift_amount.toString()
+                    ? circleDist.gift_amount?.toString() || '0'
                     : amountField.value.toString()
                 }
                 disabled={giftSubmitting || !!circleDist || vaults.length === 0}

--- a/src/pages/DistributionsPage/DistributionForm.tsx
+++ b/src/pages/DistributionsPage/DistributionForm.tsx
@@ -3,7 +3,8 @@ import React, { useEffect, useState } from 'react';
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { formatRelative, parseISO } from 'date-fns';
-import { BigNumber } from 'ethers';
+import { BigNumber, constants as ethersConstants } from 'ethers';
+import { parseUnits, formatUnits } from 'ethers/lib/utils';
 import { getWrappedAmount } from 'lib/vaults';
 import { useForm, SubmitHandler, useController } from 'react-hook-form';
 import { z } from 'zod';
@@ -28,7 +29,7 @@ const headerStyle = {
 };
 
 const DistributionFormSchema = z.object({
-  amount: z.number().gte(0),
+  amount: z.string(),
   selectedVaultSymbol: z.string(),
 });
 
@@ -37,12 +38,12 @@ type TDistributionForm = z.infer<typeof DistributionFormSchema>;
 type SubmitFormProps = {
   epoch: EpochDataResult;
   users: (Gift['recipient'] & { received: number })[];
-  setAmount: (amount: number) => void;
+  setAmount: (amount: string) => void;
   setGiftVaultSymbol: (giftVaultSymbol: string) => void;
   vaults: { id: number; symbol: string }[];
   circleUsers: IUser[];
   giftVaultSymbol: string;
-  formGiftAmount: number;
+  formGiftAmount: string;
   refetch: () => void;
   circleDist: EpochDataResult['distributions'][0] | undefined;
   fixedDist: EpochDataResult['distributions'][0] | undefined;
@@ -72,8 +73,10 @@ export function DistributionForm({
   const [sufficientFixedPaymentTokens, setSufficientFixPaymentTokens] =
     useState(false);
   const [sufficientGiftTokens, setSufficientGiftTokens] = useState(false);
-  const [maxGiftTokens, setMaxGiftTokens] = useState(0);
-  const [maxFixedPaymentTokens, setMaxFixedPaymentTokens] = useState(0);
+  const [maxGiftTokens, setMaxGiftTokens] = useState(ethersConstants.Zero);
+  const [maxFixedPaymentTokens, setMaxFixedPaymentTokens] = useState(
+    ethersConstants.Zero
+  );
 
   const { showError } = useApeSnackbar();
   const submitDistribution = useSubmitDistribution();
@@ -83,7 +86,8 @@ export function DistributionForm({
   const fixedPaymentTokenType = circle.fixed_payment_token_type;
   const totalFixedPayment = circleUsers
     .map(g => g.fixed_payment_amount ?? 0)
-    .reduce((total, tokens) => tokens + total);
+    .reduce((total, tokens) => tokens + total)
+    .toString();
   const fpTokenSymbol = fixedPaymentTokenType
     ? vaults.find(
         v => v.symbol.toLowerCase() === fixedPaymentTokenType.toLowerCase()
@@ -103,14 +107,14 @@ export function DistributionForm({
   const { field: amountField, fieldState: amountFieldState } = useController({
     name: 'amount',
     control,
-    defaultValue: 0,
+    defaultValue: '0',
   });
 
   const { field: fixedAmountField, fieldState: fixedAmountFieldState } =
     useController({
       name: 'amount',
       control,
-      defaultValue: 0,
+      defaultValue: '0',
     });
 
   useEffect(() => {
@@ -162,12 +166,14 @@ export function DistributionForm({
       {} as Record<string, BigNumber>
     );
     const type =
-      isCombinedDistribution() && !circleDist && formGiftAmount > 0
+      isCombinedDistribution() &&
+      !circleDist &&
+      BigNumber.from(formGiftAmount).gt(0)
         ? DISTRIBUTION_TYPE.COMBINED
         : DISTRIBUTION_TYPE.FIXED;
     const gifts = {} as Record<string, number>;
     if (type === DISTRIBUTION_TYPE.COMBINED) {
-      users.map(user => {
+      users.forEach(user => {
         if (!(user.address in gifts)) gifts[user.address] = 0;
         gifts[user.address] += user.received;
       });
@@ -181,8 +187,13 @@ export function DistributionForm({
       const result = await submitDistribution({
         amount:
           type === DISTRIBUTION_TYPE.COMBINED
-            ? String(totalFixedPayment + formGiftAmount)
-            : String(totalFixedPayment),
+            ? formatUnits(
+                parseUnits(totalFixedPayment, vault.decimals).add(
+                  parseUnits(formGiftAmount, vault.decimals)
+                ),
+                vault.decimals
+              )
+            : totalFixedPayment,
         vault,
         gifts,
         fixedGifts,
@@ -291,10 +302,10 @@ export function DistributionForm({
   const getButtonText = (
     sufficientTokens: boolean,
     symbol: string,
-    amount: number,
+    amount: string,
     type: string
   ): string => {
-    if (amount === 0) return `Please input a token amount`;
+    if (amount === '0') return `Please input a token amount`;
     if (!sufficientTokens) return 'Insufficient Tokens';
     if (
       (giftSubmitting && type === 'gift') ||
@@ -314,40 +325,43 @@ export function DistributionForm({
 
   const updateBalanceState = async (
     symbol: string,
-    amountSet: number,
+    amountSet: string,
     formType: string
   ): Promise<void> => {
     assert(circle);
     const vault = findVault({ symbol });
+    assert(vault);
+    const amountSetBN = parseUnits(amountSet || '0', vault.decimals);
     assert(contracts, 'This network is not supported');
-    const tokenBalance = vault
-      ? (await contracts.getVaultBalance(vault))
-          .div(BigNumber.from(10).pow(vault.decimals))
-          .toNumber()
-      : 0;
+    const tokenBalance = await contracts.getVaultBalance(vault);
     const isCombinedDist =
       // check if the two symbols are the same
       ((formType === 'gift' && fpTokenSymbol === symbol) ||
         (formType === 'fixed' && giftVaultSymbol === symbol)) &&
       // check if a non combined distribution is selected
       ((!fixedDist && !circleDist) || (circleDist && fixedDist));
-    const totalAmt = isCombinedDist ? amountSet + totalFixedPayment : amountSet;
+    const totalAmt: BigNumber = isCombinedDist
+      ? amountSetBN.add(parseUnits(totalFixedPayment, vault.decimals))
+      : amountSetBN;
 
     if (isCombinedDist) {
       setMaxGiftTokens(tokenBalance);
       setMaxFixedPaymentTokens(tokenBalance);
-      setSufficientFixPaymentTokens(tokenBalance >= totalAmt && totalAmt > 0);
+      setSufficientFixPaymentTokens(
+        totalAmt.lte(tokenBalance) && totalAmt.gt(0)
+      );
     } else if (formType === 'gift') {
-      setSufficientGiftTokens(tokenBalance >= totalAmt && totalAmt > 0);
+      setSufficientGiftTokens(tokenBalance.gte(totalAmt) && totalAmt.gt(0));
       setMaxGiftTokens(tokenBalance);
       // if switching from combined dist selection to non combined
       // we need to recheck if the fixed payment have sufficient tokens
       if (fpTokenSymbol === giftVaultSymbol)
         setSufficientFixPaymentTokens(
-          maxFixedPaymentTokens >= totalFixedPayment && totalFixedPayment > 0
+          maxFixedPaymentTokens.gte(totalFixedPayment) &&
+            ethersConstants.Zero.lt(totalFixedPayment)
         );
     } else {
-      setSufficientFixPaymentTokens(tokenBalance >= totalAmt && totalAmt > 0);
+      setSufficientFixPaymentTokens(tokenBalance >= totalAmt && totalAmt.gt(0));
       setMaxFixedPaymentTokens(tokenBalance);
     }
   };
@@ -410,9 +424,19 @@ export function DistributionForm({
                 type="number"
                 placeholder="0"
                 error={!!amountFieldState.error}
-                value={circleDist ? circleDist.gift_amount : amountField.value}
+                value={
+                  circleDist
+                    ? circleDist.gift_amount.toString()
+                    : amountField.value.toString()
+                }
                 disabled={giftSubmitting || !!circleDist || vaults.length === 0}
-                max={Number(maxGiftTokens)}
+                max={formatUnits(
+                  maxGiftTokens,
+                  getDecimals({
+                    distribution: circleDist,
+                    symbol: giftVaultSymbol,
+                  })
+                )}
                 prelabel="Budget Amount"
                 infoTooltip={
                   <>
@@ -421,7 +445,13 @@ export function DistributionForm({
                   </>
                 }
                 label={`Avail. ${numberWithCommas(
-                  maxGiftTokens
+                  formatUnits(
+                    maxGiftTokens,
+                    getDecimals({
+                      distribution: circleDist,
+                      symbol: giftVaultSymbol,
+                    })
+                  )
                 )} ${giftVaultSymbol}`}
                 onChange={value => {
                   amountField.onChange(value);
@@ -441,7 +471,8 @@ export function DistributionForm({
                 return (
                   <Text css={{ fontSize: '$small' }}>
                     Combined Distribution. Total{' '}
-                    {totalFixedPayment + formGiftAmount} {fpTokenSymbol}
+                    {renderCombinedSum(formGiftAmount, totalFixedPayment)}{' '}
+                    {fpTokenSymbol}
                   </Text>
                 );
               } else {
@@ -534,10 +565,15 @@ export function DistributionForm({
                     placeholder="0"
                     error={!!fixedAmountFieldState.error}
                     value={
-                      fixedDist ? fixedDist.fixed_amount : totalFixedPayment
+                      fixedDist
+                        ? fixedDist.fixed_amount.toString()
+                        : totalFixedPayment
                     }
                     disabled={true}
-                    max={Number(maxFixedPaymentTokens)}
+                    max={formatUnits(
+                      maxFixedPaymentTokens,
+                      fixedDist?.vault.decimals
+                    )}
                     prelabel={'Budget Amount'}
                     infoTooltip={
                       <>
@@ -545,9 +581,15 @@ export function DistributionForm({
                         fixed payment.
                       </>
                     }
-                    label={`Avail. ${numberWithCommas(maxFixedPaymentTokens)} ${
-                      fpTokenSymbol || ''
-                    }`}
+                    label={`Avail. ${numberWithCommas(
+                      formatUnits(
+                        maxFixedPaymentTokens,
+                        getDecimals({
+                          distribution: circleDist,
+                          symbol: giftVaultSymbol,
+                        })
+                      )
+                    )} ${fpTokenSymbol || ''}`}
                     onChange={() => {}}
                     apeSize="small"
                   />
@@ -575,7 +617,7 @@ export function DistributionForm({
                       sufficientFixedPaymentTokens,
                       fpTokenSymbol,
                       isCombinedDistribution()
-                        ? totalFixedPayment + formGiftAmount
+                        ? renderCombinedSum(formGiftAmount, totalFixedPayment)
                         : totalFixedPayment,
                       'fixed'
                     )}
@@ -615,6 +657,9 @@ const Summary = ({
     </Flex>
   );
 };
+
+const renderCombinedSum = (giftAmt: string, fixedAmt: string) =>
+  formatUnits(parseUnits(giftAmt).add(parseUnits(fixedAmt)));
 
 const EtherscanButton = ({
   distribution,

--- a/src/pages/DistributionsPage/DistributionsPage.test.tsx
+++ b/src/pages/DistributionsPage/DistributionsPage.test.tsx
@@ -98,6 +98,8 @@ test('render with a distribution', async () => {
         {
           created_at: '2022-04-27T00:28:03.27622',
           total_amount: '10000000',
+          gift_amount: 500,
+          fixed_amount: 5000,
           pricePerShare: FixedNumber.from('1.08'),
           distribution_type: 1,
           vault: {

--- a/src/pages/DistributionsPage/DistributionsPage.tsx
+++ b/src/pages/DistributionsPage/DistributionsPage.tsx
@@ -40,7 +40,7 @@ export function DistributionsPage() {
     { enabled: !!(contracts && address), retry: false }
   );
 
-  const [formGiftAmount, setFormGiftAmount] = useState<number>(0);
+  const [formGiftAmount, setFormGiftAmount] = useState<string>('0');
   const [giftVaultSymbol, setGiftVaultSymbol] = useState<string>('');
   const { users: circleUsers, circleId } = useSelectedCircle();
   const { downloadCSV } = useApiAdminCircle(circleId);
@@ -215,7 +215,7 @@ export function DistributionsPage() {
             users={usersWithGiftnFixedAmounts}
             tokenName={tokenName}
             totalGive={totalGive}
-            formGiftAmount={formGiftAmount}
+            formGiftAmount={Number(formGiftAmount)}
             fixedTokenName={
               fixedDist
                 ? fixedDist.vault.symbol

--- a/src/pages/VaultsPage/DepositModal.tsx
+++ b/src/pages/VaultsPage/DepositModal.tsx
@@ -11,7 +11,7 @@ import { useForm, useController } from 'react-hook-form';
 import * as z from 'zod';
 
 import { ReactComponent as WalletConnectSVG } from 'assets/svgs/wallet/wallet-connect.svg';
-import { FormTokenField } from 'components';
+import { FormTokenField, zTokenString } from 'components';
 import type { Vault } from 'hooks/gql/useVaults';
 import useConnectedAddress from 'hooks/useConnectedAddress';
 import { useContracts } from 'hooks/useContracts';
@@ -72,7 +72,9 @@ export default function DepositModal({
     })();
   }, [selectedContracts, isSecondaryAccountActive]);
 
-  const schema = z.object({ amount: z.number().min(0).max(max) }).strict();
+  const schema = z
+    .object({ amount: zTokenString('0', max, vault.decimals) })
+    .strict();
   type DepositFormSchema = z.infer<typeof schema>;
   const {
     handleSubmit,
@@ -85,7 +87,7 @@ export default function DepositModal({
   const { field: amountField } = useController({
     name: 'amount',
     control,
-    defaultValue: 0,
+    defaultValue: '',
   });
 
   const { deposit } = useVaultRouter(selectedContracts);

--- a/src/pages/VaultsPage/WithdrawModal.tsx
+++ b/src/pages/VaultsPage/WithdrawModal.tsx
@@ -5,7 +5,7 @@ import round from 'lodash/round';
 import { useForm, useController } from 'react-hook-form';
 import * as z from 'zod';
 
-import { FormTokenField } from 'components';
+import { FormTokenField, zTokenString } from 'components';
 import type { Vault } from 'hooks/gql/useVaults';
 import { useContracts } from 'hooks/useContracts';
 import { useVaultRouter } from 'hooks/useVaultRouter';
@@ -25,7 +25,7 @@ export default function WithdrawModal({
   balance,
 }: WithdrawModalProps) {
   const schema = z
-    .object({ amount: z.number().positive().max(balance) })
+    .object({ amount: zTokenString('0', balance.toString(), vault.decimals) })
     .strict();
   type WithdrawFormSchema = z.infer<typeof schema>;
   const contracts = useContracts();
@@ -41,7 +41,7 @@ export default function WithdrawModal({
   const { field: amountField } = useController({
     name: 'amount',
     control,
-    defaultValue: 0,
+    defaultValue: '',
   });
   const { withdraw } = useVaultRouter(contracts);
 
@@ -71,7 +71,7 @@ export default function WithdrawModal({
         onSubmit={handleSubmit(onSubmit)}
       >
         <FormTokenField
-          max={balance}
+          max={balance.toString()}
           symbol={vault.symbol}
           decimals={vault.decimals}
           label={`Available to Withdraw: ${numberWithCommas(

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -1,5 +1,8 @@
 import { numberWithCommas } from './';
 
 test('numberWithCommas', () => {
-  expect(numberWithCommas('12345678.90123456')).toEqual('12,345,678.90123456');
+  expect(numberWithCommas('12345678.901222221')).toEqual('12,345,678.901222');
+  expect(numberWithCommas('12345678.9012345678')).toEqual('12,345,678.901235');
+  expect(numberWithCommas('12345678.901222221', 4)).toEqual('12,345,678.9012');
+  expect(numberWithCommas('12345678.901292221', 4)).toEqual('12,345,678.9013');
 });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,6 +9,6 @@ export const numberWithCommas = (x: number | string | undefined) => {
   const [beforeDot, afterDot] = x.toString().split('.');
   return (
     beforeDot.replace(/\B(?=(\d{3})+(?!\d))/g, ',') +
-    (afterDot ? '.' + afterDot : '')
+    (afterDot ? '.' + afterDot.substring(0, 4) : '')
   );
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,14 +1,27 @@
+import { round } from 'lodash';
 export const shortenAddress = (address: string) => {
   return `${address.substring(0, 6)}...${address.substring(
     address.length - 4
   )}`;
 };
 
-export const numberWithCommas = (x: number | string | undefined) => {
+/**
+ * Also rounds to the nearest `precision` value, defaulting to 6
+ */
+export const numberWithCommas = (
+  x: number | string | undefined,
+  precision = 6
+) => {
   if (!x) return '0';
   const [beforeDot, afterDot] = x.toString().split('.');
   return (
     beforeDot.replace(/\B(?=(\d{3})+(?!\d))/g, ',') +
-    (afterDot ? '.' + afterDot.substring(0, 4) : '')
+    (afterDot
+      ? '.' +
+        (afterDot.length > precision
+          ? round(Number.parseInt(afterDot), -(afterDot.length - precision))
+          : afterDot)
+      : ''
+    ).substring(0, precision + 1)
   );
 };


### PR DESCRIPTION
FormTokenField was handling token decimals incorrectly. This fix makes
it impossible to enter a value with more decimals than a token has
available. The amount will remain at the value with the smallest
possible decimal. If a user pastes in a value with more decimals than is
can be handled, the amount is truncated to the valid decimal quantity.

Additionally, this refactor removes that annoying thing where the field
can't be empty and you need to "type around" a placeholder zero.
Validation treats empty fields correctly in my testing on deposits,
           withdraws and distributions.

This change also led to an upstream refactor to move all calculations
away from Numbers and to BigNumbers in all views that consume
FormTokenField.

Test Plan: unit and E2E tests should pass.

