### PR TITLE
Render decimals For Vault Transaction Histories

### DIFF
--- a/src/pages/VaultsPage/VaultTransactions.tsx
+++ b/src/pages/VaultsPage/VaultTransactions.tsx
@@ -1,5 +1,5 @@
+import { formatUnits } from '@ethersproject/units';
 import { ContractsReadonly } from 'common-lib/contracts';
-import { BigNumber } from 'ethers';
 import { decodeCircleId, getDisplayTokenString } from 'lib/vaults';
 import { DateTime } from 'luxon';
 import { useQuery } from 'react-query';
@@ -82,7 +82,7 @@ interface RawTransaction {
   date: string;
   type: string;
   details: string;
-  amount: BigNumber | number;
+  amount: string | number;
   hash: string;
 }
 async function getDepositEvents(
@@ -134,7 +134,7 @@ async function getDepositEvents(
       deposits.push({
         block: event.blockNumber,
         type: 'Deposit',
-        amount: transferEvent.args.value.div(BigNumber.from(10).pow(decimals)),
+        amount: formatUnits(transferEvent.args.value, decimals),
         details: `By ${user?.name || transferEvent.args.from}`,
         date: DateTime.fromSeconds(block.timestamp).toFormat('DD'),
         hash: event.transactionHash,
@@ -208,7 +208,7 @@ async function getWithdrawEvents(
         block: event.blockNumber,
         type: 'Withdraw',
         details: `By ${user?.name || transferEvent.args.from}`,
-        amount: transferEvent.args.value.div(BigNumber.from(10).pow(decimals)),
+        amount: formatUnits(transferEvent.args.value, decimals),
         date: DateTime.fromSeconds(block.timestamp).toFormat('DD'),
         hash: event.transactionHash,
       });


### PR DESCRIPTION
We were just truncating decimals. Now, we handle decimals correctly.

![image](https://user-images.githubusercontent.com/17910833/186231782-8d145cb0-a173-474b-b291-fbb703226cbf.png)


## Motivation and Context

<!-- Why is this change required? What problem does it solve? This can be omitted if a linked issue is provided
-->

## Description

<!-- Describe your changes -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->
