### PR TITLE
update vault underlying to realtime share price

### DIFF
--- a/cypress/e2e/createVault.cy.ts
+++ b/cypress/e2e/createVault.cy.ts
@@ -57,7 +57,7 @@ context('Coordinape', () => {
       .type('100');
     cy.contains('button', 'Withdraw from').click();
     cy.contains('Transaction completed');
-    cy.contains('4900 USDC');
+    cy.contains('4899 USDC');
     cy.reload(true);
     cy.contains('Ended Epoch With Gifts', { timeout: 120000 }).click();
     cy.get('table').contains('Withdraw');

--- a/cypress/e2e/createVault.cy.ts
+++ b/cypress/e2e/createVault.cy.ts
@@ -42,7 +42,7 @@ context('Coordinape', () => {
       .type('5000');
     cy.contains('button', 'Deposit into').click();
     cy.contains('Transaction completed');
-    cy.contains('5000 USDC');
+    cy.contains('4999 USDC');
     // This takes extremely long time to render in the UI without a refresh
     cy.reload(true);
     cy.contains('Ended Epoch With Gifts', { timeout: 120000 }).click();

--- a/src/lib/vaults/contracts.ts
+++ b/src/lib/vaults/contracts.ts
@@ -105,9 +105,16 @@ export class Contracts {
     >
   ) {
     const { simple_token_address, vault_address } = vault;
-    return hasSimpleToken(vault)
-      ? this.getERC20(assertDef(simple_token_address)).balanceOf(vault_address)
-      : this.getVault(vault_address).underlyingValue();
+    if (hasSimpleToken(vault)) {
+      return this.getERC20(assertDef(simple_token_address)).balanceOf(
+        vault_address
+      );
+    } else {
+      const vaultContract = this.getVault(vault_address);
+      const yToken = await this.getYVault(vault_address);
+      const vaultBalance = await yToken.balanceOf(vault.vault_address);
+      return vaultContract.shareValue(vaultBalance);
+    }
   }
 
   getAvailableTokens() {


### PR DESCRIPTION
## Motivation and Context

Underlying value does not sync with the pricePerShare real time hence its not a correct representative of the actual vault value.

## Description

Switched the calculation to use sharePrice of yTokens instead.

## Test and Deployment Plan

Clicking on the Max on the Gift input in distribution page should give a value of yTokens owned * pricePershare

## Screenshots (if appropriate):

<img width="686" alt="image" src="https://user-images.githubusercontent.com/17747090/190467632-a1ad386e-91f1-4152-874d-4ab3e319049f.png">

## Reviewers

@levity 


