### PR TITLE
open up hasura permissions to view contributions from all circle members

### DIFF
--- a/hasura/metadata/databases/default/tables/public_contributions.yaml
+++ b/hasura/metadata/databases/default/tables/public_contributions.yaml
@@ -35,9 +35,10 @@ select_permissions:
         - user_id
       filter:
         _and:
-          - user:
-              profile:
-                id:
-                  _eq: X-Hasura-User-Id
+          - circle:
+              users:
+                profile:
+                  id:
+                    _eq: X-Hasura-User-Id
           - deleted_at:
-              _is_null: true
+            _is_null: true


### PR DESCRIPTION
## Motivation and Context

on the new allocations workflow, circle members need to be able to see contributions from other members

## Description

opened up the perms in hasura based on code snippet from topo
