### PR TITLE
Create updateContribution Handler

### DIFF
--- a/api-lib/contributions.ts
+++ b/api-lib/contributions.ts
@@ -1,0 +1,65 @@
+import type { VercelResponse } from '@vercel/node';
+
+import { adminClient } from './gql/adminClient';
+import { errorResponseWithStatusCode } from './HttpError';
+
+export async function fetchAndVerifyContribution({
+  res,
+  id,
+  userAddress,
+  operationName,
+}: {
+  res: VercelResponse;
+  id: number;
+  userAddress: string;
+  operationName: string;
+}) {
+  const { contributions_by_pk: contribution } = await adminClient.query(
+    {
+      contributions_by_pk: [
+        { id },
+        {
+          datetime_created: true,
+          deleted_at: true,
+          circle: {
+            epochs_aggregate: [
+              { where: { ended: { _eq: true } } },
+              { aggregate: { max: { end_date: true } } },
+            ],
+          },
+          user: {
+            address: true,
+          },
+        },
+      ],
+    },
+    { operationName: `${operationName}_getContributionDetails` }
+  );
+
+  if (
+    !contribution ||
+    contribution.deleted_at ||
+    contribution.user?.address !== userAddress
+  ) {
+    errorResponseWithStatusCode(
+      res,
+      { message: 'contribution does not exist' },
+      422
+    );
+    return;
+  }
+
+  if (
+    contribution?.datetime_created <
+    contribution?.circle.epochs_aggregate.aggregate?.max?.end_date
+  ) {
+    errorResponseWithStatusCode(
+      res,
+      { message: 'contribution in an ended epoch is not editable' },
+      422
+    );
+    return;
+  }
+
+  return contribution;
+}

