### PR TITLE
fix lag when typing notes during allocation

### DIFF
--- a/src/pages/AllocationPage/AllocationGive.tsx
+++ b/src/pages/AllocationPage/AllocationGive.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 
 import clsx from 'clsx';
 import iti from 'itiriri';
@@ -231,29 +231,32 @@ const AllocationGive = ({
     }
   };
 
-  const updateLocalGift = (updatedGift: ISimpleGift): void => {
-    setLocalGifts(prevState => {
-      // This is to ensure it can't go negative in the UI
-      updatedGift.tokens = Math.max(0, updatedGift.tokens);
+  const updateLocalGift = useCallback(
+    (updatedGift: ISimpleGift): void => {
+      setLocalGifts(prevState => {
+        // This is to ensure it can't go negative in the UI
+        updatedGift.tokens = Math.max(0, updatedGift.tokens);
 
-      const idx = prevState.findIndex(g => g.user.id === updatedGift.user.id);
+        const idx = prevState.findIndex(g => g.user.id === updatedGift.user.id);
 
-      let updatedGifts;
-      if (idx === -1) {
-        updatedGifts = [...prevState, updatedGift];
-      } else {
-        updatedGifts = prevState.slice();
-        updatedGifts[idx] = updatedGift;
-      }
+        let updatedGifts;
+        if (idx === -1) {
+          updatedGifts = [...prevState, updatedGift];
+        } else {
+          updatedGifts = prevState.slice();
+          updatedGifts[idx] = updatedGift;
+        }
 
-      // prevent giving more than you have
-      const total = updatedGifts.reduce((t, g) => t + g.tokens, 0);
-      if (total > (myUser.non_giver ? 0 : myUser.starting_tokens))
-        return prevState;
+        // prevent giving more than you have
+        const total = updatedGifts.reduce((t, g) => t + g.tokens, 0);
+        if (total > (myUser.non_giver ? 0 : myUser.starting_tokens))
+          return prevState;
 
-      return updatedGifts;
-    });
-  };
+        return updatedGifts;
+      });
+    },
+    [setLocalGifts, myUser]
+  );
 
   const saveGifts = useRecoilLoadCatch(
     () => async () => {
@@ -395,9 +398,7 @@ const AllocationGive = ({
                 tokenName={myUser.circle.tokenName}
                 user={gift.user}
                 gift={gift}
-                setGift={(gift: ISimpleGift) => {
-                  updateLocalGift(gift);
-                }}
+                setGift={updateLocalGift}
               />
             ))}
         </div>


### PR DESCRIPTION
simple fix: just wrap updateLocalGift in useCallback

fixes #1202

## Test and Deployment Plan

type very quickly into a notes field during allocation. the list of people you're allocating to should have lots of bio statements filled out, otherwise the slowness is not as noticeable

----

also see #597, a previous version of this fix 