### PR TITLE
UI/fix number alignment

### DIFF
--- a/src/pages/ClaimsPage/ClaimsPage.tsx
+++ b/src/pages/ClaimsPage/ClaimsPage.tsx
@@ -1,6 +1,6 @@
 import { ApeInfoTooltip, LoadingModal, makeTable } from 'components';
 import { DISTRIBUTION_TYPE } from 'config/constants';
-import { Avatar, Box, Panel, Flex, Text, Button } from 'ui';
+import { Avatar, Box, Panel, Flex, Text, Button, Link } from 'ui';
 import { SingleColumnLayout } from 'ui/layouts';
 import { numberWithCommas } from 'utils';
 import { makeExplorerUrl } from 'utils/provider';
@@ -11,7 +11,7 @@ import { formatDistributionDates, formatClaimAmount } from './utils';
 
 const styles = {
   th: { whiteSpace: 'nowrap', textAlign: 'left' },
-  thLast: { textAlign: 'right', width: '98%' },
+  thLast: { textAlign: 'right', pr: '$md' },
 };
 
 const buttonStyles = {
@@ -75,21 +75,9 @@ const ClaimsRow: React.FC<ClaimsRowData> = ({ claim, group, children }) => {
         </Text>
       </td>
       <td>
-        <Flex css={{ justifyContent: 'flex-end' }}>
-          <Flex
-            css={{
-              minWidth: '10vw',
-              justifyContent: 'flex-end',
-              gap: '$md',
-              mr: '$md',
-              '@sm': { minWidth: '20vw' },
-            }}
-          >
-            <Text>{formatClaimAmount(group)}</Text>
-            {children}
-          </Flex>
-        </Flex>
+        <Text>{formatClaimAmount(group)}</Text>
       </td>
+      <td className="alignRight">{children}</td>
     </tr>
   );
 };
@@ -137,7 +125,8 @@ export default function ClaimsPage() {
             { title: 'Organization', css: styles.th },
             { title: 'Circle', css: styles.th },
             { title: 'Distributions', css: styles.th },
-            { title: 'Rewards', css: styles.thLast },
+            { title: 'Rewards', css: styles.th },
+            { title: 'Claims', css: styles.thLast },
           ]}
           data={unclaimedClaimsRows}
           startingSortIndex={2}
@@ -151,19 +140,21 @@ export default function ClaimsPage() {
             const isClaimed = claiming[claim.id] === 'claimed';
             return (
               <ClaimsRow claim={claim} key={claim.id} group={group}>
-                <Button
-                  color="primary"
-                  outlined
-                  css={buttonStyles}
-                  onClick={() => processClaim(claim.id)}
-                  disabled={isClaiming || isClaimed}
-                >
-                  {isClaiming
-                    ? 'Claiming...'
-                    : isClaimed
-                    ? 'Claimed'
-                    : `Claim ${claim.distribution.vault.symbol}`}
-                </Button>
+                <Flex css={{ justifyContent: 'end', pr: '$md' }}>
+                  <Button
+                    color="primary"
+                    outlined
+                    css={buttonStyles}
+                    onClick={() => processClaim(claim.id)}
+                    disabled={isClaiming || isClaimed}
+                  >
+                    {isClaiming
+                      ? 'Claiming...'
+                      : isClaimed
+                      ? 'Claimed'
+                      : `Claim ${claim.distribution.vault.symbol}`}
+                  </Button>
+                </Flex>
               </ClaimsRow>
             );
           }}
@@ -179,7 +170,8 @@ export default function ClaimsPage() {
             { title: 'Organization', css: styles.th },
             { title: 'Circle', css: styles.th },
             { title: 'Epochs', css: styles.th },
-            { title: 'Rewards', css: styles.thLast },
+            { title: 'Rewards', css: styles.th },
+            { title: 'Transactions', css: styles.thLast },
           ]}
           data={claimedClaimsRows}
           startingSortIndex={2}