--- a/api-lib/gql/__generated__/zeus/const.ts
+++ b/api-lib/gql/__generated__/zeus/const.ts
@@ -41,6 +41,9 @@ export const AllTypesProps: Record<string, any> = {
   LogVaultTxInput: {},
   String_comparison_exp: {},
   UpdateCircleInput: {},
+  UpdateContributionInput: {
+    datetime_created: 'timestamptz',
+  },
   UpdateEpochInput: {
     start_date: 'timestamptz',
   },
@@ -2062,7 +2065,6 @@ export const AllTypesProps: Record<string, any> = {
     org_id: 'Int_comparison_exp',
     profile_id: 'Int_comparison_exp',
     updated_at: 'timestamptz_comparison_exp',
-    user_id: 'Int_comparison_exp',
   },
   interaction_events_constraint: true,
   interaction_events_delete_at_path_input: {},
@@ -2089,7 +2091,6 @@ export const AllTypesProps: Record<string, any> = {
     org_id: 'order_by',
     profile_id: 'order_by',
     updated_at: 'order_by',
-    user_id: 'order_by',
   },
   interaction_events_pk_columns_input: {},
   interaction_events_prepend_input: {
@@ -2549,6 +2550,9 @@ export const AllTypesProps: Record<string, any> = {
     },
     updateCircle: {
       payload: 'UpdateCircleInput',
+    },
+    updateContribution: {
+      payload: 'UpdateContributionInput',
     },
     updateEpoch: {
       payload: 'UpdateEpochInput',
@@ -5690,6 +5694,9 @@ export const ReturnTypes: Record<string, any> = {
     circle: 'circles',
     id: 'Int',
   },
+  UpdateContributionResponse: {
+    id: 'ID',
+  },
   UpdateOrgResponse: {
     id: 'Int',
     org: 'organizations',
@@ -7104,7 +7111,6 @@ export const ReturnTypes: Record<string, any> = {
     org_id: 'Int',
     profile_id: 'Int',
     updated_at: 'timestamptz',
-    user_id: 'Int',
   },
   interaction_events_aggregate: {
     aggregate: 'interaction_events_aggregate_fields',
@@ -7128,7 +7134,6 @@ export const ReturnTypes: Record<string, any> = {
     id: 'Float',
     org_id: 'Float',
     profile_id: 'Float',
-    user_id: 'Float',
   },
   interaction_events_max_fields: {
     circle_id: 'Int',
@@ -7139,7 +7144,6 @@ export const ReturnTypes: Record<string, any> = {
     org_id: 'Int',
     profile_id: 'Int',
     updated_at: 'timestamptz',
-    user_id: 'Int',
   },
   interaction_events_min_fields: {
     circle_id: 'Int',
@@ -7150,7 +7154,6 @@ export const ReturnTypes: Record<string, any> = {
     org_id: 'Int',
     profile_id: 'Int',
     updated_at: 'timestamptz',
-    user_id: 'Int',
   },
   interaction_events_mutation_response: {
     affected_rows: 'Int',
@@ -7161,49 +7164,42 @@ export const ReturnTypes: Record<string, any> = {
     id: 'Float',
     org_id: 'Float',
     profile_id: 'Float',
-    user_id: 'Float',
   },
   interaction_events_stddev_pop_fields: {
     circle_id: 'Float',
     id: 'Float',
     org_id: 'Float',
     profile_id: 'Float',
-    user_id: 'Float',
   },
   interaction_events_stddev_samp_fields: {
     circle_id: 'Float',
     id: 'Float',
     org_id: 'Float',
     profile_id: 'Float',
-    user_id: 'Float',
   },
   interaction_events_sum_fields: {
     circle_id: 'Int',
     id: 'Int',
     org_id: 'Int',
     profile_id: 'Int',
-    user_id: 'Int',
   },
   interaction_events_var_pop_fields: {
     circle_id: 'Float',
     id: 'Float',
     org_id: 'Float',
     profile_id: 'Float',
-    user_id: 'Float',
   },
   interaction_events_var_samp_fields: {
     circle_id: 'Float',
     id: 'Float',
     org_id: 'Float',
     profile_id: 'Float',
-    user_id: 'Float',
   },
   interaction_events_variance_fields: {
     circle_id: 'Float',
     id: 'Float',
     org_id: 'Float',
     profile_id: 'Float',
-    user_id: 'Float',
   },
   mutation_root: {
     adminUpdateUser: 'UserResponse',
@@ -7336,6 +7332,7 @@ export const ReturnTypes: Record<string, any> = {
     restoreCoordinape: 'ConfirmationResponse',
     updateAllocations: 'AllocationsResponse',
     updateCircle: 'UpdateCircleOutput',
+    updateContribution: 'UpdateContributionResponse',
     updateEpoch: 'EpochResponse',
     updateTeammates: 'UpdateTeammatesResponse',
     updateUser: 'UserResponse',

--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -890,6 +890,15 @@ export type ValueTypes = {
     id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
+  ['UpdateContributionInput']: {
+    datetime_created: ValueTypes['timestamptz'];
+    description: string;
+    id: number;
+  };
+  ['UpdateContributionResponse']: AliasType<{
+    id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
   ['UpdateEpochInput']: {
     circle_id: number;
     days: number;
@@ -5966,7 +5975,6 @@ columns and relationships of "distributions" */
     org_id?: boolean | `@${string}`;
     profile_id?: boolean | `@${string}`;
     updated_at?: boolean | `@${string}`;
-    user_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregated selection of "interaction_events" */
@@ -6009,7 +6017,6 @@ columns and relationships of "distributions" */
     id?: boolean | `@${string}`;
     org_id?: boolean | `@${string}`;
     profile_id?: boolean | `@${string}`;
-    user_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** Boolean expression to filter rows from the table "interaction_events". All fields are combined with a logical 'AND'. */
@@ -6026,7 +6033,6 @@ columns and relationships of "distributions" */
     org_id?: ValueTypes['Int_comparison_exp'] | undefined | null;
     profile_id?: ValueTypes['Int_comparison_exp'] | undefined | null;
     updated_at?: ValueTypes['timestamptz_comparison_exp'] | undefined | null;
-    user_id?: ValueTypes['Int_comparison_exp'] | undefined | null;
   };
   /** unique or primary key constraints on table "interaction_events" */
   ['interaction_events_constraint']: interaction_events_constraint;
@@ -6048,7 +6054,6 @@ columns and relationships of "distributions" */
     id?: number | undefined | null;
     org_id?: number | undefined | null;
     profile_id?: number | undefined | null;
-    user_id?: number | undefined | null;
   };
   /** input type for inserting data into table "interaction_events" */
   ['interaction_events_insert_input']: {
@@ -6061,7 +6066,6 @@ columns and relationships of "distributions" */
     org_id?: number | undefined | null;
     profile_id?: number | undefined | null;
     updated_at?: ValueTypes['timestamptz'] | undefined | null;
-    user_id?: number | undefined | null;
   };
   /** aggregate max on columns */
   ['interaction_events_max_fields']: AliasType<{
@@ -6073,7 +6077,6 @@ columns and relationships of "distributions" */
     org_id?: boolean | `@${string}`;
     profile_id?: boolean | `@${string}`;
     updated_at?: boolean | `@${string}`;
-    user_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregate min on columns */
@@ -6086,7 +6089,6 @@ columns and relationships of "distributions" */
     org_id?: boolean | `@${string}`;
     profile_id?: boolean | `@${string}`;
     updated_at?: boolean | `@${string}`;
-    user_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** response of any mutation on the table "interaction_events" */
@@ -6114,7 +6116,6 @@ columns and relationships of "distributions" */
     org_id?: ValueTypes['order_by'] | undefined | null;
     profile_id?: ValueTypes['order_by'] | undefined | null;
     updated_at?: ValueTypes['order_by'] | undefined | null;
-    user_id?: ValueTypes['order_by'] | undefined | null;
   };
   /** primary key columns input for table: interaction_events */
   ['interaction_events_pk_columns_input']: {
@@ -6137,7 +6138,6 @@ columns and relationships of "distributions" */
     org_id?: number | undefined | null;
     profile_id?: number | undefined | null;
     updated_at?: ValueTypes['timestamptz'] | undefined | null;
-    user_id?: number | undefined | null;
   };
   /** aggregate stddev on columns */
   ['interaction_events_stddev_fields']: AliasType<{
@@ -6145,7 +6145,6 @@ columns and relationships of "distributions" */
     id?: boolean | `@${string}`;
     org_id?: boolean | `@${string}`;
     profile_id?: boolean | `@${string}`;
-    user_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregate stddev_pop on columns */
@@ -6154,7 +6153,6 @@ columns and relationships of "distributions" */
     id?: boolean | `@${string}`;
     org_id?: boolean | `@${string}`;
     profile_id?: boolean | `@${string}`;
-    user_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregate stddev_samp on columns */
@@ -6163,7 +6161,6 @@ columns and relationships of "distributions" */
     id?: boolean | `@${string}`;
     org_id?: boolean | `@${string}`;
     profile_id?: boolean | `@${string}`;
-    user_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregate sum on columns */
@@ -6172,7 +6169,6 @@ columns and relationships of "distributions" */
     id?: boolean | `@${string}`;
     org_id?: boolean | `@${string}`;
     profile_id?: boolean | `@${string}`;
-    user_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** update columns of table "interaction_events" */
@@ -6183,7 +6179,6 @@ columns and relationships of "distributions" */
     id?: boolean | `@${string}`;
     org_id?: boolean | `@${string}`;
     profile_id?: boolean | `@${string}`;
-    user_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregate var_samp on columns */
@@ -6192,7 +6187,6 @@ columns and relationships of "distributions" */
     id?: boolean | `@${string}`;
     org_id?: boolean | `@${string}`;
     profile_id?: boolean | `@${string}`;
-    user_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregate variance on columns */
@@ -6201,7 +6195,6 @@ columns and relationships of "distributions" */
     id?: boolean | `@${string}`;
     org_id?: boolean | `@${string}`;
     profile_id?: boolean | `@${string}`;
-    user_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   ['json']: unknown;
@@ -7165,6 +7158,10 @@ columns and relationships of "distributions" */
     updateCircle?: [
       { payload: ValueTypes['UpdateCircleInput'] },
       ValueTypes['UpdateCircleOutput']
+    ];
+    updateContribution?: [
+      { payload: ValueTypes['UpdateContributionInput'] },
+      ValueTypes['UpdateContributionResponse']
     ];
     updateEpoch?: [
       { payload: ValueTypes['UpdateEpochInput'] },
@@ -16263,6 +16260,10 @@ export type ModelTypes = {
     circle: GraphQLTypes['circles'];
     id: number;
   };
+  ['UpdateContributionInput']: GraphQLTypes['UpdateContributionInput'];
+  ['UpdateContributionResponse']: {
+    id: string;
+  };
   ['UpdateEpochInput']: GraphQLTypes['UpdateEpochInput'];
   ['UpdateOrgResponse']: {
     id: number;
@@ -18466,7 +18467,6 @@ columns and relationships of "distributions" */
     org_id?: number | undefined;
     profile_id?: number | undefined;
     updated_at?: GraphQLTypes['timestamptz'] | undefined;
-    user_id?: number | undefined;
   };
   /** aggregated selection of "interaction_events" */
   ['interaction_events_aggregate']: {
@@ -18499,7 +18499,6 @@ columns and relationships of "distributions" */
     id?: number | undefined;
     org_id?: number | undefined;
     profile_id?: number | undefined;
-    user_id?: number | undefined;
   };
   /** Boolean expression to filter rows from the table "interaction_events". All fields are combined with a logical 'AND'. */
   ['interaction_events_bool_exp']: GraphQLTypes['interaction_events_bool_exp'];
@@ -18525,7 +18524,6 @@ columns and relationships of "distributions" */
     org_id?: number | undefined;
     profile_id?: number | undefined;
     updated_at?: GraphQLTypes['timestamptz'] | undefined;
-    user_id?: number | undefined;
   };
   /** aggregate min on columns */
   ['interaction_events_min_fields']: {
@@ -18537,7 +18535,6 @@ columns and relationships of "distributions" */
     org_id?: number | undefined;
     profile_id?: number | undefined;
     updated_at?: GraphQLTypes['timestamptz'] | undefined;
-    user_id?: number | undefined;
   };
   /** response of any mutation on the table "interaction_events" */
   ['interaction_events_mutation_response']: {
@@ -18564,7 +18561,6 @@ columns and relationships of "distributions" */
     id?: number | undefined;
     org_id?: number | undefined;
     profile_id?: number | undefined;
-    user_id?: number | undefined;
   };
   /** aggregate stddev_pop on columns */
   ['interaction_events_stddev_pop_fields']: {
@@ -18572,7 +18568,6 @@ columns and relationships of "distributions" */
     id?: number | undefined;
     org_id?: number | undefined;
     profile_id?: number | undefined;
-    user_id?: number | undefined;
   };
   /** aggregate stddev_samp on columns */
   ['interaction_events_stddev_samp_fields']: {
@@ -18580,7 +18575,6 @@ columns and relationships of "distributions" */
     id?: number | undefined;
     org_id?: number | undefined;
     profile_id?: number | undefined;
-    user_id?: number | undefined;
   };
   /** aggregate sum on columns */
   ['interaction_events_sum_fields']: {
@@ -18588,7 +18582,6 @@ columns and relationships of "distributions" */
     id?: number | undefined;
     org_id?: number | undefined;
     profile_id?: number | undefined;
-    user_id?: number | undefined;
   };
   /** update columns of table "interaction_events" */
   ['interaction_events_update_column']: GraphQLTypes['interaction_events_update_column'];
@@ -18598,7 +18591,6 @@ columns and relationships of "distributions" */
     id?: number | undefined;
     org_id?: number | undefined;
     profile_id?: number | undefined;
-    user_id?: number | undefined;
   };
   /** aggregate var_samp on columns */
   ['interaction_events_var_samp_fields']: {
@@ -18606,7 +18598,6 @@ columns and relationships of "distributions" */
     id?: number | undefined;
     org_id?: number | undefined;
     profile_id?: number | undefined;
-    user_id?: number | undefined;
   };
   /** aggregate variance on columns */
   ['interaction_events_variance_fields']: {
@@ -18614,7 +18605,6 @@ columns and relationships of "distributions" */
     id?: number | undefined;
     org_id?: number | undefined;
     profile_id?: number | undefined;
-    user_id?: number | undefined;
   };
   ['json']: any;
   /** Boolean expression to compare columns of type "json". All fields are combined with logical 'AND'. */
@@ -18961,6 +18951,8 @@ columns and relationships of "distributions" */
     restoreCoordinape?: GraphQLTypes['ConfirmationResponse'] | undefined;
     updateAllocations?: GraphQLTypes['AllocationsResponse'] | undefined;
     updateCircle?: GraphQLTypes['UpdateCircleOutput'] | undefined;
+    /** users can modify contributions and update their dates. */
+    updateContribution?: GraphQLTypes['UpdateContributionResponse'] | undefined;
     updateEpoch?: GraphQLTypes['EpochResponse'] | undefined;
     updateTeammates?: GraphQLTypes['UpdateTeammatesResponse'] | undefined;
     /** Update own user */
@@ -22116,6 +22108,15 @@ export type GraphQLTypes = {
     /** An object relationship */
     circle: GraphQLTypes['circles'];
     id: number;
+  };
+  ['UpdateContributionInput']: {
+    datetime_created: GraphQLTypes['timestamptz'];
+    description: string;
+    id: number;
+  };
+  ['UpdateContributionResponse']: {
+    __typename: 'UpdateContributionResponse';
+    id: string;
   };
   ['UpdateEpochInput']: {
     circle_id: number;
@@ -26271,7 +26272,6 @@ columns and relationships of "distributions" */
     org_id?: number | undefined;
     profile_id?: number | undefined;
     updated_at?: GraphQLTypes['timestamptz'] | undefined;
-    user_id?: number | undefined;
   };
   /** aggregated selection of "interaction_events" */
   ['interaction_events_aggregate']: {
@@ -26309,7 +26309,6 @@ columns and relationships of "distributions" */
     id?: number | undefined;
     org_id?: number | undefined;
     profile_id?: number | undefined;
-    user_id?: number | undefined;
   };
   /** Boolean expression to filter rows from the table "interaction_events". All fields are combined with a logical 'AND'. */
   ['interaction_events_bool_exp']: {
@@ -26325,7 +26324,6 @@ columns and relationships of "distributions" */
     org_id?: GraphQLTypes['Int_comparison_exp'] | undefined;
     profile_id?: GraphQLTypes['Int_comparison_exp'] | undefined;
     updated_at?: GraphQLTypes['timestamptz_comparison_exp'] | undefined;
-    user_id?: GraphQLTypes['Int_comparison_exp'] | undefined;
   };
   /** unique or primary key constraints on table "interaction_events" */
   ['interaction_events_constraint']: interaction_events_constraint;
@@ -26347,7 +26345,6 @@ columns and relationships of "distributions" */
     id?: number | undefined;
     org_id?: number | undefined;
     profile_id?: number | undefined;
-    user_id?: number | undefined;
   };
   /** input type for inserting data into table "interaction_events" */
   ['interaction_events_insert_input']: {
@@ -26360,7 +26357,6 @@ columns and relationships of "distributions" */
     org_id?: number | undefined;
     profile_id?: number | undefined;
     updated_at?: GraphQLTypes['timestamptz'] | undefined;
-    user_id?: number | undefined;
   };
   /** aggregate max on columns */
   ['interaction_events_max_fields']: {
@@ -26373,7 +26369,6 @@ columns and relationships of "distributions" */
     org_id?: number | undefined;
     profile_id?: number | undefined;
     updated_at?: GraphQLTypes['timestamptz'] | undefined;
-    user_id?: number | undefined;
   };
   /** aggregate min on columns */
   ['interaction_events_min_fields']: {
@@ -26386,7 +26381,6 @@ columns and relationships of "distributions" */
     org_id?: number | undefined;
     profile_id?: number | undefined;
     updated_at?: GraphQLTypes['timestamptz'] | undefined;
-    user_id?: number | undefined;
   };
   /** response of any mutation on the table "interaction_events" */
   ['interaction_events_mutation_response']: {
@@ -26413,7 +26407,6 @@ columns and relationships of "distributions" */
     org_id?: GraphQLTypes['order_by'] | undefined;
     profile_id?: GraphQLTypes['order_by'] | undefined;
     updated_at?: GraphQLTypes['order_by'] | undefined;
-    user_id?: GraphQLTypes['order_by'] | undefined;
   };
   /** primary key columns input for table: interaction_events */
   ['interaction_events_pk_columns_input']: {
@@ -26436,7 +26429,6 @@ columns and relationships of "distributions" */
     org_id?: number | undefined;
     profile_id?: number | undefined;
     updated_at?: GraphQLTypes['timestamptz'] | undefined;
-    user_id?: number | undefined;
   };
   /** aggregate stddev on columns */
   ['interaction_events_stddev_fields']: {
@@ -26445,7 +26437,6 @@ columns and relationships of "distributions" */
     id?: number | undefined;
     org_id?: number | undefined;
     profile_id?: number | undefined;
-    user_id?: number | undefined;
   };
   /** aggregate stddev_pop on columns */
   ['interaction_events_stddev_pop_fields']: {
@@ -26454,7 +26445,6 @@ columns and relationships of "distributions" */
     id?: number | undefined;
     org_id?: number | undefined;
     profile_id?: number | undefined;
-    user_id?: number | undefined;
   };
   /** aggregate stddev_samp on columns */
   ['interaction_events_stddev_samp_fields']: {
@@ -26463,7 +26453,6 @@ columns and relationships of "distributions" */
     id?: number | undefined;
     org_id?: number | undefined;
     profile_id?: number | undefined;
-    user_id?: number | undefined;
   };
   /** aggregate sum on columns */
   ['interaction_events_sum_fields']: {
@@ -26472,7 +26461,6 @@ columns and relationships of "distributions" */
     id?: number | undefined;
     org_id?: number | undefined;
     profile_id?: number | undefined;
-    user_id?: number | undefined;
   };
   /** update columns of table "interaction_events" */
   ['interaction_events_update_column']: interaction_events_update_column;
@@ -26483,7 +26471,6 @@ columns and relationships of "distributions" */
     id?: number | undefined;
     org_id?: number | undefined;
     profile_id?: number | undefined;
-    user_id?: number | undefined;
   };
   /** aggregate var_samp on columns */
   ['interaction_events_var_samp_fields']: {
@@ -26492,7 +26479,6 @@ columns and relationships of "distributions" */
     id?: number | undefined;
     org_id?: number | undefined;
     profile_id?: number | undefined;
-    user_id?: number | undefined;
   };
   /** aggregate variance on columns */
   ['interaction_events_variance_fields']: {
@@ -26501,7 +26487,6 @@ columns and relationships of "distributions" */
     id?: number | undefined;
     org_id?: number | undefined;
     profile_id?: number | undefined;
-    user_id?: number | undefined;
   };
   ['json']: any;
   /** Boolean expression to compare columns of type "json". All fields are combined with logical 'AND'. */
@@ -26879,6 +26864,8 @@ columns and relationships of "distributions" */
     restoreCoordinape?: GraphQLTypes['ConfirmationResponse'] | undefined;
     updateAllocations?: GraphQLTypes['AllocationsResponse'] | undefined;
     updateCircle?: GraphQLTypes['UpdateCircleOutput'] | undefined;
+    /** users can modify contributions and update their dates. */
+    updateContribution?: GraphQLTypes['UpdateContributionResponse'] | undefined;
     updateEpoch?: GraphQLTypes['EpochResponse'] | undefined;
     updateTeammates?: GraphQLTypes['UpdateTeammatesResponse'] | undefined;
     /** Update own user */
@@ -32156,7 +32143,6 @@ export const enum interaction_events_select_column {
   org_id = 'org_id',
   profile_id = 'profile_id',
   updated_at = 'updated_at',
-  user_id = 'user_id',
 }
 /** update columns of table "interaction_events" */
 export const enum interaction_events_update_column {
@@ -32169,7 +32155,6 @@ export const enum interaction_events_update_column {
   org_id = 'org_id',
   profile_id = 'profile_id',
   updated_at = 'updated_at',
-  user_id = 'user_id',
 }
 /** unique or primary key constraints on table "nominees" */
 export const enum nominees_constraint {

--- a/api/hasura/actions/_handlers/updateContribution.test.ts
+++ b/api/hasura/actions/_handlers/updateContribution.test.ts
@@ -1,0 +1,144 @@
+import { VercelRequest } from '@vercel/node';
+import { DateTime } from 'luxon';
+
+import { adminClient } from '../../../../api-lib/gql/adminClient';
+import { mockContribution } from '../../../../src/utils/testing/mocks';
+
+import handler from './updateContribution';
+
+jest.mock('../../../../api-lib/gql/adminClient', () => ({
+  adminClient: { query: jest.fn(), mutate: jest.fn() },
+}));
+const default_req = {
+  id: 1,
+  datetime_created: DateTime.now().toISO(),
+  description: 'wen moon',
+};
+
+const makeRequest = ({
+  id,
+  datetime_created,
+  description,
+}: {
+  id: number;
+  datetime_created: string;
+  description: string;
+} = default_req) => {
+  return {
+    headers: { verification_key: process.env.HASURA_EVENT_SECRET },
+    body: {
+      input: {
+        payload: {
+          id,
+          datetime_created,
+          description,
+        },
+      },
+      action: { name: 'updateContribution' },
+      session_variables: {
+        'x-hasura-address': mockContribution.user.address,
+        'x-hasura-user-id': mockContribution.user.id.toString(),
+        'x-hasura-role': 'user',
+      },
+    },
+  } as unknown as VercelRequest;
+};
+
+const res: any = { status: jest.fn(() => res), json: jest.fn() };
+
+describe('Update Contribution action handler', () => {
+  test('Test normal update contribution flow', async () => {
+    (adminClient.query as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        contributions_by_pk: mockContribution,
+      })
+    );
+
+    (adminClient.mutate as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        update_contributions_by_pk: { id: mockContribution.id },
+      })
+    );
+
+    await handler(makeRequest(), res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalled();
+    const results = (res.json as any).mock.calls[0][0];
+    expect(results.id).toBe(mockContribution.id);
+  });
+
+  test('cannot modify a contribution in a closed epoch', async () => {
+    const res: any = { status: jest.fn(() => res), json: jest.fn() };
+    (adminClient.query as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        contributions_by_pk: {
+          ...mockContribution,
+          datetime_created: DateTime.fromJSDate(
+            new Date(Date.now() - 39000 * 1000 * 24)
+          ).toISO(),
+        },
+      })
+    );
+
+    (adminClient.mutate as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        update_contributions_by_pk: { id: mockContribution.id },
+      })
+    );
+
+    await handler(makeRequest(), res);
+
+    expect(res.status).toHaveBeenCalledWith(422);
+    expect(res.json).toHaveBeenCalled();
+    const results = (res.json as any).mock.calls[0][0];
+    expect(results.message).toBe(
+      'contribution in an ended epoch is not editable'
+    );
+  });
+
+  test('cannot move contribution to a closed epoch', async () => {
+    const res: any = { status: jest.fn(() => res), json: jest.fn() };
+    (adminClient.query as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        contributions_by_pk: {
+          ...mockContribution,
+          datetime_created: DateTime.now(),
+        },
+      })
+    );
+
+    (adminClient.mutate as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        update_contributions_by_pk: { id: mockContribution.id },
+      })
+    );
+
+    const req = makeRequest({
+      id: 1,
+      description: 'yolo',
+      datetime_created: new Date(Date.now() - 4000 * 1000 * 24).toISOString(),
+    });
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(422);
+    expect(res.json).toHaveBeenCalled();
+    const results = (res.json as any).mock.calls[0][0];
+    expect(results.message).toBe(
+      'cannot reassign contribution to a closed epoch'
+    );
+  });
+  test('cannot modify a contribution from a different user', async () => {
+    (adminClient.query as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        contributions_by_pk: mockContribution,
+      })
+    );
+
+    const req = makeRequest();
+    req.body.session_variables['x-hasura-address'] =
+      '0x63c389cb2c573dd8a9239a16a3eb65935ddb5e2e';
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(422);
+  });
+});

