### PR TITLE
Allow option to read dev seed phrase from ENV

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ IMAGE_DIR=assets/static/images/
 # separate allowed domains with commas
 SIWE_ALLOWED_DOMAINS=localhost:3000,
 
+# Note: use dashes instead of spaces for mnemonic since bash parses spaces incorrectly
+DEV_SEED_PHRASE="test-test-test-test-test-test-test-test-test-test-test-junk"
+
 # Default local variables
 LOCAL_HASURA_PORT=8080
 LOCAL_POSTGRES_PORT=5432

--- a/scripts/util/eth.ts
+++ b/scripts/util/eth.ts
@@ -1,4 +1,9 @@
+function swapDashSpace(s?: string) {
+  return s?.replace(/-/g, ' ');
+}
+
 export const SEED_PHRASE =
+  swapDashSpace(process.env.DEV_SEED_PHRASE) ||
   'test test test test test test test test test test test junk';
 export function getAccountPath(index: number): string {
   return `m/44'/60'/0'/0/${index}`;


### PR DESCRIPTION
Allow option to read dev seed phrase from ENV

Parse out dashes as workaround for bash's handling of spaces

@topocount 