### PR TITLE
Enhance sorting and fix cypress tests

### DIFF
--- a/cypress/e2e/updateUser.cy.ts
+++ b/cypress/e2e/updateUser.cy.ts
@@ -18,7 +18,7 @@ context('Coordinape', () => {
       '0x51508887c3fef0b4390091c5a4b2b91562881526'.toLowerCase();
 
     cy.visit(`/circles/${circleId}/members`);
-    cy.login();
+    cy.login().wait(5000);
 
     // Assert that the old address is there and correct
     assertAddr(oldAddress);
@@ -36,7 +36,7 @@ context('Coordinape', () => {
       .click()
       .type(newAddress);
 
-    cy.contains('Save').click();
+    cy.contains('Save').click().wait(5000);
 
     // Assert that the new address is there and correct now
     assertAddr(newAddress);
@@ -57,15 +57,14 @@ context('Coordinape', () => {
       .type(oldAddress);
 
     // enter the fixed payment amount
-    cy.getInputByLabel('Fixed Payment Amount').clear().type('1200').blur();
+    cy.getInputByLabel('Member Fixed Payment').clear().type('1200').blur();
 
-    cy.contains('Save').click();
-
+    cy.contains('Save').click().wait(5000);
     // Verify new value in contributors table
     cy.contains('Kasey', { timeout: 120000 })
       .parents('tr')
       .within(() => {
-        cy.get('td').eq(7).should('have.text', '1200');
+        cy.get('td').eq(4).should('have.text', '1200 DAI');
       });
 
     // Assert that the old address is there and correct
@@ -77,6 +76,6 @@ const assertAddr = (addr: string) => {
   cy.contains('Kasey', { timeout: 120000 })
     .parents('tr')
     .within(() => {
-      cy.get('td').eq(1).contains(addr.substr(0, 6), { timeout: 45000 });
+      cy.get('td').eq(1).contains(addr.substr(0, 5), { timeout: 45000 });
     });
 };

--- a/src/pages/AdminPage/MembersTable.tsx
+++ b/src/pages/AdminPage/MembersTable.tsx
@@ -41,8 +41,6 @@ import {
 import { TwoColumnLayout } from 'ui/layouts';
 import { shortenAddress } from 'utils';
 
-import { Paginator } from './Paginator';
-
 import { IUser } from 'types';
 
 const GIFT_CIRCLE_DOCS_URL =
@@ -391,7 +389,7 @@ const MemberRow = ({
         </TD>
       </TR>
       {open && (
-        <TR>
+        <TR key={user.address}>
           <TD colSpan={isMobile ? 4 : 7}>
             <Form>
               <Text h3 semibold css={{ my: '$md' }}>
@@ -787,7 +785,6 @@ export const MembersTable = ({
 }) => {
   const { isMobile } = useMobileDetect();
   const isAdmin = isUserAdmin(me);
-  const [page, setPage] = useState<number>(1);
 
   const [view, setView] = useState<IUser[]>([]);
 
@@ -807,12 +804,6 @@ export const MembersTable = ({
     const filtered = filter ? users.filter(filter) : users;
     setView(filtered);
   }, [users, perPage, filter, circle]);
-
-  const pagedView = useMemo(
-    () =>
-      view.slice((page - 1) * perPage, Math.min(page * perPage, view.length)),
-    [view, perPage, page]
-  );
 
   const MemberTable = makeTable<IUser>('MemberTable');
 
@@ -857,8 +848,9 @@ export const MembersTable = ({
     <>
       <MemberTable
         headers={headers}
-        data={pagedView}
+        data={view}
         startingSortIndex={0}
+        perPage={perPage}
         sortByColumn={(index: number) => {
           if (index === 0) return (u: IUser) => u.name.toLowerCase();
           if (index === 1) return (u: IUser) => u.address.toLowerCase();
@@ -883,12 +875,6 @@ export const MembersTable = ({
           />
         )}
       </MemberTable>
-      <Paginator
-        totalItems={users.length}
-        currentPage={page}
-        onPageChange={setPage}
-        itemsPerPage={perPage}
-      />
     </>
   );
 };

--- a/src/pages/AdminPage/NomineeTable.tsx
+++ b/src/pages/AdminPage/NomineeTable.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 
 import { vouchUser } from 'lib/gql/mutations';
 import { isUserAdmin } from 'lib/users';
@@ -11,7 +11,6 @@ import { TwoColumnLayout } from 'ui/layouts';
 import { shortenAddress } from 'utils';
 
 import { IActiveNominee } from './getActiveNominees';
-import { Paginator } from './Paginator';
 
 import { IUser } from 'types';
 
@@ -101,7 +100,7 @@ const NomineeRow = ({
         </TD>
       </TR>
       {open && (
-        <TR>
+        <TR key={nominee.address}>
           <TD colSpan={isAdmin ? 4 : 3}>
             <Flex column>
               <Text h3 semibold>
@@ -204,19 +203,7 @@ export const NomineesTable = ({
   vouchingText: string;
 }) => {
   type Nominee = IActiveNominee[0];
-  const pageSize = 3;
-  const [page, setPage] = useState(1);
-
   const isAdmin = isUserAdmin(myUser);
-
-  const pagedView = useMemo(
-    () =>
-      nominees?.slice(
-        (page - 1) * pageSize,
-        Math.min(page * pageSize, nominees.length)
-      ),
-    [nominees, page]
-  );
 
   const NomineeTable = makeTable<Nominee>('NomineeTable');
   const headers = [
@@ -244,9 +231,10 @@ export const NomineesTable = ({
       </Flex>
       <NomineeTable
         headers={headers}
-        data={pagedView}
+        data={nominees}
         startingSortIndex={0}
         startingSortDesc
+        perPage={3}
         sortByColumn={(index: number) => {
           if (index === 0) return (n: Nominee) => n.name.toLowerCase();
           if (index === 1) return (n: Nominee) => n.address.toLowerCase();
@@ -267,12 +255,6 @@ export const NomineesTable = ({
           />
         )}
       </NomineeTable>
-      <Paginator
-        totalItems={nominees?.length || 0}
-        currentPage={page}
-        onPageChange={setPage}
-        itemsPerPage={pageSize}
-      />
     </Panel>
   );
 };

--- a/src/pages/DistributionsPage/AllocationsTable.tsx
+++ b/src/pages/DistributionsPage/AllocationsTable.tsx
@@ -1,9 +1,8 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback } from 'react';
 
 import sumBy from 'lodash/sumBy';
 import uniqBy from 'lodash/uniqBy';
 
-import { Paginator } from '../../components/Paginator';
 import { DISTRIBUTION_TYPE } from '../../config/constants';
 import { NewApeAvatar, makeTable } from 'components';
 import { Flex, Text, Panel, Button, Link } from 'ui';
@@ -56,12 +55,6 @@ export const AllocationsTable = ({
   circleDist: EpochDataResult['distributions'][0] | undefined;
 }) => {
   type User = Exclude<typeof users[0], undefined>;
-  const pageSize = 10;
-  const [page, setPage] = useState(0);
-  const shownUsers = useMemo(
-    () => users.slice(page * pageSize, (page + 1) * pageSize),
-    [users, page]
-  );
   const givenPercent = useCallback(
     (received: number) => received / totalGive,
     [totalGive]
@@ -83,7 +76,6 @@ export const AllocationsTable = ({
 
   const combinedDist =
     tokenName && fixedTokenName && tokenName === fixedTokenName;
-  const totalPages = Math.ceil(users.length / pageSize);
 
   const UserTable = makeTable<User>('UserTable');
   const headers = [
@@ -138,9 +130,10 @@ export const AllocationsTable = ({
       </Flex>
       <UserTable
         headers={headers}
-        data={shownUsers}
+        data={users}
         startingSortIndex={2}
         startingSortDesc
+        perPage={10}
         sortByColumn={(index: number) => {
           if (index === 0) return (u: User) => u.name.toLowerCase();
           if (index === 1) return (u: User) => u.address.toLowerCase();
@@ -217,7 +210,6 @@ export const AllocationsTable = ({
             Documentation: Paying Your Team
           </Link>
         </Text>
-        <Paginator pages={totalPages} current={page} onSelect={setPage} />
       </Flex>
     </Panel>
   );


### PR DESCRIPTION
## Motivation and Context

Fix Failed tests due to Changes in Members Page
Fix the issue regarding that every page is sorted separately

## Description

1- Add wait time after saving and update searched string in cypress tests
2- Move slicing for pages after sorting so that all the data is sorted unlike the current the situation where every page is sorted Separately
