### PR TITLE
Choose Current Org upon switching to vaults page after selecting a circle

### DIFF
--- a/src/pages/VaultsPage/VaultsPage.tsx
+++ b/src/pages/VaultsPage/VaultsPage.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from 'react';
 
 import { isUserAdmin } from 'lib/users';
+import { useRecoilValueLoadable } from 'recoil';
 
 import { LoadingModal } from 'components';
 import { useOverviewMenuQuery } from 'components/OverviewMenu/getOverviewMenuData';
 import { useContracts } from 'hooks';
 import { useVaults } from 'hooks/gql/useVaults';
+import { rSelectedCircleId } from 'recoilState/app';
 import {
   EXTERNAL_URL_LEARN_ABOUT_VAULTS,
   EXTERNAL_URL_YEARN_VAULTS,
@@ -19,14 +21,21 @@ import { VaultRow } from './VaultRow';
 const VaultsPage = () => {
   const [modal, setModal] = useState<'' | 'create'>('');
 
+  const circleId = useRecoilValueLoadable(rSelectedCircleId).valueMaybe();
   const orgsQuery = useOverviewMenuQuery();
   const contracts = useContracts();
 
   const [currentOrgId, setCurrentOrgId] = useState<number | undefined>();
 
   useEffect(() => {
+    const orgIndex = circleId
+      ? orgsQuery?.data?.organizations.findIndex(o =>
+          o.circles.some(c => c.id === circleId)
+        )
+      : 0;
+
     if (!currentOrgId && orgsQuery.data)
-      setCurrentOrgId(orgsQuery.data.organizations[0].id);
+      setCurrentOrgId(orgsQuery.data.organizations[orgIndex ?? 0].id);
   }, [orgsQuery.data]);
 
   const orgs = orgsQuery.data?.organizations;


### PR DESCRIPTION
## Motivation and Context
resolves #1066 

## Description
1- Use CircleId to switch to current org on vaults page
2- The index of the org that contains the circle will be filtered if circleID is available otherwise it will be 0

## Test and Deployment Plan
1- Choose a circle from circles page or overview menu
2- Switch to covaults from overview menu and notice the selected org.
Expected:
The current org should be selected.
3- use browser address bar to navigate to app.coordinape.com/vaults
Expected:
The first org should be selected

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/34943689/186043595-913c0a3e-9c43-4632-aeb8-821c65b8b59e.png)

