### PR TITLE
Fix admin and fixed payment coulmns sorting in members table 

### DIFF
--- a/src/pages/AdminPage/MembersTable.tsx
+++ b/src/pages/AdminPage/MembersTable.tsx
@@ -855,8 +855,9 @@ export const MembersTable = ({
           if (index === 0) return (u: IUser) => u.name.toLowerCase();
           if (index === 1) return (u: IUser) => u.address.toLowerCase();
           if (index === 2) return (u: IUser) => u.non_giver;
-          if (index === 3) return (u: IUser) => u.fixed_payment_amount;
-          if (index === 5) return (u: IUser) => u.isCircleAdmin;
+          if (index === 3) return (u: IUser) => u.non_receiver;
+          if (index === 4) return (u: IUser) => u.fixed_payment_amount;
+          if (index === 6) return (u: IUser) => u.isCircleAdmin;
           return (u: IUser) => u.name.toLowerCase();
         }}
       >


### PR DESCRIPTION
## Motivation and Context

Members table is not sorted correctly if admin or fixed payment columns are clicked

## Description
Corrected wrong indices for fixed payment and admin columns and added non receiver column index

## Test and Deployment Plan

Go to Members page and sort the members table using different criteria

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/34943689/192641540-16d28f6d-a61c-4a7c-b2ec-eb777ad96fb8.png)
![image](https://user-images.githubusercontent.com/34943689/192641579-c0305a8f-524c-418f-8e1b-2cc670aa314a.png)
![image](https://user-images.githubusercontent.com/34943689/192641662-210d671e-f33b-4e56-b0e8-5df9196185c4.png)