@@ -190,11 +182,8 @@ export default function ClaimsPage() {
         >
           {({ claim, group }) => (
             <ClaimsRow claim={claim} key={claim.id} group={group}>
-              <Button
-                color="primary"
-                outlined
-                css={buttonStyles}
-                as="a"
+              <Link
+                css={{ mr: '$md' }}
                 target="_blank"
                 href={makeExplorerUrl(
                   claim.distribution.vault.chain_id,
@@ -202,7 +191,7 @@ export default function ClaimsPage() {
                 )}
               >
                 View on Etherscan
-              </Button>
+              </Link>
             </ClaimsRow>
           )}
         </ClaimsTable>

--- a/src/pages/VaultsPage/VaultTransactions.tsx
+++ b/src/pages/VaultsPage/VaultTransactions.tsx
@@ -293,22 +293,25 @@ export const TransactionTable = ({
     css={{
       width: '100%',
       borderSpacing: 0,
-      fontFamily: 'Inter',
+      fontSize: '$small',
       th: {
         textAlign: 'left',
         color: '$secondaryText',
         textTransform: 'uppercase',
-        fontSize: '$small',
-        pb: '$sm',
-        pl: '$sm',
+        p: '$sm',
       },
       tbody: { backgroundColor: '$white' },
       tr: {
         borderTop: '1px solid $border',
       },
       td: {
-        padding: '$sm',
+        p: '$sm',
         color: '$text',
+      },
+      'th, td': {
+        '&.alignRight': {
+          textAlign: 'right',
+        },
       },
     }}
   >
@@ -318,8 +321,8 @@ export const TransactionTable = ({
         <th>Circle</th>
         <th>Type</th>
         <th>Details</th>
-        <th>Amount</th>
-        <th>Transaction</th>
+        <th className="alignRight">Amount</th>
+        <th className="alignRight">Transaction</th>
       </tr>
     </thead>
     <tbody>
@@ -329,10 +332,10 @@ export const TransactionTable = ({
           <td>{row.circle}</td>
           <td>{row.type}</td>
           <td>{row.details}</td>
-          <td>{numberWithCommas(row.amount, 2)}</td>
-          <td>
+          <td className="alignRight">{numberWithCommas(row.amount, 2)}</td>
+          <td className="alignRight">
             <Link target="_blank" href={makeExplorerUrl(chainId, row.hash)}>
-              Etherscan
+              View on Etherscan
             </Link>
           </td>
         </tr>

--- a/src/ui/Link/Link.tsx
+++ b/src/ui/Link/Link.tsx
@@ -5,6 +5,9 @@ import { styled } from '../../stitches.config';
 export const Link = styled('a', {
   color: '$link',
   textDecoration: 'none',
+  '&:hover': {
+    textDecoration: 'underline',
+  },
   cursor: 'pointer',
   fontFamily: 'Inter',
   variants: {

--- a/src/ui/Table/Table.tsx
+++ b/src/ui/Table/Table.tsx
@@ -19,6 +19,9 @@ export const Table = styled('table', {
     textAlign: 'center',
     fontWeight: 'normal',
     color: '$text',
+    '&.alignRight': {
+      textAlign: 'right',
+    },
   },
   'th:first-child, td:first-child': {
     textAlign: 'left',


### PR DESCRIPTION
Vault UI Improvements:

- Update vault tables with right alignment for values
<img width="1395" alt="Screen Shot 2022-08-19 at 12 08 14 PM" src="https://user-images.githubusercontent.com/83605543/185690052-14469c6b-93ce-4524-91a0-26b9b853bb5b.png">


- Update claims page
<img width="1478" alt="Screen Shot 2022-08-19 at 11 14 34 AM" src="https://user-images.githubusercontent.com/83605543/185689967-a49a2967-4fae-4b9e-9854-6b3dee3c670f.png">

- Update links with text-decoration: underline on hover.