### PR TITLE
Add Members Page w/ just bulk add member by address

### DIFF
--- a/api/hasura/actions/_handlers/createUsers.ts
+++ b/api/hasura/actions/_handlers/createUsers.ts
@@ -29,10 +29,13 @@ async function handler(req: VercelRequest, res: VercelResponse) {
 
   // Check if bulk contains duplicates.
   if (uniqueAddresses.length < users.length) {
+    const dupes = uniqueAddresses.filter(
+      uq => users.filter(u => u.address.toLowerCase() == uq).length > 1
+    );
     return errorResponseWithStatusCode(
       res,
       {
-        message: `Users list contains duplicate address.`,
+        message: `Users list contains duplicate addresses: ${dupes}`,
       },
       422
     );

--- a/api/hasura/actions/_handlers/createUsers.ts
+++ b/api/hasura/actions/_handlers/createUsers.ts
@@ -16,11 +16,12 @@ const USER_ALIAS_PREFIX = 'update_user_';
 const NOMINEE_ALIAS_PREFIX = 'update_nominee_';
 
 async function handler(req: VercelRequest, res: VercelResponse) {
+  // this has to do parseAsync due to the ENS validation
   const {
     input: { payload: input },
-  } = composeHasuraActionRequestBody(createUsersBulkSchemaInput).parse(
-    req.body
-  );
+  } = await composeHasuraActionRequestBody(
+    createUsersBulkSchemaInput
+  ).parseAsync(req.body);
 
   const { circle_id, users } = input;
 

--- a/cypress/e2e/createUser.cy.ts
+++ b/cypress/e2e/createUser.cy.ts
@@ -13,27 +13,35 @@ context('Coordinape', () => {
     });
   });
 
+  after(() => {
+    // might want something more surgical and lightweight
+    // to facilitate faster idempotent testing
+    // cy.exec('yarn db-seed-fresh');
+  });
   it('can create a new user with fixed payment amount', () => {
     cy.visit(`/circles/${circleId}/members`);
     cy.login();
 
-    cy.contains('Add Contributor', { timeout: 120000 }).should('be.visible');
-    cy.contains('Add Contributor').click();
-    cy.getInputByLabel('Contributor Name').type('A Test User').blur();
-    cy.getInputByLabel('Contributor ETH address')
-      .type('0xe00b84525b71ef52014e59f633c97530cb278e09')
-      .blur();
-    // enter the fixed payment amount
-    cy.getInputByLabel('Fixed Payment Amount').clear().type('1200').blur();
+    cy.contains('Add Members', { timeout: 120000 }).should('be.visible');
+    cy.contains('Add Members').click();
 
-    cy.contains('Save').click();
-    cy.reload(true);
+    cy.get('[data-testid=new-members]').within(() => {
+      cy.get('input').eq(0).click().type('A Test User').blur();
+      cy.get('input')
+        .eq(1)
+        .click()
+        .type('0xe00b84525b71ef52014e59f633c97530cb278e09')
+        .blur();
+    });
+
+    cy.get('button')
+      .contains('Add Members', { timeout: 120000 })
+      .should('be.enabled');
+    cy.get('button').contains('Add Members').click();
+    cy.contains('You have added 1 member!', { timeout: 120000 }).should(
+      'be.visible'
+    );
+    cy.get('button').contains('Back').click();
     cy.contains('A Test User', { timeout: 120000 }).should('be.visible');
-    // Verify new value in contributors table
-    cy.contains('A Test User', { timeout: 120000 })
-      .parents('tr')
-      .within(() => {
-        cy.get('td').eq(7).should('have.text', '1200');
-      });
   });
 });

