### PR TITLE
fixing indenting in the contributions select perms

### DIFF
--- a/hasura/metadata/databases/default/tables/public_contributions.yaml
+++ b/hasura/metadata/databases/default/tables/public_contributions.yaml
@@ -27,12 +27,12 @@ select_permissions:
     permission:
       columns:
         - circle_id
+        - id
+        - user_id
+        - description
         - created_at
         - datetime_created
-        - description
-        - id
         - updated_at
-        - user_id
       filter:
         _and:
           - circle:
@@ -41,4 +41,4 @@ select_permissions:
                   id:
                     _eq: X-Hasura-User-Id
           - deleted_at:
-            _is_null: true
+              _is_null: true


### PR DESCRIPTION
## Motivation and Context

some kind of typo that i don't fully understand was breaking metadata parsing, this is generated by hasura console and seems to work 