### PR TITLE
bugfix: FormTokenField handles empty strings

### DIFF
--- a/src/components/FormTokenField/FormTokenField.test.tsx
+++ b/src/components/FormTokenField/FormTokenField.test.tsx
@@ -32,7 +32,7 @@ test('can render a change to an empty string', () => {
   const input: HTMLInputElement = screen.getByTestId('FormTokenField');
   fireEvent.change(input, { target: { value: '500' } });
   fireEvent.change(input, { target: { value: '' } });
-  expect(input.value).toBe('');
+  expect(input.value).toBe('0');
 });
 
 test('can render a valid token amount', () => {

--- a/src/components/FormTokenField/FormTokenField.test.tsx
+++ b/src/components/FormTokenField/FormTokenField.test.tsx
@@ -25,6 +25,16 @@ const MockTokenPage = () => {
   );
 };
 
+test('can render a change to an empty string', () => {
+  act(() => {
+    render(<MockTokenPage />);
+  });
+  const input: HTMLInputElement = screen.getByTestId('FormTokenField');
+  fireEvent.change(input, { target: { value: '500' } });
+  fireEvent.change(input, { target: { value: '' } });
+  expect(input.value).toBe('');
+});
+
 test('can render a valid token amount', () => {
   act(() => {
     render(<MockTokenPage />);

--- a/src/components/FormTokenField/FormTokenField.tsx
+++ b/src/components/FormTokenField/FormTokenField.tsx
@@ -49,7 +49,7 @@ export const FormTokenField = React.forwardRef((props: Props, ref) => {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     // only accept floating point inputs
     const matches = e.target.value.match(/\d*\.?\d*/);
-    if (matches == null) {
+    if (matches == null || e.target.value.length === 0) {
       onChange('');
       return;
     }

--- a/src/components/FormTokenField/FormTokenField.tsx
+++ b/src/components/FormTokenField/FormTokenField.tsx
@@ -50,7 +50,7 @@ export const FormTokenField = React.forwardRef((props: Props, ref) => {
     // only accept floating point inputs
     const matches = e.target.value.match(/\d*\.?\d*/);
     if (matches == null || e.target.value.length === 0) {
-      onChange('');
+      onChange('0');
       return;
     }
     const nextValue = matches[0];


### PR DESCRIPTION
This used to throw an error when the string was parsed into a BigNumber.
Now it just short-circuits and doesn't attempt to parse.