--- a/api/hasura/actions/_handlers/updateContribution.ts
+++ b/api/hasura/actions/_handlers/updateContribution.ts
@@ -1,0 +1,68 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { DateTime } from 'luxon';
+
+import { fetchAndVerifyContribution } from '../../../../api-lib/contributions';
+import { adminClient } from '../../../../api-lib/gql/adminClient';
+import { errorResponseWithStatusCode } from '../../../../api-lib/HttpError';
+import { verifyHasuraRequestMiddleware } from '../../../../api-lib/validate';
+import {
+  composeHasuraActionRequestBodyWithSession,
+  HasuraUserSessionVariables,
+  updateContributionInput,
+} from '../../../../src/lib/zod';
+
+async function handler(req: VercelRequest, res: VercelResponse) {
+  const {
+    action: { name: actionName },
+    session_variables: { hasuraAddress: userAddress },
+    input: { payload },
+  } = composeHasuraActionRequestBodyWithSession(
+    updateContributionInput,
+    HasuraUserSessionVariables
+  ).parse(req.body);
+
+  const { id, description, datetime_created } = payload;
+
+  const contribution = await fetchAndVerifyContribution({
+    id,
+    res,
+    userAddress,
+    operationName: actionName,
+  });
+
+  if (!contribution) return;
+
+  if (
+    datetime_created <
+    DateTime.fromISO(
+      contribution.circle.epochs_aggregate.aggregate?.max?.end_date
+    )
+  ) {
+    errorResponseWithStatusCode(
+      res,
+      { message: 'cannot reassign contribution to a closed epoch' },
+      422
+    );
+    return;
+  }
+
+  const mutationResult = await adminClient.mutate(
+    {
+      update_contributions_by_pk: [
+        {
+          pk_columns: { id },
+          _set: {
+            description,
+            datetime_created: datetime_created.toISO(),
+          },
+        },
+        { id: true },
+      ],
+    },
+    { operationName: 'updateContribution_update' }
+  );
+
+  return res.status(200).json(mutationResult.update_contributions_by_pk);
+}
+
+export default verifyHasuraRequestMiddleware(handler);

