### PR TITLE
remove requirement for voucher_profile_id in non-api call

### DIFF
--- a/api-lib/gql/mutations.ts
+++ b/api-lib/gql/mutations.ts
@@ -1,3 +1,5 @@
+import assert from 'assert';
+
 import { order_by, ValueTypes } from './__generated__/zeus';
 import { adminClient } from './adminClient';
 
@@ -229,7 +231,11 @@ export async function updateExpiredNominees(idList: number[]) {
 }
 
 export async function insertCircleWithAdmin(
-  circleInput: ValueTypes['circles_insert_input'],
+  circleInput: ValueTypes['circles_insert_input'] & {
+    user_name: string;
+    circle_name: string;
+    protocol_name?: string;
+  },
   userAddress: string,
   coordinapeAddress: string,
   fileName: string | null
@@ -293,6 +299,7 @@ export async function insertCircleWithAdmin(
     );
     retVal = insert_circles_one;
   } else {
+    assert(circleInput.protocol_name);
     const { insert_organizations_one } = await adminClient.mutate(
       {
         insert_organizations_one: [

--- a/api/hasura/actions/_handlers/vouch.ts
+++ b/api/hasura/actions/_handlers/vouch.ts
@@ -44,6 +44,8 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     } else if (sessionVariables.hasuraRole === 'api-user') {
       // Make sure this field is here since it is optional in zod (not required for user-authed non-api key call)
       assert('voucher_profile_id' in input, 'voucher_profile_id not specified');
+      // just to make TS happy
+      assert(input.voucher_profile_id);
       voucherProfileId = input.voucher_profile_id;
 
       // Check if voucher exists in the same circle as the API key

--- a/api/hasura/actions/_handlers/vouch.ts
+++ b/api/hasura/actions/_handlers/vouch.ts
@@ -42,7 +42,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
       voucherProfileId = sessionVariables.hasuraProfileId;
       // Allow passing in voucher_profile_id for api-users to vouch on behalf of a user
     } else if (sessionVariables.hasuraRole === 'api-user') {
-      // Just to make TS happy, shouldn't fire since Zod validates the input above
+      // Make sure this field is here since it is optional in zod (not required for user-authed non-api key call)
       assert('voucher_profile_id' in input, 'voucher_profile_id not specified');
       voucherProfileId = input.voucher_profile_id;
 

--- a/src/lib/zod/index.ts
+++ b/src/lib/zod/index.ts
@@ -170,7 +170,7 @@ export const vouchInput = z
 export const vouchApiInput = z
   .object({
     nominee_id: z.number(),
-    voucher_profile_id: z.number().int().positive(),
+    voucher_profile_id: z.number().int().positive().optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Motivation and Context

User hit error vouching, broken for all in UI.

## Description

Write API changes made voucher_profile_id required but it isn't actually required for user based (non-api) workflows because it is set using the current user. 

## Test and Deployment Plan

Try to vouch for someone using the UI. 

