### PR TITLE
fix: Map cut off

### DIFF
--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -19,6 +19,11 @@ export const Drawer = ({ open, setOpen, children }: IProps) => {
           fontSize: '$h1',
           fontWeights: '$semibold',
           ml: '$lg',
+          position: 'absolute',
+          top: 0,
+          bottom: 0,
+          zIndex: 2,
+          flexDirection: 'column',
         }}
       >
         Circle Map
@@ -32,10 +37,9 @@ export const Drawer = ({ open, setOpen, children }: IProps) => {
             alignItems: 'center',
             ml: '$lg',
             position: 'absolute',
-            top: 100,
+            top: 130,
             bottom: 0,
             backgroundColor: 'transparent',
-            display: 'flex',
             transition: 'width .4s ease',
             border: 1,
             width: 'calc($xl * 12)',
@@ -51,9 +55,9 @@ export const Drawer = ({ open, setOpen, children }: IProps) => {
           size="large"
           onClick={() => setOpen(!open)}
           css={{
-            zIndex: 1,
+            zIndex: 3,
             position: 'absolute',
-            top: 100,
+            top: 130,
             bottom: 0,
             width: 'fit-content',
             height: 'fit-content',

--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -22,7 +22,7 @@ export const Drawer = ({ open, setOpen, children }: IProps) => {
           position: 'absolute',
           top: 0,
           bottom: 0,
-          zIndex: 2,
+          zIndex: 1,
           flexDirection: 'column',
         }}
       >
@@ -55,7 +55,7 @@ export const Drawer = ({ open, setOpen, children }: IProps) => {
           size="large"
           onClick={() => setOpen(!open)}
           css={{
-            zIndex: 3,
+            zIndex: 1,
             position: 'absolute',
             top: 130,
             bottom: 0,

--- a/src/pages/AssetMapPage/AMProfileCard.tsx
+++ b/src/pages/AssetMapPage/AMProfileCard.tsx
@@ -68,11 +68,15 @@ const useStyles = makeStyles(theme => ({
     flexDirection: 'column',
     marginLeft: theme.spacing(1.25),
     justifyContent: 'center',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
   },
   headerName: {
     fontSize: 22,
     fontWeight: 600,
     lineHeight: 1.2,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
   },
   headerMeasure: {
     fontSize: 14,

--- a/src/pages/AssetMapPage/AMProfileCard.tsx
+++ b/src/pages/AssetMapPage/AMProfileCard.tsx
@@ -69,7 +69,6 @@ const useStyles = makeStyles(theme => ({
     marginLeft: theme.spacing(1.25),
     justifyContent: 'center',
     overflow: 'hidden',
-    textOverflow: 'ellipsis',
   },
   headerName: {
     fontSize: 22,


### PR DESCRIPTION
## Motivation and Context

<!-- Why is this change required? What problem does it solve? This can be omitted if a linked issue is provided
-->

Map should not be cut off at top of page, refer to issue https://github.com/coordinape/coordinape/issues/1421

## Description

<!-- Describe your changes -->

Makes the position of the text absolute pinned to the top of the page

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->

Ran locally and saw the map not being cut off, refer to screenshots below

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

### Drawer opened

<img width="940" alt="Screen Shot 2022-10-03 at 3 12 40 pm" src="https://user-images.githubusercontent.com/78794805/193574266-dc284c3f-968f-4b7d-974c-20023abc316a.png">

### Drawer closed

<img width="776" alt="Screen Shot 2022-10-03 at 3 12 52 pm" src="https://user-images.githubusercontent.com/78794805/193574259-a66c8302-5acf-4733-a631-872b79718966.png">

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

@levity 

## Related Issue

<!-- Please link to the issue here -->

Fixes https://github.com/coordinape/coordinape/issues/1421
