### PR TITLE
ui/fixups

### DIFF
--- a/cypress/e2e/createVault.cy.ts
+++ b/cypress/e2e/createVault.cy.ts
@@ -47,7 +47,7 @@ context('Coordinape', () => {
     cy.reload(true);
     cy.contains('Ended Epoch With Gifts', { timeout: 120000 }).click();
     cy.get('table').contains('Deposit');
-    cy.get('table').contains('5000');
+    cy.get('table').contains('5000.00');
 
     // Withdraw USDC from the Vault
     cy.contains('Withdraw').click();

--- a/cypress/e2e/createVault.cy.ts
+++ b/cypress/e2e/createVault.cy.ts
@@ -79,7 +79,7 @@ context('Coordinape', () => {
     cy.contains('1 Distribution');
     cy.contains('6 Unique Contributors Paid');
     cy.get('table').contains('Distribution');
-    cy.get('table').contains('4500');
+    cy.get('table').contains('4,500.00');
 
     // claims allocations
     cy.contains('button', 'Claim Allocations').click();

--- a/cypress/e2e/createVault.cy.ts
+++ b/cypress/e2e/createVault.cy.ts
@@ -47,7 +47,7 @@ context('Coordinape', () => {
     cy.reload(true);
     cy.contains('Ended Epoch With Gifts', { timeout: 120000 }).click();
     cy.get('table').contains('Deposit');
-    cy.get('table').contains('5000.00');
+    cy.get('table').contains('5,000.00');
 
     // Withdraw USDC from the Vault
     cy.contains('Withdraw').click();

--- a/src/pages/DistributionsPage/AllocationsTable.tsx
+++ b/src/pages/DistributionsPage/AllocationsTable.tsx
@@ -157,7 +157,7 @@ export const AllocationsTable = ({
             </td>
             <td>{shortenAddress(user.address)}</td>
             <td>{user.givers}</td>
-            <td>{numberWithCommas(user.received)}</td>
+            <td>{user.received}</td>
             <td>{numberWithCommas(givenPercent(user.received) * 100, 2)}%</td>
             <td>
               {user.circle_claimed

--- a/src/pages/VaultsPage/VaultTransactions.tsx
+++ b/src/pages/VaultsPage/VaultTransactions.tsx
@@ -9,6 +9,7 @@ import { styled } from 'stitches.config';
 import { LoadingModal } from 'components/LoadingModal/LoadingModal';
 import { Link, Panel, Text } from 'ui';
 import { OrgLayout, SingleColumnLayout } from 'ui/layouts';
+import { numberWithCommas } from 'utils';
 import { getProviderForChain, makeExplorerUrl } from 'utils/provider';
 
 import { getVaultAndTransactions } from './queries';
@@ -328,7 +329,7 @@ export const TransactionTable = ({
           <td>{row.circle}</td>
           <td>{row.type}</td>
           <td>{row.details}</td>
-          <td>{row.amount.toString()}</td>
+          <td>{numberWithCommas(row.amount, 2)}</td>
           <td>
             <Link target="_blank" href={makeExplorerUrl(chainId, row.hash)}>
               Etherscan


### PR DESCRIPTION
- Use 2 precision number formatting on All Txs Page:
![image](https://user-images.githubusercontent.com/83605543/185253798-76634190-b5e1-4da1-bce9-907179bef715.png)

- Remove GIVE precision on Distribution page"


<img width="239" alt="Screen Shot 2022-08-17 at 3 21 47 PM" src="https://user-images.githubusercontent.com/83605543/185253933-f64c81b7-aadc-4baa-b907-ea6a41446799.png">

