### PR TITLE
Standardize Linter runs across CI and husky

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,4 @@
 {
-    "singleQuote": true,
-    "arrowParens": "avoid"
+  "singleQuote": true,
+  "arrowParens": "avoid"
 }

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -1,91 +1,61 @@
 type Mutation {
-  adminUpdateUser(
-    payload: AdminUpdateUserInput!
-  ): UserResponse
+  adminUpdateUser(payload: AdminUpdateUserInput!): UserResponse
 }
 
 type Mutation {
-  allocationCsv(
-    payload: AllocationCsvInput!
-  ): AllocationCsvResponse
+  allocationCsv(payload: AllocationCsvInput!): AllocationCsvResponse
 }
 
 type Mutation {
-  createCircle(
-    payload: CreateCircleInput!
-  ): CreateCircleResponse
+  createCircle(payload: CreateCircleInput!): CreateCircleResponse
 }
 
 type Mutation {
-  createEpoch(
-    payload: CreateEpochInput!
-  ): EpochResponse
+  createEpoch(payload: CreateEpochInput!): EpochResponse
 }
 
 type Mutation {
-  createNominee(
-    payload: CreateNomineeInput!
-  ): CreateNomineeResponse
+  createNominee(payload: CreateNomineeInput!): CreateNomineeResponse
 }
 
 type Mutation {
-  createUser(
-    payload: CreateUserInput!
-  ): UserResponse
+  createUser(payload: CreateUserInput!): UserResponse
 }
 
 type Mutation {
-  createUserWithToken(
-    payload: CreateUserWithTokenInput!
-  ): UserResponse
+  createUserWithToken(payload: CreateUserWithTokenInput!): UserResponse
 }
 
 type Mutation {
-  createUsers(
-    payload: CreateUsersInput!
-  ): [UserResponse]
+  createUsers(payload: CreateUsersInput!): [UserResponse]
 }
 
 type Mutation {
-  createVault(
-    payload: CreateVaultInput!
-  ): VaultResponse
+  createVault(payload: CreateVaultInput!): VaultResponse
 }
 
 type Mutation {
-  createVaultTx(
-    payload: LogVaultTxInput!
-  ): LogVaultTxResponse
+  createVaultTx(payload: LogVaultTxInput!): LogVaultTxResponse
 }
 
 type Mutation {
-  deleteCircle(
-    payload: DeleteCircleInput!
-  ): ConfirmationResponse
+  deleteCircle(payload: DeleteCircleInput!): ConfirmationResponse
 }
 
 type Mutation {
-  deleteContribution(
-    payload: DeleteContributionInput!
-  ): ConfirmationResponse
+  deleteContribution(payload: DeleteContributionInput!): ConfirmationResponse
 }
 
 type Mutation {
-  deleteEpoch(
-    payload: DeleteEpochInput!
-  ): DeleteEpochResponse
+  deleteEpoch(payload: DeleteEpochInput!): DeleteEpochResponse
 }
 
 type Mutation {
-  deleteUser(
-    payload: DeleteUserInput!
-  ): ConfirmationResponse
+  deleteUser(payload: DeleteUserInput!): ConfirmationResponse
 }
 
 type Mutation {
-  generateApiKey(
-    payload: GenerateApiKeyInput!
-  ): GenerateApiKeyResponse
+  generateApiKey(payload: GenerateApiKeyInput!): GenerateApiKeyResponse
 }
 
 type Mutation {
@@ -93,69 +63,47 @@ type Mutation {
 }
 
 type Mutation {
-  restoreCoordinape(
-    payload: CoordinapeInput!
-  ): ConfirmationResponse
+  restoreCoordinape(payload: CoordinapeInput!): ConfirmationResponse
 }
 
 type Mutation {
-  updateAllocations(
-    payload: Allocations!
-  ): AllocationsResponse
+  updateAllocations(payload: Allocations!): AllocationsResponse
 }
 
 type Mutation {
-  updateCircle(
-    payload: UpdateCircleInput!
-  ): UpdateCircleOutput
+  updateCircle(payload: UpdateCircleInput!): UpdateCircleOutput
 }
 
 type Mutation {
-  updateEpoch(
-    payload: UpdateEpochInput!
-  ): EpochResponse
+  updateEpoch(payload: UpdateEpochInput!): EpochResponse
 }
 
 type Mutation {
-  updateTeammates(
-    payload: UpdateTeammatesInput!
-  ): UpdateTeammatesResponse
+  updateTeammates(payload: UpdateTeammatesInput!): UpdateTeammatesResponse
 }
 
 type Mutation {
-  updateUser(
-    payload: UpdateUserInput!
-  ): UserResponse
+  updateUser(payload: UpdateUserInput!): UserResponse
 }
 
 type Mutation {
-  uploadCircleLogo(
-    payload: UploadCircleImageInput!
-  ): UpdateCircleResponse
+  uploadCircleLogo(payload: UploadCircleImageInput!): UpdateCircleResponse
 }
 
 type Mutation {
-  uploadOrgLogo(
-    payload: UploadOrgImageInput!
-  ): UpdateOrgResponse
+  uploadOrgLogo(payload: UploadOrgImageInput!): UpdateOrgResponse
 }
 
 type Mutation {
-  uploadProfileAvatar(
-    payload: UploadImageInput!
-  ): UpdateProfileResponse
+  uploadProfileAvatar(payload: UploadImageInput!): UpdateProfileResponse
 }
 
 type Mutation {
-  uploadProfileBackground(
-    payload: UploadImageInput!
-  ): UpdateProfileResponse
+  uploadProfileBackground(payload: UploadImageInput!): UpdateProfileResponse
 }
 
 type Mutation {
-  vouch(
-    payload: VouchInput!
-  ): VouchOutput
+  vouch(payload: VouchInput!): VouchOutput
 }
 
 input CreateCircleInput {
@@ -445,4 +393,3 @@ type CircleLandingInfoResponse {
 }
 
 scalar timestamptz
-

--- a/package.json
+++ b/package.json
@@ -101,10 +101,10 @@
     "test": "yarn hardhat:ganache --exec craco test --runInBand",
     "test:ci": "yarn hardhat:ganache --exec ./scripts/ci.sh",
     "eject": "craco eject",
-    "lint:check": "eslint \"{api,api-lib,cypress,hasura,src}/**/*.{js,ts,tsx,graphql}\"",
+    "lint:check": "eslint \"{{api,api-lib,cypress,hasura,src}/**/*.{js,ts,tsx,graphql},*.{js,ts,tsx,graphql}}\"",
     "lint:fix": "yarn lint:check --fix",
     "postinstall": "./scripts/link_hardhat.sh",
-    "prettier": "prettier \"{api,api-lib,cypress,hasura,src}/**/*.{js,ts,tsx}\"",
+    "prettier": "prettier \"{{api,api-lib,cypress,hasura,src}/**/*.{js,ts,tsx,graphql,json},*.{js,ts,tsx,graphql,json}}\"",
     "prettier:check": "yarn prettier --check",
     "prettier:fix": "yarn prettier --write",
     "typecheck": "tsc --noEmit && tsc -p tsconfig-backend.json --noEmit",
@@ -118,7 +118,8 @@
     "{api,api-lib,hasura,src}/**/*.{js,ts,tsx,graphql}": [
       "eslint --fix",
       "prettier --write"
-    ]
+    ],
+    "{{api,api-lib,cypress,hasura,src}/**/*.json,*.json}": "prettier --write"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
It's "pretty" apparent some of us aren't running lint-staged on commit,
which is fine. However, lint-stage prettier fixing was divergent from
our CI-enforced `yarn prettier:check`. This has caused some spam for
git-blames which isn't the biggest deal but has really irked me for
a while.

This change makes prettier executions consistent across lint-staged and
CI.

I've also configured our prettier CLI commands to run on all
our config files, which is best practice.

I'm also open to getting rid of husky, since I think devs should be responsible for configuring their IDEs to hook into a project's config correctly.