### PR TITLE
fix: Remove deleted users from CSV

### DIFF
--- a/api-lib/gql/queries.ts
+++ b/api-lib/gql/queries.ts
@@ -544,6 +544,10 @@ export async function getEpoch(
           token_gifts: [
             {},
             {
+              recipient: {
+                id: true,
+                deleted_at: true,
+              },
               tokens: true,
             },
           ],

--- a/api-lib/gql/queries.ts
+++ b/api-lib/gql/queries.ts
@@ -542,12 +542,8 @@ export async function getEpoch(
             },
           },
           token_gifts: [
-            {},
+            { where: { recipient: { deleted_at: { _is_null: true } } } },
             {
-              recipient: {
-                id: true,
-                deleted_at: true,
-              },
               tokens: true,
             },
           ],


### PR DESCRIPTION
## Motivation and Context

<!-- Why is this change required? What problem does it solve? This can be omitted if a linked issue is provided
-->

When there is an epoch where a member has received GIVE, but also was deleted, the CSV export is showing different data than the distribution page because the deleted users are still being taken into account.

## Description

<!-- Describe your changes -->

Remove deleted users from CSV so their received GIVE will not be taken into consideration when calculating the percentages of other users. This is what happens in the distribution page's table.

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->

Ran locally and observed the CSV without the deleted user as well as the correct adjusted percentages to account for the absence of the deleted users, refer to the screenshots below

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

### CSV (before)

<img width="1372" alt="csv-before" src="https://user-images.githubusercontent.com/78794805/191255453-0739ace4-7b24-4a93-baae-05bca0b44246.png">

### CSV (after)

<img width="1372" alt="csv-after" src="https://user-images.githubusercontent.com/78794805/191255447-76f35d87-6551-44c9-95f3-a6cd143bcba1.png">

### Table (before)

<img width="1388" alt="table-before" src="https://user-images.githubusercontent.com/78794805/191255456-3858b8fa-609d-43f5-b295-b87708259fc2.png">

### Table (after)

<img width="1403" alt="table-after" src="https://user-images.githubusercontent.com/78794805/191255454-29767f93-e765-4c17-910f-9bd79b6ad474.png">

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

@ashmbanks

## Related Issue

<!-- Please link to the issue here -->

Fixes https://github.com/coordinape/coordinape/issues/1363