### PR TITLE
Serverless hardhat import

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,15 +37,9 @@ jobs:
           key: nodeModules-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 
       - run: yarn --frozen-lockfile
-      - run: ./scripts/link_hardhat.sh
       - run: yarn typecheck
       - run: yarn lint:check
       - run: yarn prettier:check
-
-      # remove symlink to prevent redundant caching
-      - name: Cleanup
-        run: |
-          rm node_modules/@coordinape/hardhat
   test:
     runs-on: ubuntu-latest
     needs: skip_duplicates
@@ -112,8 +106,3 @@ jobs:
           curl -Os https://uploader.codecov.io/latest/linux/codecov
           chmod +x codecov
           ./codecov
-
-      # remove symlink to prevent redundant caching
-      - name: Cleanup
-        run: |
-          rm node_modules/@coordinape/hardhat

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Stack: **React**, **Hasura** graphql server & **vercel** serverless functions
 
 - `yarn install`
 - `yarn setup`
-  - init git submodules & link hardhat
+  - init git submodules & hardhat dependencies
 - `cp .env.example .env`
   - Set `HARDHAT_OWNER_ADDRESS` and `LOCAL_SEED_ADDRESS` to your local dev wallet
 - `yarn docker:start` - Start **Hasura** and **postgres**
@@ -95,8 +95,7 @@ These will be applied to the production instance once the PR is merged.
 - Set `ETHEREUM_RPC_URL` in .env
   - From Infura project id: [Infura](https://infura.io) & create new project
   - Needs to have access to archive data
-- `./scripts/setup.sh` - link the react app generated code
-- `./scripts/rebuild-hardhat.sh` - Rebuild the generated code
+- `./scripts/rebuild_hardhat.sh` - Rebuild the generated code
 - `yarn test` - Run tests
   - make sure `HARDHAT_FORK_BLOCK` is set (13500000 is a good value) and `ETHEREUM_RPC_URL` points to an archive node
 
@@ -107,6 +106,3 @@ These will be applied to the production instance once the PR is merged.
 
 - `TypeError: Cannot read properties of undefined (reading 'replace')`
   You need to configure a local `.env` file with some private variables. Ask someone for these.
-
-- `error: no template named 'remove_cv_t' in namespace 'std'; did you mean 'remove_cv'`
-  Probably related to node-sass versions. Node v16 only works with node-sass 6.0.1 or newer. https://github.com/sass/node-sass/issues/3077

--- a/hardhat/scripts/start-ganache.sh
+++ b/hardhat/scripts/start-ganache.sh
@@ -21,7 +21,6 @@ while [[ "$#" > 0 ]]; do case $1 in
   --exec) EXEC=1;;
   --no-deploy) NO_DEPLOY=1;;
   -p|--port) PORT="$2"; shift;;
-  --rebuild) REBUILD=1;;
   -v|--verbose) VERBOSE=1;;
   *) EXECARGS+=($1);;
 esac; shift; done
@@ -82,17 +81,6 @@ else
 
   if [ ! "$NO_DEPLOY" ]; then
     FORK_MAINNET=1 yarn --cwd hardhat deploy --network ci
-  fi
-
-  if [ "$REBUILD" ]; then
-    yarn --cwd hardhat codegen
-    yarn --cwd hardhat build
-
-    cd hardhat
-    yarn unlink >/dev/null 2>&1 || echo -n
-    yarn link
-    cd ..
-    yarn link @coordinape/hardhat
   fi
 
   if [ "$EXEC" ]; then

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "@amplitude/node": "^1.10.1",
     "@apollo/client": "3.5.7",
+    "@coordinape/hardhat": "file:./hardhat",
     "@craco/craco": "6.4.3",
     "@date-io/luxon": "1.3.13",
     "@gqty/react": "2.1.0",
@@ -106,7 +107,6 @@
     "eject": "craco eject",
     "lint:check": "eslint \"{{api,api-lib,cypress,hasura,src}/**/*.{js,ts,tsx,graphql},*.{js,ts,tsx,graphql}}\"",
     "lint:fix": "yarn lint:check --fix",
-    "postinstall": "./scripts/link_hardhat.sh",
     "prettier": "prettier \"{{api,api-lib,cypress,hasura,src}/**/*.{js,ts,tsx,graphql,json},*.{js,ts,tsx,graphql,json}}\"",
     "prettier:check": "yarn prettier --check",
     "prettier:fix": "yarn prettier --write",

--- a/scripts/link_hardhat.sh
+++ b/scripts/link_hardhat.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 set -e
 
-cd hardhat
-yarn unlink >/dev/null 2>&1 || echo -n
-yarn link
-cd ..
-yarn link @coordinape/hardhat
+rm -r node_modules/@coordinape
+yarn --check-files

--- a/scripts/rebuild_hardhat.sh
+++ b/scripts/rebuild_hardhat.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-
+SCRIPT_DIR="${0%/*}"
 FIND_DEV_PID="lsof -t -i:8545 -sTCP:LISTEN"
 
 while [[ "$#" > 0 ]]; do case $1 in
@@ -29,8 +29,4 @@ if [ "$FULL" ]; then
   kill $(eval $FIND_DEV_PID)
 fi
 
-cd hardhat
-yarn unlink >/dev/null 2>&1 || echo -n
-yarn link
-cd ..
-yarn link @coordinape/hardhat
+$SCRIPT_DIR/link_hardhat.sh

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,4 +3,3 @@ set -e
 
 git submodule update --init --recursive
 yarn --cwd hardhat install --frozen-lockfile
-./scripts/link_hardhat.sh

--- a/yarn.lock
+++ b/yarn.lock
@@ -2197,6 +2197,9 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@coordinape/hardhat@file:./hardhat":
+  version "1.0.0"
+
 "@craco/craco@6.4.3":
   version "6.4.3"
   resolved "https://registry.yarnpkg.com/@craco/craco/-/craco-6.4.3.tgz#784395b6ebab764056550a2860494d24c3abd44e"


### PR DESCRIPTION
## Motivation and Context

The deployment of #1424 failed because the way we were using `yarn link` to import `@coordinape/hardhat` from the `hardhat` folder within the project didn't work with serverless functions. This PR implements an alternative.

## Description

Use a `file:` dependency in package.json for `@coordinape/hardhat` instead of `yarn link`. 

The downside of this is that incorporating changes from hardhat is slower because `yarn install` has to run again -- see changes to `link_hardhat.sh`.

## Test and Deployment Plan

Works with `vercel dev` locally. Will deploy to staging to make sure it works with staging Hasura as well.