### PR TITLE
Remove unused old laravel tables

### DIFF
--- a/hasura/migrations/default/1663957477889_remove-old-laravel-tables/down.sql
+++ b/hasura/migrations/default/1663957477889_remove-old-laravel-tables/down.sql
@@ -1,0 +1,58 @@
+CREATE SEQUENCE IF NOT EXISTS public.migrations_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+CREATE TABLE public.migrations (
+    id integer DEFAULT nextval('public.migrations_id_seq'::regclass) NOT NULL,
+    migration character varying(510) NOT NULL,
+    batch integer NOT NULL
+);
+
+CREATE SEQUENCE IF NOT EXISTS public.failed_jobs_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+CREATE TABLE public.failed_jobs (
+    id bigint DEFAULT nextval('public.failed_jobs_id_seq'::regclass) NOT NULL,
+    uuid character varying(510) NOT NULL,
+    connection text NOT NULL,
+    queue text NOT NULL,
+    payload text NOT NULL,
+    exception text NOT NULL,
+    failed_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE SEQUENCE IF NOT EXISTS public.feedbacks_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+CREATE TABLE public.feedbacks (
+    id bigint DEFAULT nextval('public.feedbacks_id_seq'::regclass) NOT NULL,
+    user_id integer NOT NULL,
+    telegram_username character varying(510) NOT NULL,
+    message text NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE SEQUENCE IF NOT EXISTS public.jobs_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+CREATE TABLE public.jobs (
+    id bigint DEFAULT nextval('public.jobs_id_seq'::regclass) NOT NULL,
+    queue character varying(510) NOT NULL,
+    payload text NOT NULL,
+    attempts boolean NOT NULL,
+    reserved_at integer,
+    available_at integer NOT NULL,
+    created_at integer NOT NULL
+);

--- a/hasura/migrations/default/1663957477889_remove-old-laravel-tables/up.sql
+++ b/hasura/migrations/default/1663957477889_remove-old-laravel-tables/up.sql
@@ -1,0 +1,9 @@
+DROP TABLE IF EXISTS "public"."migrations";
+DROP TABLE IF EXISTS "public"."jobs";
+DROP TABLE IF EXISTS "public"."failed_jobs";
+DROP TABLE IF EXISTS "public"."feedbacks";
+
+DROP SEQUENCE IF EXISTS "public".migrations_id_seq;
+DROP SEQUENCE IF EXISTS "public".failed_jobs_id_seq;
+DROP SEQUENCE IF EXISTS "public".jobs_id_seqs;
+DROP SEQUENCE IF EXISTS "public".feedbacks_id_seqs;


### PR DESCRIPTION
Remove unused old laravel tables

### Testing

Run the up and down migrations to test.