### PR TITLE
Tag variant

### DIFF
--- a/src/stitches.config.ts
+++ b/src/stitches.config.ts
@@ -53,6 +53,7 @@ export const SvgIconConfig = {
 };
 
 const spaces = {
+  xxs: '2px',
   xs: '4px',
   sm: '8px',
   md: '16px',
@@ -79,6 +80,9 @@ export const colors = {
 
   success: figmaColors.green1,
   successDark: figmaColors.green16,
+
+  active: figmaColors.yellow4,
+  activeDark: figmaColors.yellow20,
 
   secondary: figmaColors.teal12,
   secondaryDark: figmaColors.teal20,

--- a/src/ui/Text/Text.tsx
+++ b/src/ui/Text/Text.tsx
@@ -21,6 +21,7 @@ export const Text = styled('span', {
       neutral: { color: '$neutral' },
       alert: { color: '$alert' },
       primary: { color: '$primary' },
+      active: { color: '$activeDark' },
       complete: { color: '$complete' },
       inherit: { color: 'inherit' },
     },
@@ -80,7 +81,32 @@ export const Text = styled('span', {
         whiteSpace: 'nowrap',
       },
     },
+    tag: {
+      true: {
+        fontSize: '$small',
+        fontWeight: '$semibold',
+        lineHeight: '$shorter',
+        p: '$xs calc($xs + $xxs)',
+        borderRadius: '$1',
+      },
+    },
   },
+  compoundVariants: [
+    {
+      tag: true,
+      color: 'active',
+      css: {
+        backgroundColor: '$active',
+      },
+    },
+    {
+      tag: true,
+      color: 'complete',
+      css: {
+        backgroundColor: '$success',
+      },
+    },
+  ],
 
   defaultVariants: { font: 'inter', color: 'default' },
 });


### PR DESCRIPTION
<img width="838" alt="Screen Shot 2022-09-27 at 2 48 20 PM" src="https://user-images.githubusercontent.com/100873710/192641957-bc3638a9-4065-4ef4-913d-87ce2f419f67.png">

text compound variant for tags.  

nice paradigm to follow: buttons should have dark bg, non-clickable tags should have light bg