### PR TITLE
Add token sent & received columns to members table

### DIFF
--- a/src/pages/AdminPage/MembersTable.tsx
+++ b/src/pages/AdminPage/MembersTable.tsx
@@ -316,7 +316,6 @@ const MemberRow = ({
                 <X color="neutral" />
               )}
             </TD>
-
             <TD
               css={{
                 textAlign: 'center !important',
@@ -351,6 +350,32 @@ const MemberRow = ({
             <X color="neutral" />
           )}
         </TD>
+        {isAdmin && (
+          <>
+            <TD
+              css={{
+                textAlign: 'center !important',
+              }}
+            >
+              {!user.non_giver ||
+              user.starting_tokens - user.give_token_remaining != 0
+                ? `${user.starting_tokens - user.give_token_remaining}/${
+                    user.starting_tokens
+                  }`
+                : '-'}
+            </TD>
+            <TD
+              css={{
+                textAlign: 'center !important',
+              }}
+            >
+              {user.give_token_received === 0 &&
+              (!!user.fixed_non_receiver || !!user.non_receiver)
+                ? '-'
+                : user.give_token_received}
+            </TD>
+          </>
+        )}
         <TD>
           {isAdmin && user.role !== 2 && (
             <Button
@@ -394,7 +419,7 @@ const MemberRow = ({
       </TR>
       {open && (
         <TR key={user.address}>
-          <TD colSpan={isMobile ? 4 : 7}>
+          <TD colSpan={isMobile ? 6 : 9}>
             <Form>
               <Text h3 semibold css={{ my: '$md' }}>
                 {user.name} Member Settings
@@ -788,6 +813,16 @@ export const MembersTable = ({
       },
     },
     {
+      title: `${circle.tokenName} sent`,
+      css: { ...headerStyles, textAlign: 'center' },
+      isHidden: !isAdmin,
+    },
+    {
+      title: `${circle.tokenName} received`,
+      css: { ...headerStyles, textAlign: 'center' },
+      isHidden: !isAdmin,
+    },
+    {
       title: 'Actions',
       css: { ...headerStyles, textAlign: 'right' },
       isHidden: !isAdmin,
@@ -808,6 +843,14 @@ export const MembersTable = ({
           if (index === 3) return (u: IUser) => u.non_receiver;
           if (index === 4) return (u: IUser) => u.fixed_payment_amount;
           if (index === 6) return (u: IUser) => u.isCircleAdmin;
+          if (index === 7)
+            return (u: IUser) =>
+              !u.non_giver ? u.starting_tokens - u.give_token_remaining : -1;
+          if (index === 8)
+            return (u: IUser) =>
+              !!u.fixed_non_receiver || !!u.non_receiver
+                ? -1
+                : u.give_token_received;
           return (u: IUser) => u.name.toLowerCase();
         }}
       >


### PR DESCRIPTION
## Motivation and Context

implements #1415

## Description

1- Add Give sent and Give received columns to members table
2- The columns will be visible only to Admins
3- Admins can sort the table by received and sent gives
4- GIVE in table header can be changed if token name is changed

## Test and Deployment Plan

Check Members table as Admin

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/34943689/193142993-5704c646-eb72-40fb-9d0a-1768142560d8.png)
![image](https://user-images.githubusercontent.com/34943689/193143051-1a3876a6-3ef8-4f2e-a3d9-569952ec5f52.png)

