### PR TITLE
Feature/Circle admin page fixed payment section

### DIFF
--- a/src/pages/AdminPage/AdminUserModal.tsx
+++ b/src/pages/AdminPage/AdminUserModal.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 
+import { useQueryClient } from 'react-query';
 import { NavLink } from 'react-router-dom';
 
 import { makeStyles } from '@material-ui/core';
@@ -75,6 +76,8 @@ export const AdminUserModal = ({
   const isOptedOut = !!user?.fixed_non_receiver || !!user?.non_receiver;
   const hasGiveAllocated = !!user?.give_token_received;
 
+  const queryClient = useQueryClient();
+
   const source = useMemo(
     () => ({
       user: user,
@@ -97,7 +100,10 @@ export const AdminUserModal = ({
         } else {
           setShowOptOutChangeWarning(false);
           (user ? updateUser(user.address, params) : createUser(params))
-            .then(() => onClose())
+            .then(() => {
+              queryClient.invalidateQueries('fixedPayment');
+              onClose();
+            })
             .catch(console.warn);
         }
       }}

--- a/src/pages/CircleAdminPage/CircleAdminPage.tsx
+++ b/src/pages/CircleAdminPage/CircleAdminPage.tsx
@@ -371,6 +371,20 @@ export const CircleAdminPage = () => {
     }
   };
 
+  const fixedPaymentToken = (vaultId: string | undefined) => {
+    const tokenType = circle?.fixed_payment_token_type;
+    return vaultId
+      ? removeYearnPrefix(
+          vaultOptions.find(o => o.value == getValues('fixed_payment_vault_id'))
+            ?.label ?? ''
+        )
+      : tokenType
+      ? tokenType.startsWith('Yearn')
+        ? removeYearnPrefix(tokenType)
+        : tokenType
+      : '';
+  };
+
   if (
     isLoading ||
     isIdle ||
@@ -637,15 +651,9 @@ export const CircleAdminPage = () => {
                   <Text variant="label" css={{ mb: '$xs' }}>
                     Fixed Payments Total
                   </Text>
-                  <Text size="medium">{`${fixedPayment?.fixedPaymentTotal} ${
-                    watchFixedPaymentVaultId
-                      ? removeYearnPrefix(
-                          vaultOptions.find(
-                            o => o.value == getValues('fixed_payment_vault_id')
-                          )?.label ?? ''
-                        )
-                      : circle?.fixed_payment_token_type ?? ''
-                  }`}</Text>
+                  <Text size="medium">{`${
+                    fixedPayment?.fixedPaymentTotal
+                  } ${fixedPaymentToken(watchFixedPaymentVaultId)}`}</Text>
                 </Flex>
                 <Flex column>
                   <Text variant="label" css={{ mb: '$xs' }}>
@@ -656,15 +664,7 @@ export const CircleAdminPage = () => {
                       maxGiftTokens,
                       getDecimals(getValues('fixed_payment_vault_id') ?? '')
                     )
-                  )} ${
-                    getValues('fixed_payment_vault_id')?.trim().length !== 0
-                      ? removeYearnPrefix(
-                          vaultOptions.find(
-                            o => o.value == getValues('fixed_payment_vault_id')
-                          )?.label ?? ''
-                        )
-                      : circle?.fixed_payment_token_type ?? ''
-                  }`}</Text>
+                  )} ${fixedPaymentToken(watchFixedPaymentVaultId)}`}</Text>
                 </Flex>
               </Flex>
             </Panel>

--- a/src/pages/CircleAdminPage/CircleAdminPage.tsx
+++ b/src/pages/CircleAdminPage/CircleAdminPage.tsx
@@ -346,29 +346,21 @@ export const CircleAdminPage = () => {
     }
   };
 
-  const getDecimals = ({ symbol }: { symbol: string | undefined }) => {
-    if (symbol) {
-      const v = findVault({ symbol });
+  const getDecimals = (vaultId: string) => {
+    if (vaultId) {
+      const v = findVault(vaultId);
       if (v) return v.decimals;
     }
     return 0;
   };
 
-  const findVault = ({
-    vaultId,
-    symbol,
-  }: {
-    vaultId?: number | undefined;
-    symbol?: string | undefined;
-  }) => {
-    return vaultsQuery?.data?.find(v =>
-      vaultId ? v.id === vaultId : v.symbol === symbol
-    );
+  const findVault = (vaultId: string) => {
+    return vaultsQuery?.data?.find(v => v.id === parseInt(vaultId));
   };
 
-  const updateBalanceState = async (symbol: string): Promise<void> => {
+  const updateBalanceState = async (vaultId: string): Promise<void> => {
     assert(circle);
-    const vault = findVault({ symbol });
+    const vault = findVault(vaultId);
     assert(contracts, 'This network is not supported');
 
     if (vault) {
@@ -613,9 +605,7 @@ export const CircleAdminPage = () => {
                           { shouldDirty: true }
                         );
                         updateBalanceState(
-                          vaultOptions.find(
-                            o => o.value == getValues('fixed_payment_vault_id')
-                          )?.label ?? ''
+                          getValues('fixed_payment_vault_id') ?? ''
                         );
                       },
                       defaultValue: stringifiedVaultId(),
@@ -648,13 +638,13 @@ export const CircleAdminPage = () => {
                     Fixed Payments Total
                   </Text>
                   <Text size="medium">{`${fixedPayment?.fixedPaymentTotal} ${
-                    !watchFixedPaymentVaultId
-                      ? circle?.fixed_payment_token_type
-                      : removeYearnPrefix(
+                    watchFixedPaymentVaultId
+                      ? removeYearnPrefix(
                           vaultOptions.find(
                             o => o.value == getValues('fixed_payment_vault_id')
                           )?.label ?? ''
                         )
+                      : circle?.fixed_payment_token_type ?? ''
                   }`}</Text>
                 </Flex>
                 <Flex column>
@@ -664,16 +654,7 @@ export const CircleAdminPage = () => {
                   <Text size="medium">{`${numberWithCommas(
                     formatUnits(
                       maxGiftTokens,
-                      getDecimals({
-                        symbol:
-                          getValues('fixed_payment_vault_id')?.trim().length !==
-                          0
-                            ? vaultOptions.find(
-                                o =>
-                                  o.value == getValues('fixed_payment_vault_id')
-                              )?.label
-                            : undefined,
-                      })
+                      getDecimals(getValues('fixed_payment_vault_id') ?? '')
                     )
                   )} ${
                     getValues('fixed_payment_vault_id')?.trim().length !== 0
@@ -682,7 +663,7 @@ export const CircleAdminPage = () => {
                             o => o.value == getValues('fixed_payment_vault_id')
                           )?.label ?? ''
                         )
-                      : circle?.fixed_payment_token_type
+                      : circle?.fixed_payment_token_type ?? ''
                   }`}</Text>
                 </Flex>
               </Flex>

--- a/src/pages/CircleAdminPage/CircleAdminPage.tsx
+++ b/src/pages/CircleAdminPage/CircleAdminPage.tsx
@@ -1,7 +1,11 @@
+import assert from 'assert';
 import React, { MouseEvent, useState } from 'react';
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { InfoCircledIcon } from '@radix-ui/react-icons';
+import { constants as ethersConstants } from 'ethers';
+import { formatUnits } from 'ethers/lib/utils';
+import { removeYearnPrefix } from 'lib/vaults';
 import { useForm, SubmitHandler, useController } from 'react-hook-form';
 import { useQuery } from 'react-query';
 import * as z from 'zod';
@@ -31,10 +35,12 @@ import {
   Select,
 } from 'ui';
 import { SingleColumnLayout } from 'ui/layouts';
+import { numberWithCommas } from 'utils';
 import { getCircleAvatar } from 'utils/domain';
 
 import { AdminIntegrations } from './AdminIntegrations';
 import { getCircleSettings } from './getCircleSettings';
+import { getFixedPayment } from './getFixedPayment';
 
 const panelStyles = {
   alignItems: 'start',
@@ -182,6 +188,21 @@ export const CircleAdminPage = () => {
       notifyOnChangeProps: ['data'],
     }
   );
+
+  const {
+    data: fixedPayment,
+    isLoading: fixedPaymentIsLoading,
+    isIdle: fixedPaymentIsIdle,
+  } = useQuery(['fixedPayment', circleId], () => getFixedPayment(circleId), {
+    // the query will not be executed untill circleId exists
+    enabled: !!circleId,
+    //minmize background refetch
+    refetchOnWindowFocus: false,
+
+    staleTime: Infinity,
+    notifyOnChangeProps: ['data'],
+  });
+
   const contracts = useContracts();
   const { showInfo } = useApeSnackbar();
   const orgQuery = useCircleOrg(circleId);
@@ -210,6 +231,7 @@ export const CircleAdminPage = () => {
 
   const { updateCircle, updateCircleLogo, getDiscordWebhook } =
     useApiAdminCircle(circleId);
+  const [maxGiftTokens, setMaxGiftTokens] = useState(ethersConstants.Zero);
   const [logoData, setLogoData] = useState<{
     avatar: string;
     avatarRaw: File | null;
@@ -236,6 +258,7 @@ export const CircleAdminPage = () => {
     handleSubmit,
     register,
     setValue,
+    getValues,
     watch,
     formState: { isDirty },
   } = useForm<CircleAdminFormSchema>({
@@ -323,13 +346,48 @@ export const CircleAdminPage = () => {
     }
   };
 
+  const getDecimals = ({ symbol }: { symbol: string | undefined }) => {
+    if (symbol) {
+      const v = findVault({ symbol });
+      if (v) return v.decimals;
+    }
+    return 0;
+  };
+
+  const findVault = ({
+    vaultId,
+    symbol,
+  }: {
+    vaultId?: number | undefined;
+    symbol?: string | undefined;
+  }) => {
+    return vaultsQuery?.data?.find(v =>
+      vaultId ? v.id === vaultId : v.symbol === symbol
+    );
+  };
+
+  const updateBalanceState = async (symbol: string): Promise<void> => {
+    assert(circle);
+    const vault = findVault({ symbol });
+    assert(contracts, 'This network is not supported');
+
+    if (vault) {
+      const tokenBalance = await contracts.getVaultBalance(vault);
+      setMaxGiftTokens(tokenBalance);
+    } else {
+      setMaxGiftTokens(ethersConstants.Zero);
+    }
+  };
+
   if (
     isLoading ||
     isIdle ||
     isRefetching ||
     !circle ||
     (isFeatureEnabled('vaults') && !vaultsQuery.data) ||
-    !orgQuery.data
+    !orgQuery.data ||
+    fixedPaymentIsLoading ||
+    fixedPaymentIsIdle
   )
     return <LoadingModal visible />;
   if (isError) {
@@ -554,6 +612,11 @@ export const CircleAdminPage = () => {
                             : vaultOptions.find(o => o.value == value)?.label,
                           { shouldDirty: true }
                         );
+                        updateBalanceState(
+                          vaultOptions.find(
+                            o => o.value == getValues('fixed_payment_vault_id')
+                          )?.label ?? ''
+                        );
                       },
                       defaultValue: stringifiedVaultId(),
                     })}
@@ -573,6 +636,56 @@ export const CircleAdminPage = () => {
                   showFieldErrors
                 />
               </Box>
+              <Flex css={{ gap: '$lg', mt: '$lg' }}>
+                <Flex column>
+                  <Text variant="label" css={{ mb: '$xs' }}>
+                    Members
+                  </Text>
+                  <Text size="medium">{fixedPayment?.fixedPaymentNumber}</Text>
+                </Flex>
+                <Flex column>
+                  <Text variant="label" css={{ mb: '$xs' }}>
+                    Fixed Payments Total
+                  </Text>
+                  <Text size="medium">{`${fixedPayment?.fixedPaymentTotal} ${
+                    !watchFixedPaymentVaultId
+                      ? circle?.fixed_payment_token_type
+                      : removeYearnPrefix(
+                          vaultOptions.find(
+                            o => o.value == getValues('fixed_payment_vault_id')
+                          )?.label ?? ''
+                        )
+                  }`}</Text>
+                </Flex>
+                <Flex column>
+                  <Text variant="label" css={{ mb: '$xs' }}>
+                    Available in Vault
+                  </Text>{' '}
+                  <Text size="medium">{`${numberWithCommas(
+                    formatUnits(
+                      maxGiftTokens,
+                      getDecimals({
+                        symbol:
+                          getValues('fixed_payment_vault_id')?.trim().length !==
+                          0
+                            ? vaultOptions.find(
+                                o =>
+                                  o.value == getValues('fixed_payment_vault_id')
+                              )?.label
+                            : undefined,
+                      })
+                    )
+                  )} ${
+                    getValues('fixed_payment_vault_id')?.trim().length !== 0
+                      ? removeYearnPrefix(
+                          vaultOptions.find(
+                            o => o.value == getValues('fixed_payment_vault_id')
+                          )?.label ?? ''
+                        )
+                      : circle?.fixed_payment_token_type
+                  }`}</Text>
+                </Flex>
+              </Flex>
             </Panel>
           </Panel>
         )}

--- a/src/pages/CircleAdminPage/CircleAdminPage.tsx
+++ b/src/pages/CircleAdminPage/CircleAdminPage.tsx
@@ -405,6 +405,7 @@ export const CircleAdminPage = () => {
       console.warn(error);
     }
   }
+  updateBalanceState(stringifiedVaultId());
   return (
     <Form id="circle_admin">
       <SingleColumnLayout>

--- a/src/pages/CircleAdminPage/getFixedPayment.ts
+++ b/src/pages/CircleAdminPage/getFixedPayment.ts
@@ -1,0 +1,40 @@
+import { client } from 'lib/gql/client';
+
+import type { Awaited } from 'types/shim';
+
+export const getFixedPayment = async (circleId: number) => {
+  const { circles_by_pk } = await client.query(
+    {
+      circles_by_pk: [
+        { id: circleId },
+        {
+          users: [
+            {},
+            {
+              user_private: { fixed_payment_amount: true },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      operationName: 'getFixedPayment',
+    }
+  );
+
+  const fixedPayments = circles_by_pk?.users
+    ?.filter(user => user.user_private?.fixed_payment_amount > 0)
+    .map(user => user.user_private?.fixed_payment_amount);
+
+  const fixedPaymentTotal = fixedPayments?.reduce((a, b) => a + b, 0);
+
+  const fixedPaymentNumber = fixedPayments?.length;
+
+  const fixedPayment = {
+    fixedPaymentTotal,
+    fixedPaymentNumber,
+  };
+  return fixedPayment;
+};
+
+export type FixedPaymentResult = Awaited<ReturnType<typeof getFixedPayment>>;


### PR DESCRIPTION
## Motivation and Context

implements #982 https://www.figma.com/file/L4oZwYVUdpgacZtwipGaYe/App-1.5?node-id=5303%3A21149

## Description

1- Add Members, Fixed payments total and available in vault fields to Fixed Payment section
2- Added a new query to fix the number of fixed payment receivers and used that to calculate the total and the number of members
3- Reused some functions from DistributionForm to calculate the total in vaults

## Test and Deployment Plan

1- Reach Circle settings page and add a token name to the field Token name for CSV export
2- Add fixed Payment to multiple users in the circle
expected:
The total of fixed payments and the number of members should be shown in Circle Settings fixed payment section
actual:
![image](https://user-images.githubusercontent.com/34943689/185275142-e9abb0d0-08fb-44a2-95dd-7bad8d736457.png)

3- Add vaults the circle and test with the token symbol of these vaults
![image](https://user-images.githubusercontent.com/34943689/185275240-866739ae-3298-4b49-a367-107d47ede1ea.png)
![image](https://user-images.githubusercontent.com/34943689/185275284-5453028b-b640-4de8-8701-41ab6978970f.png)
