### PR TITLE
bugfix: prevent duplicate vaults

### DIFF
--- a/src/pages/VaultsPage/CreateForm.tsx
+++ b/src/pages/VaultsPage/CreateForm.tsx
@@ -3,7 +3,7 @@ import { MouseEvent, useState, useEffect, useCallback } from 'react';
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { ethers } from 'ethers';
-import { Asset } from 'lib/vaults';
+import { Asset, removeYearnPrefix } from 'lib/vaults';
 import type { Contracts } from 'lib/vaults';
 import debounce from 'lodash/debounce';
 import isEmpty from 'lodash/isEmpty';
@@ -53,7 +53,12 @@ const useFormSetup = (
     )
     .refine(
       async ({ symbol, customAddress }) => {
-        if (symbol && existingVaults?.some(v => v.symbol.includes(symbol)))
+        if (
+          symbol &&
+          existingVaults?.some(
+            v => removeYearnPrefix(v.symbol) === removeYearnPrefix(symbol)
+          )
+        )
           return false;
 
         if (

--- a/src/pages/VaultsPage/CreateForm.tsx
+++ b/src/pages/VaultsPage/CreateForm.tsx
@@ -53,7 +53,7 @@ const useFormSetup = (
     )
     .refine(
       async ({ symbol, customAddress }) => {
-        if (symbol && existingVaults?.some(v => v.symbol === symbol))
+        if (symbol && existingVaults?.some(v => v.symbol.includes(symbol)))
           return false;
 
         if (


### PR DESCRIPTION
now the existing vault symbols cannot contain the token symbol. This
regression occurred because Yearn vaults now have the yearn prefix
