### PR TITLE
Update nav for members and admin

### DIFF
--- a/src/components/MainLayout/CircleNav.tsx
+++ b/src/components/MainLayout/CircleNav.tsx
@@ -33,13 +33,13 @@ export const CircleNav = () => {
         'Allocate',
         [paths.epoch(circleId), paths.team(circleId), paths.give(circleId)],
       ],
-      [paths.map(circleId), 'Map'],
     ];
 
     if (circle?.hasVouching) l.push([paths.vouching(circleId), 'Vouching']);
-    if (myUser.isCircleAdmin) {
-      l.push([paths.members(circleId), 'Admin']);
-    }
+    if (myUser.isCircleAdmin) l.push([paths.members(circleId), 'Members']);
+
+    l.push([paths.map(circleId), 'Map']);
+    if (myUser.isCircleAdmin) l.push([paths.circleAdmin(circleId), 'Admin']);
 
     return l;
   }, [circleId, circle?.hasVouching]);

--- a/src/pages/AdminPage/AdminPage.tsx
+++ b/src/pages/AdminPage/AdminPage.tsx
@@ -1,23 +1,20 @@
 import React, { useState, useMemo, useEffect } from 'react';
 
 import { useQuery } from 'react-query';
-import { useNavigate } from 'react-router-dom';
 
 import { ActionDialog } from 'components';
 import { useApiAdminCircle } from 'hooks';
 import useMobileDetect from 'hooks/useMobileDetect';
-import { EditIcon, PlusCircleIcon } from 'icons';
 import { getCircleSettings } from 'pages/CircleAdminPage/getCircleSettings';
 import { useSelectedCircle } from 'recoilState/app';
 import { NEW_CIRCLE_CREATED_PARAMS, paths } from 'routes/paths';
-import { AppLink, Button, Flex, Panel, Text, TextField } from 'ui';
+import { AppLink, Flex, Panel, Text, TextField } from 'ui';
 import { SingleColumnLayout } from 'ui/layouts';
 
 import { AdminUserModal } from './AdminUserModal';
 import {
   AddContributorButton,
   MembersTable,
-  SettingsIconButton,
   UsersTableHeader,
 } from './components';
 
@@ -39,8 +36,6 @@ const AdminPage = () => {
       setNewCircle(window.location.search === NEW_CIRCLE_CREATED_PARAMS);
     }
   }, []);
-
-  const navigate = useNavigate();
 
   const {
     circleId,
@@ -80,7 +75,7 @@ const AdminPage = () => {
       <Panel>
         <Flex css={{ alignItems: 'center', mb: '$lg' }}>
           <Text h2>{circle?.name}</Text>
-          {!isMobile ? (
+          {!isMobile && (
             <Flex
               css={{
                 flexGrow: 1,
@@ -89,29 +84,10 @@ const AdminPage = () => {
                 gap: '$md',
               }}
             >
-              <AppLink to={paths.circleAdmin(circleId)}>
-                <Button color="primary" outlined css={{ minWidth: '180px' }}>
-                  <EditIcon />
-                  Settings
-                </Button>
-              </AppLink>
               <AppLink to={paths.membersAdd(selectedCircle.id)}>
                 <AddContributorButton tokenName={circle?.tokenName || 'GIVE'} />
               </AppLink>
-              <Button
-                color="primary"
-                outlined
-                onClick={() => navigate(paths.createCircle)}
-                css={{ minWidth: '180px' }}
-              >
-                <PlusCircleIcon />
-                Add Circle
-              </Button>
             </Flex>
-          ) : (
-            <AppLink to={paths.circleAdmin(circleId)}>
-              <SettingsIconButton />
-            </AppLink>
           )}
         </Flex>
         {isMobile && (

--- a/src/pages/AdminPage/components.tsx
+++ b/src/pages/AdminPage/components.tsx
@@ -116,7 +116,7 @@ export const UsersTableHeader = ({
       }}
     >
       <Text h3>Users</Text>
-      <AppLink to={paths.circleAdmin(circleId)}>
+      <AppLink to={paths.membersAdd(circleId)}>
         <AddContributorButton inline tokenName={tokenName} />
       </AppLink>
     </Box>


### PR DESCRIPTION
## Motivation and Context

resolves #1313 

## Description
1- Add Admin button in navigation bar to navigate to Admin settings
2- Remove Settings and add circle buttons from Members page
3- Members Page address should be circleId/members instead of circleID/Admin
4- fix Add members bug in Mobile mode

## Test and Deployment Plan
1- Enter a circle as admin and check the Admin and Members button in Navbar
expected:
1- Members button should navigate to Members page that should not have settings or add circle buttons
Address bar should show circles/circleId/members
2- Admin button will navigate to circle settings page

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/34943689/186997531-4c6bcf14-7c92-415b-8c70-2f424c822778.png)
![image](https://user-images.githubusercontent.com/34943689/186997564-83a9cb5c-8531-456f-95f4-8cc1229eee4c.png)

non Admin
![image](https://user-images.githubusercontent.com/34943689/186997624-b70c34a1-de7e-4c16-889d-2dcdc841eff0.png)

Mobile
![image](https://user-images.githubusercontent.com/34943689/186997395-ad650588-91a3-4799-bfcc-4fbe7839f7d2.png)
![image](https://user-images.githubusercontent.com/34943689/186997453-a5bfadbd-860a-4644-a8a4-f78666db6f29.png)



## Reviewers
@wingfeatherwave 