### PR TITLE
fix note re-use and stomp issue discovered by crabsinger

### DIFF
--- a/src/pages/GivePage/GiveDrawer.tsx
+++ b/src/pages/GivePage/GiveDrawer.tsx
@@ -205,7 +205,7 @@ export const GiveDrawer = ({
             mt: '$xs',
             mb: '$md',
           }}
-          value={note}
+          value={note ?? ''}
           onChange={e => noteChanged(e.target.value)}
           placeholder="Say thanks or give constructive feedback."
         />


### PR DESCRIPTION
## Motivation and Context

When scrolling from a member w/ a note to a member w/o a note, the previous member's note was being cached in the textarea, which can cause other notes to get stomped. 

## Description

pass `note ?? ''` instead of `note` to the textarea value field

## Test and Deployment Plan

Change a note on a user adjacent to a member w/ no note and then scroll to the member with no note. The textarea should be empty. 

