### PR TITLE
Use cloud hasura graphiql for all dev portals

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
   # Hasura
   graphql-engine: &graphql_engine
     profiles: ['dev']
-    image: hasura/graphql-engine:v2.1.1.cli-migrations-v3
+    image: hasura/graphql-engine:v2.11.2.cli-migrations-v3
     volumes:
       - ./hasura/migrations:/hasura-migrations
       - ./hasura/metadata:/hasura-metadata

--- a/src/utils/apiKeyHelper.ts
+++ b/src/utils/apiKeyHelper.ts
@@ -1,14 +1,10 @@
-import { IN_DEVELOPMENT, REACT_APP_HASURA_URL } from '../config/env';
+import { REACT_APP_HASURA_URL } from '../config/env';
 
 const EXAMPLE_QUERY =
   'query+MyCircles+%7B%0A++circles%28limit%3A+3%29+%7B%0A++++name%0A++++organization+%7B%0A++++++name%0A++++%7D%0A++++epochs%28limit%3A+3%2C+where%3A+%7Bended%3A+%7B_eq%3A+true%7D%7D%29+%7B%0A++++++id%0A++++++end_date%0A++++++start_date%0A++++%7D%0A++++users%28limit%3A+5%2C+order_by%3A+%7Bcreated_at%3A+asc%7D%29+%7B%0A++++++id%0A++++++name%0A++++++give_token_received%0A++++++give_token_remaining%0A++++++profile+%7B%0A++++++++twitter_username%0A++++++%7D%0A++++%7D%0A++%7D%0A%7D%0A';
 
 export const getConsoleUrl = (authToken: string, withExample?: boolean) => {
-  const hasuraGui = IN_DEVELOPMENT
-    ? `http://localhost:8080/console`
-    : 'https://cloud.hasura.io/public/graphiql';
-
-  return `${hasuraGui}?endpoint=${REACT_APP_HASURA_URL}&header=Authorization:${encodeURIComponent(
+  return `https://cloud.hasura.io/public/graphiql?endpoint=${REACT_APP_HASURA_URL}&header=Authorization:${encodeURIComponent(
     `Bearer ${authToken}`
   )}${withExample ? `&query=${EXAMPLE_QUERY}` : ''}`;
 };


### PR DESCRIPTION
Resolves #1391 

- bump hasura version to 2.11.2 (matching prod's current version)
- fix DevPortal link

@levity 

Seems this fix is working for me in localhost. Just use prod console pointed at localhost.