--- a/api/hasura/actions/actionManager.ts
+++ b/api/hasura/actions/actionManager.ts
@@ -22,6 +22,7 @@ import logoutUser from './_handlers/logoutUser';
 import restoreCoordinape from './_handlers/restoreCoordinape';
 import updateAllocations from './_handlers/updateAllocations';
 import updateCircle from './_handlers/updateCircle';
+import updateContribution from './_handlers/updateContribution';
 import updateEpoch from './_handlers/updateEpoch';
 import updateTeammates from './_handlers/updateTeammates';
 import updateUser from './_handlers/updateUser';
@@ -52,6 +53,7 @@ const HANDLERS: HandlerDict = {
   restoreCoordinape,
   updateAllocations,
   updateCircle,
+  updateContribution,
   updateEpoch,
   updateTeammates,
   updateUser,

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -75,6 +75,12 @@ type Mutation {
 }
 
 type Mutation {
+  updateContribution(
+    payload: UpdateContributionInput!
+  ): UpdateContributionResponse
+}
+
+type Mutation {
   updateEpoch(payload: UpdateEpochInput!): EpochResponse
 }
 
@@ -309,6 +315,12 @@ input DeleteContributionInput {
   contribution_id: Int!
 }
 
+input UpdateContributionInput {
+  id: Int!
+  description: String!
+  datetime_created: timestamptz!
+}
+
 type CreateCircleResponse {
   id: Int!
 }
@@ -390,6 +402,10 @@ type CircleLandingInfoResponse {
   circle_id: Int!
   name: String!
   logo: String!
+}
+
+type UpdateContributionResponse {
+  id: ID!
 }
 
 scalar timestamptz

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -103,6 +103,15 @@ actions:
           value_from_env: HASURA_EVENT_SECRET
     permissions:
       - role: user
+  - name: deleteContribution
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_API_BASE_URL}}/actions/actionManager'
+      headers:
+        - name: verification_key
+          value_from_env: HASURA_EVENT_SECRET
+    permissions:
+      - role: user
   - name: deleteEpoch
     definition:
       kind: synchronous
