### PR TITLE
invalidate overview circles after adding or removing circles

### DIFF
--- a/src/pages/CircleAdminPage/RemoveCircleModal.tsx
+++ b/src/pages/CircleAdminPage/RemoveCircleModal.tsx
@@ -32,7 +32,7 @@ export const RemoveCircleModal = ({
     },
     onSuccess: () => {
       queryClient.invalidateQueries('myOrgs');
-      queryClient.invalidateQueries('OverviewMenu');
+      queryClient.invalidateQueries('MainHeader');
       navigate(paths.circles);
     },
     onError: err => {

--- a/src/pages/CircleAdminPage/RemoveCircleModal.tsx
+++ b/src/pages/CircleAdminPage/RemoveCircleModal.tsx
@@ -5,7 +5,9 @@ import { useMutation, useQueryClient } from 'react-query';
 import { useNavigate } from 'react-router';
 
 import { LoadingModal } from 'components';
+import { QUERY_KEY_MAIN_HEADER } from 'components/MainLayout/getMainHeaderData';
 import { useApeSnackbar } from 'hooks';
+import { QUERY_KEY_MY_ORGS } from 'pages/CirclesPage/getOrgData';
 import { paths } from 'routes/paths';
 import { Button, Flex, Modal, Text } from 'ui';
 import { normalizeError } from 'utils/reporting';
@@ -31,8 +33,8 @@ export const RemoveCircleModal = ({
       setIsLoading(true);
     },
     onSuccess: () => {
-      queryClient.invalidateQueries('myOrgs');
-      queryClient.invalidateQueries('MainHeader');
+      queryClient.invalidateQueries(QUERY_KEY_MY_ORGS);
+      queryClient.invalidateQueries(QUERY_KEY_MAIN_HEADER);
       navigate(paths.circles);
     },
     onError: err => {

--- a/src/pages/CirclesPage/CirclesPage.tsx
+++ b/src/pages/CirclesPage/CirclesPage.tsx
@@ -19,7 +19,7 @@ import {
 import { AppLink, Box, Button, Flex, Image, Link, Panel, Text } from 'ui';
 import { SingleColumnLayout } from 'ui/layouts';
 
-import { getOrgData } from './getOrgData';
+import { getOrgData, QUERY_KEY_MY_ORGS } from './getOrgData';
 
 import type { Awaited } from 'types/shim';
 type QueryResult = Awaited<ReturnType<typeof getOrgData>>;
@@ -28,7 +28,7 @@ export const CirclesPage = () => {
   const navigate = useNavigate();
   const address = useConnectedAddress();
   const query = useQuery(
-    ['myOrgs', address],
+    [QUERY_KEY_MY_ORGS, address],
     () => getOrgData(address as string),
     {
       enabled: !!address,

--- a/src/pages/CirclesPage/getOrgData.ts
+++ b/src/pages/CirclesPage/getOrgData.ts
@@ -43,3 +43,4 @@ export const getOrgData = (address: string) =>
       operationName: 'getOrgData',
     }
   );
+export const QUERY_KEY_MY_ORGS = 'myOrgs';

--- a/src/pages/CreateCirclePage/CreateCirclePage.tsx
+++ b/src/pages/CreateCirclePage/CreateCirclePage.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 import { InfoCircledIcon } from '@radix-ui/react-icons';
 import uniqBy from 'lodash/uniqBy';
+import { useQueryClient } from 'react-query';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { FormAutocomplete, DeprecatedFormTextField } from 'components';
@@ -16,6 +17,8 @@ export const SummonCirclePage = () => {
   const navigate = useNavigate();
   const [params] = useSearchParams();
   // const { myUser } = useSelectedCircle();
+
+  const queryClient = useQueryClient();
 
   const { address: myAddress, myUsers } = useMyProfile();
 
@@ -83,6 +86,8 @@ export const SummonCirclePage = () => {
             submit={async ({ ...params }) => {
               try {
                 const newCircle = await createCircle({ ...params });
+                queryClient.invalidateQueries('myOrgs');
+                queryClient.invalidateQueries('MainHeader');
                 navigate({
                   pathname: paths.paths.members(newCircle.id),
                   search: paths.NEW_CIRCLE_CREATED_PARAMS,

--- a/src/pages/CreateCirclePage/CreateCirclePage.tsx
+++ b/src/pages/CreateCirclePage/CreateCirclePage.tsx
@@ -6,8 +6,10 @@ import { useQueryClient } from 'react-query';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { FormAutocomplete, DeprecatedFormTextField } from 'components';
+import { QUERY_KEY_MAIN_HEADER } from 'components/MainLayout/getMainHeaderData';
 import CreateCircleForm from 'forms/CreateCircleForm';
 import { useApiWithProfile } from 'hooks';
+import { QUERY_KEY_MY_ORGS } from 'pages/CirclesPage/getOrgData';
 import { useMyProfile } from 'recoilState/app';
 import * as paths from 'routes/paths';
 import { Box, Button, Panel, Text, Tooltip } from 'ui';
@@ -86,8 +88,8 @@ export const SummonCirclePage = () => {
             submit={async ({ ...params }) => {
               try {
                 const newCircle = await createCircle({ ...params });
-                queryClient.invalidateQueries('myOrgs');
-                queryClient.invalidateQueries('MainHeader');
+                queryClient.invalidateQueries(QUERY_KEY_MY_ORGS);
+                queryClient.invalidateQueries(QUERY_KEY_MAIN_HEADER);
                 navigate({
                   pathname: paths.paths.members(newCircle.id),
                   search: paths.NEW_CIRCLE_CREATED_PARAMS,


### PR DESCRIPTION
## Motivation and Context

fixes #1045

## Description

1- invalidate overview menu and orgs list after adding or deleting a circle
2- Deleting circle was working previously but change in queries required an update

## Test and Deployment Plan

1- Add a new circle and notice overview menu
2- Navigate to overview page and check the circles

## Screenshots (if appropriate):
![Screenshot from 2022-08-24 18-36-08](https://user-images.githubusercontent.com/34943689/186474802-8404c48a-96a6-494a-b5c8-b13165aba9c2.png)
![image](https://user-images.githubusercontent.com/34943689/186475069-c2101040-3afa-447f-93dc-cada70630f52.png)

