### PR TITLE
Refactor: expose all public vault info and conceal org id

### DIFF
--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -323,7 +323,7 @@ export class GraphQLError extends Error {
   constructor(public response: GraphQLResponse) {
     super('');
     // eslint-disable-next-line no-console
-    console.info(JSON.stringify(response));
+    console.info(JSON.stringify(response, null, 2));
   }
   toString() {
     return 'GraphQL Response Error';

--- a/hasura/metadata/databases/default/tables/public_vaults.yaml
+++ b/hasura/metadata/databases/default/tables/public_vaults.yaml
@@ -32,23 +32,10 @@ select_permissions:
     - decimals
     - deployment_block
     - id
-    - org_id
     - simple_token_address
     - symbol
     - token_address
     - updated_at
     - vault_address
-    filter:
-      protocol:
-        circles:
-          _and:
-          - deleted_at:
-              _is_null: true
-          - users:
-              _and:
-              - deleted_at:
-                  _is_null: true
-              - profile:
-                  id:
-                    _eq: X-Hasura-User-Id
+    filter: {}
   role: user

--- a/src/hooks/gql/useVaults.ts
+++ b/src/hooks/gql/useVaults.ts
@@ -22,7 +22,10 @@ export function useVaults({
         {
           vaults: [
             {
-              where: { chain_id: { _eq: chainId }, org_id: { _eq: orgId } },
+              where: {
+                chain_id: { _eq: chainId },
+                protocol: { id: { _eq: orgId } },
+              },
             },
             {
               ...allVaultFields,

--- a/src/lib/gql/__generated__/zeus/const.ts
+++ b/src/lib/gql/__generated__/zeus/const.ts
@@ -527,7 +527,6 @@ export const AllTypesProps: Record<string, any> = {
     vouching: 'Boolean_comparison_exp',
     vouching_text: 'String_comparison_exp',
   },
-  circles_inc_input: {},
   circles_max_order_by: {
     alloc_text: 'order_by',
     created_at: 'order_by',
@@ -596,11 +595,7 @@ export const AllTypesProps: Record<string, any> = {
     vouching: 'order_by',
     vouching_text: 'order_by',
   },
-  circles_pk_columns_input: {
-    id: 'bigint',
-  },
   circles_select_column: true,
-  circles_set_input: {},
   circles_stddev_order_by: {
     fixed_payment_vault_id: 'order_by',
     id: 'order_by',
@@ -1450,16 +1445,6 @@ export const AllTypesProps: Record<string, any> = {
     },
     updateUser: {
       payload: 'UpdateUserInput',
-    },
-    update_circles: {
-      _inc: 'circles_inc_input',
-      _set: 'circles_set_input',
-      where: 'circles_bool_exp',
-    },
-    update_circles_by_pk: {
-      _inc: 'circles_inc_input',
-      _set: 'circles_set_input',
-      pk_columns: 'circles_pk_columns_input',
     },
     update_claims: {
       _set: 'claims_set_input',
@@ -3096,7 +3081,6 @@ export const AllTypesProps: Record<string, any> = {
     decimals: 'order_by',
     deployment_block: 'order_by',
     id: 'order_by',
-    org_id: 'order_by',
   },
   vaults_bool_exp: {
     _and: 'vaults_bool_exp',
@@ -3109,7 +3093,6 @@ export const AllTypesProps: Record<string, any> = {
     deployment_block: 'bigint_comparison_exp',
     distributions: 'distributions_bool_exp',
     id: 'bigint_comparison_exp',
-    org_id: 'bigint_comparison_exp',
     profile: 'profiles_bool_exp',
     protocol: 'organizations_bool_exp',
     simple_token_address: 'String_comparison_exp',
@@ -3126,7 +3109,6 @@ export const AllTypesProps: Record<string, any> = {
     decimals: 'order_by',
     deployment_block: 'order_by',
     id: 'order_by',
-    org_id: 'order_by',
     simple_token_address: 'order_by',
     symbol: 'order_by',
     token_address: 'order_by',
@@ -3140,7 +3122,6 @@ export const AllTypesProps: Record<string, any> = {
     decimals: 'order_by',
     deployment_block: 'order_by',
     id: 'order_by',
-    org_id: 'order_by',
     simple_token_address: 'order_by',
     symbol: 'order_by',
     token_address: 'order_by',
@@ -3155,7 +3136,6 @@ export const AllTypesProps: Record<string, any> = {
     deployment_block: 'order_by',
     distributions_aggregate: 'distributions_aggregate_order_by',
     id: 'order_by',
-    org_id: 'order_by',
     profile: 'profiles_order_by',
     protocol: 'organizations_order_by',
     simple_token_address: 'order_by',
@@ -3172,7 +3152,6 @@ export const AllTypesProps: Record<string, any> = {
     decimals: 'order_by',
     deployment_block: 'order_by',
     id: 'order_by',
-    org_id: 'order_by',
   },
   vaults_stddev_pop_order_by: {
     chain_id: 'order_by',
@@ -3180,7 +3159,6 @@ export const AllTypesProps: Record<string, any> = {
     decimals: 'order_by',
     deployment_block: 'order_by',
     id: 'order_by',
-    org_id: 'order_by',
   },
   vaults_stddev_samp_order_by: {
     chain_id: 'order_by',
@@ -3188,7 +3166,6 @@ export const AllTypesProps: Record<string, any> = {
     decimals: 'order_by',
     deployment_block: 'order_by',
     id: 'order_by',
-    org_id: 'order_by',
   },
   vaults_sum_order_by: {
     chain_id: 'order_by',
@@ -3196,7 +3173,6 @@ export const AllTypesProps: Record<string, any> = {
     decimals: 'order_by',
     deployment_block: 'order_by',
     id: 'order_by',
-    org_id: 'order_by',
   },
   vaults_var_pop_order_by: {
     chain_id: 'order_by',
@@ -3204,7 +3180,6 @@ export const AllTypesProps: Record<string, any> = {
     decimals: 'order_by',
     deployment_block: 'order_by',
     id: 'order_by',
-    org_id: 'order_by',
   },
   vaults_var_samp_order_by: {
     chain_id: 'order_by',
@@ -3212,7 +3187,6 @@ export const AllTypesProps: Record<string, any> = {
     decimals: 'order_by',
     deployment_block: 'order_by',
     id: 'order_by',
-    org_id: 'order_by',
   },
   vaults_variance_order_by: {
     chain_id: 'order_by',
@@ -3220,7 +3194,6 @@ export const AllTypesProps: Record<string, any> = {
     decimals: 'order_by',
     deployment_block: 'order_by',
     id: 'order_by',
-    org_id: 'order_by',
   },
   vouches_aggregate_order_by: {
     avg: 'vouches_avg_order_by',
@@ -3488,10 +3461,6 @@ export const ReturnTypes: Record<string, any> = {
     vault_transactions: 'vault_transactions',
     vouching: 'Boolean',
     vouching_text: 'String',
-  },
-  circles_mutation_response: {
-    affected_rows: 'Int',
-    returning: 'circles',
   },
   claims: {
     address: 'String',
@@ -3935,8 +3904,6 @@ export const ReturnTypes: Record<string, any> = {
     updateEpoch: 'EpochResponse',
     updateTeammates: 'UpdateTeammatesResponse',
     updateUser: 'UserResponse',
-    update_circles: 'circles_mutation_response',
-    update_circles_by_pk: 'circles',
     update_claims: 'claims_mutation_response',
     update_claims_by_pk: 'claims',
     update_contributions: 'contributions_mutation_response',
@@ -4515,7 +4482,6 @@ export const ReturnTypes: Record<string, any> = {
     distributions: 'distributions',
     distributions_aggregate: 'distributions_aggregate',
     id: 'bigint',
-    org_id: 'bigint',
     profile: 'profiles',
     protocol: 'organizations',
     simple_token_address: 'String',

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -321,7 +321,7 @@ export class GraphQLError extends Error {
   constructor(public response: GraphQLResponse) {
     super('');
     // eslint-disable-next-line no-console
-    console.info(JSON.stringify(response));
+    console.info(JSON.stringify(response, null, 2));
   }
   toString() {
     return 'GraphQL Response Error';
@@ -1856,11 +1856,6 @@ columns and relationships of "circle_api_keys" */
     vouching?: ValueTypes['Boolean_comparison_exp'] | undefined | null;
     vouching_text?: ValueTypes['String_comparison_exp'] | undefined | null;
   };
-  /** input type for incrementing numeric columns in table "circles" */
-  ['circles_inc_input']: {
-    min_vouches?: number | undefined | null;
-    nomination_days_limit?: number | undefined | null;
-  };
   /** order by max() on columns of table "circles" */
   ['circles_max_order_by']: {
     alloc_text?: ValueTypes['order_by'] | undefined | null;
@@ -1897,14 +1892,6 @@ columns and relationships of "circle_api_keys" */
     updated_at?: ValueTypes['order_by'] | undefined | null;
     vouching_text?: ValueTypes['order_by'] | undefined | null;
   };
-  /** response of any mutation on the table "circles" */
-  ['circles_mutation_response']: AliasType<{
-    /** number of rows affected by the mutation */
-    affected_rows?: boolean | `@${string}`;
-    /** data from the rows affected by the mutation */
-    returning?: ValueTypes['circles'];
-    __typename?: boolean | `@${string}`;
-  }>;
   /** Ordering options when selecting data from "circles". */
   ['circles_order_by']: {
     alloc_text?: ValueTypes['order_by'] | undefined | null;
@@ -1961,31 +1948,8 @@ columns and relationships of "circle_api_keys" */
     vouching?: ValueTypes['order_by'] | undefined | null;
     vouching_text?: ValueTypes['order_by'] | undefined | null;
   };
-  /** primary key columns input for table: circles */
-  ['circles_pk_columns_input']: {
-    id: ValueTypes['bigint'];
-  };
   /** select columns of table "circles" */
   ['circles_select_column']: circles_select_column;
-  /** input type for updating data in table "circles" */
-  ['circles_set_input']: {
-    alloc_text?: string | undefined | null;
-    auto_opt_out?: boolean | undefined | null;
-    default_opt_in?: boolean | undefined | null;
-    discord_webhook?: string | undefined | null;
-    fixed_payment_token_type?: string | undefined | null;
-    is_verified?: boolean | undefined | null;
-    logo?: string | undefined | null;
-    min_vouches?: number | undefined | null;
-    name?: string | undefined | null;
-    nomination_days_limit?: number | undefined | null;
-    only_giver_vouch?: boolean | undefined | null;
-    team_sel_text?: string | undefined | null;
-    team_selection?: boolean | undefined | null;
-    token_name?: string | undefined | null;
-    vouching?: boolean | undefined | null;
-    vouching_text?: string | undefined | null;
-  };
   /** order by stddev() on columns of table "circles" */
   ['circles_stddev_order_by']: {
     fixed_payment_vault_id?: ValueTypes['order_by'] | undefined | null;
@@ -3756,33 +3720,6 @@ columns and relationships of "distributions" */
     updateUser?: [
       { payload: ValueTypes['UpdateUserInput'] },
       ValueTypes['UserResponse']
-    ];
-    update_circles?: [
-      {
-        /** increments the numeric columns with given value of the filtered values */
-        _inc?:
-          | ValueTypes['circles_inc_input']
-          | undefined
-          | null /** sets the columns of the filtered rows to the given values */;
-        _set?:
-          | ValueTypes['circles_set_input']
-          | undefined
-          | null /** filter the rows which have to be updated */;
-        where: ValueTypes['circles_bool_exp'];
-      },
-      ValueTypes['circles_mutation_response']
-    ];
-    update_circles_by_pk?: [
-      {
-        /** increments the numeric columns with given value of the filtered values */
-        _inc?:
-          | ValueTypes['circles_inc_input']
-          | undefined
-          | null /** sets the columns of the filtered rows to the given values */;
-        _set?: ValueTypes['circles_set_input'] | undefined | null;
-        pk_columns: ValueTypes['circles_pk_columns_input'];
-      },
-      ValueTypes['circles']
     ];
     update_claims?: [
       {
@@ -7743,7 +7680,6 @@ columns and relationships of "users" */
       ValueTypes['distributions_aggregate']
     ];
     id?: boolean | `@${string}`;
-    org_id?: boolean | `@${string}`;
     /** An object relationship */
     profile?: ValueTypes['profiles'];
     /** An object relationship */
@@ -7799,7 +7735,6 @@ columns and relationships of "users" */
     decimals?: ValueTypes['order_by'] | undefined | null;
     deployment_block?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
-    org_id?: ValueTypes['order_by'] | undefined | null;
   };
   /** Boolean expression to filter rows from the table "vaults". All fields are combined with a logical 'AND'. */
   ['vaults_bool_exp']: {
@@ -7813,7 +7748,6 @@ columns and relationships of "users" */
     deployment_block?: ValueTypes['bigint_comparison_exp'] | undefined | null;
     distributions?: ValueTypes['distributions_bool_exp'] | undefined | null;
     id?: ValueTypes['bigint_comparison_exp'] | undefined | null;
-    org_id?: ValueTypes['bigint_comparison_exp'] | undefined | null;
     profile?: ValueTypes['profiles_bool_exp'] | undefined | null;
     protocol?: ValueTypes['organizations_bool_exp'] | undefined | null;
     simple_token_address?:
@@ -7837,7 +7771,6 @@ columns and relationships of "users" */
     decimals?: ValueTypes['order_by'] | undefined | null;
     deployment_block?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
-    org_id?: ValueTypes['order_by'] | undefined | null;
     simple_token_address?: ValueTypes['order_by'] | undefined | null;
     symbol?: ValueTypes['order_by'] | undefined | null;
     token_address?: ValueTypes['order_by'] | undefined | null;
@@ -7852,7 +7785,6 @@ columns and relationships of "users" */
     decimals?: ValueTypes['order_by'] | undefined | null;
     deployment_block?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
-    org_id?: ValueTypes['order_by'] | undefined | null;
     simple_token_address?: ValueTypes['order_by'] | undefined | null;
     symbol?: ValueTypes['order_by'] | undefined | null;
     token_address?: ValueTypes['order_by'] | undefined | null;
@@ -7871,7 +7803,6 @@ columns and relationships of "users" */
       | undefined
       | null;
     id?: ValueTypes['order_by'] | undefined | null;
-    org_id?: ValueTypes['order_by'] | undefined | null;
     profile?: ValueTypes['profiles_order_by'] | undefined | null;
     protocol?: ValueTypes['organizations_order_by'] | undefined | null;
     simple_token_address?: ValueTypes['order_by'] | undefined | null;
@@ -7893,7 +7824,6 @@ columns and relationships of "users" */
     decimals?: ValueTypes['order_by'] | undefined | null;
     deployment_block?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
-    org_id?: ValueTypes['order_by'] | undefined | null;
   };
   /** order by stddev_pop() on columns of table "vaults" */
   ['vaults_stddev_pop_order_by']: {
@@ -7902,7 +7832,6 @@ columns and relationships of "users" */
     decimals?: ValueTypes['order_by'] | undefined | null;
     deployment_block?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
-    org_id?: ValueTypes['order_by'] | undefined | null;
   };
   /** order by stddev_samp() on columns of table "vaults" */
   ['vaults_stddev_samp_order_by']: {
@@ -7911,7 +7840,6 @@ columns and relationships of "users" */
     decimals?: ValueTypes['order_by'] | undefined | null;
     deployment_block?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
-    org_id?: ValueTypes['order_by'] | undefined | null;
   };
   /** order by sum() on columns of table "vaults" */
   ['vaults_sum_order_by']: {
@@ -7920,7 +7848,6 @@ columns and relationships of "users" */
     decimals?: ValueTypes['order_by'] | undefined | null;
     deployment_block?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
-    org_id?: ValueTypes['order_by'] | undefined | null;
   };
   /** order by var_pop() on columns of table "vaults" */
   ['vaults_var_pop_order_by']: {
@@ -7929,7 +7856,6 @@ columns and relationships of "users" */
     decimals?: ValueTypes['order_by'] | undefined | null;
     deployment_block?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
-    org_id?: ValueTypes['order_by'] | undefined | null;
   };
   /** order by var_samp() on columns of table "vaults" */
   ['vaults_var_samp_order_by']: {
@@ -7938,7 +7864,6 @@ columns and relationships of "users" */
     decimals?: ValueTypes['order_by'] | undefined | null;
     deployment_block?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
-    org_id?: ValueTypes['order_by'] | undefined | null;
   };
   /** order by variance() on columns of table "vaults" */
   ['vaults_variance_order_by']: {
@@ -7947,7 +7872,6 @@ columns and relationships of "users" */
     decimals?: ValueTypes['order_by'] | undefined | null;
     deployment_block?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
-    org_id?: ValueTypes['order_by'] | undefined | null;
   };
   /** columns and relationships of "vouches" */
   ['vouches']: AliasType<{
@@ -8435,27 +8359,14 @@ columns and relationships of "circle_api_keys" */
   ['circles_avg_order_by']: GraphQLTypes['circles_avg_order_by'];
   /** Boolean expression to filter rows from the table "circles". All fields are combined with a logical 'AND'. */
   ['circles_bool_exp']: GraphQLTypes['circles_bool_exp'];
-  /** input type for incrementing numeric columns in table "circles" */
-  ['circles_inc_input']: GraphQLTypes['circles_inc_input'];
   /** order by max() on columns of table "circles" */
   ['circles_max_order_by']: GraphQLTypes['circles_max_order_by'];
   /** order by min() on columns of table "circles" */
   ['circles_min_order_by']: GraphQLTypes['circles_min_order_by'];
-  /** response of any mutation on the table "circles" */
-  ['circles_mutation_response']: {
-    /** number of rows affected by the mutation */
-    affected_rows: number;
-    /** data from the rows affected by the mutation */
-    returning: Array<GraphQLTypes['circles']>;
-  };
   /** Ordering options when selecting data from "circles". */
   ['circles_order_by']: GraphQLTypes['circles_order_by'];
-  /** primary key columns input for table: circles */
-  ['circles_pk_columns_input']: GraphQLTypes['circles_pk_columns_input'];
   /** select columns of table "circles" */
   ['circles_select_column']: GraphQLTypes['circles_select_column'];
-  /** input type for updating data in table "circles" */
-  ['circles_set_input']: GraphQLTypes['circles_set_input'];
   /** order by stddev() on columns of table "circles" */
   ['circles_stddev_order_by']: GraphQLTypes['circles_stddev_order_by'];
   /** order by stddev_pop() on columns of table "circles" */
@@ -9183,10 +9094,6 @@ columns and relationships of "distributions" */
     updateTeammates?: GraphQLTypes['UpdateTeammatesResponse'] | undefined;
     /** Update own user */
     updateUser?: GraphQLTypes['UserResponse'] | undefined;
-    /** update data of the table: "circles" */
-    update_circles?: GraphQLTypes['circles_mutation_response'] | undefined;
-    /** update single row of the table: "circles" */
-    update_circles_by_pk?: GraphQLTypes['circles'] | undefined;
     /** update data of the table: "claims" */
     update_claims?: GraphQLTypes['claims_mutation_response'] | undefined;
     /** update single row of the table: "claims" */
@@ -10236,7 +10143,6 @@ columns and relationships of "users" */
     /** An aggregate relationship */
     distributions_aggregate: GraphQLTypes['distributions_aggregate'];
     id: GraphQLTypes['bigint'];
-    org_id: GraphQLTypes['bigint'];
     /** An object relationship */
     profile: GraphQLTypes['profiles'];
     /** An object relationship */
@@ -11299,11 +11205,6 @@ columns and relationships of "circle_api_keys" */
     vouching?: GraphQLTypes['Boolean_comparison_exp'] | undefined;
     vouching_text?: GraphQLTypes['String_comparison_exp'] | undefined;
   };
-  /** input type for incrementing numeric columns in table "circles" */
-  ['circles_inc_input']: {
-    min_vouches?: number | undefined;
-    nomination_days_limit?: number | undefined;
-  };
   /** order by max() on columns of table "circles" */
   ['circles_max_order_by']: {
     alloc_text?: GraphQLTypes['order_by'] | undefined;
@@ -11339,14 +11240,6 @@ columns and relationships of "circle_api_keys" */
     token_name?: GraphQLTypes['order_by'] | undefined;
     updated_at?: GraphQLTypes['order_by'] | undefined;
     vouching_text?: GraphQLTypes['order_by'] | undefined;
-  };
-  /** response of any mutation on the table "circles" */
-  ['circles_mutation_response']: {
-    __typename: 'circles_mutation_response';
-    /** number of rows affected by the mutation */
-    affected_rows: number;
-    /** data from the rows affected by the mutation */
-    returning: Array<GraphQLTypes['circles']>;
   };
   /** Ordering options when selecting data from "circles". */
   ['circles_order_by']: {
@@ -11395,31 +11288,8 @@ columns and relationships of "circle_api_keys" */
     vouching?: GraphQLTypes['order_by'] | undefined;
     vouching_text?: GraphQLTypes['order_by'] | undefined;
   };
-  /** primary key columns input for table: circles */
-  ['circles_pk_columns_input']: {
-    id: GraphQLTypes['bigint'];
-  };
   /** select columns of table "circles" */
   ['circles_select_column']: circles_select_column;
-  /** input type for updating data in table "circles" */
-  ['circles_set_input']: {
-    alloc_text?: string | undefined;
-    auto_opt_out?: boolean | undefined;
-    default_opt_in?: boolean | undefined;
-    discord_webhook?: string | undefined;
-    fixed_payment_token_type?: string | undefined;
-    is_verified?: boolean | undefined;
-    logo?: string | undefined;
-    min_vouches?: number | undefined;
-    name?: string | undefined;
-    nomination_days_limit?: number | undefined;
-    only_giver_vouch?: boolean | undefined;
-    team_sel_text?: string | undefined;
-    team_selection?: boolean | undefined;
-    token_name?: string | undefined;
-    vouching?: boolean | undefined;
-    vouching_text?: string | undefined;
-  };
   /** order by stddev() on columns of table "circles" */
   ['circles_stddev_order_by']: {
     fixed_payment_vault_id?: GraphQLTypes['order_by'] | undefined;
@@ -12815,10 +12685,6 @@ columns and relationships of "distributions" */
     updateTeammates?: GraphQLTypes['UpdateTeammatesResponse'] | undefined;
     /** Update own user */
     updateUser?: GraphQLTypes['UserResponse'] | undefined;
-    /** update data of the table: "circles" */
-    update_circles?: GraphQLTypes['circles_mutation_response'] | undefined;
-    /** update single row of the table: "circles" */
-    update_circles_by_pk?: GraphQLTypes['circles'] | undefined;
     /** update data of the table: "claims" */
     update_claims?: GraphQLTypes['claims_mutation_response'] | undefined;
     /** update single row of the table: "claims" */
@@ -14884,7 +14750,6 @@ columns and relationships of "users" */
     /** An aggregate relationship */
     distributions_aggregate: GraphQLTypes['distributions_aggregate'];
     id: GraphQLTypes['bigint'];
-    org_id: GraphQLTypes['bigint'];
     /** An object relationship */
     profile: GraphQLTypes['profiles'];
     /** An object relationship */
@@ -14918,7 +14783,6 @@ columns and relationships of "users" */
     decimals?: GraphQLTypes['order_by'] | undefined;
     deployment_block?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
-    org_id?: GraphQLTypes['order_by'] | undefined;
   };
   /** Boolean expression to filter rows from the table "vaults". All fields are combined with a logical 'AND'. */
   ['vaults_bool_exp']: {
@@ -14932,7 +14796,6 @@ columns and relationships of "users" */
     deployment_block?: GraphQLTypes['bigint_comparison_exp'] | undefined;
     distributions?: GraphQLTypes['distributions_bool_exp'] | undefined;
     id?: GraphQLTypes['bigint_comparison_exp'] | undefined;
-    org_id?: GraphQLTypes['bigint_comparison_exp'] | undefined;
     profile?: GraphQLTypes['profiles_bool_exp'] | undefined;
     protocol?: GraphQLTypes['organizations_bool_exp'] | undefined;
     simple_token_address?: GraphQLTypes['String_comparison_exp'] | undefined;
@@ -14952,7 +14815,6 @@ columns and relationships of "users" */
     decimals?: GraphQLTypes['order_by'] | undefined;
     deployment_block?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
-    org_id?: GraphQLTypes['order_by'] | undefined;
     simple_token_address?: GraphQLTypes['order_by'] | undefined;
     symbol?: GraphQLTypes['order_by'] | undefined;
     token_address?: GraphQLTypes['order_by'] | undefined;
@@ -14967,7 +14829,6 @@ columns and relationships of "users" */
     decimals?: GraphQLTypes['order_by'] | undefined;
     deployment_block?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
-    org_id?: GraphQLTypes['order_by'] | undefined;
     simple_token_address?: GraphQLTypes['order_by'] | undefined;
     symbol?: GraphQLTypes['order_by'] | undefined;
     token_address?: GraphQLTypes['order_by'] | undefined;
@@ -14985,7 +14846,6 @@ columns and relationships of "users" */
       | GraphQLTypes['distributions_aggregate_order_by']
       | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
-    org_id?: GraphQLTypes['order_by'] | undefined;
     profile?: GraphQLTypes['profiles_order_by'] | undefined;
     protocol?: GraphQLTypes['organizations_order_by'] | undefined;
     simple_token_address?: GraphQLTypes['order_by'] | undefined;
@@ -15006,7 +14866,6 @@ columns and relationships of "users" */
     decimals?: GraphQLTypes['order_by'] | undefined;
     deployment_block?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
-    org_id?: GraphQLTypes['order_by'] | undefined;
   };
   /** order by stddev_pop() on columns of table "vaults" */
   ['vaults_stddev_pop_order_by']: {
@@ -15015,7 +14874,6 @@ columns and relationships of "users" */
     decimals?: GraphQLTypes['order_by'] | undefined;
     deployment_block?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
-    org_id?: GraphQLTypes['order_by'] | undefined;
   };
   /** order by stddev_samp() on columns of table "vaults" */
   ['vaults_stddev_samp_order_by']: {
@@ -15024,7 +14882,6 @@ columns and relationships of "users" */
     decimals?: GraphQLTypes['order_by'] | undefined;
     deployment_block?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
-    org_id?: GraphQLTypes['order_by'] | undefined;
   };
   /** order by sum() on columns of table "vaults" */
   ['vaults_sum_order_by']: {
@@ -15033,7 +14890,6 @@ columns and relationships of "users" */
     decimals?: GraphQLTypes['order_by'] | undefined;
     deployment_block?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
-    org_id?: GraphQLTypes['order_by'] | undefined;
   };
   /** order by var_pop() on columns of table "vaults" */
   ['vaults_var_pop_order_by']: {
@@ -15042,7 +14898,6 @@ columns and relationships of "users" */
     decimals?: GraphQLTypes['order_by'] | undefined;
     deployment_block?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
-    org_id?: GraphQLTypes['order_by'] | undefined;
   };
   /** order by var_samp() on columns of table "vaults" */
   ['vaults_var_samp_order_by']: {
@@ -15051,7 +14906,6 @@ columns and relationships of "users" */
     decimals?: GraphQLTypes['order_by'] | undefined;
     deployment_block?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
-    org_id?: GraphQLTypes['order_by'] | undefined;
   };
   /** order by variance() on columns of table "vaults" */
   ['vaults_variance_order_by']: {
@@ -15060,7 +14914,6 @@ columns and relationships of "users" */
     decimals?: GraphQLTypes['order_by'] | undefined;
     deployment_block?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
-    org_id?: GraphQLTypes['order_by'] | undefined;
   };
   /** columns and relationships of "vouches" */
   ['vouches']: {
@@ -15503,7 +15356,6 @@ export const enum vaults_select_column {
   decimals = 'decimals',
   deployment_block = 'deployment_block',
   id = 'id',
-  org_id = 'org_id',
   simple_token_address = 'simple_token_address',
   symbol = 'symbol',
   token_address = 'token_address',

--- a/src/lib/gql/mutations.ts
+++ b/src/lib/gql/mutations.ts
@@ -154,7 +154,6 @@ export const allVaultFields = {
   created_at: true,
   created_by: true,
   decimals: true,
-  org_id: true,
   simple_token_address: true,
   symbol: true,
   token_address: true,


### PR DESCRIPTION
## Motivation and Context

<!-- Why is this change required? What problem does it solve? This can be omitted if a linked issue is provided
-->
Most of this data is public anyway. The org_id is the only thing worth hiding, since its entirely internal.