### PR TITLE
link based joining

### DIFF
--- a/api/circle/landing/[token].ts
+++ b/api/circle/landing/[token].ts
@@ -49,6 +49,20 @@ async function circleFromToken(token: string) {
               name: true,
               logo: true,
             },
+            users: [
+              {
+                limit: 3,
+                where: {
+                  role: { _eq: 1 },
+                },
+              },
+              {
+                name: true,
+                profile: {
+                  avatar: true,
+                },
+              },
+            ],
           },
         },
       ],
@@ -62,7 +76,7 @@ async function circleFromToken(token: string) {
   if (!tokenResult || !tokenResult.circle) {
     throw new Error('invalid token provided or not found');
   }
-  return tokenResult;
+  return { ...tokenResult, token };
 }
 
 export type TokenJoinInfo = Awaited<ReturnType<typeof circleFromToken>>;

--- a/cypress/e2e/createUser.cy.ts
+++ b/cypress/e2e/createUser.cy.ts
@@ -25,6 +25,9 @@ context('Coordinape', () => {
     cy.contains('Add Members', { timeout: 120000 }).should('be.visible');
     cy.contains('Add Members').click();
 
+    cy.contains('ETH Address', { timeout: 120000 }).should('be.visible');
+    cy.contains('ETH Address').click();
+
     cy.get('[data-testid=new-members]').within(() => {
       cy.get('input').eq(0).click().type('A Test User').blur();
       cy.get('input')

--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -4,8 +4,7 @@ export type FeatureName =
   | 'vaults'
   | 'fixed_payments'
   | 'future_feature'
-  | 'csv_import'
-  | 'link_joining';
+  | 'csv_import';
 
 // this is a very simple implementation of build-time feature flags that you can
 // hardcode or set with environment variables

--- a/src/forms/formHelpers.ts
+++ b/src/forms/formHelpers.ts
@@ -43,3 +43,15 @@ export const zEthAddressOrBlank = z.string().refine(async val => {
 export const zBytes32 = z
   .string()
   .refine(val => ethers.utils.isHexString(val, 32));
+
+export const zUsername = z
+  .string()
+  .max(255)
+  .transform(val => val.trim())
+  .refine(val => val.length >= 3, 'Name must contain at least 3 characters');
+
+export const zCircleName = z
+  .string()
+  .max(255)
+  .transform(val => val.trim())
+  .refine(val => val.length >= 3);

--- a/src/lib/gql/queries.ts
+++ b/src/lib/gql/queries.ts
@@ -504,6 +504,7 @@ export const fetchManifest = async (address: string): Promise<IApiManifest> => {
             name: true,
             created_at: true,
             updated_at: true,
+            logo: true,
           },
           auto_opt_out: true,
           fixed_payment_token_type: true,

--- a/src/lib/zod/index.ts
+++ b/src/lib/zod/index.ts
@@ -8,7 +8,9 @@ import {
   zStringISODateUTC,
   zBytes32,
   zEthAddress,
-} from '../../../src/forms/formHelpers';
+  zUsername,
+  zCircleName,
+} from '../../forms/formHelpers';
 
 const PERSONAL_SIGN_REGEX = /0x[0-9a-f]{130}/;
 
@@ -33,8 +35,8 @@ export const loginInput = z.object({
 
 export const createCircleSchemaInput = z
   .object({
-    user_name: z.string().min(3).max(255),
-    circle_name: z.string().min(3).max(255),
+    user_name: zUsername,
+    circle_name: zCircleName,
     protocol_id: z.number().int().positive().optional(),
     protocol_name: z.string().min(3).max(255).optional(),
     contact: z.string().min(3).max(255).optional(),
@@ -50,7 +52,7 @@ export const adminUpdateUserSchemaInput = z
     circle_id: z.number(),
     address: zEthAddressOnly,
     new_address: zEthAddressOnly.optional(),
-    name: z.string().min(3).max(255).optional(),
+    name: zUsername.optional(),
     starting_tokens: z.number().optional(),
     non_giver: z.boolean().optional(),
     fixed_non_receiver: z.boolean().optional(),
@@ -75,7 +77,7 @@ export const deleteCircleInput = z
 
 export const createNomineeInputSchema = z
   .object({
-    name: z.string().min(3).max(255),
+    name: zUsername,
     circle_id: z.number().int().positive(),
     address: zEthAddressOnly,
     description: z.string().min(3).max(1000),
@@ -109,7 +111,7 @@ export const updateUserSchemaInput = z
 export const createUserSchemaInput = z
   .object({
     circle_id: z.number(),
-    name: z.string().min(3).max(255),
+    name: zUsername,
     address: zEthAddress,
     non_giver: z.boolean().optional(),
     starting_tokens: z.number().optional().default(100),
@@ -123,7 +125,7 @@ export const createUserSchemaInput = z
 export const createUserFromTokenInput = z
   .object({
     token: z.string().uuid(),
-    name: z.string().min(3).max(255),
+    name: zUsername,
   })
   .strict();
 
@@ -249,11 +251,7 @@ export const updateTeammatesInput = z
 export const updateCircleInput = z
   .object({
     circle_id: z.number().positive(),
-    name: z
-      .string()
-      .max(255)
-      .refine(val => val.trim().length >= 3)
-      .optional(),
+    name: zCircleName.optional(),
     alloc_text: z.string().max(5000).optional(),
     auto_opt_out: z.boolean().optional(),
     default_opt_in: z.boolean().optional(),

--- a/src/pages/AddMembersPage/AddMembersPage.tsx
+++ b/src/pages/AddMembersPage/AddMembersPage.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 
 import { LoadingModal } from '../../components';
 import { isFeatureEnabled } from '../../config/features';
+import { AlertSolid } from '../../icons/__generated';
 import { paths } from '../../routes/paths';
 import { ICircle } from '../../types';
 import BackButton from '../../ui/BackButton';
@@ -9,9 +10,10 @@ import { Box } from '../../ui/Box/Box';
 import HintButton from '../../ui/HintButton';
 import { APP_URL } from '../../utils/domain';
 import { useSelectedCircle } from 'recoilState/app';
-import { AppLink, Button, Flex, Panel, Text } from 'ui';
+import { AppLink, Flex, Panel, Text } from 'ui';
 import { SingleColumnLayout } from 'ui/layouts';
 
+import ConstrainedBox from './ConstrainedBox';
 import CopyCodeTextField from './CopyCodeTextField';
 import NewMemberList from './NewMemberList';
 import TabButton, { Tab } from './TabButton';
@@ -78,7 +80,7 @@ const AddMembersContents = ({
   circle,
   welcomeLink,
   magicLink,
-  revokeMagic,
+  // revokeMagic, TODO: add revoke in a later PR when UI is better defined
   revokeWelcome,
 }: {
   circle: ICircle;
@@ -108,35 +110,31 @@ const AddMembersContents = ({
           </AppLink>
         </Text>
       </Box>
-      {(isFeatureEnabled('csv_import') || isFeatureEnabled('link_joining')) && (
-        <Flex css={{ mb: '$xl' }}>
+      <Flex css={{ mb: '$sm' }}>
+        <TabButton
+          tab={Tab.LINK}
+          currentTab={currentTab}
+          setCurrentTab={setCurrentTab}
+        >
+          Magic Link
+        </TabButton>
+        <TabButton
+          tab={Tab.ETH}
+          currentTab={currentTab}
+          setCurrentTab={setCurrentTab}
+        >
+          ETH Address
+        </TabButton>
+        {isFeatureEnabled('csv_import') && (
           <TabButton
-            tab={Tab.ETH}
+            tab={Tab.CSV}
             currentTab={currentTab}
             setCurrentTab={setCurrentTab}
           >
-            Add by ETH Address
+            CSV Import
           </TabButton>
-          {isFeatureEnabled('csv_import') && (
-            <TabButton
-              tab={Tab.CSV}
-              currentTab={currentTab}
-              setCurrentTab={setCurrentTab}
-            >
-              CSV Import
-            </TabButton>
-          )}
-          {isFeatureEnabled('link_joining') && (
-            <TabButton
-              tab={Tab.LINK}
-              currentTab={currentTab}
-              setCurrentTab={setCurrentTab}
-            >
-              Join Link
-            </TabButton>
-          )}
-        </Flex>
-      )}
+        )}
+      </Flex>
       <Panel>
         {currentTab === Tab.ETH && (
           <Box>
@@ -157,13 +155,36 @@ const AddMembersContents = ({
           </Box>
         )}
         {currentTab === Tab.LINK && (
-          <>
-            <div>
-              MagicLink
+          <Box>
+            <Text css={{ pb: '$lg', pt: '$sm' }} size="large">
+              Add new members by sharing a magic link.
+            </Text>
+            <ConstrainedBox css={{ mb: '$md' }}>
+              <Flex css={{ alignItems: 'center', mb: '$xs' }}>
+                <Text variant="label">Magic Circle Link</Text>
+              </Flex>
               <CopyCodeTextField value={magicLink} />
-              <Button onClick={revokeMagic}>refr</Button>
-            </div>
-          </>
+
+              <Panel alert css={{ mt: '$xl' }}>
+                <Flex>
+                  <AlertSolid
+                    color="alert"
+                    size="xl"
+                    css={{
+                      mr: '$md',
+                      '& path': { stroke: 'none' },
+                      flexShrink: 0,
+                    }}
+                  />
+                  <Text size="large">
+                    Anyone with this link can join this circle and set their
+                    name. For added security, add new members using their wallet
+                    addresses.
+                  </Text>
+                </Flex>
+              </Panel>
+            </ConstrainedBox>
+          </Box>
         )}
         <Box css={{ mt: '$md' }}>
           <HintButton

--- a/src/pages/AddMembersPage/ConstrainedBox.tsx
+++ b/src/pages/AddMembersPage/ConstrainedBox.tsx
@@ -1,0 +1,11 @@
+import { styled } from '../../stitches.config';
+import { Box } from '../../ui';
+
+const ConstrainedBox = styled(Box, {
+  width: '70%',
+  '@md': {
+    width: '100%',
+  },
+});
+
+export default ConstrainedBox;

--- a/src/pages/AddMembersPage/TabButton.tsx
+++ b/src/pages/AddMembersPage/TabButton.tsx
@@ -21,8 +21,10 @@ const TabButton = ({
 }) => {
   return (
     <Button
-      color={currentTab === tab ? 'secondary' : undefined}
-      css={{ borderRadius: '$pill', mr: '$md' }}
+      css={{ borderRadius: '$pill', mr: '$md', border: '1px solid $neutral' }}
+      key={tab}
+      color="neutral"
+      outlined={currentTab !== tab}
       onClick={() => setCurrentTab(tab)}
     >
       {children}

--- a/src/pages/AllocationPage/AllocationGive.tsx
+++ b/src/pages/AllocationPage/AllocationGive.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-console */
-
 import React, { useState } from 'react';
 
 import clsx from 'clsx';

--- a/src/pages/AllocationPage/AllocationPage.tsx
+++ b/src/pages/AllocationPage/AllocationPage.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import React, { useEffect, useState } from 'react';
 
 import isEqual from 'lodash/isEqual';

--- a/src/pages/JoinCirclePage/AddressIsNotMember.tsx
+++ b/src/pages/JoinCirclePage/AddressIsNotMember.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+
+import { TokenJoinInfo } from '../../../api/circle/landing/[token]';
+import { useMyProfile } from '../../recoilState';
+import { paths } from '../../routes/paths';
+import { AppLink, Box, Button, Panel, Text } from '../../ui';
+import CenteredBox from '../../ui/CenteredBox';
+import CircleWithLogo from '../../ui/CircleWithLogo';
+import { Flex } from '../../ui/Flex/Flex';
+
+export const AddressIsNotMember = ({
+  tokenJoinInfo,
+}: {
+  tokenJoinInfo: TokenJoinInfo;
+}) => {
+  const { address, myUsers } = useMyProfile();
+
+  const bigText = {
+    fontWeight: '$semibold',
+    mb: '$sm',
+    color: '$headingText',
+    fontSize: '$large',
+  };
+
+  return (
+    <CenteredBox>
+      <Box>
+        <Box
+          css={{
+            ...bigText,
+            fontSize: '$h2',
+            fontWeight: '$bold',
+            mb: '$lg',
+          }}
+        >
+          You&apos;re not a member of {tokenJoinInfo.circle.name}
+        </Box>
+
+        <Box css={{ my: '$lg' }}>
+          <Text p as="p">
+            If you believe this is an error, check that you have signed in with
+            the correct address or contact the Circle Administrator for further
+            instructions. You are currently logged in as {address}.
+          </Text>
+        </Box>
+
+        {myUsers.length > 0 && (
+          <>
+            <Box css={{ ...bigText, textAlign: 'left', mb: '$lg' }}>
+              You are a member of these other circles
+            </Box>
+            {myUsers.map(u => (
+              <AppLink key={u.id} to={paths.history(u.circle_id)}>
+                <Panel
+                  nested
+                  css={{
+                    border: '1px solid white',
+                    mb: '$md',
+                    cursor: 'pointer',
+                    '&:hover': {
+                      border: '1px solid $primary',
+                    },
+                  }}
+                >
+                  <CircleWithLogo
+                    logo={u.circle.logo}
+                    name={u.circle.name}
+                    orgLogo={u.circle.protocol.logo}
+                    orgName={u.circle.protocol.name}
+                  />
+                </Panel>
+              </AppLink>
+            ))}
+          </>
+        )}
+
+        {myUsers.length == 0 && (
+          <Box css={{ ...bigText, textAlign: 'center', mb: '$lg' }}>
+            You aren&apos;t a member of any circles
+          </Box>
+        )}
+
+        <Flex css={{ justifyContent: 'center', mt: '$xl' }}>
+          <Box>
+            <AppLink to={paths.profile('me')}>
+              <Button color="primary" outlined inline>
+                Complete Your Profile
+              </Button>
+            </AppLink>
+          </Box>
+        </Flex>
+      </Box>
+    </CenteredBox>
+  );
+};

--- a/src/pages/JoinCirclePage/JoinCirclePage.tsx
+++ b/src/pages/JoinCirclePage/JoinCirclePage.tsx
@@ -29,16 +29,8 @@ export const JoinCirclePage = () => {
     TokenJoinInfo | undefined
   >();
 
-  const alreadyMember = (circleId: number) => {
-    let found = false;
-    for (const user of myUsers) {
-      if (user.circle_id === circleId) {
-        found = true;
-        break;
-      }
-    }
-    return found;
-  };
+  const alreadyMember = (circleId: number) =>
+    myUsers.some(u => u.circle_id === circleId);
 
   useEffect(() => {
     const fn = async () => {

--- a/src/pages/JoinCirclePage/JoinCirclePage.tsx
+++ b/src/pages/JoinCirclePage/JoinCirclePage.tsx
@@ -1,0 +1,108 @@
+import React, { useEffect, useState } from 'react';
+
+import { useNavigate } from 'react-router';
+import { useParams } from 'react-router-dom';
+
+import { TokenJoinInfo } from '../../../api/circle/landing/[token]';
+import { CircleTokenType } from '../../common-lib/circleShareTokens';
+import { LoadingModal } from '../../components';
+import { useMyProfile } from '../../recoilState';
+import { paths } from '../../routes/paths';
+import { Panel, Text } from '../../ui';
+import CenteredBox from '../../ui/CenteredBox';
+
+import { AddressIsNotMember } from './AddressIsNotMember';
+import { JoinWithMagicLink } from './JoinWithMagicLink';
+
+export const JoinCirclePage = () => {
+  const { token } = useParams();
+
+  const navigate = useNavigate();
+
+  const { myUsers } = useMyProfile();
+
+  const [tokenError, setTokenError] = useState<string | undefined>();
+  const [wrongAddress, setWrongAddress] = useState<boolean | undefined>(
+    undefined
+  );
+  const [tokenJoinInfo, setTokenJoinInfo] = useState<
+    TokenJoinInfo | undefined
+  >();
+
+  const alreadyMember = (circleId: number) => {
+    let found = false;
+    for (const user of myUsers) {
+      if (user.circle_id === circleId) {
+        found = true;
+        break;
+      }
+    }
+    return found;
+  };
+
+  useEffect(() => {
+    const fn = async () => {
+      try {
+        const res = await fetch('/api/circle/landing/' + token);
+        if (!res.ok) {
+          setTokenError(
+            'Invalid invite link; check with the Circle Admin, there may be a new link.'
+          );
+          return;
+        }
+        const info: TokenJoinInfo = JSON.parse(await res.text());
+
+        if (alreadyMember(info.circle.id)) {
+          // shoot them off the history page
+          navigate(paths.history(info.circle.id));
+          return;
+        }
+
+        setTokenJoinInfo(info);
+        if (info.type === CircleTokenType.Welcome) {
+          setWrongAddress(true);
+          return;
+        }
+      } catch (e) {
+        setTokenError('Network error validating invite link');
+      }
+    };
+    fn()
+      .then()
+      .catch(e => {
+        if (e instanceof Error) {
+          setTokenError(e.message ?? 'unknown error');
+        } else {
+          setTokenError('invalid token');
+        }
+      });
+  }, []);
+
+  // Waiting to validate the token
+  if (!tokenError && !tokenJoinInfo) {
+    return <LoadingModal visible={true} />;
+  }
+
+  if (tokenJoinInfo && wrongAddress) {
+    return <AddressIsNotMember tokenJoinInfo={tokenJoinInfo} />;
+  }
+
+  return (
+    <>
+      {tokenError && (
+        <CenteredBox>
+          <Text
+            h2
+            css={{ mb: '$lg', textAlign: 'center', justifyContent: 'center' }}
+          >
+            Error
+          </Text>
+          <Panel nested>{tokenError}</Panel>
+        </CenteredBox>
+      )}
+      {tokenJoinInfo && <JoinWithMagicLink tokenJoinInfo={tokenJoinInfo} />}
+    </>
+  );
+};
+
+export default JoinCirclePage;

--- a/src/pages/JoinCirclePage/JoinWithMagicLink.tsx
+++ b/src/pages/JoinCirclePage/JoinWithMagicLink.tsx
@@ -1,0 +1,163 @@
+import React, { useState } from 'react';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router';
+import { z } from 'zod';
+
+import { TokenJoinInfo } from '../../../api/circle/landing/[token]';
+import { LoadingModal } from '../../components';
+import { zUsername } from '../../forms/formHelpers';
+import { useApeSnackbar, useApiBase } from '../../hooks';
+import { client } from '../../lib/gql/client';
+import { useMyProfile } from '../../recoilState';
+import { paths } from '../../routes/paths';
+import { Box, Button, TextField, Text, Panel } from '../../ui';
+import CenteredBox from '../../ui/CenteredBox';
+import CircleWithLogo from '../../ui/CircleWithLogo';
+import { normalizeError } from '../../utils/reporting';
+
+export const JoinWithMagicLink = ({
+  tokenJoinInfo,
+}: {
+  tokenJoinInfo: TokenJoinInfo;
+}) => {
+  const { fetchManifest } = useApiBase();
+  const { showError } = useApeSnackbar();
+  const navigate = useNavigate();
+  const [loading, setLoading] = useState<boolean>(false);
+  const { address } = useMyProfile();
+
+  const joinSchema = z.object({ name: zUsername });
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+  } = useForm({
+    resolver: zodResolver(joinSchema),
+    reValidateMode: 'onChange',
+    mode: 'onChange',
+    defaultValues: {
+      name: '',
+    },
+  });
+
+  const submitMagicToken = async ({ name }: { name: string }) => {
+    try {
+      setLoading(true);
+      const { createUserWithToken } = await client.mutate({
+        createUserWithToken: [
+          {
+            payload: {
+              token: tokenJoinInfo.token,
+              name: name,
+            },
+          },
+          {
+            id: true,
+          },
+        ],
+      });
+      await fetchManifest();
+      if (createUserWithToken?.id) {
+        navigate(paths.history(tokenJoinInfo.circle.id));
+      }
+    } catch (e) {
+      const err = normalizeError(e);
+      showError('Unable to finish joining: ' + err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <CenteredBox>
+      {loading && <LoadingModal visible={true} />}
+      <Panel nested>
+        <CircleWithLogo
+          logo={tokenJoinInfo.circle.logo}
+          name={tokenJoinInfo.circle.name}
+          orgName={tokenJoinInfo.circle.organization.name}
+          orgLogo={tokenJoinInfo.circle.organization.logo}
+          admins={tokenJoinInfo.circle.users.map(u => ({
+            name: u.name,
+            avatar: u.profile.avatar,
+          }))}
+        />
+      </Panel>
+      <Box css={{ textAlign: 'center', mt: '$3xl', mb: '$xl' }}>
+        <Text h2 inline bold color="neutral">
+          Join the {tokenJoinInfo.circle.name} Circle
+        </Text>
+      </Box>
+      <Box>
+        <Text
+          css={{
+            justifyContent: 'center',
+          }}
+        >
+          You&apos;ve been invited to join the {tokenJoinInfo.circle.name}{' '}
+          Circle at {tokenJoinInfo.circle.organization.name}!
+        </Text>
+      </Box>
+
+      <form onSubmit={handleSubmit(submitMagicToken)}>
+        <Box
+          css={{
+            mb: '$md',
+            mt: '$3xl',
+            alignItems: 'center',
+            display: 'grid',
+            gridColumnGap: '$md',
+            gridTemplateColumns: '35fr 65fr',
+          }}
+        >
+          <Box>
+            <Box css={{ mb: '$xs' }}>
+              <Text variant="label">Name</Text>
+            </Box>
+            <TextField
+              inPanel
+              placeholder="Name"
+              fullWidth
+              autoComplete="off"
+              error={errors.name !== undefined}
+              {...register(`name`)}
+            />
+          </Box>
+          <Box>
+            <Box css={{ mb: '$xs' }}>
+              <Text variant="label">Wallet Address</Text>
+            </Box>
+            <TextField
+              inPanel
+              placeholder="Address"
+              fullWidth
+              disabled={true}
+              value={address}
+            />
+          </Box>
+          <Box>
+            {errors.name && (
+              <Text variant="formError" css={{ mt: '$sm', textAlign: 'left' }}>
+                {errors.name.message}
+              </Text>
+            )}
+          </Box>
+        </Box>
+        <Box>
+          <Button
+            type="submit"
+            color="primary"
+            fullWidth
+            size="large"
+            disabled={loading || !isValid}
+          >
+            Join
+          </Button>
+        </Box>
+      </form>
+    </CenteredBox>
+  );
+};

--- a/src/pages/JoinCirclePage/index.ts
+++ b/src/pages/JoinCirclePage/index.ts
@@ -1,0 +1,2 @@
+import { JoinCirclePage } from './JoinCirclePage';
+export default JoinCirclePage;

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -82,6 +82,10 @@ export const paths = {
   profile: (address: string) => `/profile/${address}`,
   vaults: '/vaults',
   vaultTxs: (address: string) => `${paths.vaults}/${address}/txs`,
+
+  // for circle links
+  invite: (token: string) => `/welcome/${token}`,
+  join: (token: string) => `/join/${token}`,
 };
 
 export const isCircleSpecificPath = (location: Location) =>

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react-router-dom';
 
 import AddMembersPage from '../pages/AddMembersPage/AddMembersPage';
+import JoinCirclePage from '../pages/JoinCirclePage';
 import { useFixCircleState, useRoleInCircle } from 'hooks/migration';
 import AdminCircleApiPage from 'pages/AdminCircleApiPage/AdminCircleApiPage';
 import AdminPage from 'pages/AdminPage';
@@ -86,6 +87,9 @@ export const AppRoutes = () => {
         element={<VaultTransactions />}
       />
 
+      <Route path={paths.join(':token')} element={<JoinCirclePage />} />
+
+      <Route path={paths.invite(':token')} element={<JoinCirclePage />} />
       <Route path="*" element={<Redirect to={paths.home} note="catchall" />} />
     </Routes>
   );

--- a/src/stitches.config.ts
+++ b/src/stitches.config.ts
@@ -61,6 +61,7 @@ const spaces = {
   '1xl': '40px',
   '2xl': '48px',
   '3xl': '60px',
+  '4xl': '88px',
 };
 
 export const colors = {

--- a/src/types/api.circle.d.ts
+++ b/src/types/api.circle.d.ts
@@ -3,6 +3,7 @@ import { IEpoch } from './api.epoch';
 export interface IProtocol {
   id: number;
   name: string;
+  logo?: string;
   is_verified?: boolean;
   created_at?: Date;
   updated_at?: Date;

--- a/src/ui/Avatar/Avatar.tsx
+++ b/src/ui/Avatar/Avatar.tsx
@@ -23,6 +23,13 @@ const AvatarRoot = styled(AvatarPrimitive.Root, {
   zIndex: 1,
   variants: {
     size: {
+      xs: {
+        width: '$lg !important',
+        height: '$lg',
+        '> span': {
+          fontSize: '$medium',
+        },
+      },
       small: {
         width: '$xl !important',
         height: '$xl',
@@ -38,8 +45,18 @@ const AvatarRoot = styled(AvatarPrimitive.Root, {
         },
       },
       large: {
-        width: '$xl',
-        height: '$xl',
+        width: '$2xl !important',
+        height: '$2xl',
+        '> span': {
+          fontSize: '$medium',
+        },
+      },
+      xl: {
+        width: '$4xl !important',
+        height: '$4xl',
+        '> span': {
+          fontSize: '$medium',
+        },
       },
     },
     margin: {
@@ -76,6 +93,9 @@ const AvatarFallback = styled(AvatarPrimitive.Fallback, {
   fontWeight: '$medium',
   variants: {
     size: {
+      xs: {
+        fontSize: '$small',
+      },
       small: {
         fontSize: '$medium',
       },
@@ -83,6 +103,9 @@ const AvatarFallback = styled(AvatarPrimitive.Fallback, {
         fontSize: '$medium',
       },
       large: {
+        fontSize: '$large',
+      },
+      xl: {
         fontSize: '$large',
       },
     },
@@ -103,7 +126,7 @@ export const Avatar = ({
   name?: string;
   onClick?: () => void;
   /** represents avatar with smaller size `32x32` */
-  size?: 'large' | 'medium' | 'small';
+  size?: 'xl' | 'large' | 'medium' | 'small' | 'xs';
   margin?: 'none' | 'small'; // can be extended if needed
   children?: React.ReactNode;
   css?: Stitches.CSS;

--- a/src/ui/CenteredBox.tsx
+++ b/src/ui/CenteredBox.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import { Flex } from './Flex/Flex';
+import { Panel } from './Panel/Panel';
+
+const CenteredBox = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <Flex
+      css={{
+        alignItems: 'center',
+        justifyContent: 'center',
+        mt: '$4xl',
+      }}
+    >
+      <Panel
+        css={{
+          width: '50%',
+          textAlign: 'center',
+          padding: '$xl',
+          '@sm': { width: '90%' },
+        }}
+      >
+        {children}
+      </Panel>
+    </Flex>
+  );
+};
+
+export default CenteredBox;

--- a/src/ui/CircleWithLogo.tsx
+++ b/src/ui/CircleWithLogo.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+
+import { getCircleAvatar } from '../utils/domain';
+
+import { Avatar } from './Avatar/Avatar';
+import { Box } from './Box/Box';
+import { Flex } from './Flex/Flex';
+import { Text } from './Text/Text';
+
+const CircleWithLogo = ({
+  logo,
+  name,
+  orgLogo,
+  orgName,
+  admins,
+}: {
+  logo?: string;
+  name: string;
+  orgLogo?: string;
+  orgName: string;
+  admins?: { name: string; avatar?: string }[];
+}) => {
+  return (
+    <Flex css={{ alignItems: 'center', textAlign: 'left' }}>
+      <Avatar
+        name={name}
+        size="xl"
+        margin="none"
+        css={{ flexShrink: 0 }}
+        path={getCircleAvatar({
+          avatar: logo,
+          circleName: name,
+        })}
+      />
+      <Box css={{ ml: '$lg', flexGrow: 1 }}>
+        <Flex css={{ alignItems: 'center' }}>
+          <Avatar
+            name={orgName}
+            size="xs"
+            margin="none"
+            css={{ mr: '$sm' }}
+            path={getCircleAvatar({
+              avatar: orgLogo,
+              circleName: orgName,
+            })}
+          />
+          <Text variant="label">{orgName}</Text>
+        </Flex>
+        <Box css={{ mt: '$sm', pb: '7px' }}>
+          <Box
+            // color={'default'}
+            css={{
+              display: 'block',
+              lineHeight: '$none',
+              maxWidth: '100%',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: '',
+              color: '$text',
+              fontSize: '$h2',
+              fontWeight: '$bold',
+            }}
+          >
+            {name}
+          </Box>
+        </Box>
+      </Box>
+      {admins && admins.length > 0 && (
+        <Box>
+          <Box css={{ mb: '$xs' }}>
+            <Text variant="label">Circle Admins</Text>
+          </Box>
+          <Flex>
+            {admins.map(u => (
+              <Box key={u.name} css={{ textAlign: 'center', width: '$3xl' }}>
+                <Avatar
+                  name={u.name}
+                  size="small"
+                  margin="none"
+                  path={u.avatar}
+                />
+                <Box
+                  css={{
+                    maxWidth: '$3xl',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  <Text size={'small'} inline>
+                    {u.name}
+                  </Text>
+                </Box>
+              </Box>
+            ))}
+          </Flex>
+        </Box>
+      )}
+    </Flex>
+  );
+};
+
+export default CircleWithLogo;

--- a/src/ui/Panel/Panel.tsx
+++ b/src/ui/Panel/Panel.tsx
@@ -50,6 +50,11 @@ export const Panel = styled('div', {
         backgroundColor: '$success',
       },
     },
+    alert: {
+      true: {
+        backgroundColor: '$alertLight',
+      },
+    },
   },
 
   defaultVariants: {


### PR DESCRIPTION
## Motivation and Context

Improving onboarding of new users

## Description

This adds:
* magic link on the add members page
* a landing page for a circle where you can set your name if provided a magic link
* a welcome link for sharing with users after they were invited that will take them to the circle directly

Out of scope but targeted for future work:
* These links could work without login, but the site routing is really unfriendly for that pattern for now, so you have to login to see anything, which kind of makes the welcome link redundant, but we will improve it later
* The links could probably be shorter and more brief
* Revocation  of the links requires some more UI design so we aren't including it yet. The backend is implemented.

## Test and Deployment Plan

1. Visit the add members page and copy a magic link
2. Try using it with an account that isn't a member, and with an account that is already , and try corrupting the UUID 
3. When you are successfully joining, make sure name validation works and that the site responds as expected when you join
4. Try sharing the welcome link with users that you add by address, try similar corruptions of the uuid

## Design 

Figma: https://www.figma.com/file/L4oZwYVUdpgacZtwipGaYe/App-1.5?node-id=14451%3A54362

## Related Issue

Fixes #1299
