### PR TITLE
Fix bug showing "Add Contributor" on save

### DIFF
--- a/src/pages/GivePage/GiveRow.tsx
+++ b/src/pages/GivePage/GiveRow.tsx
@@ -90,7 +90,7 @@ export const GiveRow = ({
           >
             <ContributorButton
               css={{
-                transition: 'visibility 0.1s ease-in',
+                '&:hover': { transition: 'visibility 0.1s ease-in' },
                 visibility: hover || member.teammate ? 'visible' : 'hidden',
               }}
               member={member}


### PR DESCRIPTION
## Allocations: Fix bug showing "Add Contributor" on save

This fixues a bug where the we would intermittently flicker "Add Collaborator" in the main GiveRow when removing Collaborator status inside the Drawer. This fixes the bug, and maintains the fade-in CSS transition.

However, it doesn't keep the fade-out transition.

@CryptoGraffe 
