### PR TITLE
Fix for dework integration delete

### DIFF
--- a/src/pages/CircleAdminPage/AdminIntegrations.tsx
+++ b/src/pages/CircleAdminPage/AdminIntegrations.tsx
@@ -64,6 +64,7 @@ export const AdminIntegrations = ({ circleId }: { circleId: number }) => {
                 <Text>{integration.name}</Text>
               </Text>
               <Button
+                type="button"
                 onClick={() => setDeleteIntegration(integration)}
                 size="small"
                 color="textOnly"


### PR DESCRIPTION

## Motivation and Context

Delete Dework integration is not working

## Description

Prevent the page from submitting by declaring the button as a button type

## Test and Deployment Plan

manually delete the integration in the circle settings page

## Reviewers

@crabsinger 

