### PR TITLE
Fix number with commas utils function

### DIFF
--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -22,6 +22,10 @@ describe('numberWithCommas', () => {
     expect(numberWithCommas(6, 2)).toEqual('6.00');
     expect(numberWithCommas('6', 2)).toEqual('6.00');
     expect(numberWithCommas(6.223435987, 2)).toEqual('6.22');
+    expect(numberWithCommas(6.023435987, 2)).toEqual('6.02');
+    expect(numberWithCommas(6.025435987, 2)).toEqual('6.03');
+    expect(numberWithCommas(6.00825435987, 2)).toEqual('6.01');
+    expect(numberWithCommas(6.00325435987, 2)).toEqual('6.00');
   });
   test('with precision 0', () => {
     expect(numberWithCommas(undefined, 0)).toEqual('0');

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -26,6 +26,7 @@ describe('numberWithCommas', () => {
     expect(numberWithCommas(6.025435987, 2)).toEqual('6.03');
     expect(numberWithCommas(6.00825435987, 2)).toEqual('6.01');
     expect(numberWithCommas(6.00325435987, 2)).toEqual('6.00');
+    expect(numberWithCommas('6.06325435987000', 2)).toEqual('6.06');
   });
   test('with precision 0', () => {
     expect(numberWithCommas(undefined, 0)).toEqual('0');

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -17,7 +17,8 @@ export const numberWithCommas = (
       return '0.'.padEnd(precision + 2, '0');
     } else return '0';
   }
-  const split = x.toString().split('.');
+  // convert it to Number first to remove insignificant trailing zeroes after the decimal point
+  const split = Number(x).toString().split('.');
   const [beforeDot, afterDot] = [split[0], split[1] || ''];
   const before = beforeDot.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
   const after =

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -22,14 +22,15 @@ export const numberWithCommas = (
   const before = beforeDot.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
   const after =
     precision > 0
-      ? (
-          '.' +
-          (afterDot.length > precision
-            ? round(Number.parseInt(afterDot), -(afterDot.length - precision))
-            : afterDot)
+      ? '.' +
+        (afterDot.length > precision
+          ? String(
+              round(Number.parseInt(afterDot), -(afterDot.length - precision))
+            ).padStart(afterDot.length, '0')
+          : afterDot
         )
-          .substring(0, precision + 1)
-          .padEnd(precision + 1, '0')
+          .substring(0, precision)
+          .padEnd(precision, '0')
       : '';
   return before + after;
 };


### PR DESCRIPTION
## Motivation and Context

Decimal numbers that start with zeroes after the period will end up with an incorrect rounded result.

## Description

Pad the zeroes back after it gets converted into a number for rounding.

## Test and Deployment Plan

added more test cases in the unit test with numbers that fit this scenario.

## Related Issue

https://www.notion.so/coordinape/VAULTS-QA-dd5a668750314cbc8f9a431fac1132a0?p=52af939d7d1a4cf8aeabb777293e5908&pm=s