### PR TITLE
Allow Editing of Gift Input when there are no vaults

### DIFF
--- a/src/pages/DistributionsPage/DistributionForm.tsx
+++ b/src/pages/DistributionsPage/DistributionForm.tsx
@@ -421,7 +421,11 @@ export function DistributionForm({
                     ? circleDist.gift_amount?.toString() || '0'
                     : amountField.value.toString()
                 }
-                disabled={shouldDisableGiftInput}
+                disabled={
+                  giftSubmitting ||
+                  totalGive === 0 ||
+                  (vaults.length > 0 && !!circleDist)
+                }
                 max={formatUnits(
                   maxGiftTokens,
                   getDecimals({
@@ -457,7 +461,7 @@ export function DistributionForm({
               {renderCombinedSum(formGiftAmount, totalFixedPayment)}{' '}
               {fpVault?.symbol}
             </Text>
-          ) : (
+          ) : vaults[0] ? (
             <Button
               color="primary"
               outlined
@@ -471,7 +475,7 @@ export function DistributionForm({
                 'gift'
               )}
             </Button>
-          )}
+          ) : null}
         </Flex>
       </form>
 

--- a/src/pages/DistributionsPage/DistributionsPage.test.tsx
+++ b/src/pages/DistributionsPage/DistributionsPage.test.tsx
@@ -150,3 +150,34 @@ test('render with no allocations', async () => {
     screen.getAllByText('Yearn USDC')[0].closest('button[role="combobox"]')
   ).toBeDisabled();
 });
+
+test('render with no vaults', async () => {
+  (getEpochData as any).mockImplementation(() =>
+    Promise.resolve({
+      ...mockEpochData,
+      circle: {
+        name: mockEpoch.circle.name,
+        users: [{ role: 1 }],
+        fixed_payment_vault_id: null,
+        fixed_payment_token_type: null,
+        organization: {
+          vaults: [],
+        },
+      },
+    })
+  );
+
+  await act(async () => {
+    await render(
+      <TestWrapper withWeb3>
+        <DistributionsPage />
+      </TestWrapper>
+    );
+  });
+
+  await waitFor(() => {
+    expect(screen.getByText('Mock User 1')).toBeInTheDocument();
+  });
+
+  expect(screen.getByRole('textbox', { name: /amount/i })).not.toBeDisabled();
+});


### PR DESCRIPTION
## Motivation and Context

Admin is able to have a preview of the budget allocation before committing to create a vault.

## Description

Enable the Gift amount input when there are no vaults created for the circle.

## Test and Deployment Plan

The newly created unit test should pass. Alternatively go to Baby circle to test in the distribution page manually.

## Screenshots (if appropriate):

<img width="1397" alt="image" src="https://user-images.githubusercontent.com/17747090/190187647-193d14a9-f488-4dd4-8fed-84aa9d03d77b.png">

## Reviewers

@levity @topocount 

## Related Issue

https://www.notion.so/coordinape/CoVaults-7014c5fa5fca473aafd26d918e99df06?p=0553ea016c3c4601b1f1aaa14d7983ab&pm=s