### PR TITLE
Give notes fix

### DIFF
--- a/src/pages/GivePage/ContributorButton.tsx
+++ b/src/pages/GivePage/ContributorButton.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { useApeSnackbar } from '../../hooks';
 import { X } from '../../icons/__generated';
 import Plus from '../../icons/__generated/Plus';
+import { CSS } from '../../stitches.config';
 import { Box, Button } from '../../ui';
 import { normalizeError } from '../../utils/reporting';
 
@@ -11,12 +12,14 @@ import { Member } from './index';
 type ContributorButtonProps = {
   member: Member;
   updateTeammate(id: number, teammate: boolean): void;
+  css?: CSS;
 };
 
 // ContributorButton toggles whether a member is a contributor or not
 export const ContributorButton = ({
   member,
   updateTeammate,
+  css,
 }: ContributorButtonProps) => {
   const { showError } = useApeSnackbar();
 
@@ -40,6 +43,7 @@ export const ContributorButton = ({
     <Button
       size="small"
       css={{
+        ...css,
         width: '144px',
         '@sm': { visibility: 'visible' },
         '> .remove': { display: 'none' },

--- a/src/pages/GivePage/GiveAllocator.tsx
+++ b/src/pages/GivePage/GiveAllocator.tsx
@@ -96,6 +96,13 @@ export const GiveAllocator = ({
             css={{
               padding: 0,
               color: '$primary',
+              transition: '0.2s all ease-out',
+              '&:hover': {
+                transform: 'scale(1.1)',
+              },
+              '&:active': {
+                transform: 'scale(0.9)',
+              },
               '> svg': {
                 // This override mr: $xs set in Button for some reason, almost lost my mind over this -g
                 mr: '0',
@@ -142,6 +149,13 @@ export const GiveAllocator = ({
             css={{
               padding: 0,
               color: '$primary',
+              transition: '0.2s all ease-out',
+              '&:hover': {
+                transform: 'scale(1.1)',
+              },
+              '&:active': {
+                transform: 'scale(0.9)',
+              },
               '> svg': {
                 // This override mr: $xs set in Button for some reason, almost lost my mind over this -g
                 mr: '0',

--- a/src/pages/GivePage/GiveDrawer.tsx
+++ b/src/pages/GivePage/GiveDrawer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { useQuery } from 'react-query';
 
@@ -68,17 +68,13 @@ export const GiveDrawer = ({
   // note is the current state of the note
   const [note, setNote] = useState(gift.note);
 
-  // we need a ref for async saving purposes
-  const noteRef = useRef(note);
-  noteRef.current = note;
-
   // saveTimeout is the timeout handle for the buffered async saving
   const [saveTimeout, setSaveTimeout] =
     useState<ReturnType<typeof setTimeout>>();
 
   // update the note in the to level page state
-  const saveNote = () => {
-    updateNote({ ...gift, note: noteRef.current });
+  const saveNote = (gift: Gift, note?: string) => {
+    updateNote({ ...gift, note: note });
   };
 
   // noteChanged schedules a save to the underlying state in the parent component, clearing any pending save
@@ -88,7 +84,7 @@ export const GiveDrawer = ({
       clearTimeout(saveTimeout);
     }
     // only save every 1s , if user increments or edits note, delay 1s
-    setSaveTimeout(setTimeout(saveNote, 1000));
+    setSaveTimeout(setTimeout(() => saveNote({ ...gift }, newNote), 1000));
   };
 
   useEffect(() => {
@@ -99,6 +95,10 @@ export const GiveDrawer = ({
       setNeedToSave(undefined);
     }
   }, [member]);
+
+  useEffect(() => {
+    setNote(gift.note);
+  }, [gift]);
 
   const nextPrevCss = {
     color: '$text',
@@ -115,7 +115,7 @@ export const GiveDrawer = ({
   };
 
   return (
-    <Box css={{ height: '100%', pt: '$md' }}>
+    <Box key={selectedMemberIdx} css={{ height: '100%', pt: '$md' }}>
       <Flex>
         <Button
           color="white"
@@ -152,6 +152,8 @@ export const GiveDrawer = ({
             css={{ mr: '$sm' }}
           />
           <Text ellipsis h3 semibold>
+            {selectedMemberIdx}
+            {gift.recipient_id}
             {member.name}
           </Text>
         </Flex>

--- a/src/pages/GivePage/GiveDrawer.tsx
+++ b/src/pages/GivePage/GiveDrawer.tsx
@@ -152,8 +152,6 @@ export const GiveDrawer = ({
             css={{ mr: '$sm' }}
           />
           <Text ellipsis h3 semibold>
-            {selectedMemberIdx}
-            {gift.recipient_id}
             {member.name}
           </Text>
         </Flex>

--- a/src/pages/GivePage/GiveRow.tsx
+++ b/src/pages/GivePage/GiveRow.tsx
@@ -48,10 +48,11 @@ export const GiveRow = ({
         pr: '$md',
         border: '2px solid transparent',
         cursor: 'pointer',
-        background: docExample || selected ? '$highlight' : undefined,
+        backgroundColor: docExample || selected ? '$highlight' : undefined,
         borderColor: docExample || selected ? '$link' : undefined,
+        transition: 'background-color 0.3s, border-color 0.3s',
         '&:hover': {
-          background: '$highlight',
+          backgroundColor: '$highlight',
           borderColor: '$link',
         },
         '@sm': {
@@ -87,12 +88,14 @@ export const GiveRow = ({
             }}
             alignItems="center"
           >
-            {(hover || member.teammate) && (
-              <ContributorButton
-                member={member}
-                updateTeammate={updateTeammate}
-              />
-            )}
+            <ContributorButton
+              css={{
+                transition: 'visibility 0.1s ease-in',
+                visibility: hover || member.teammate ? 'visible' : 'hidden',
+              }}
+              member={member}
+              updateTeammate={updateTeammate}
+            />
           </Flex>
           {!docExample && (
             <Flex


### PR DESCRIPTION
## Motivation and Context

Notes weren't properly changing when scrolling through users in the give drawer. There was also no animations on plus/minus or hovering on selected users, and I thought I'd add some for fun. 