@@ -112,15 +121,6 @@ actions:
           value_from_env: HASURA_EVENT_SECRET
     permissions:
       - role: user
-  - name: deleteContribution
-    definition:
-      kind: synchronous
-      handler: '{{HASURA_API_BASE_URL}}/actions/actionManager'
-      headers:
-      - name: verification_key
-        value_from_env: HASURA_EVENT_SECRET
-    permissions:
-    - role: user
   - name: deleteUser
     definition:
       kind: synchronous
@@ -178,6 +178,16 @@ actions:
     permissions:
       - role: api-user
       - role: user
+  - name: updateContribution
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_API_BASE_URL}}/actions/actionManager'
+      headers:
+        - name: verification_key
+          value_from_env: HASURA_EVENT_SECRET
+    permissions:
+      - role: user
+    comment: users can modify contributions and update their dates.
   - name: updateEpoch
     definition:
       kind: synchronous
@@ -287,6 +297,7 @@ custom_types:
     - name: CircleLandingInfoInput
     - name: CreateUserWithTokenInput
     - name: DeleteContributionInput
+    - name: UpdateContributionInput
   objects:
     - name: CreateCircleResponse
       relationships:
@@ -451,5 +462,15 @@ custom_types:
             id: id
     - name: DeleteCircleResponse
     - name: CircleLandingInfoResponse
