### PR TITLE
Add etherscan link to create vaults wait modal

### DIFF
--- a/src/hooks/useVaultFactory.ts
+++ b/src/hooks/useVaultFactory.ts
@@ -16,10 +16,12 @@ export function useVaultFactory(orgId?: number) {
   const { showInfo, showError } = useApeSnackbar();
 
   const createVault = async ({
+    setTxHash,
     simpleTokenAddress,
     type,
     customSymbol,
   }: {
+    setTxHash?: (txtHash: string) => void;
     simpleTokenAddress?: string;
     type?: Asset;
     customSymbol?: string;
@@ -49,13 +51,15 @@ export function useVaultFactory(orgId?: number) {
           showError,
           description: `Create ${type || customSymbol} Vault`,
           chainId: contracts.chainId,
-          savePending: async (txHash: string) =>
-            savePendingVaultTx({
+          savePending: async (txHash: string) => {
+            if (setTxHash) setTxHash(txHash);
+            return savePendingVaultTx({
               tx_hash: txHash,
               org_id: orgId,
               chain_id: Number.parseInt(contracts.chainId),
               tx_type: vault_tx_types_enum.Vault_Deploy,
-            }),
+            });
+          },
         }
       );
 

--- a/src/pages/VaultsPage/CreateForm.tsx
+++ b/src/pages/VaultsPage/CreateForm.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { MouseEvent, useState, useEffect, useCallback } from 'react';
+import React, { MouseEvent, useState, useCallback } from 'react';
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { ethers } from 'ethers';
@@ -16,6 +16,7 @@ import { useContracts } from 'hooks/useContracts';
 import { useVaultFactory } from 'hooks/useVaultFactory';
 import { PlusCircle } from 'icons/__generated';
 import { Box, Button, Form, HR, Link, Panel, Text, TextField } from 'ui';
+import { makeExplorerUrl } from 'utils/provider';
 
 const useFormSetup = (
   contracts: Contracts | undefined,
@@ -101,7 +102,7 @@ export const CreateForm = ({
   );
   const [customSymbol, setCustomSymbol] = useState<string | undefined>();
   const [saving, setSavingLocal] = useState(false);
-
+  const [txHash, setTxHash] = useState<string>('');
   const {
     control,
     formState: { errors, isValid },
@@ -190,6 +191,7 @@ export const CreateForm = ({
       type: symbol,
       simpleTokenAddress: customAddress,
       customSymbol,
+      setTxHash,
     }).then(vault => {
       setSaving?.(false);
       setSavingLocal(false);
@@ -198,7 +200,8 @@ export const CreateForm = ({
     });
   };
 
-  if (saving) return <SavingInProgress />;
+  const chainId = Number(contracts.chainId);
+  if (saving) return <SavingInProgress txHash={txHash} chainId={chainId} />;
 
   return (
     <Form
@@ -332,7 +335,13 @@ const AssetButton = styled(Button, {
   },
 });
 
-const SavingInProgress = () => {
+const SavingInProgress = ({
+  txHash,
+  chainId,
+}: {
+  txHash: string;
+  chainId: number;
+}) => {
   return (
     <>
       <Text p as="p" css={{ mb: '$md' }}>
@@ -342,6 +351,20 @@ const SavingInProgress = () => {
       <Text p as="p">
         Do not leave this page.
       </Text>
+      {txHash ? (
+        <Button
+          css={{ mt: '$md' }}
+          type="button"
+          color="primary"
+          outlined
+          fullWidth
+          as="a"
+          target="_blank"
+          href={makeExplorerUrl(chainId, txHash)}
+        >
+          View on Etherscan
+        </Button>
+      ) : null}
     </>
   );
 };


### PR DESCRIPTION
## Description

Adding a button in the modal that directs to the etherscan link of the tx hash when a vault is created.

## Test and Deployment Plan

Button should appear when creating a new vault. Existing unit tests should pass

## Screenshots (if appropriate):

<img width="673" alt="image" src="https://user-images.githubusercontent.com/17747090/191056820-2a2a3ccd-1742-4cb2-ad73-ad43955fec6b.png">

## Reviewers

@topocount @levity @crabsinger 

## Related Issue

https://www.notion.so/coordinape/78924b82ebe4445cbe20f586cdcb2795?v=bbf298c4fee34b5ea4eb18db638676bf&p=db7f5e55c27c4986ba5dd50e9324708a&pm=s