### PR TITLE
adding margin around avatar on give page that was lost in avatar updates

### DIFF
--- a/src/pages/GivePage/AvatarAndName.tsx
+++ b/src/pages/GivePage/AvatarAndName.tsx
@@ -18,7 +18,7 @@ export const AvatarAndName = ({
         minWidth: 0,
       }}
     >
-      <Avatar size="small" name={name} path={avatar} />
+      <Avatar size="small" name={name} path={avatar} css={{ mx: '$sm' }} />
       <Text h3 semibold ellipsis>
         {name}
       </Text>


### PR DESCRIPTION
## Motivation and Context

#1365 removed margin around the avatar, so this restores it on the give page 
