### PR TITLE
style: Epoch dropdown on the map's page

### DIFF
--- a/src/pages/AssetMapPage/AMDrawer.tsx
+++ b/src/pages/AssetMapPage/AMDrawer.tsx
@@ -101,8 +101,7 @@ const useStyles = makeStyles(theme => ({
     padding: theme.spacing(2, 1.5),
   },
   selectWrapper: {
-    display: 'flex',
-    marginTop: 8,
+    margin: '16px 0',
   },
 }));
 
@@ -226,6 +225,7 @@ export const AMDrawer = () => {
               defaultValue={String(amEpochId)}
               options={epochOptions}
               onValueChange={value => setAmEpochId(Number(value))}
+              background={'bgWhite'}
             />
           </div>
           {showHiddenFeatures && (
@@ -234,6 +234,7 @@ export const AMDrawer = () => {
                 defaultValue={metric2}
                 options={metricOptions}
                 onValueChange={value => setMetric2(value as MetricEnum)}
+                background={'bgWhite'}
               />
             </div>
           )}
@@ -246,6 +247,10 @@ export const AMDrawer = () => {
             isSelect
             InputProps={{
               endAdornment: <Search color="neutral" />,
+              style: {
+                border: 'none',
+                paddingRight: '12px',
+              },
             }}
           />
         </div>

--- a/src/pages/CircleAdminPage/CircleAdminPage.tsx
+++ b/src/pages/CircleAdminPage/CircleAdminPage.tsx
@@ -636,6 +636,7 @@ export const CircleAdminPage = () => {
               >
                 <Box>
                   <Select
+                    background={'bgGray'}
                     {...(register('fixed_payment_vault_id'),
                     {
                       onValueChange: value => {

--- a/src/pages/DistributionsPage/DistributionForm.tsx
+++ b/src/pages/DistributionsPage/DistributionForm.tsx
@@ -407,6 +407,7 @@ export function DistributionForm({
           <TwoColumnLayout css={{ pt: '$md' }}>
             <Box css={{ width: '100%' }}>
               <Select
+                background={'bgGray'}
                 {...(register('selectedVaultId'),
                 {
                   defaultValue: circleDist
@@ -545,6 +546,7 @@ export function DistributionForm({
               <TwoColumnLayout css={{ pt: '$md' }}>
                 <Box css={{ width: '100%' }}>
                   <Select
+                    background={'bgGray'}
                     {...(fixedRegister('selectedVaultId'),
                     {
                       defaultValue: fpVault

--- a/src/ui/Select/Select.stories.tsx
+++ b/src/ui/Select/Select.stories.tsx
@@ -9,7 +9,7 @@ export default {
   decorators: [
     withDesign,
     Story => (
-      <div style={{ padding: 20 }}>
+      <div style={{ padding: 20, backgroundColor: '#edf1f4' }}>
         <Story />
       </div>
     ),
@@ -31,6 +31,7 @@ const options = [
 SingleSelect.args = {
   defaultValue: 'apple',
   options,
+  background: 'bgWhite',
 };
 
 SingleSelect.parameters = {

--- a/src/ui/Select/Select.tsx
+++ b/src/ui/Select/Select.tsx
@@ -17,7 +17,6 @@ const StyledTrigger = styled(SelectPrimitive.SelectTrigger, {
   padding: '$sm',
   lineHeight: '$short',
   fontSize: '$medium',
-  border: '1px solid transparent',
   width: 'calc(100% - $sm - $sm)',
   color: '$text',
   '&:hover': { cursor: 'pointer' },
@@ -33,6 +32,7 @@ const StyledTrigger = styled(SelectPrimitive.SelectTrigger, {
       },
       bgGray: {
         backgroundColor: '$surface',
+        border: '1px solid transparent',
       },
     },
   },

--- a/src/ui/Select/Select.tsx
+++ b/src/ui/Select/Select.tsx
@@ -19,13 +19,25 @@ const StyledTrigger = styled(SelectPrimitive.SelectTrigger, {
   fontSize: '$medium',
   border: '1px solid transparent',
   width: 'calc(100% - $sm - $sm)',
-  backgroundColor: '$surface',
   color: '$text',
   '&:hover': { cursor: 'pointer' },
   '&:disabled': {
     cursor: 'pointer',
     pointerEvents: 'none',
     opacity: 0.3,
+  },
+  variants: {
+    background: {
+      bgWhite: {
+        backgroundColor: '$white',
+      },
+      bgGray: {
+        backgroundColor: '$surface',
+      },
+    },
+  },
+  defaultVariants: {
+    background: 'bgGray',
   },
 });
 
@@ -113,6 +125,7 @@ export const Select = (
     css?: CSS;
     label?: React.ReactNode;
     infoTooltip?: React.ReactNode;
+    background: 'bgWhite' | 'bgGray';
   }
 ) => {
   const {
@@ -124,6 +137,7 @@ export const Select = (
     disabled,
     label,
     infoTooltip,
+    background,
   } = props;
 
   return (
@@ -145,7 +159,7 @@ export const Select = (
         </FormLabel>
       )}
       <RadixSelect defaultValue={defaultValue} {...props}>
-        <SelectTrigger disabled={disabled}>
+        <SelectTrigger background={background} disabled={disabled}>
           <SelectValue placeholder={placeholder} />
           <SelectIcon>
             <ChevronDown color="neutral" />


### PR DESCRIPTION
## Motivation and Context

<!-- Why is this change required? What problem does it solve? This can be omitted if a linked issue is provided
-->

Visual regression on the epoch dropdown on the map, refer to https://github.com/coordinape/coordinape/issues/1409 for further details

## Description

<!-- Describe your changes -->

Created a new variant for the `Select` component, happy to hear suggestions about the variant's name, for now due to the only difference being the background (after @levity's comment the border now as well) I've named it as such. We only have 2 "background" variants `bgWhite` and `bgGray` for now.

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->

Ran locally and saw the [correct style](https://www.figma.com/file/L4oZwYVUdpgacZtwipGaYe/App-1.5?node-id=2825%3A1498) being applied 

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

<img width="573" alt="Coordinape" src="https://user-images.githubusercontent.com/78794805/193314443-3774b709-9734-42f0-85fc-bcdfda0a7f7d.png">

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

@levity 

## Related Issue

<!-- Please link to the issue here -->

Closes https://github.com/coordinape/coordinape/issues/1409
