### PR TITLE
Refresh team selection settings on change

### DIFF
--- a/src/components/MainLayout/CircleNav.tsx
+++ b/src/components/MainLayout/CircleNav.tsx
@@ -3,7 +3,10 @@ import { useMemo } from 'react';
 
 import { useQuery } from 'react-query';
 
-import { getCircleSettings } from 'pages/CircleAdminPage/getCircleSettings';
+import {
+  getCircleSettings,
+  QUERY_KEY_CIRCLE_SETTINGS,
+} from 'pages/CircleAdminPage/getCircleSettings';
 import { useSelectedCircle } from 'recoilState/app';
 import { paths } from 'routes/paths';
 
@@ -14,7 +17,7 @@ export const CircleNav = () => {
   const { myUser, circleId, circle: initialData } = useSelectedCircle();
 
   const { data: circle } = useQuery(
-    ['circleSettings', circleId],
+    [QUERY_KEY_CIRCLE_SETTINGS, circleId],
     () => getCircleSettings(circleId),
     {
       initialData,

--- a/src/pages/AddMembersPage/NewMemberList.tsx
+++ b/src/pages/AddMembersPage/NewMemberList.tsx
@@ -12,6 +12,7 @@ import { zEthAddress, zUsername } from '../../forms/formHelpers';
 import { useApeSnackbar, useApiBase } from '../../hooks';
 import { Box, Button, Flex, Panel, Text } from '../../ui';
 import { Check } from 'icons/__generated';
+import { QUERY_KEY_CIRCLE_SETTINGS } from 'pages/CircleAdminPage/getCircleSettings';
 
 import NewMemberEntry from './NewMemberEntry';
 import NewMemberGridBox from './NewMemberGridBox';
@@ -132,7 +133,10 @@ const NewMemberList = ({
       setDefaultMembers([]);
       reset({ newMembers: [emptyMember, emptyMember] });
       successRef.current?.scrollIntoView();
-      await queryClient.invalidateQueries(['circleSettings', circleId]);
+      await queryClient.invalidateQueries([
+        QUERY_KEY_CIRCLE_SETTINGS,
+        circleId,
+      ]);
       await fetchCircle({ circleId });
     } catch (e) {
       showError(e);

--- a/src/pages/AdminPage/AdminPage.tsx
+++ b/src/pages/AdminPage/AdminPage.tsx
@@ -12,7 +12,10 @@ import { useCircleOrg } from 'hooks/gql/useCircleOrg';
 import { useVaults } from 'hooks/gql/useVaults';
 import useMobileDetect from 'hooks/useMobileDetect';
 import { Search } from 'icons/__generated';
-import { getCircleSettings } from 'pages/CircleAdminPage/getCircleSettings';
+import {
+  getCircleSettings,
+  QUERY_KEY_CIRCLE_SETTINGS,
+} from 'pages/CircleAdminPage/getCircleSettings';
 import {
   getFixedPayment,
   QUERY_KEY_FIXED_PAYMENT,
@@ -57,7 +60,7 @@ const AdminPage = () => {
   } = useSelectedCircle();
 
   const { data: circle } = useQuery(
-    ['circleSettings', circleId],
+    [QUERY_KEY_CIRCLE_SETTINGS, circleId],
     () => getCircleSettings(circleId),
     {
       initialData: selectedCircle,

--- a/src/pages/AllocationPage/AllocationEpoch.tsx
+++ b/src/pages/AllocationPage/AllocationEpoch.tsx
@@ -8,11 +8,7 @@ import { makeStyles } from '@material-ui/core';
 import { useApiWithSelectedCircle } from '../../hooks';
 import { STEP_ALLOCATION, STEP_MY_TEAM } from '../../routes/allocation';
 import { IAllocationStep } from '../../types';
-import {
-  OptInput,
-  ApeInfoTooltip,
-  LoadingModal,
-} from 'components';
+import { OptInput, ApeInfoTooltip } from 'components';
 import { MAX_BIO_LENGTH } from 'config/constants';
 import { useSelectedCircle } from 'recoilState/app';
 import { Button, Flex, Text, Modal } from 'ui';

--- a/src/pages/AllocationPage/AllocationEpoch.tsx
+++ b/src/pages/AllocationPage/AllocationEpoch.tsx
@@ -180,7 +180,7 @@ const AllocationEpoch = ({
           </span>
           <ApeInfoTooltip>
             An Epoch is a period of time where circle members contribute value &
-            allocate {selectedCircle.tokenName} tokens to one another.{' '}
+            allocate {selectedCircle?.tokenName} tokens to one another.{' '}
             <a
               rel="noreferrer"
               target="_blank"
@@ -195,22 +195,22 @@ const AllocationEpoch = ({
           className={classes.bioTextarea}
           maxLength={MAX_BIO_LENGTH}
           onChange={onChangeBio}
-          placeholder={`Tell us about your contributions in the ${selectedCircle.name} Circle this epoch...`}
+          placeholder={`Tell us about your contributions in the ${selectedCircle?.name} Circle this epoch...`}
           value={epochBio}
         />
         {!fixedNonReceiver ? (
           <>
             <p className={classes.titleTwo}>
-              Should you receive {selectedCircle.token_name || 'GIVE'}{' '}
+              Should you receive {selectedCircle?.token_name || 'GIVE'}{' '}
               distributions in the{' '}
-              <b>{capitalize(selectedCircle.name)} Circle</b> this epoch?
+              <b>{capitalize(selectedCircle?.name)} Circle</b> this epoch?
             </p>
             <hr className={classes.optHr} />
             <div className={classes.optInputContainer}>
               <OptInput
                 isChecked={!nonReceiver}
                 subTitle={`I want to be eligible to receive ${
-                  selectedCircle.token_name || 'GIVE'
+                  selectedCircle?.token_name || 'GIVE'
                 }`}
                 title="Opt In"
                 updateOpt={() => setNonReceiver(false)}
@@ -262,15 +262,15 @@ const AllocationEpoch = ({
           <>
             <p className={classes.title}>
               Your administrator opted you out of receiving{' '}
-              {selectedCircle.token_name || 'GIVE'}
+              {selectedCircle?.token_name || 'GIVE'}
             </p>
             <hr className={classes.optHr} />
             <div className={classes.optInputContainer}>
               <p className={classes.optLabel}>
-                You can still distribute {selectedCircle.token_name || 'GIVE'}{' '}
+                You can still distribute {selectedCircle?.token_name || 'GIVE'}{' '}
                 as normal. Generally people are opted out of receiving{' '}
-                {selectedCircle.token_name || 'GIVE'} if they are compensated in
-                other ways by their organization. Please contact your circle
+                {selectedCircle?.token_name || 'GIVE'} if they are compensated
+                in other ways by their organization. Please contact your circle
                 admin for more details.
               </p>
             </div>

--- a/src/pages/AllocationPage/AllocationPage.tsx
+++ b/src/pages/AllocationPage/AllocationPage.tsx
@@ -275,6 +275,7 @@ const AllocationContents = ({
         activeStep={activeStep}
         completedSteps={completedSteps}
         getHandleStep={getHandleStep}
+        teamSelection={teamSelection}
       />
       <Box
         css={{

--- a/src/pages/AllocationPage/AllocationPage.tsx
+++ b/src/pages/AllocationPage/AllocationPage.tsx
@@ -18,6 +18,10 @@ import {
 } from '../../routes/allocation';
 import { IAllocationStep, ISimpleGift, ISimpleGiftUser } from '../../types';
 import { Box } from '../../ui/Box/Box';
+import {
+  getCircleSettings,
+  QUERY_KEY_CIRCLE_SETTINGS,
+} from 'pages/CircleAdminPage/getCircleSettings';
 
 import AllocationEpoch from './AllocationEpoch';
 import AllocationGive from './AllocationGive';
@@ -34,26 +38,46 @@ import {
 
 const AllocationPage = () => {
   const address = useConnectedAddress();
-  const { circle: selectedCircle } = useSelectedCircle();
+  const { circle: initialData, circleId } = useSelectedCircle();
 
   /* Make sure the teammates are loaded */
   const { data, refetch: refetchTeammates } = useQuery(
-    ['teammates', selectedCircle.id],
-    () => getTeammates(selectedCircle.id, address as string),
+    ['teammates', circleId],
+    () => getTeammates(circleId, address as string),
     {
-      enabled: !!(selectedCircle.id && address),
+      enabled: !!(circleId && address),
       refetchOnReconnect: false,
       refetchOnWindowFocus: false,
       staleTime: Infinity,
     }
   );
+  const {
+    isLoading,
+    isIdle,
+    isError,
+    isRefetching,
+    error,
+    data: selectedCircle,
+  } = useQuery(
+    [QUERY_KEY_CIRCLE_SETTINGS, circleId],
+    () => getCircleSettings(circleId),
+    {
+      // the query will not be executed untill circleId exists
+      enabled: !!circleId,
+      initialData,
+      //minmize background refetch
+      refetchOnWindowFocus: false,
 
+      staleTime: Infinity,
+      notifyOnChangeProps: ['data'],
+    }
+  );
   // Make sure the pendingGifts are loaded
   const { data: pendingGiftsFrom, refetch: refetchGifts } = useQuery(
-    ['pending-gifts', selectedCircle.id],
-    () => getPendingGiftsFrom(selectedCircle.id, address as string),
+    ['pending-gifts', circleId],
+    () => getPendingGiftsFrom(circleId, address as string),
     {
-      enabled: !!(selectedCircle.id && address),
+      enabled: !!(circleId && address),
       refetchOnReconnect: false,
       refetchOnWindowFocus: false,
       staleTime: Infinity,
@@ -78,13 +102,21 @@ const AllocationPage = () => {
 
   const { allUsers, startingTeammates } = data;
 
+  if (isLoading || isIdle || isRefetching) return <LoadingModal visible />;
+  if (isError) {
+    if (error instanceof Error) {
+      console.warn(error);
+    }
+  }
+
   return (
     <AllocationContents
       startingTeammates={
-        selectedCircle.team_selection ? startingTeammates : allUsers
+        selectedCircle?.team_selection ? startingTeammates : allUsers
       }
       allUsers={allUsers}
       pendingGiftsFrom={pendingGiftsFrom}
+      teamSelection={selectedCircle?.team_selection}
     />
   );
 };
@@ -93,11 +125,13 @@ type AllocationContentsProps = {
   startingTeammates: Teammate[];
   allUsers: PotentialTeammate[];
   pendingGiftsFrom: PendingGift[];
+  teamSelection?: boolean;
 };
 const AllocationContents = ({
   startingTeammates,
   allUsers,
   pendingGiftsFrom,
+  teamSelection,
 }: AllocationContentsProps) => {
   const navigate = useNavigate();
   const location = useLocation();
@@ -105,7 +139,6 @@ const AllocationContents = ({
   const {
     circleId,
     myUser: selectedMyUser,
-    circle: selectedCircle,
     circleEpochsStatus: { epochIsActive },
   } = useSelectedCircle();
 
@@ -140,7 +173,7 @@ const AllocationContents = ({
     setActiveStep(step.key);
   };
 
-  const allSteps = !selectedCircle.team_selection ? NO_TEAM_STEPS : STEPS;
+  const allSteps = !teamSelection ? NO_TEAM_STEPS : STEPS;
   const [completedSteps, setCompletedSteps] = useState<
     Set<IAllocationStep> | undefined
   >(undefined);
@@ -153,7 +186,7 @@ const AllocationContents = ({
       if (!completedSteps.has(STEP_MY_EPOCH)) {
         navigate(STEP_MY_EPOCH.pathFn(circleId));
       } else if (!epochIsActive) {
-        if (selectedCircle.team_selection) {
+        if (teamSelection) {
           navigate(STEP_MY_TEAM.pathFn(circleId));
         }
       } else {

--- a/src/pages/AllocationPage/AllocationPage.tsx
+++ b/src/pages/AllocationPage/AllocationPage.tsx
@@ -292,6 +292,7 @@ const AllocationContents = ({
             <AllocationEpoch
               getHandleStep={getHandleStep}
               setActiveStep={setActiveStep}
+              teamSelection={teamSelection}
             />
           </>
         )}

--- a/src/pages/AllocationPage/AllocationStepper.tsx
+++ b/src/pages/AllocationPage/AllocationStepper.tsx
@@ -38,6 +38,7 @@ type AllocationStepperProps = {
   activeStep: number;
   allSteps: IAllocationStep[];
   completedSteps: Set<IAllocationStep> | undefined;
+  teamSelection?: boolean;
 };
 
 export const AllocationStepper = ({
@@ -45,6 +46,7 @@ export const AllocationStepper = ({
   activeStep,
   allSteps,
   completedSteps,
+  teamSelection,
 }: AllocationStepperProps) => {
   const classes = useStyles();
   const {
@@ -81,7 +83,7 @@ export const AllocationStepper = ({
               }
               disabled={
                 (step === STEP_ALLOCATION && !epochIsActive) ||
-                (!selectedCircle.team_selection && step === STEP_MY_TEAM)
+                (!teamSelection && step === STEP_MY_TEAM)
               }
             >
               {step.buildLabel(selectedCircle)}

--- a/src/pages/AllocationPage/AllocationTeam.tsx
+++ b/src/pages/AllocationPage/AllocationTeam.tsx
@@ -257,6 +257,19 @@ const AllocationTeam = ({
     setLocalTeammates(newTeammates);
   };
 
+  const setAllLocalTeammates = () => {
+    assert(allUsers);
+    setLocalTeammates(allUsers);
+  };
+
+  const clearLocalTeammates = () => {
+    if (!teamSelection) {
+      console.error('clearLocalTeammates with circle without team selection');
+      return;
+    }
+    setLocalTeammates([]);
+  };
+
   const saveTeammates = useLoadAndTryMutation(
     async () => {
       await updateTeammates(
@@ -273,19 +286,6 @@ const AllocationTeam = ({
       success: 'Saved Teammates',
     }
   );
-
-  const setAllLocalTeammates = () => {
-    assert(allUsers);
-    setLocalTeammates(allUsers);
-  };
-
-  const clearLocalTeammates = () => {
-    if (!teamSelection) {
-      console.error('clearLocalTeammates with circle without team selection');
-      return;
-    }
-    setLocalTeammates([]);
-  };
 
   const onChangeKeyword = (event: React.ChangeEvent<HTMLInputElement>) => {
     setKeyword(event.target.value);
@@ -324,9 +324,9 @@ const AllocationTeam = ({
           </Text>
         )}
         <Text h2>
-          Who are your Teammates in the {selectedCircle.name} Circle?
+          Who are your Teammates in the {selectedCircle?.name} Circle?
         </Text>
-        <p className={classes.subTitle}>{selectedCircle.team_sel_text}</p>
+        <p className={classes.subTitle}>{selectedCircle?.team_sel_text}</p>
       </div>
       <div className={classes.content}>
         <div className={classes.accessaryContainer}>
@@ -397,7 +397,8 @@ const AllocationTeam = ({
         {allUsers.filter(a => a.non_receiver).length > 0 && (
           <>
             <p className={classes.contentTitle}>
-              These users are opted-out of receiving {selectedCircle.token_name}
+              These users are opted-out of receiving{' '}
+              {selectedCircle?.token_name}
             </p>
             <hr className={classes.hr} />
             <div className={classes.teammatesContainer}>

--- a/src/pages/CircleAdminPage/CircleAdminPage.tsx
+++ b/src/pages/CircleAdminPage/CircleAdminPage.tsx
@@ -43,7 +43,10 @@ import { numberWithCommas } from 'utils';
 import { getCircleAvatar } from 'utils/domain';
 
 import { AdminIntegrations } from './AdminIntegrations';
-import { getCircleSettings } from './getCircleSettings';
+import {
+  getCircleSettings,
+  QUERY_KEY_CIRCLE_SETTINGS,
+} from './getCircleSettings';
 import { getFixedPayment, QUERY_KEY_FIXED_PAYMENT } from './getFixedPayment';
 import { RemoveCircleModal } from './RemoveCircleModal';
 
@@ -180,7 +183,7 @@ export const CircleAdminPage = () => {
     error,
     data: circle,
   } = useQuery(
-    ['circleSettings', circleId],
+    [QUERY_KEY_CIRCLE_SETTINGS, circleId],
     () => getCircleSettings(circleId),
     {
       // the query will not be executed untill circleId exists

--- a/src/pages/CircleAdminPage/getCircleSettings.ts
+++ b/src/pages/CircleAdminPage/getCircleSettings.ts
@@ -63,3 +63,4 @@ export const getCircleSettings = async (circleId: number) => {
 export type CircleSettingsResult = Awaited<
   ReturnType<typeof getCircleSettings>
 >;
+export const QUERY_KEY_CIRCLE_SETTINGS = 'circleSettings';


### PR DESCRIPTION
## Motivation and Context
fixes #1399

## Description
1- refetch team selection using reac-query and use recoil data as initial data for it

## Test and Deployment Plan
1- Go to Allocate page and opt-in then select a team
2- Go to circle settings and turn off team selection
Expected: all circle members should appear and team selection should be removed from the stepper
3- Re enable team selection
Expected: selected members and team selection step should return

## Screenshots (if appropriate):

![Peek 2022-09-28 19-27](https://user-images.githubusercontent.com/34943689/192849323-22db65f0-70e3-43ca-8a7c-9b1afa793e5d.gif)