+    - name: UpdateContributionResponse
+      relationships:
+        - remote_table:
+            schema: public
+            name: contributions
+          name: updateContribution_Contribution
+          source: default
+          type: object
+          field_mapping:
+            id: id
   scalars:
     - name: timestamptz

--- a/hasura/metadata/databases/default/tables/public_contributions.yaml
+++ b/hasura/metadata/databases/default/tables/public_contributions.yaml
@@ -12,42 +12,32 @@ insert_permissions:
   - role: user
     permission:
       check:
-        user:
-          profile:
-            id:
-              _eq: X-Hasura-User-Id
-    columns:
-    - circle_id
-    - datetime_created
-    - description
-    backend_only: false
-    set:
-      user_id: x-hasura-User-Id
+        circle:
+          users:
+            profile:
+              id:
+                _eq: X-Hasura-User-Id
+      set:
+        user_id: x-hasura-User-Id
+      columns:
+        - circle_id
+        - description
 select_permissions:
   - role: user
     permission:
       columns:
-      - circle_id
-      - created_at
-      - datetime_created
-      - description
-      - id
-      - updated_at
-      - user_id
-      filter:
-        user:
-          profile:
-            id:
-              _eq: X-Hasura-User-Id
-update_permissions:
-  - role: user
-    permission:
-        check: null
-        columns:
+        - circle_id
+        - created_at
         - datetime_created
         - description
