### PR TITLE
Allow access to distribution page form when there are no allocations

### DIFF
--- a/src/pages/DistributionsPage/DistributionForm.tsx
+++ b/src/pages/DistributionsPage/DistributionForm.tsx
@@ -357,11 +357,8 @@ export function DistributionForm({
     }
   };
 
-  const shouldDisableGiftInput = () => {
-    return (
-      giftSubmitting || !!circleDist || vaults.length === 0 || totalGive === 0
-    );
-  };
+  const shouldDisableGiftInput =
+    giftSubmitting || !!circleDist || vaults.length === 0 || totalGive === 0;
 
   const displayAvailableAmount = (type: 'gift' | 'fixed') => {
     const max = type === 'gift' ? maxGiftTokens : maxFixedPaymentTokens;
@@ -390,7 +387,7 @@ export function DistributionForm({
                     ? vaults[0].id.toString()
                     : '',
                   label: 'CoVault',
-                  disabled: shouldDisableGiftInput(),
+                  disabled: shouldDisableGiftInput,
                   onValueChange: value => {
                     setValue('selectedVaultId', value, {
                       shouldDirty: true,
@@ -424,7 +421,7 @@ export function DistributionForm({
                     ? circleDist.gift_amount?.toString() || '0'
                     : amountField.value.toString()
                 }
-                disabled={shouldDisableGiftInput()}
+                disabled={shouldDisableGiftInput}
                 max={formatUnits(
                   maxGiftTokens,
                   getDecimals({

--- a/src/pages/DistributionsPage/DistributionForm.tsx
+++ b/src/pages/DistributionsPage/DistributionForm.tsx
@@ -54,6 +54,7 @@ type SubmitFormProps = {
   refetch: () => void;
   circleDist: EpochDataResult['distributions'][0] | undefined;
   fixedDist: EpochDataResult['distributions'][0] | undefined;
+  totalGive: number;
 };
 
 /**
@@ -73,6 +74,7 @@ export function DistributionForm({
   refetch,
   circleDist,
   fixedDist,
+  totalGive,
 }: SubmitFormProps) {
   const [giftSubmitting, setGiftSubmitting] = useState(false);
   const [fixedSubmitting, setFixedSubmitting] = useState(false);
@@ -355,6 +357,12 @@ export function DistributionForm({
     }
   };
 
+  const shouldDisableGiftInput = () => {
+    return (
+      giftSubmitting || !!circleDist || vaults.length === 0 || totalGive === 0
+    );
+  };
+
   const displayAvailableAmount = (type: 'gift' | 'fixed') => {
     const max = type === 'gift' ? maxGiftTokens : maxFixedPaymentTokens;
     const distribution = type === 'gift' ? circleDist : fixedDist;
@@ -382,8 +390,7 @@ export function DistributionForm({
                     ? vaults[0].id.toString()
                     : '',
                   label: 'CoVault',
-                  disabled:
-                    giftSubmitting || !!circleDist || vaults.length === 0,
+                  disabled: shouldDisableGiftInput(),
                   onValueChange: value => {
                     setValue('selectedVaultId', value, {
                       shouldDirty: true,
@@ -417,7 +424,7 @@ export function DistributionForm({
                     ? circleDist.gift_amount?.toString() || '0'
                     : amountField.value.toString()
                 }
-                disabled={giftSubmitting || !!circleDist || vaults.length === 0}
+                disabled={shouldDisableGiftInput()}
                 max={formatUnits(
                   maxGiftTokens,
                   getDecimals({

--- a/src/pages/DistributionsPage/DistributionsPage.test.tsx
+++ b/src/pages/DistributionsPage/DistributionsPage.test.tsx
@@ -124,3 +124,29 @@ test('render with a distribution', async () => {
 
   expect(screen.getAllByText('10.80 Yearn USDC').length).toEqual(2);
 });
+
+test('render with no allocations', async () => {
+  (getEpochData as any).mockImplementation(() =>
+    Promise.resolve({
+      ...mockEpochData,
+      token_gifts: [],
+    })
+  );
+
+  await act(async () => {
+    await render(
+      <TestWrapper withWeb3>
+        <DistributionsPage />
+      </TestWrapper>
+    );
+  });
+
+  await waitFor(() => {
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+
+  expect(screen.getByText('Gift Circle')).toBeInTheDocument();
+  expect(
+    screen.getAllByText('Yearn USDC')[0].closest('button[role="combobox"]')
+  ).toBeDisabled();
+});

--- a/src/pages/DistributionsPage/DistributionsPage.tsx
+++ b/src/pages/DistributionsPage/DistributionsPage.tsx
@@ -87,8 +87,6 @@ export function DistributionsPage() {
     epochError = 'You are not an admin of this circle.';
   } else if (!epoch.ended) {
     epochError = 'This epoch has not ended yet.';
-  } else if (totalGive === 0) {
-    epochError = 'No tokens were allocated during this epoch.';
   }
 
   const circleDist = epoch.distributions.find(
@@ -238,6 +236,7 @@ export function DistributionsPage() {
               vaults={vaults}
               circleUsers={circleUsers}
               refetch={refetch}
+              totalGive={totalGive}
             />
           </Box>
           <AllocationsTable


### PR DESCRIPTION
## Motivation and Context

https://www.notion.so/coordinape/VAULTS-QA-dd5a668750314cbc8f9a431fac1132a0?p=d04cef68e3184b2187e504398d8bbc06&pm=s

## Description

This change allows distribution page to be accessed even if epoch has no allocations, so the admin still is able to make a fixed payments distribution if desired

## Test and Deployment Plan

Added a unit test for a test case with no allocations, alternatively you can test it manually by ending an epoch and going to the distribution page after creating a vault+ deposit
