### PR TITLE
fix updation of collaborator status in give drawer when scrolled to other member

### DIFF
--- a/src/pages/GivePage/index.tsx
+++ b/src/pages/GivePage/index.tsx
@@ -455,12 +455,10 @@ const AllocateContents = ({
         })
       );
 
-      // also need to patch it up in the membersToIterate list so we have updated collaborator state etc
+      // need to patch up members in the iterate list so we have updated collaborator state etc
       const mtoi = [...membersToIterate];
       for (let i = 0; i < mtoi.length; i++) {
-        if (mtoi[i].id === selectedMember.id) {
-          mtoi[i] = members.find(m => selectedMember.id === m.id) ?? mtoi[i];
-        }
+        mtoi[i] = members.find(m => mtoi[i].id === m.id) ?? mtoi[i];
       }
       setMembersToIterate(mtoi);
     }


### PR DESCRIPTION

## Motivation and Context

If you click add/remove contributor in the give drawer and quickly scroll to a different member, the give drawer doesn't update when you scroll back to the original member. 

## Description

When the underlying members list was changing, we were only patching up the state of the currently selected member in the drawer, rather than all members. This fix updates all members. 

## Test and Deployment Plan

Change collaborator status and quickly scroll to a different user. After seeing the collab status change in the main members list,  scroll back to the original member in the give drawer and note that their collaborator status is correct. 