-        filter:
-            user:
+        - id
+        - updated_at
+        - user_id
+      filter:
+        _and:
+          - user:
               profile:
                 id:
                   _eq: X-Hasura-User-Id
+          - deleted_at:
+              _is_null: true

--- a/src/lib/zod/index.ts
+++ b/src/lib/zod/index.ts
@@ -149,6 +149,15 @@ export const circleIdInput = z
   })
   .strip();
 
+export const updateContributionInput = z
+  .object({
+    // this should probably be handled as a bigint
+    id: z.number().int().positive(),
+    description: z.string().nonempty(),
+    datetime_created: zStringISODateUTC,
+  })
+  .strict();
+
 export const uploadImageInput = z
   .object({ image_data_base64: z.string() })
   .strict();

--- a/src/utils/testing/mocks.ts
+++ b/src/utils/testing/mocks.ts
@@ -58,9 +58,14 @@ export const mockContribution = {
   id: 1,
   circle_id: 1,
   deleted_at: null,
+  datetime_created: new Date(),
   circle: {
     epochs_aggregate: {
-      aggregate: { max: { end_date: new Date(Date.now() + 3600 * 1000 * 24) } },
+      aggregate: {
+        max: {
+          end_date: new Date(Date.now() - 3600 * 1000 * 24).toISOString(),
+        },
+      },
     },
   },
   user: {


### PR DESCRIPTION
## Summary

The update contribution handler ensures a contribution can't be changed
to a time that was included in a closed epoch. Contributions with a
timestamp in closed epochs are not editable. Contributions cannot have
empty descriptions. Contributions must exist for the user as well.

## Permissions Updates

Make inserts allowable from the autogenerated api. It's impossible to spam
contributions thanks to the custom check.

completely disallow updates from the autogenerated api since the action
exists.

allow selects for all contributions added by the user.

## Test Plan

Added unit tests to ensure all error cases are handled

integration tests will be written when the frontend is implemented (imminent)

## Merge Plan

Merge after #1327 and rebase on top of it.
