### PR TITLE
show member receive info regardless of vaults

### DIFF
--- a/src/components/MainLayout/MainHeader.tsx
+++ b/src/components/MainLayout/MainHeader.tsx
@@ -83,7 +83,7 @@ const NormalHeader = ({ inCircle }: { inCircle: boolean }) => {
             </Box>
           )}
         </Box>
-        {inCircle && !isFeatureEnabled('vaults') && (
+        {inCircle && (
           <Suspense fallback={null}>
             <ReceiveInfo />
           </Suspense>


### PR DESCRIPTION
## Motivation and Context

Received Gives doesn't show if vaults feature is enabled

## Description

1- remove vaults disabled condition for ReceiveInfo component

## Test and Deployment Plan

1- Enter a circle where you have received gives in the current epoch
Expected:
Received gives should appear beside your avatar
![image](https://user-images.githubusercontent.com/34943689/186536668-1b69bbf8-2e13-4a5a-a482-b97c7f434952.png)

after distribution
![Screenshot from 2022-08-25 00-35-02](https://user-images.githubusercontent.com/34943689/186536602-027c136d-ea80-4731-8239-b8c2270a541f.png)