--- a/cypress/e2e/updateUser.cy.ts
+++ b/cypress/e2e/updateUser.cy.ts
@@ -56,7 +56,17 @@ context('Coordinape', () => {
       .click()
       .type(oldAddress);
 
+    // enter the fixed payment amount
+    cy.getInputByLabel('Fixed Payment Amount').clear().type('1200').blur();
+
     cy.contains('Save').click();
+
+    // Verify new value in contributors table
+    cy.contains('Kasey', { timeout: 120000 })
+      .parents('tr')
+      .within(() => {
+        cy.get('td').eq(7).should('have.text', '1200');
+      });
 
     // Assert that the old address is there and correct
     assertAddr(oldAddress);

--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -1,6 +1,11 @@
 // add your own feature names here
 
-export type FeatureName = 'vaults' | 'fixed_payments' | 'future_feature';
+export type FeatureName =
+  | 'vaults'
+  | 'fixed_payments'
+  | 'future_feature'
+  | 'csv_import'
+  | 'link_joining';
 
 // this is a very simple implementation of build-time feature flags that you can
 // hardcode or set with environment variables
@@ -8,6 +13,8 @@ export type FeatureName = 'vaults' | 'fixed_payments' | 'future_feature';
 const staticFeatureFlags: Partial<Record<FeatureName, boolean>> = {
   vaults: !!process.env.REACT_APP_FEATURE_FLAG_VAULTS,
   fixed_payments: !!process.env.REACT_APP_FEATURE_FLAG_FIXED_PAYMENTS,
+  csv_import: false,
+  link_joining: false,
 };
 
 // we make the export a function so that we can implement run-time feature flags

--- a/src/lib/zod/index.ts
+++ b/src/lib/zod/index.ts
@@ -7,6 +7,7 @@ import {
   zEthAddressOnly,
   zStringISODateUTC,
   zBytes32,
+  zEthAddress,
 } from '../../../src/forms/formHelpers';
 
 const PERSONAL_SIGN_REGEX = /0x[0-9a-f]{130}/;
@@ -109,7 +110,7 @@ export const createUserSchemaInput = z
   .object({
     circle_id: z.number(),
     name: z.string().min(3).max(255),
-    address: zEthAddressOnly,
+    address: zEthAddress,
     non_giver: z.boolean().optional(),
     starting_tokens: z.number().optional().default(100),
     fixed_non_receiver: z.boolean().optional(),

--- a/src/pages/AddMembersPage/AddMembersPage.tsx
+++ b/src/pages/AddMembersPage/AddMembersPage.tsx
@@ -1,0 +1,182 @@
+import React, { useState } from 'react';
+
+import { LoadingModal } from '../../components';
+import { isFeatureEnabled } from '../../config/features';
+import { paths } from '../../routes/paths';
+import { ICircle } from '../../types';
+import BackButton from '../../ui/BackButton';
+import { Box } from '../../ui/Box/Box';
+import HintButton from '../../ui/HintButton';
+import { APP_URL } from '../../utils/domain';
+import { useSelectedCircle } from 'recoilState/app';
+import { AppLink, Button, Flex, Panel, Text } from 'ui';
+import { SingleColumnLayout } from 'ui/layouts';
+
+import CopyCodeTextField from './CopyCodeTextField';
+import NewMemberList from './NewMemberList';
+import TabButton, { Tab } from './TabButton';
+import {
+  deleteMagicToken,
+  deleteWelcomeToken,
+  useMagicToken,
+  useWelcomeToken,
+} from './useCircleTokens';
+
+const AddMembersPage = () => {
+  const { circleId, circle } = useSelectedCircle();
+
+  const [loading, setLoading] = useState<boolean>(false);
+
+  const { data: magicLinkUuid, refetch: refetchMagicToken } =
+    useMagicToken(circleId);
+  const { data: welcomeUuid, refetch: refetchWelcomeToken } =
+    useWelcomeToken(circleId);
+
+  // Wait for initial load, show nothing but loading modal
+  if (!magicLinkUuid || !welcomeUuid) {
+    return <LoadingModal visible={true} />;
+  }
+
+  const revokeMagic = async () => {
+    try {
+      setLoading(true);
+      await deleteMagicToken(circleId);
+      await refetchMagicToken();
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const revokeWelcome = async () => {
+    try {
+      setLoading(true);
+      await deleteWelcomeToken(circleId);
+      await refetchWelcomeToken();
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const magicLink = APP_URL + '/join/' + magicLinkUuid;
+  const welcomeLink = APP_URL + '/welcome/' + welcomeUuid;
+
+  return (
+    <>
+      <LoadingModal visible={loading} />
+      <AddMembersContents
+        circle={circle}
+        welcomeLink={welcomeLink}
+        magicLink={magicLink}
+        revokeMagic={revokeMagic}
+        revokeWelcome={revokeWelcome}
+      />
+    </>
+  );
+};
+
+const AddMembersContents = ({
+  circle,
+  welcomeLink,
+  magicLink,
+  revokeMagic,
+  revokeWelcome,
+}: {
+  circle: ICircle;
+  welcomeLink: string;
+  magicLink: string;
+  revokeMagic(): void;
+  revokeWelcome(): void;
+}) => {
+  const [currentTab, setCurrentTab] = useState<Tab>(Tab.ETH);
+
+  return (
+    <SingleColumnLayout>
+      <Box>
+        <AppLink to={paths.members(circle.id)}>
+          <BackButton />
+        </AppLink>
+      </Box>
+
+      <Flex css={{ alignItems: 'center', mb: '$sm' }}>
+        <Text h1>Add Members to {circle.name}</Text>
+      </Flex>
+      <Box css={{ mb: '$md' }}>
+        <Text inline>
+          Note that after adding members you can see and manage them in the
+          <AppLink to={paths.members(circle.id)} css={{ display: 'inline' }}>
+            &nbsp;members table.
+          </AppLink>
+        </Text>
+      </Box>
+      {(isFeatureEnabled('csv_import') || isFeatureEnabled('link_joining')) && (
+        <Flex css={{ mb: '$xl' }}>
+          <TabButton
+            tab={Tab.ETH}
+            currentTab={currentTab}
+            setCurrentTab={setCurrentTab}
+          >
+            Add by ETH Address
+          </TabButton>
+          {isFeatureEnabled('csv_import') && (
+            <TabButton
+              tab={Tab.CSV}
+              currentTab={currentTab}
+              setCurrentTab={setCurrentTab}
+            >
+              CSV Import
+            </TabButton>
+          )}
+          {isFeatureEnabled('link_joining') && (
+            <TabButton
+              tab={Tab.LINK}
+              currentTab={currentTab}
+              setCurrentTab={setCurrentTab}
+            >
+              Join Link
+            </TabButton>
+          )}
+        </Flex>
+      )}
+      <Panel>
+        {currentTab === Tab.ETH && (
+          <Box>
+            <Text css={{ pb: '$lg', pt: '$sm' }} size={'large'}>
+              Add new members by wallet address.
+            </Text>
+
+            <NewMemberList
+              circleId={circle.id}
+              welcomeLink={welcomeLink}
+              revokeWelcome={revokeWelcome}
+            />
+          </Box>
+        )}
+        {currentTab === Tab.CSV && (
+          <Box>
+            <Box>CSV Import</Box>
+          </Box>
+        )}
+        {currentTab === Tab.LINK && (
+          <>
+            <div>
+              MagicLink
+              <CopyCodeTextField value={magicLink} />
+              <Button onClick={revokeMagic}>refr</Button>
+            </div>
+          </>
+        )}
+        <Box css={{ mt: '$md' }}>
+          <HintButton
+            href={
+              'https://docs.coordinape.com/get-started/get-started/new-coordinape-admins/admin-best-practices#ways-to-give'
+            }
+          >
+            Documentation: GIVE Circle Best Practices
+          </HintButton>
+        </Box>
+      </Panel>
+    </SingleColumnLayout>
+  );
+};
+
+export default AddMembersPage;

--- a/src/pages/AddMembersPage/CopyCodeTextField.tsx
+++ b/src/pages/AddMembersPage/CopyCodeTextField.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import copy from 'copy-to-clipboard';
+
+import { useApeSnackbar } from '../../hooks';
+import { Copy } from '../../icons/__generated';
+import { Button, TextField } from '../../ui';
+import { Box } from '../../ui/Box/Box';
+
+const CopyCodeTextField = ({ value }: { value: string }) => {
+  const { showInfo } = useApeSnackbar();
+
+  const copyToClip = () => {
+    copy(value);
+    showInfo('Copied to clipboard');
+  };
+
+  return (
+    <Box css={{ position: 'relative', flexGrow: 1 }}>
+      <TextField
+        inPanel
+        value={value}
+        readOnly={true}
+        onClick={copyToClip}
+        css={{
+          width: '100%',
+          cursor: 'pointer',
+          height: '$xl',
+          fontSize: '$small',
+          textAlign: 'left',
+          pl: '$sm',
+        }}
+      />
+      <Button
+        color={'transparent'}
+        css={{ ml: '$sm', position: 'absolute', top: 0, right: 0 }}
+        onClick={copyToClip}
+      >
+        <Copy color={'neutral'} size={'md'} />
+      </Button>
+    </Box>
+  );
+};
+
+export default CopyCodeTextField;

--- a/src/pages/AddMembersPage/NewMemberEntry.tsx
+++ b/src/pages/AddMembersPage/NewMemberEntry.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+
+import { FieldValues, UseFormRegister } from 'react-hook-form';
+
+import { CloseIcon } from '../../icons/CloseIcon';
+import { Box, Flex, Text, TextField } from '../../ui';
+
+import NewMemberGridBox from './NewMemberGridBox';
+
+const NewMemberEntry = ({
+  onFocus,
+  onRemove,
+  register,
+  index,
+  error,
+}: {
+  onFocus(): void;
+  onRemove?(): void;
+  register: UseFormRegister<FieldValues>;
+  index: number;
+  error?: { name?: string; address?: string };
+}) => {
+  return (
+    <>
+      <NewMemberGridBox>
+        <Box>
+          <TextField
+            placeholder="Name"
+            fullWidth
+            error={error?.name ? true : undefined}
+            autoComplete={'off'}
+            onFocus={() => {
+              onFocus();
+            }}
+            {...register(`newMembers.${index}.name`)}
+          />
+        </Box>
+        <Box css={{ mr: '$xs' }}>
+          <TextField
+            placeholder="ETH Address or ENS"
+            fullWidth
+            error={error?.address ? true : undefined}
+            autoComplete={'off'}
+            onFocus={() => {
+              onFocus();
+            }}
+            {...register(`newMembers.${index}.address`)}
+          />
+        </Box>
+        <Box>
+          {onRemove && (
+            <>
+              <Flex
+                onClick={onRemove}
+                css={{
+                  cursor: 'pointer',
+                  padding: 0,
+                  margin: 0,
+                }}
+              >
+                <CloseIcon color={'neutral'} size={'md'} />
+              </Flex>
+            </>
+          )}
+        </Box>
+      </NewMemberGridBox>
+      <NewMemberGridBox css={{ mb: '$sm' }}>
+        <Box css={{ mt: '$xs' }}>
+          <Text variant={'formError'}>{error?.name && error?.name}</Text>
+        </Box>
+        <Box css={{ mt: '$xs' }}>
+          <Text variant={'formError'}>{error?.address && error?.address}</Text>
+        </Box>
+      </NewMemberGridBox>
+    </>
+  );
+};
+
+export default NewMemberEntry;

--- a/src/pages/AddMembersPage/NewMemberGridBox.tsx
+++ b/src/pages/AddMembersPage/NewMemberGridBox.tsx
@@ -1,0 +1,11 @@
+import { styled } from '../../stitches.config';
+
+const NewMemberGridBox = styled('div', {
+  mb: '$xs',
+  alignItems: 'center',
+  display: 'grid',
+  gap: '$md',
+  gridTemplateColumns: '35fr 60fr 5fr',
+});
+
+export default NewMemberGridBox;

--- a/src/pages/AddMembersPage/NewMemberList.tsx
+++ b/src/pages/AddMembersPage/NewMemberList.tsx
@@ -1,0 +1,269 @@
+import React, { useRef, useState } from 'react';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useFieldArray, useForm } from 'react-hook-form';
+import { useQueryClient } from 'react-query';
+import { z } from 'zod';
+
+import { LoadingModal } from '../../components';
+import { isFeatureEnabled } from '../../config/features';
+import { zEthAddress } from '../../forms/formHelpers';
+import { useApeSnackbar, useApiBase } from '../../hooks';
+import { Check /* Working */ } from '../../icons/__generated';
+import { client } from '../../lib/gql/client';
+import { Box, Button, Flex, Panel, Text } from '../../ui';
+import { normalizeError } from '../../utils/reporting';
+
+import CopyCodeTextField from './CopyCodeTextField';
+import NewMemberEntry from './NewMemberEntry';
+import NewMemberGridBox from './NewMemberGridBox';
+
+const NewMemberList = ({
+  // TODO: figure out what to do w/ revoke
+  // revokeWelcome,
+  circleId,
+  welcomeLink,
+}: {
+  circleId: number;
+  welcomeLink: string;
+  revokeWelcome(): void;
+}) => {
+  const { fetchCircle } = useApiBase();
+  const { showError } = useApeSnackbar();
+
+  const [loading, setLoading] = useState<boolean>();
+  const [successCount, setSuccessCount] = useState<number>(0);
+
+  const successRef = useRef<HTMLDivElement>(null);
+
+  const queryClient = useQueryClient();
+
+  const newMemberSchema = z.object({
+    newMembers: z
+      .array(
+        z
+          .object({
+            address: zEthAddress.or(z.literal('')),
+            name: z
+              .string()
+              .min(3, 'Name must be at least 3 characters')
+              .or(z.literal('')),
+          })
+          .superRefine((data, ctx) => {
+            if (data.name && data.name !== '' && data.address === '') {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ['address'],
+                message: 'Address is required if name is provided',
+              });
+            }
+            if (data.address && data.address !== '' && data.name === '') {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ['name'],
+                message: 'Name is required if address is provided',
+              });
+            }
+          })
+      )
+      .superRefine(data => {
+        if (data.filter(m => m.address != '' && m.name != '').length == 0) {
+          //TODO: I want to use this to prevent form submission of there are no valid entries
+          // but it just breaks the more useful errors from rendering
+          // ctx.addIssue({
+          //   code: z.ZodIssueCode.custom,
+          //   message: 'no valid members entered',
+          // });
+        }
+      }),
+  });
+
+  const defaultValues = {
+    newMembers: [
+      { name: '', address: '' },
+      { name: '', address: '' },
+    ],
+  };
+
+  const { register, control, handleSubmit, reset, formState, getValues } =
+    useForm({
+      resolver: zodResolver(newMemberSchema),
+      reValidateMode: 'onChange',
+      mode: 'onChange',
+      defaultValues,
+    });
+  const { errors } = formState;
+
+  const {
+    fields: newMemberFields,
+    append: appendNewMember,
+    remove: removeNewMember,
+  } = useFieldArray({
+    name: 'newMembers',
+    control,
+  });
+
+  const submitNewMembers = async () => {
+    const newMembers = getValues('newMembers') as {
+      name: string;
+      address: string;
+    }[];
+    try {
+      setLoading(true);
+      setSuccessCount(0);
+      const filteredMembers = newMembers.filter(
+        m => m.address != '' && m.name != ''
+      );
+      await client.mutate({
+        createUsers: [
+          {
+            payload: {
+              circle_id: circleId,
+              users: filteredMembers,
+            },
+          },
+          {
+            __typename: true,
+          },
+        ],
+      });
+      // ok it worked, clear out?
+      setSuccessCount(filteredMembers.length);
+      reset();
+      successRef.current?.scrollIntoView();
+      await queryClient.invalidateQueries(['circleSettings', circleId]);
+      await fetchCircle({ circleId });
+    } catch (e) {
+      showError(normalizeError(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const newMemberFocused = (idx: number) => {
+    // make sure there is at least idx+1 elements in the namesToAdd Array
+    if (newMemberFields.length - 1 <= idx) {
+      appendNewMember(
+        {
+          name: '',
+          address: '',
+        },
+        {
+          shouldFocus: false,
+        }
+      );
+    }
+  };
+
+  return (
+    <Box>
+      <Box
+        css={{
+          width: '70%',
+          '@md': {
+            width: '100%',
+          },
+        }}
+      >
+        <Panel nested>
+          <form onSubmit={handleSubmit(submitNewMembers)}>
+            {loading && <LoadingModal visible={true} />}
+            <Box data-testid="new-members">
+              <NewMemberGridBox>
+                <Box>
+                  <Text variant={'label'}>Name</Text>
+                </Box>
+                <Box>
+                  <Text variant={'label'}>Wallet Address</Text>
+                </Box>
+              </NewMemberGridBox>
+              {newMemberFields.map((field, idx) => {
+                let err: { name?: string; address?: string } | undefined =
+                  undefined;
+                if (errors) {
+                  const addrErrors = errors['newMembers'] as {
+                    address?: { message?: string };
+                    name?: { message?: string };
+                    message?: string;
+                  }[];
+                  if (addrErrors) {
+                    const e = {
+                      name: addrErrors[idx]?.name?.message,
+                      address: addrErrors[idx]?.address?.message,
+                    };
+                    if (e.name || e.address) {
+                      // if there is an error pass it along
+                      err = e;
+                    }
+                  }
+                }
+                return (
+                  <NewMemberEntry
+                    key={field.id}
+                    onFocus={() => newMemberFocused(idx)}
+                    onRemove={idx > 0 ? () => removeNewMember(idx) : undefined}
+                    register={register}
+                    index={idx}
+                    error={err}
+                  />
+                );
+              })}
+            </Box>
+            <Box>
+              <Button
+                type="submit"
+                disabled={loading || errors?.newMembers !== undefined}
+                color="primary"
+                size="large"
+                fullWidth
+              >
+                Add Members
+              </Button>
+            </Box>
+          </form>
+        </Panel>
+
+        <div ref={successRef}>
+          {successCount > 0 && (
+            <>
+              <Panel success css={{ mt: '$xl' }}>
+                <Flex>
+                  <Check
+                    color={'successDark'}
+                    size={'lg'}
+                    css={{ mr: '$md' }}
+                  />
+                  <Text size={'large'}>
+                    You have added {successCount} member
+                    {successCount == 1 ? '' : 's'}
+                    !&nbsp;
+                    {isFeatureEnabled('link_joining') && (
+                      <Text bold>Share the link to get them started.</Text>
+                    )}
+                  </Text>
+                </Flex>
+              </Panel>
+
+              {isFeatureEnabled('link_joining') && (
+                <Box css={{ mt: '$xl' }}>
+                  <div>
+                    <Text variant={'label'} css={{ mb: '$xs' }}>
+                      Shareable Circle Link
+                    </Text>
+                    <CopyCodeTextField value={welcomeLink} />
+                    {/* Revoke is disabled for now until we figure out the UI for it*/}
+                    {/*<Button color={'transparent'} onClick={revokeWelcome}>*/}
+                    {/*  <Working />*/}
+                    {/*</Button>*/}
+                  </div>
+                </Box>
+              )}
+            </>
+          )}
+        </div>
+      </Box>
+    </Box>
+  );
+};
+
+export default NewMemberList;

--- a/src/pages/AddMembersPage/TabButton.tsx
+++ b/src/pages/AddMembersPage/TabButton.tsx
@@ -1,0 +1,33 @@
+import React, { ReactNode } from 'react';
+
+import { Button } from '../../ui';
+
+export const enum Tab {
+  ETH,
+  CSV,
+  LINK,
+}
+
+const TabButton = ({
+  tab,
+  children,
+  currentTab,
+  setCurrentTab,
+}: {
+  tab: Tab;
+  children: ReactNode;
+  currentTab: Tab;
+  setCurrentTab(tab: Tab): void;
+}) => {
+  return (
+    <Button
+      color={currentTab === tab ? 'secondary' : undefined}
+      css={{ borderRadius: '$pill', mr: '$md' }}
+      onClick={() => setCurrentTab(tab)}
+    >
+      {children}
+    </Button>
+  );
+};
+
+export default TabButton;

--- a/src/pages/AddMembersPage/useCircleTokens.ts
+++ b/src/pages/AddMembersPage/useCircleTokens.ts
@@ -1,0 +1,82 @@
+import assert from 'assert';
+
+import { useQuery } from 'react-query';
+
+import { CircleTokenType } from '../../common-lib/circleShareTokens';
+import { client } from '../../lib/gql/client';
+
+export const useMagicToken = (circleId: number) => {
+  return useCircleTokens(circleId, CircleTokenType.Magic);
+};
+
+export const useWelcomeToken = (circleId: number) => {
+  return useCircleTokens(circleId, CircleTokenType.Welcome);
+};
+
+export const deleteMagicToken = (circleId: number) => {
+  return deleteToken(circleId, CircleTokenType.Magic);
+};
+
+export const deleteWelcomeToken = (circleId: number) => {
+  return deleteToken(circleId, CircleTokenType.Welcome);
+};
+
+const useCircleTokens = (circleId: number, type: CircleTokenType) => {
+  return useQuery(
+    ['circle-token-', circleId, type],
+    async (): Promise<string> => {
+      const { circle_share_tokens } = await client.query({
+        circle_share_tokens: [
+          {
+            where: {
+              circle_id: {
+                _eq: circleId,
+              },
+              type: {
+                _eq: type,
+              },
+            },
+          },
+          {
+            uuid: true,
+          },
+        ],
+      });
+      const token = circle_share_tokens?.pop();
+      if (token) {
+        return token.uuid;
+      }
+
+      // none exists, need to make one
+      const { insert_circle_share_tokens_one } = await client.mutate({
+        insert_circle_share_tokens_one: [
+          {
+            object: {
+              circle_id: circleId,
+              type: type,
+            },
+          },
+          {
+            uuid: true,
+          },
+        ],
+      });
+      assert(insert_circle_share_tokens_one);
+      return insert_circle_share_tokens_one.uuid;
+    }
+  );
+};
+
+const deleteToken = async (circleId: number, type: CircleTokenType) => {
+  await client.mutate({
+    delete_circle_share_tokens_by_pk: [
+      {
+        circle_id: circleId,
+        type: type,
+      },
+      {
+        __typename: true,
+      },
+    ],
+  });
+};

--- a/src/pages/AddMembersPage/useCircleTokens.ts
+++ b/src/pages/AddMembersPage/useCircleTokens.ts
@@ -29,6 +29,11 @@ const useCircleTokens = (circleId: number, type: CircleTokenType) => {
         circle_share_tokens: [
           {
             where: {
+              circle: {
+                deleted_at: {
+                  _is_null: true,
+                },
+              },
               circle_id: {
                 _eq: circleId,
               },

--- a/src/pages/AdminPage/AdminPage.tsx
+++ b/src/pages/AdminPage/AdminPage.tsx
@@ -31,7 +31,6 @@ const AdminPage = () => {
   const [deleteUserDialog, setDeleteUserDialog] = useState<IUser | undefined>(
     undefined
   );
-  const [newUser, setNewUser] = useState<boolean>(false);
   const [newCircle, setNewCircle] = useState<boolean>(false);
 
   useEffect(() => {
@@ -96,11 +95,9 @@ const AdminPage = () => {
                   Settings
                 </Button>
               </AppLink>
-              <AddContributorButton
-                onClick={() => setNewUser(true)}
-                tokenName={circle?.tokenName || 'GIVE'}
-              />
-
+              <AppLink to={paths.membersAdd(selectedCircle.id)}>
+                <AddContributorButton tokenName={circle?.tokenName || 'GIVE'} />
+              </AppLink>
               <Button
                 color="primary"
                 outlined
@@ -119,7 +116,7 @@ const AdminPage = () => {
         </Flex>
         {isMobile && (
           <UsersTableHeader
-            onClick={() => setNewUser(true)}
+            circleId={selectedCircle.id}
             tokenName={circle?.tokenName || 'GIVE'}
           />
         )}
@@ -139,7 +136,6 @@ const AdminPage = () => {
             visibleUsers={visibleUsers}
             myUser={me}
             circle={circle}
-            setNewUser={setNewUser}
             filter={filterUser}
             setEditUser={setEditUser}
             setDeleteUserDialog={setDeleteUserDialog}
@@ -147,9 +143,9 @@ const AdminPage = () => {
           />
         )}
       </Panel>
-      {circle && (editUser || newUser) && (
+      {circle && editUser && (
         <AdminUserModal
-          onClose={() => (newUser ? setNewUser(false) : setEditUser(undefined))}
+          onClose={() => setEditUser(undefined)}
           user={editUser}
           fixedPaymentToken={circle.fixed_payment_token_type}
           tokenName={circle.tokenName}

--- a/src/pages/AdminPage/AdminUserModal.tsx
+++ b/src/pages/AdminPage/AdminUserModal.tsx
@@ -57,7 +57,7 @@ export const AdminUserModal = ({
   fixedPaymentToken,
   tokenName,
 }: {
-  user?: IUser;
+  user: IUser;
   open?: boolean;
   onClose: () => void;
   fixedPaymentToken: string | undefined;
@@ -66,14 +66,14 @@ export const AdminUserModal = ({
   const classes = useStyles();
 
   const { circle: selectedCircle, circleId } = useSelectedCircle();
-  const { updateUser, createUser } = useApiAdminCircle(circleId);
+  const { updateUser } = useApiAdminCircle(circleId);
 
   const [showOptOutChangeWarning, setShowOptOutChangeWarning] = useState(false);
   const [hasAcceptedOptOutWarning, setHasAcceptedOptOutWarning] =
     useState(false);
 
-  const isOptedOut = !!user?.fixed_non_receiver || !!user?.non_receiver;
-  const hasGiveAllocated = !!user?.give_token_received;
+  const isOptedOut = !!user.fixed_non_receiver || !!user.non_receiver;
+  const hasGiveAllocated = !!user.give_token_received;
 
   const source = useMemo(
     () => ({
@@ -96,7 +96,7 @@ export const AdminUserModal = ({
           setShowOptOutChangeWarning(true);
         } else {
           setShowOptOutChangeWarning(false);
-          (user ? updateUser(user.address, params) : createUser(params))
+          updateUser(user.address, params)
             .then(() => onClose())
             .catch(console.warn);
         }
@@ -123,7 +123,7 @@ export const AdminUserModal = ({
         <FormModal
           onClose={onClose}
           open={open === undefined ? true : open}
-          title={user ? `Edit ${user.name}` : 'Create User'}
+          title={`Edit ${user.name}`}
           onSubmit={handleSubmit}
           submitDisabled={!changedOutput}
           errors={errors}

--- a/src/pages/AdminPage/components.tsx
+++ b/src/pages/AdminPage/components.tsx
@@ -4,6 +4,7 @@ import { GearIcon, InfoCircledIcon } from '@radix-ui/react-icons';
 import { Link as RouterLink } from 'react-router-dom';
 import { styled } from 'stitches.config';
 
+import { paths } from '../../routes/paths';
 import {
   USER_COORDINAPE_ADDRESS,
   USER_ROLE_ADMIN,
@@ -14,7 +15,17 @@ import { useApiAdminCircle, useNavigation } from 'hooks';
 import useMobileDetect from 'hooks/useMobileDetect';
 import { PlusCircleIcon, CheckIcon, CloseIcon } from 'icons';
 import { CircleSettingsResult } from 'pages/CircleAdminPage/getCircleSettings';
-import { Avatar, Box, Button, Flex, IconButton, Link, Tooltip, Text } from 'ui';
+import {
+  Avatar,
+  Box,
+  Button,
+  Flex,
+  IconButton,
+  Link,
+  Tooltip,
+  Text,
+  AppLink,
+} from 'ui';
 import { shortenAddress } from 'utils';
 
 import { Paginator } from './Paginator';
@@ -50,23 +61,20 @@ export const SettingsIconButton = ({ onClick }: { onClick?: () => void }) => {
 };
 
 export const AddContributorButton = ({
-  onClick,
   tokenName,
   inline,
 }: {
   inline?: boolean;
   tokenName: string;
-  onClick: () => void;
 }) => {
   return (
     <Button
       color="primary"
       outlined
       size={inline ? 'inline' : 'medium'}
-      onClick={onClick}
       css={{ minWidth: '180px' }}
     >
-      Add Contributor
+      Add Members
       <Tooltip
         css={{ ml: '$xs' }}
         content={
@@ -92,9 +100,9 @@ export const AddContributorButton = ({
 
 export const UsersTableHeader = ({
   tokenName,
-  onClick,
+  circleId,
 }: {
-  onClick: () => void;
+  circleId: number;
   tokenName: string;
 }) => {
   return (
@@ -108,7 +116,9 @@ export const UsersTableHeader = ({
       }}
     >
       <Text h3>Users</Text>
-      <AddContributorButton inline onClick={onClick} tokenName={tokenName} />
+      <AppLink to={paths.circleAdmin(circleId)}>
+        <AddContributorButton inline tokenName={tokenName} />
+      </AppLink>
     </Box>
   );
 };
@@ -247,11 +257,9 @@ const renderActions = (onEdit?: () => void, onDelete?: () => void) => (
 const EmptyTable = ({
   content,
   createLabel,
-  onClick,
 }: {
   content: string;
   createLabel: string;
-  onClick: () => void;
 }) => {
   return (
     <Flex
@@ -273,7 +281,7 @@ const EmptyTable = ({
       >
         {content}
       </Text>
-      <Button color="secondary" onClick={() => onClick()}>
+      <Button color="secondary">
         <PlusCircleIcon />
         {createLabel}
       </Button>
@@ -319,7 +327,6 @@ export const MembersTable = ({
   visibleUsers,
   myUser: me,
   circle,
-  setNewUser,
   setEditUser,
   setDeleteUserDialog,
   filter,
@@ -328,7 +335,6 @@ export const MembersTable = ({
   visibleUsers: IUser[];
   myUser: IUser;
   circle: CircleSettingsResult;
-  setNewUser: (newUser: boolean) => void;
   setEditUser: (u: IUser) => void;
   setDeleteUserDialog: (u: IUser) => void;
   filter: (u: IUser) => boolean;
@@ -660,11 +666,12 @@ export const MembersTable = ({
           ) : (
             <Table.Row>
               <Table.Cell colSpan={4}>
-                <EmptyTable
-                  content="You haven’t added any contributors"
-                  createLabel="Add Contributor"
-                  onClick={() => setNewUser(true)}
-                />
+                <AppLink to={paths.membersAdd(circle.id)}>
+                  <EmptyTable
+                    content="You haven’t added any contributors"
+                    createLabel="Add Contributor"
+                  />
+                </AppLink>
               </Table.Cell>
             </Table.Row>
           )}

--- a/src/pages/DistributionsPage/DistributionsPage.tsx
+++ b/src/pages/DistributionsPage/DistributionsPage.tsx
@@ -11,11 +11,11 @@ import { useParams } from 'react-router-dom';
 import { DISTRIBUTION_TYPE } from '../../config/constants';
 import { useSelectedCircle } from '../../recoilState';
 import { paths } from '../../routes/paths';
-import { ReactComponent as LeftArrowSVG } from 'assets/svgs/button/left-arrow.svg';
+import BackButton from '../../ui/BackButton';
 import { LoadingModal } from 'components';
 import { useApiAdminCircle, useContracts } from 'hooks';
 import useConnectedAddress from 'hooks/useConnectedAddress';
-import { AppLink, Box, Button, Text } from 'ui';
+import { AppLink, Box, Text } from 'ui';
 import { SingleColumnLayout } from 'ui/layouts';
 
 import { AllocationsTable } from './AllocationsTable';
@@ -181,14 +181,7 @@ export function DistributionsPage() {
   return (
     <SingleColumnLayout>
       <AppLink to={paths.history(circle.id)}>
-        <Button
-          size="small"
-          outlined
-          css={{ padding: '$sm', color: '$neutral', borderColor: '$neutral' }}
-        >
-          <LeftArrowSVG />
-          Back
-        </Button>
+        <BackButton />
       </AppLink>
       <Text h1 css={{ '@sm': { display: 'block' } }}>
         Distributions&nbsp;

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -64,6 +64,7 @@ export const paths = {
   give: circlePath('give'),
   history: circlePath('history'),
   members: circlePath('members'),
+  membersAdd: circlePath('members/add'),
   team: circlePath('team'),
   vouching: circlePath('vouching'),
   distributions: (circleId: number, epochId: number | string) =>

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -11,6 +11,7 @@ import {
   useLocation,
 } from 'react-router-dom';
 
+import AddMembersPage from '../pages/AddMembersPage/AddMembersPage';
 import { useFixCircleState, useRoleInCircle } from 'hooks/migration';
 import AdminCircleApiPage from 'pages/AdminCircleApiPage/AdminCircleApiPage';
 import AdminPage from 'pages/AdminPage';
@@ -50,6 +51,7 @@ export const AppRoutes = () => {
         <Route path="map" element={<LazyAssetMapPage />} />
         <Route path="vouching" element={<VouchingPage />} />
         <Route path="members" element={<AdminRouteHandler />}>
+          <Route path="add" element={<AddMembersPage />} />
           <Route path="" element={<AdminPage />} />
         </Route>
         <Route path="admin" element={<AdminRouteHandler />}>

--- a/src/stitches.config.ts
+++ b/src/stitches.config.ts
@@ -76,6 +76,9 @@ export const colors = {
   alertDark: figmaColors.red20,
   textOnAlert: '#fff',
 
+  success: figmaColors.green1,
+  successDark: figmaColors.green16,
+
   secondary: figmaColors.teal12,
   secondaryDark: figmaColors.teal20,
   neutral: figmaColors.grey12,

--- a/src/ui/BackButton.tsx
+++ b/src/ui/BackButton.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import { ArrowLeft } from '../icons/__generated';
+
+import { Button } from './Button/Button';
+import { Text } from './Text/Text';
+
+const BackButton = () => {
+  return (
+    <Button
+      size="small"
+      color="neutral"
+      outlined
+      css={{
+        padding: '$xs $sm',
+        // color: '$neutral',
+        // borderColor: '$neutral',
+        '&:hover': {
+          '& path': {
+            fill: '$white',
+          },
+        },
+      }}
+    >
+      <ArrowLeft color={'neutral'} />
+      <Text color={'inherit'} semibold>
+        Back
+      </Text>
+    </Button>
+  );
+};
+
+export default BackButton;

--- a/src/ui/Button/Button.tsx
+++ b/src/ui/Button/Button.tsx
@@ -42,7 +42,7 @@ export const Button = styled('button', {
         color: '$textOnAlert',
       },
       neutral: {
-        backgroundColor: '$headingText',
+        backgroundColor: '$neutral',
         color: 'white',
       },
       surface: {
@@ -233,16 +233,16 @@ export const Button = styled('button', {
       outlined: true,
       css: {
         color: '$text',
-        borderColor: '$borderMedium',
+        borderColor: '$neutral',
         '&:hover': {
           color: '$white',
           filter: 'saturate(1)',
-          backgroundColor: '$headingText !important',
+          backgroundColor: '$neutral !important',
         },
         '&:focus': {
           color: '$white',
           filter: 'saturate(1)',
-          backgroundColor: '$headingText !important',
+          backgroundColor: '$neutral !important',
         },
       },
     },

--- a/src/ui/HintButton.tsx
+++ b/src/ui/HintButton.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import { Link } from './Link/Link';
+
+const HintButton = ({
+  children,
+  href,
+}: {
+  href: string;
+  children: React.ReactNode;
+}) => {
+  return (
+    <Link
+      css={{ color: '$primary' }}
+      target="_blank"
+      rel={'noreferrer'}
+      href={href}
+    >
+      {children}
+    </Link>
+  );
+};
+
+export default HintButton;

--- a/src/ui/Panel/Panel.tsx
+++ b/src/ui/Panel/Panel.tsx
@@ -47,6 +47,11 @@ export const Panel = styled('div', {
         backgroundColor: '$info',
       },
     },
+    success: {
+      true: {
+        backgroundColor: '$success',
+      },
+    },
   },
 
   defaultVariants: {

--- a/src/ui/Text/Text.tsx
+++ b/src/ui/Text/Text.tsx
@@ -20,6 +20,7 @@ export const Text = styled('span', {
       neutral: { color: '$neutral' },
       alert: { color: '$alert' },
       primary: { color: '$primary' },
+      inherit: { color: 'inherit' },
     },
     bold: { true: { fontWeight: '$bold !important' } },
     normal: { true: { fontWeight: '$normal !important' } },
@@ -53,6 +54,11 @@ export const Text = styled('span', {
         lineHeight: '$shorter',
         display: 'flex',
         gap: '$xs',
+      },
+      formError: {
+        color: '$alert',
+        fontSize: '$small',
+        fontWeight: '$semibold',
       },
     },
     p: {

--- a/src/ui/TextField/TextField.tsx
+++ b/src/ui/TextField/TextField.tsx
@@ -41,10 +41,18 @@ export const TextField = styled('input', {
         lineHeight: '$short',
       },
     },
+    fullWidth: {
+      true: {
+        width: '100%',
+      },
+    },
     error: {
       true: {
         backgroundColor: '$alertLight',
         boxSizing: 'border-box',
+        '&:focus': {
+          borderColor: '$alert',
+        },
       },
     },
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,13 +29,6 @@
     tslib "^2.3.0"
     zen-observable-ts "^1.2.0"
 
-"@ardatan/sync-fetch@0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@ardatan/sync-fetch/-/sync-fetch-0.0.1.tgz#3385d3feedceb60a896518a1db857ec1e945348f"
-  integrity sha512-xhlTqH0m31mnsG0tIP4ETgfSB6gXDaYYsUWTrlUV93fFQPI9dd8hE0Ot6MHLCtqgB32hwJAC3YZMWlXZw7AleA==
-  dependencies:
-    node-fetch "^2.6.1"
-
 "@babel/code-frame@7.12.11":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
@@ -2394,6 +2387,16 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
+"@endemolshinegroup/cosmiconfig-typescript-loader@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@endemolshinegroup/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-3.0.2.tgz#eea4635828dde372838b0909693ebd9aafeec22d"
+  integrity sha512-QRVtqJuS1mcT56oHpVegkKBlgtWjXw/gHNWO3eL9oyB5Sc7HBoc2OLG/nYpVfT/Jejvo3NUrD0Udk7XgoyDKkA==
+  dependencies:
+    lodash.get "^4"
+    make-error "^1"
+    ts-node "^9"
+    tslib "^2"
+
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.3.tgz#9e42981ef035beb3dd49add17acb96e8ff6f394c"
@@ -2908,9 +2911,9 @@
     tslib "~2.3.0"
 
 "@graphql-eslint/eslint-plugin@^3.10.4":
-  version "3.10.7"
-  resolved "https://registry.yarnpkg.com/@graphql-eslint/eslint-plugin/-/eslint-plugin-3.10.7.tgz#9a203e2084371eca933d88b73ce7a6bebbbb9872"
-  integrity sha512-Vp32LMsHTgRNc2q+OrXRNR1i2nlAbVfN0tMTlFHgnzJfnEJDV332cpjiUF9F82IKjNFSde/pF3cuYccu+UUR/g==
+  version "3.10.4"
+  resolved "https://registry.yarnpkg.com/@graphql-eslint/eslint-plugin/-/eslint-plugin-3.10.4.tgz#fcc3b54ef1d6d38e89daf848d93be2d5359fef98"
+  integrity sha512-+Vmi1E5uSWOgtylosHS3HYWHF+x0GMgaMOHmSfOflTE51VXnLM2tvGKMd3lpyngCEZG1wjvqdlB5rn2iwhhzqA==
   dependencies:
     "@babel/code-frame" "^7.16.7"
     "@graphql-tools/code-file-loader" "^7.2.14"
@@ -2923,12 +2926,12 @@
     graphql-depth-limit "^1.1.0"
     lodash.lowercase "^4.3.0"
 
-"@graphql-tools/batch-execute@8.5.1":
-  version "8.5.1"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/batch-execute/-/batch-execute-8.5.1.tgz#fa3321d58c64041650be44250b1ebc3aab0ba7a9"
-  integrity sha512-hRVDduX0UDEneVyEWtc2nu5H2PxpfSfM/riUlgZvo/a/nG475uyehxR5cFGvTEPEQUKY3vGIlqvtRigzqTfCew==
+"@graphql-tools/batch-execute@8.5.0":
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/batch-execute/-/batch-execute-8.5.0.tgz#2767a9abf4e2712871a69360a27ef13ada1c019e"
+  integrity sha512-S9/76X4uYIbVlJyRzXhCBbTJvVD0VvaWNqGiKgkITxlq4aBsTOHVuE84OSi3E1QKP3PTiJYrgMIn220iFOkyQw==
   dependencies:
-    "@graphql-tools/utils" "8.9.0"
+    "@graphql-tools/utils" "8.8.0"
     dataloader "2.1.0"
     tslib "^2.4.0"
     value-or-promise "1.0.11"
@@ -2944,24 +2947,24 @@
     value-or-promise "1.0.11"
 
 "@graphql-tools/code-file-loader@^7.2.14":
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/code-file-loader/-/code-file-loader-7.3.1.tgz#82cf1e7c5366fd6e084f607e6c14a4447110f035"
-  integrity sha512-nyr0zln7fi4E8lK98THdb8k3gPsSCiyXRFTTNhPRUCPeOD2RCpUZCClM5AB0xv8HjILAipdaxjhb2elPvnY5dw==
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/code-file-loader/-/code-file-loader-7.3.0.tgz#4a9cc213bb726ab049aad806a51707689bd7340a"
+  integrity sha512-mzevVv5JYyyRIbE6R0mxIniCAZWUGdoNYX97HdVgqChLOl2XRf9I8MarVPewHLmjLTZuWrdQx4ta4sPTLk4tUQ==
   dependencies:
-    "@graphql-tools/graphql-tag-pluck" "7.3.1"
-    "@graphql-tools/utils" "8.9.0"
+    "@graphql-tools/graphql-tag-pluck" "7.3.0"
+    "@graphql-tools/utils" "8.8.0"
     globby "^11.0.3"
     tslib "^2.4.0"
     unixify "^1.0.0"
 
-"@graphql-tools/delegate@8.8.1":
-  version "8.8.1"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/delegate/-/delegate-8.8.1.tgz#0653a72f38947f38ab7917dfac50ebf6a6b883e9"
-  integrity sha512-NDcg3GEQmdEHlnF7QS8b4lM1PSF+DKeFcIlLEfZFBvVq84791UtJcDj8734sIHLukmyuAxXMfA1qLd2l4lZqzA==
+"@graphql-tools/delegate@8.8.0":
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/delegate/-/delegate-8.8.0.tgz#acd3e48e4ca82aace92cc3d920b5c727c35eaf7b"
+  integrity sha512-dbhfOI8rQXPcowXrbwHLOBY9oGi7qxtlrXF4RuRXmjqGTs2AgogdOE3Ep1+6wFD7qYTuFmHXZ8Cl0PmhoZUgrg==
   dependencies:
-    "@graphql-tools/batch-execute" "8.5.1"
-    "@graphql-tools/schema" "8.5.1"
-    "@graphql-tools/utils" "8.9.0"
+    "@graphql-tools/batch-execute" "8.5.0"
+    "@graphql-tools/schema" "8.5.0"
+    "@graphql-tools/utils" "8.8.0"
     dataloader "2.1.0"
     tslib "~2.4.0"
     value-or-promise "1.0.11"
@@ -2979,62 +2982,62 @@
     value-or-promise "1.0.11"
 
 "@graphql-tools/graphql-file-loader@^7.3.7":
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.5.0.tgz#b08e2a7c64a1fecb5fc01d557a07116a3151ee14"
-  integrity sha512-X3wcC+ZljbXTwdTTSp3oUHJd66mFLDKI750uhB0HidBxE6+wyw7fhmJVJiYROXPswaGliuabpo0JEyLj7hhWKA==
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.4.0.tgz#c06e36248dd6a2025de65a1cfce03222ad0e74c2"
+  integrity sha512-r1lslE5GlWO/nbDX82enHjvva7qQiZEIPm+LC9JSgKaYuVoYHuIuIAVYkpBHeaRK1Kbh/86pEhL7PuBZ/cIWSA==
   dependencies:
-    "@graphql-tools/import" "6.7.1"
-    "@graphql-tools/utils" "8.9.0"
+    "@graphql-tools/import" "6.7.0"
+    "@graphql-tools/utils" "8.8.0"
     globby "^11.0.3"
     tslib "^2.4.0"
     unixify "^1.0.0"
 
-"@graphql-tools/graphql-tag-pluck@7.3.1", "@graphql-tools/graphql-tag-pluck@^7.2.6":
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-7.3.1.tgz#067880a923bacbb522eab68d994975346d68ab64"
-  integrity sha512-+Aayl4y42ASrxDvu613lp3NiK1JRggy/m9wlo93dJp/9L5vKPYlrtFvuQ1tpPEEuSBboYNa/erOsELrRwzzakA==
+"@graphql-tools/graphql-tag-pluck@7.3.0", "@graphql-tools/graphql-tag-pluck@^7.2.6":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-7.3.0.tgz#e83b568151b2cd0f8678489bb927e2bf9cf24af9"
+  integrity sha512-GxtgGTSOiQuFc/yNWXsPJ5QEgGlH+4qBf1paqUJtjFpm89dZA+VkdjoIDiFg8fyXGivjZ37+XAUbuu6UlsT+6Q==
   dependencies:
     "@babel/parser" "^7.16.8"
     "@babel/traverse" "^7.16.8"
     "@babel/types" "^7.16.8"
-    "@graphql-tools/utils" "8.9.0"
+    "@graphql-tools/utils" "8.8.0"
     tslib "^2.4.0"
 
-"@graphql-tools/import@6.7.1":
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/import/-/import-6.7.1.tgz#bb62a109503266f25e6dd8799763eddaeba8da3a"
-  integrity sha512-StLosFVhdw+eZkL+v9dBabszxCAZtEYW4Oy1+750fDkH39GrmzOB8mWiYna7rm9+GMisC9atJtXuAfMF02Aoag==
+"@graphql-tools/import@6.7.0":
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/import/-/import-6.7.0.tgz#5174c46b73f5931e68b9715fec9178bc924d2bba"
+  integrity sha512-u9JL4fClKKyBTQpgb4QFacYUwgBCs4lW1NaHX0hD2zBdahIYidokBY0QkOqOCEAnWeFqpEmAjB62ulLiAJWc2g==
   dependencies:
-    "@graphql-tools/utils" "8.9.0"
+    "@graphql-tools/utils" "8.8.0"
     resolve-from "5.0.0"
     tslib "^2.4.0"
 
 "@graphql-tools/json-file-loader@^7.3.7":
-  version "7.4.1"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/json-file-loader/-/json-file-loader-7.4.1.tgz#40414a57195a9d4f96e25e5041d674426937e11a"
-  integrity sha512-+QaeRyJcvUXUNEoIaecYrABunqk8/opFbpdHPAijJyVHvlsYfqXR12/501g+/QZzGHKYnyi+Q3lsZbBboj5LBg==
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/json-file-loader/-/json-file-loader-7.4.0.tgz#c25059ebce34db6190a11580e2bc7c66df68a7b9"
+  integrity sha512-6oR7Ulc5iZc5SM3g1Yj91DqSu3TNbfGK/0baE8KyUlvq6KiIuWFWDy13RGnNesftt4RSWvZqGzu/kzXcBHtt+A==
   dependencies:
-    "@graphql-tools/utils" "8.9.0"
+    "@graphql-tools/utils" "8.8.0"
     globby "^11.0.3"
     tslib "^2.4.0"
     unixify "^1.0.0"
 
 "@graphql-tools/load@^7.5.5":
-  version "7.7.1"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/load/-/load-7.7.1.tgz#937354e5123a8b0e0d59585ebca7c55165265a98"
-  integrity sha512-rJ2WUV41wwAkMnBgtcBym3TKVbPgz7z9tBCjOmbNVLy5bB9StVPdo2Uci0D5xYSgLV9XIt+zdyAnYGptioJeWg==
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/load/-/load-7.7.0.tgz#668f70f09bc1c34b87c3267853cf73451897a22e"
+  integrity sha512-6KX7Z8BtlFScDr0pIac92QZWlPGbHcpNMesX/6Y3Vsp3FeFnAYfzZldXZQcJoW7Yl+gHdFwYVq683wSH64kNrw==
   dependencies:
-    "@graphql-tools/schema" "8.5.1"
-    "@graphql-tools/utils" "8.9.0"
+    "@graphql-tools/schema" "8.5.0"
+    "@graphql-tools/utils" "8.8.0"
     p-limit "3.1.0"
     tslib "^2.4.0"
 
-"@graphql-tools/merge@8.3.1", "@graphql-tools/merge@^8.2.6":
-  version "8.3.1"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-8.3.1.tgz#06121942ad28982a14635dbc87b5d488a041d722"
-  integrity sha512-BMm99mqdNZbEYeTPK3it9r9S6rsZsQKtlqJsSBknAclXq2pGEfOxjcIZi+kBSkHZKPKCRrYDd5vY0+rUmIHVLg==
+"@graphql-tools/merge@8.3.0", "@graphql-tools/merge@^8.2.6":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-8.3.0.tgz#d3a8ba10942f8598788c3e03f97cc1d0c0b055f8"
+  integrity sha512-xRa7RAQok/0DD2YnjuqikMrr7dUAxTpdGtZ7BkvUUGhYs3B3p7reCAfvOVr1DJAqVToP7hdlMk+S5+Ylk+AaqA==
   dependencies:
-    "@graphql-tools/utils" "8.9.0"
+    "@graphql-tools/utils" "8.8.0"
     tslib "^2.4.0"
 
 "@graphql-tools/merge@^8.2.1":
@@ -3061,13 +3064,13 @@
     relay-compiler "12.0.0"
     tslib "~2.3.0"
 
-"@graphql-tools/schema@8.5.1":
-  version "8.5.1"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-8.5.1.tgz#c2f2ff1448380919a330312399c9471db2580b58"
-  integrity sha512-0Esilsh0P/qYcB5DKQpiKeQs/jevzIadNTaT0jeWklPMwNbT7yMX4EqZany7mbeRRlSRwMzNzL5olyFdffHBZg==
+"@graphql-tools/schema@8.5.0":
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-8.5.0.tgz#0332b3a2e674d16e9bf8a58dfd47432449ce2368"
+  integrity sha512-VeFtKjM3SA9/hCJJfr95aEdC3G0xIKM9z0Qdz4i+eC1g2fdZYnfWFt2ucW4IME+2TDd0enHlKzaV0qk2SLVUww==
   dependencies:
-    "@graphql-tools/merge" "8.3.1"
-    "@graphql-tools/utils" "8.9.0"
+    "@graphql-tools/merge" "8.3.0"
+    "@graphql-tools/utils" "8.8.0"
     tslib "^2.4.0"
     value-or-promise "1.0.11"
 
@@ -3082,30 +3085,30 @@
     value-or-promise "1.0.11"
 
 "@graphql-tools/url-loader@^7.9.7":
-  version "7.13.3"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/url-loader/-/url-loader-7.13.3.tgz#bbded3c86325c26bdc32d4a8c0a2767e045f6603"
-  integrity sha512-92z2HJd+Ae2wlZH0kFb20aSxX8CkJDcYyUtbtBNSadu5rKzkiYQPlihfRJFJs4zmDdV+DSmmGvQtDuAKLV+iNg==
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/url-loader/-/url-loader-7.12.1.tgz#931a65da4faced1a71ddc5af638b87140ff3dfb6"
+  integrity sha512-Fd3ZZLEEr9GGFHEbdrcaMHFQu01BLpFnNDBkISupvjokd497O5Uh0xZvsZGC6mxVt0WWQWpgaK2ef+oLuOdLqQ==
   dependencies:
-    "@ardatan/sync-fetch" "0.0.1"
-    "@graphql-tools/delegate" "8.8.1"
-    "@graphql-tools/utils" "8.9.0"
-    "@graphql-tools/wrap" "8.5.1"
-    "@n1ru4l/graphql-live-query" "^0.10.0"
+    "@graphql-tools/delegate" "8.8.0"
+    "@graphql-tools/utils" "8.8.0"
+    "@graphql-tools/wrap" "8.5.0"
+    "@n1ru4l/graphql-live-query" "^0.9.0"
     "@types/ws" "^8.0.0"
-    "@whatwg-node/fetch" "^0.2.4"
+    cross-undici-fetch "^0.4.11"
     dset "^3.1.2"
     extract-files "^11.0.0"
     graphql-ws "^5.4.1"
     isomorphic-ws "^5.0.0"
     meros "^1.1.4"
+    sync-fetch "^0.4.0"
     tslib "^2.4.0"
     value-or-promise "^1.0.11"
     ws "^8.3.0"
 
-"@graphql-tools/utils@8.9.0", "@graphql-tools/utils@^8.6.5", "@graphql-tools/utils@^8.6.9":
-  version "8.9.0"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.9.0.tgz#c6aa5f651c9c99e1aca55510af21b56ec296cdb7"
-  integrity sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==
+"@graphql-tools/utils@8.8.0", "@graphql-tools/utils@^8.6.5", "@graphql-tools/utils@^8.6.9":
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.8.0.tgz#8332ff80a1da9204ccf514750dd6f5c5cccf17dc"
+  integrity sha512-KJrtx05uSM/cPYFdTnGAS1doL5bftJLAiFCDMZ8Vkifztz3BFn3gpFiy/o4wDtM8s39G46mxmt2Km/RmeltfGw==
   dependencies:
     tslib "^2.4.0"
 
@@ -3116,14 +3119,14 @@
   dependencies:
     tslib "~2.3.0"
 
-"@graphql-tools/wrap@8.5.1":
-  version "8.5.1"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/wrap/-/wrap-8.5.1.tgz#d4bd1f89850bb1ce0209f35f66d002080b439495"
-  integrity sha512-KpVVfha2wLSpE08YLX0jeo5nXPfDLASlxOqMlvfa/B4X8SOVmuLyN1L5YZ132tPLDF93uflwlHFnUO5ahpRNlA==
+"@graphql-tools/wrap@8.5.0":
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/wrap/-/wrap-8.5.0.tgz#ce1b0d775e1fc3a17404df566f4d2196d31c6e20"
+  integrity sha512-I+x9dBNzC135WWPi04ejqurR/zDmhfeGbCftCaYKF4CvgWd+ZaJx4Uc74n1SBegQtrj+KDrOS4HgKwf9vAVR7A==
   dependencies:
-    "@graphql-tools/delegate" "8.8.1"
-    "@graphql-tools/schema" "8.5.1"
-    "@graphql-tools/utils" "8.9.0"
+    "@graphql-tools/delegate" "8.8.0"
+    "@graphql-tools/schema" "8.5.0"
+    "@graphql-tools/utils" "8.8.0"
     tslib "^2.4.0"
     value-or-promise "1.0.11"
 
@@ -3636,10 +3639,10 @@
   resolved "https://registry.yarnpkg.com/@multiformats/base-x/-/base-x-4.0.1.tgz#95ff0fa58711789d53aefb2590a8b7a4e715d121"
   integrity sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==
 
-"@n1ru4l/graphql-live-query@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@n1ru4l/graphql-live-query/-/graphql-live-query-0.10.0.tgz#2306151630b0e74b017cc1067ebbea351acf56f8"
-  integrity sha512-qZ7OHH/NB0NcG/Xa7irzgjE63UH0CkofZT0Bw4Ko6iRFagPRHBM8RgFXwTt/6JbFGIEUS4STRtaFoc/Eq/ZtzQ==
+"@n1ru4l/graphql-live-query@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@n1ru4l/graphql-live-query/-/graphql-live-query-0.9.0.tgz#defaebdd31f625bee49e6745934f36312532b2bc"
+  integrity sha512-BTpWy1e+FxN82RnLz4x1+JcEewVdfmUhV1C6/XYD5AjS7PQp9QFF7K8bCD6gzPTr2l+prvqOyVueQhFJxB1vfg==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -3690,33 +3693,6 @@
   dependencies:
     colors "^1.3.3"
     util "^0.11.1"
-
-"@peculiar/asn1-schema@^2.1.6":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@peculiar/asn1-schema/-/asn1-schema-2.2.0.tgz#d8a54527685c8dee518e6448137349444310ad64"
-  integrity sha512-1ENEJNY7Lwlua/1wvzpYP194WtjQBfFxvde2FlzfBFh/ln6wvChrtxlORhbKEnYswzn6fOC4c7HdC5izLPMTJg==
-  dependencies:
-    asn1js "^3.0.5"
-    pvtsutils "^1.3.2"
-    tslib "^2.4.0"
-
-"@peculiar/json-schema@^1.1.12":
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/@peculiar/json-schema/-/json-schema-1.1.12.tgz#fe61e85259e3b5ba5ad566cb62ca75b3d3cd5339"
-  integrity sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==
-  dependencies:
-    tslib "^2.0.0"
-
-"@peculiar/webcrypto@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@peculiar/webcrypto/-/webcrypto-1.4.0.tgz#f941bd95285a0f8a3d2af39ccda5197b80cd32bf"
-  integrity sha512-U58N44b2m3OuTgpmKgf0LPDOmP3bhwNz01vAnj1mBwxBASRhptWYK+M3zG+HBkDqGQM+bFsoIihTW8MdmPXEqg==
-  dependencies:
-    "@peculiar/asn1-schema" "^2.1.6"
-    "@peculiar/json-schema" "^1.1.12"
-    pvtsutils "^1.3.2"
-    tslib "^2.4.0"
-    webcrypto-core "^1.7.4"
 
 "@pedrouid/environment@^1.0.1":
   version "1.0.1"
@@ -7359,21 +7335,6 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
-"@whatwg-node/fetch@^0.2.4":
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/@whatwg-node/fetch/-/fetch-0.2.7.tgz#8699d9950d2f07365b2b49936ceca551c18757ba"
-  integrity sha512-AYU3W9q6qIkSlJOLAjBdOeMuWZwaPy7eeDhl2uG0udMRwO6+CVfAa/hG/kMX1Zp0wH2plhOm4eJrWtuf4f2+2A==
-  dependencies:
-    "@peculiar/webcrypto" "^1.4.0"
-    abort-controller "^3.0.0"
-    busboy "^1.6.0"
-    event-target-polyfill "^0.0.3"
-    form-data-encoder "^1.7.1"
-    formdata-node "^4.3.1"
-    node-fetch "^2.6.7"
-    undici "^5.8.0"
-    web-streams-polyfill "^3.2.0"
-
 "@wry/context@^0.6.0":
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.6.1.tgz#c3c29c0ad622adb00f6a53303c4f965ee06ebeb2"
@@ -7901,15 +7862,6 @@ asn1@~0.2.3:
   integrity sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==
   dependencies:
     safer-buffer "~2.1.0"
-
-asn1js@^3.0.1, asn1js@^3.0.5:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/asn1js/-/asn1js-3.0.5.tgz#5ea36820443dbefb51cc7f88a2ebb5b462114f38"
-  integrity sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==
-  dependencies:
-    pvtsutils "^1.3.2"
-    pvutils "^1.1.3"
-    tslib "^2.4.0"
 
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
@@ -8836,7 +8788,7 @@ buffer@6.0.3, buffer@^6.0.3:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
 
-buffer@^5.4.3, buffer@^5.5.0, buffer@^5.6.0:
+buffer@^5.4.3, buffer@^5.5.0, buffer@^5.6.0, buffer@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
   integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
@@ -9790,11 +9742,6 @@ cosmiconfig-typescript-loader@^1.0.0:
     cosmiconfig "^7"
     ts-node "^10.4.0"
 
-cosmiconfig-typescript-loader@^3.1.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-3.1.1.tgz#9cdc2ae1a219cf52b0bc0647596c6691b9ab56a3"
-  integrity sha512-SR5/NciF0vyYqcGsmB9WJ4QOKkcSSSzcBPLrnT6094BYahMy0eImWvlH3zoEOYqpF2zgiyAKHtWTXTo+fqgxPg==
-
 cosmiconfig@7.0.1, cosmiconfig@^7, cosmiconfig@^7.0.0, cosmiconfig@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.1.tgz#714d756522cace867867ccb4474c5d01bbae5d6d"
@@ -9912,6 +9859,19 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+cross-undici-fetch@^0.4.11:
+  version "0.4.11"
+  resolved "https://registry.yarnpkg.com/cross-undici-fetch/-/cross-undici-fetch-0.4.11.tgz#bef38dc729a01db6e07c84fee6de1089b5d3d0a4"
+  integrity sha512-pRp+EWewyOPYIeUvwOqCIqylCFWqlBwwr6nlZB38v3PhWxS1RYfSgHUJApYTT8jm71SbL5p4qg5kUQv6ZyS24A==
+  dependencies:
+    abort-controller "^3.0.0"
+    busboy "^1.6.0"
+    form-data-encoder "^1.7.1"
+    formdata-node "^4.3.1"
+    node-fetch "^2.6.7"
+    undici "5.5.1"
+    web-streams-polyfill "^3.2.0"
 
 crypto-browserify@3.12.0, crypto-browserify@^3.11.0:
   version "3.12.0"
@@ -12003,11 +11963,6 @@ ethjs-util@0.1.6, ethjs-util@^0.1.3:
     is-hex-prefixed "1.0.0"
     strip-hex-prefix "1.0.0"
 
-event-target-polyfill@^0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/event-target-polyfill/-/event-target-polyfill-0.0.3.tgz#ed373295f3b257774b5d75afb2599331d9f3406c"
-  integrity sha512-ZMc6UuvmbinrCk4RzGyVmRyIsAyxMRlp4CqSrcQRO8Dy0A9ldbiRy5kdtBj4OtP7EClGdqGfIqo9JmOClMsGLQ==
-
 event-target-shim@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
@@ -13159,10 +13114,11 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, 
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
 graphql-config@^4.3.0:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/graphql-config/-/graphql-config-4.3.3.tgz#5bf0da2b1493d1eccb34c00515f02ac4587225b0"
-  integrity sha512-ju2LAbOk6GLp+8JY7mh3CrEe0iEj2AdImNKv58G0DyISBo72kDEJYNJ07hKmkHdIzhDsSHiVzaCVIyBU2LCUug==
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/graphql-config/-/graphql-config-4.3.1.tgz#636b539b1acc06fb48012d0e0f228014ccb0325f"
+  integrity sha512-czBWzJSGaLJfOHBLuUTZVRTjfgohPfvlaeN1B5nXBVptFARpiFuS7iI4FnRhCGwm6qt1h2j1g05nkg0OIGA6bg==
   dependencies:
+    "@endemolshinegroup/cosmiconfig-typescript-loader" "3.0.2"
     "@graphql-tools/graphql-file-loader" "^7.3.7"
     "@graphql-tools/json-file-loader" "^7.3.7"
     "@graphql-tools/load" "^7.5.5"
@@ -13171,10 +13127,8 @@ graphql-config@^4.3.0:
     "@graphql-tools/utils" "^8.6.5"
     cosmiconfig "7.0.1"
     cosmiconfig-toml-loader "1.0.0"
-    cosmiconfig-typescript-loader "^3.1.0"
     minimatch "4.2.1"
     string-env-interpolation "1.0.1"
-    ts-node "^10.8.1"
 
 graphql-depth-limit@^1.1.0:
   version "1.1.0"
@@ -15910,6 +15864,11 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
+lodash.get@^4:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
 lodash.lowercase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.lowercase/-/lodash.lowercase-4.3.0.tgz#46515aced4acb0b7093133333af068e4c3b14e9d"
@@ -16092,7 +16051,7 @@ make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   dependencies:
     semver "^6.0.0"
 
-make-error@1.x, make-error@^1.1.1:
+make-error@1.x, make-error@^1, make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -21126,6 +21085,14 @@ symbol.prototype.description@^1.0.0:
     has-symbols "^1.0.2"
     object.getownpropertydescriptors "^2.1.2"
 
+sync-fetch@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/sync-fetch/-/sync-fetch-0.4.1.tgz#87b8684eef2fa25c96c4683ae308473a4e5c571f"
+  integrity sha512-JDtyFEvnKUzt1CxRtzzsGgkBanEv8XRmLyJo0F0nGkpCR8EjYmpOJJXz8GA/SWtlPU0nAYh0+CNMNnFworGyOA==
+  dependencies:
+    buffer "^5.7.1"
+    node-fetch "^2.6.1"
+
 synchronous-promise@^2.0.15:
   version "2.0.15"
   resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.15.tgz#07ca1822b9de0001f5ff73595f3d08c4f720eb8e"
@@ -21628,6 +21595,18 @@ ts-node@^10.8.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
+ts-node@^9:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
+  integrity sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==
+  dependencies:
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.17"
+    yn "3.1.1"
+
 ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
@@ -21648,15 +21627,15 @@ tslib@^1.0.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
+tslib@^2, tslib@^2.4.0, tslib@~2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
 tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@~2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
-
-tslib@^2.4.0, tslib@~2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
-  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tslib@~2.1.0:
   version "2.1.0"
@@ -22491,17 +22470,6 @@ web3-provider-engine@15.0.12:
     ws "^5.1.1"
     xhr "^2.2.0"
     xtend "^4.0.1"
-
-webcrypto-core@^1.7.4:
-  version "1.7.5"
-  resolved "https://registry.yarnpkg.com/webcrypto-core/-/webcrypto-core-1.7.5.tgz#c02104c953ca7107557f9c165d194c6316587ca4"
-  integrity sha512-gaExY2/3EHQlRNNNVSrbG2Cg94Rutl7fAaKILS1w8ZDhGxdFOaw6EbCfHIxPy9vt/xwp5o0VQAx9aySPF6hU1A==
-  dependencies:
-    "@peculiar/asn1-schema" "^2.1.6"
-    "@peculiar/json-schema" "^1.1.12"
-    asn1js "^3.0.1"
-    pvtsutils "^1.3.2"
-    tslib "^2.4.0"
 
 webidl-conversions@^3.0.0:
   version "3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2189,13 +2189,6 @@
   dependencies:
     "@cspotcode/source-map-consumer" "0.8.0"
 
-"@cspotcode/source-map-support@^0.8.0":
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
-  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
-  dependencies:
-    "@jridgewell/trace-mapping" "0.3.9"
-
 "@csstools/convert-colors@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
@@ -3426,14 +3419,6 @@
   version "1.4.14"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
-
-"@jridgewell/trace-mapping@0.3.9":
-  version "0.3.9"
-  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
-  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
-  dependencies:
-    "@jridgewell/resolve-uri" "^3.0.3"
-    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.14"
@@ -18725,18 +18710,6 @@ pupa@^2.1.1:
   dependencies:
     escape-goat "^2.0.0"
 
-pvtsutils@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/pvtsutils/-/pvtsutils-1.3.2.tgz#9f8570d132cdd3c27ab7d51a2799239bf8d8d5de"
-  integrity sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==
-  dependencies:
-    tslib "^2.4.0"
-
-pvutils@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/pvutils/-/pvutils-1.1.3.tgz#f35fc1d27e7cd3dfbd39c0826d173e806a03f5a3"
-  integrity sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==
-
 q@^1.1.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
@@ -21576,25 +21549,6 @@ ts-node@^10.4.0:
     make-error "^1.1.1"
     yn "3.1.1"
 
-ts-node@^10.8.1:
-  version "10.9.1"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
-  integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
-  dependencies:
-    "@cspotcode/source-map-support" "^0.8.0"
-    "@tsconfig/node10" "^1.0.7"
-    "@tsconfig/node12" "^1.0.7"
-    "@tsconfig/node14" "^1.0.0"
-    "@tsconfig/node16" "^1.0.2"
-    acorn "^8.4.1"
-    acorn-walk "^8.1.1"
-    arg "^4.1.0"
-    create-require "^1.1.0"
-    diff "^4.0.1"
-    make-error "^1.1.1"
-    v8-compile-cache-lib "^3.0.1"
-    yn "3.1.1"
-
 ts-node@^9:
   version "9.1.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
@@ -21791,10 +21745,10 @@ unc-path-regex@^0.1.2:
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
   integrity sha1-5z3T17DXxe2G+6xrCufYxqadUPo=
 
-undici@^5.8.0:
-  version "5.9.1"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-5.9.1.tgz#fc9fd85dd488f965f153314a63d9426a11f3360b"
-  integrity sha512-6fB3a+SNnWEm4CJbgo0/CWR8RGcOCQP68SF4X0mxtYTq2VNN8T88NYrWVBAeSX+zb7bny2dx2iYhP3XHi00omg==
+undici@5.5.1:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.5.1.tgz#baaf25844a99eaa0b22e1ef8d205bffe587c8f43"
+  integrity sha512-MEvryPLf18HvlCbLSzCW0U00IMftKGI5udnjrQbC5D4P0Hodwffhv+iGfWuJwg16Y/TK11ZFK8i+BPVW2z/eAw==
 
 unfetch@^4.2.0:
   version "4.2.0"
@@ -22197,11 +22151,6 @@ v8-compile-cache-lib@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz#0582bcb1c74f3a2ee46487ceecf372e46bce53e8"
   integrity sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==
-
-v8-compile-cache-lib@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
-  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"


### PR DESCRIPTION
## Motivation and Context

Breaking off a chunk of the add members work to get deployed. This just includes the add one member or add many members by eth addr/name functionality.

This is based on our hybrid onboarding pod / 1.5 add members concepts.  Figma here: https://www.figma.com/file/qSap4xHYicSvZb3xXqmBzI/Onboarding-Wireframes?node-id=323%3A20725

This also includes feature flagging for the link sharing stuff, which is off for now and is half-baked because the UI isn't done. 

## Description

* New Add members page, which will have tabs for more styles of adding, but are hidden for now. 
* Getting rid of the add contributor dialog , which means adding users is now simple, and doesn't have advanced options

## Test and Deployment Plan

* I have tested this quite well, including validation varieties, but I could use thorough testing from a reviewer.  
* Also test editing members after simply adding them
