### PR TITLE
Remove logging containing confusing ports

### DIFF
--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -9,7 +9,7 @@ esac; shift; done
 
 PROXY_PORT=$(( $RANDOM % 900 + 3100 ))
 
-BROWSER=none PORT=$PROXY_PORT yarn craco start & CRACO_PID=$!
+BROWSER=none PORT=$PROXY_PORT yarn craco start > /dev/null & CRACO_PID=$!
 
 trap 'kill $CRACO_PID' EXIT
 

--- a/scripts/serve_dev.ts
+++ b/scripts/serve_dev.ts
@@ -43,9 +43,14 @@ app.get('/stats/js/script.js', (req, res) => {
 
 app.use(
   '/',
-  createProxyMiddleware({ target: `http://localhost:${proxyPort}` })
+  createProxyMiddleware({
+    target: `http://localhost:${proxyPort}`,
+    logLevel: 'warn',
+  })
 );
 
 app.listen(port, () => {
-  console.log(`Listening on port ${port}`);
+  console.log(
+    `Listening on port ${port}\n\nHack away at http://localhost:${port}`
+  );
 });


### PR DESCRIPTION
now that we're proxying webpack dev server, we don't want contributors
browsing to that port. With this config, webpack will still log any
compilation or typechecking errors, but the only url logged is one
that is actually useful.