### PR TITLE
fix: Allow for empty string in the `GiveAllocator` input

### DIFF
--- a/src/pages/AllocationPage/AllocationGive.tsx
+++ b/src/pages/AllocationPage/AllocationGive.tsx
@@ -161,7 +161,11 @@ enum FilterType {
 type AllocationGiveProps = {
   givePerUser: Map<number, ISimpleGift>;
   localGifts: ISimpleGift[];
-  pendingGiftsFrom: { recipient_id: number; tokens: number; note?: string }[];
+  pendingGiftsFrom: {
+    recipient_id: number;
+    tokens?: number;
+    note?: string;
+  }[];
   setLocalGifts: (value: React.SetStateAction<ISimpleGift[]>) => void;
 };
 

--- a/src/pages/AllocationPage/AllocationPage.tsx
+++ b/src/pages/AllocationPage/AllocationPage.tsx
@@ -205,7 +205,7 @@ const AllocationContents = ({
       }
       newGifts.push({
         user: u,
-        tokens: g.tokens,
+        tokens: g.tokens ?? 0,
         note: g.note,
       });
     }

--- a/src/pages/AllocationPage/calculations.ts
+++ b/src/pages/AllocationPage/calculations.ts
@@ -32,11 +32,11 @@ export const calculateGifts =
 type TokenNote = [number, string];
 
 export const buildDiffMap = (
-  pendingGiftsFrom: { recipient_id: number; tokens: number; note?: string }[],
+  pendingGiftsFrom: { recipient_id: number; tokens?: number; note?: string }[],
   localGifts: ISimpleGift[]
 ) => {
   const remoteMap = new Map<number, TokenNote>(
-    pendingGiftsFrom.map(g => [g.recipient_id, [g.tokens, g.note ?? '']])
+    pendingGiftsFrom.map(g => [g.recipient_id, [g.tokens ?? 0, g.note ?? '']])
   );
   const localMap = new Map<number, TokenNote>(
     localGifts.map(g => [g.user.id, [g.tokens, g.note ?? '']])
@@ -68,7 +68,7 @@ export const buildDiffMap = (
 };
 
 export const isLocalGiftsChanged = (
-  pendingGiftsFrom: { recipient_id: number; tokens: number; note?: string }[],
+  pendingGiftsFrom: { recipient_id: number; tokens?: number; note?: string }[],
   localGifts: ISimpleGift[]
 ): boolean => {
   return buildDiffMap(pendingGiftsFrom, localGifts).size > 0;

--- a/src/pages/AllocationPage/queries.ts
+++ b/src/pages/AllocationPage/queries.ts
@@ -35,8 +35,8 @@ export const getPendingGiftsFrom = async (
 
   type GiftWithNote = Omit<
     typeof data.pending_token_gifts[number],
-    'gift_private'
-  > & { note?: string };
+    'gift_private' | 'tokens'
+  > & { tokens?: number; note?: string };
 
   return data.pending_token_gifts.map(g => {
     const gm = g;

--- a/src/pages/GivePage/GiveAllocator.tsx
+++ b/src/pages/GivePage/GiveAllocator.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { ApeInfoTooltip } from '../../components';
 import { MinusCircle, PlusCircle } from '../../icons/__generated';
@@ -26,6 +26,8 @@ export const GiveAllocator = ({
   maxedOut,
   optedOut,
 }: GiveAllocatorProps) => {
+  const [isInputEmpty, setIsInputEmpty] = useState(false);
+
   //incGift increments the gift by 1
   const incGift = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     e.stopPropagation();
@@ -36,7 +38,7 @@ export const GiveAllocator = ({
   //decGift decrements the gift by 1
   const decGift = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     e.stopPropagation();
-    if (gift.tokens > 0) {
+    if ((gift.tokens ?? 0) > 0) {
       adjustGift(gift.recipient_id, -1);
     }
   };
@@ -47,7 +49,7 @@ export const GiveAllocator = ({
       return;
     }
     const newValue = +value;
-    const adjustment = newValue - gift.tokens;
+    const adjustment = newValue - (gift.tokens ?? 0);
     // TODO: can never erase the 0 cuz empty string evaluates to 0 here, need gift.tokens to be optional for this -g
     // https://github.com/coordinape/coordinape/issues/1401
     adjustGift(gift.recipient_id, adjustment);
@@ -91,7 +93,7 @@ export const GiveAllocator = ({
             data-testid="decrement"
             size="small"
             onClick={decGift}
-            disabled={gift.tokens < 1 || disabled}
+            disabled={(gift.tokens ?? 0) < 1 || disabled}
             color="transparent"
             css={{
               padding: 0,
@@ -111,14 +113,20 @@ export const GiveAllocator = ({
           >
             <MinusCircle css={{ width: iconSize, height: iconSize }} />
           </Button>
-          {(gift.tokens < 1 || disabled) && <ClickTrapperIcon />}
+          {((gift.tokens ?? 0) < 1 || disabled) && <ClickTrapperIcon />}
         </Flex>
         <TextField
           data-testid="tokenCount"
-          value={gift.tokens}
-          onChange={evt => setGiftTokens(evt.target.value)}
+          value={isInputEmpty ? '' : gift.tokens}
+          onChange={evt => {
+            setGiftTokens(evt.target.value);
+            setIsInputEmpty(evt.target.value === '');
+          }}
           maxLength={5}
           disabled={disabled}
+          onBlur={() => {
+            isInputEmpty ? setIsInputEmpty(false) : gift.tokens;
+          }}
           onClick={e => e.stopPropagation()}
           css={{
             width: '5em',

--- a/src/pages/GivePage/GiveAllocator.tsx
+++ b/src/pages/GivePage/GiveAllocator.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import { ApeInfoTooltip } from '../../components';
 import { MinusCircle, PlusCircle } from '../../icons/__generated';
@@ -9,7 +9,7 @@ import { Gift } from './index';
 const iconSize = 40;
 
 type GiveAllocatorProps = {
-  adjustGift(recipientId: number, amount: number): void;
+  adjustGift(recipientId: number, amount: number | null): void;
   gift: Gift;
   inPanel?: boolean;
   disabled: boolean;
@@ -26,8 +26,6 @@ export const GiveAllocator = ({
   maxedOut,
   optedOut,
 }: GiveAllocatorProps) => {
-  const [isInputEmpty, setIsInputEmpty] = useState(false);
-
   //incGift increments the gift by 1
   const incGift = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     e.stopPropagation();
@@ -48,8 +46,7 @@ export const GiveAllocator = ({
     if (value.length > 5) {
       return;
     }
-    const newValue = +value;
-    const adjustment = newValue - (gift.tokens ?? 0);
+    const adjustment = value !== '' ? +value - (gift.tokens ?? 0) : null;
     // TODO: can never erase the 0 cuz empty string evaluates to 0 here, need gift.tokens to be optional for this -g
     // https://github.com/coordinape/coordinape/issues/1401
     adjustGift(gift.recipient_id, adjustment);
@@ -117,16 +114,11 @@ export const GiveAllocator = ({
         </Flex>
         <TextField
           data-testid="tokenCount"
-          value={isInputEmpty ? '' : gift.tokens}
-          onChange={evt => {
-            setGiftTokens(evt.target.value);
-            setIsInputEmpty(evt.target.value === '');
-          }}
+          value={gift.tokens ?? ''}
+          onChange={evt => setGiftTokens(evt.target.value)}
           maxLength={5}
           disabled={disabled}
-          onBlur={() => {
-            isInputEmpty ? setIsInputEmpty(false) : gift.tokens;
-          }}
+          onBlur={() => setGiftTokens(gift.tokens ? String(gift.tokens) : '0')}
           onClick={e => e.stopPropagation()}
           css={{
             width: '5em',

--- a/src/pages/GivePage/index.tsx
+++ b/src/pages/GivePage/index.tsx
@@ -164,6 +164,7 @@ const GivePage = () => {
               circle_id: selectedCircle.id,
               allocations: Object.values(giftsRef.current).map(g => ({
                 ...g,
+                tokens: g.tokens ?? 0,
                 // note is required in the db schema
                 note: g.note ?? '',
               })),
@@ -196,7 +197,7 @@ const GivePage = () => {
         recipient_id: recipientId,
       };
       const afterUpdateTotal = Object.values(newGifts).reduce(
-        (total, g) => total + g.tokens,
+        (total, g) => total + (g.tokens ?? 0),
         0
       );
 
@@ -272,7 +273,7 @@ const GivePage = () => {
   // update the total give used whenever the gifts change
   useEffect(() => {
     setTotalGiveUsed(
-      Object.values(gifts).reduce((total, g) => total + g.tokens, 0)
+      Object.values(gifts).reduce((total, g) => total + (g.tokens ?? 0), 0)
     );
   }, [gifts]);
 

--- a/src/pages/GivePage/index.tsx
+++ b/src/pages/GivePage/index.tsx
@@ -185,7 +185,7 @@ const GivePage = () => {
   };
 
   // adjustGift adjusts a gift by an amount if it is allowed wrt the max give, then schedules saving
-  const adjustGift = (recipientId: number, amount: number) => {
+  const adjustGift = (recipientId: number, amount: number | null) => {
     const updated = false;
     setGifts(prevState => {
       // check if this takes us over the limit before updating
@@ -193,7 +193,7 @@ const GivePage = () => {
       const gift = newGifts[recipientId];
       newGifts[recipientId] = {
         note: gift?.note ?? '',
-        tokens: (gift?.tokens ?? 0) + amount,
+        tokens: amount !== null ? (gift?.tokens ?? 0) + amount : undefined,
         recipient_id: recipientId,
       };
       const afterUpdateTotal = Object.values(newGifts).reduce(


### PR DESCRIPTION
## Motivation and Context

<!-- Why is this change required? What problem does it solve? This can be omitted if a linked issue is provided
-->

The new GiveAllocator allows for manual entry of a number, but you can't actually erase the 0 to start from scratch. 

## Description

<!-- Describe your changes -->

* Made the `tokens` field optional;
* Added a logic to handle the empty string and zero on the input field.

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->

Ran locally and tried it out, refer to screenshot below

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

<img width="1423" alt="Screen Shot 2022-09-29 at 10 27 46 am" src="https://user-images.githubusercontent.com/78794805/192967984-dc310f96-172d-4820-aad4-931751569998.png">

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

@CryptoGraffe

## Related Issue

Fixes https://github.com/coordinape/coordinape/issues/1401

<!-- Please link to the issue here -->
