### PR TITLE
add markClaimed action to hasura schema

### DIFF
--- a/api-lib/gql/__generated__/zeus/const.ts
+++ b/api-lib/gql/__generated__/zeus/const.ts
@@ -39,6 +39,7 @@ export const AllTypesProps: Record<string, any> = {
   GenerateApiKeyInput: {},
   Int_comparison_exp: {},
   LogVaultTxInput: {},
+  MarkClaimedInput: {},
   String_comparison_exp: {},
   UpdateCircleInput: {},
   UpdateContributionInput: {
@@ -287,6 +288,7 @@ export const AllTypesProps: Record<string, any> = {
     hash: 'String_comparison_exp',
     name: 'String_comparison_exp',
     read_circle: 'Boolean_comparison_exp',
+    read_discord: 'Boolean_comparison_exp',
     read_epochs: 'Boolean_comparison_exp',
     read_member_profiles: 'Boolean_comparison_exp',
     read_nominees: 'Boolean_comparison_exp',
@@ -335,6 +337,7 @@ export const AllTypesProps: Record<string, any> = {
     hash: 'order_by',
     name: 'order_by',
     read_circle: 'order_by',
+    read_discord: 'order_by',
     read_epochs: 'order_by',
     read_member_profiles: 'order_by',
     read_nominees: 'order_by',
@@ -2541,6 +2544,9 @@ export const AllTypesProps: Record<string, any> = {
     insert_vouches_one: {
       object: 'vouches_insert_input',
       on_conflict: 'vouches_on_conflict',
+    },
+    markClaimed: {
+      payload: 'MarkClaimedInput',
     },
     restoreCoordinape: {
       payload: 'CoordinapeInput',
@@ -5686,6 +5692,9 @@ export const ReturnTypes: Record<string, any> = {
     id: 'Int',
     profile: 'profiles',
   },
+  MarkClaimedOutput: {
+    ids: 'Int',
+  },
   UpdateCircleOutput: {
     circle: 'circles',
     id: 'Int',
@@ -5861,6 +5870,7 @@ export const ReturnTypes: Record<string, any> = {
     hash: 'String',
     name: 'String',
     read_circle: 'Boolean',
+    read_discord: 'Boolean',
     read_epochs: 'Boolean',
     read_member_profiles: 'Boolean',
     read_nominees: 'Boolean',
@@ -7330,6 +7340,7 @@ export const ReturnTypes: Record<string, any> = {
     insert_vouches: 'vouches_mutation_response',
     insert_vouches_one: 'vouches',
     logoutUser: 'LogoutResponse',
+    markClaimed: 'MarkClaimedOutput',
     restoreCoordinape: 'ConfirmationResponse',
     updateAllocations: 'AllocationsResponse',
     updateCircle: 'UpdateCircleOutput',

--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -323,7 +323,7 @@ export class GraphQLError extends Error {
   constructor(public response: GraphQLResponse) {
     super('');
     // eslint-disable-next-line no-console
-    console.info(JSON.stringify(response));
+    console.info(JSON.stringify(response, null, 2));
   }
   toString() {
     return 'GraphQL Response Error';

--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -323,7 +323,7 @@ export class GraphQLError extends Error {
   constructor(public response: GraphQLResponse) {
     super('');
     // eslint-disable-next-line no-console
-    console.info(JSON.stringify(response, null, 2));
+    console.info(JSON.stringify(response));
   }
   toString() {
     return 'GraphQL Response Error';
@@ -828,6 +828,14 @@ export type ValueTypes = {
     id?: boolean | `@${string}`;
     /** An object relationship */
     profile?: ValueTypes['profiles'];
+    __typename?: boolean | `@${string}`;
+  }>;
+  ['MarkClaimedInput']: {
+    claim_id: number;
+    tx_hash: string;
+  };
+  ['MarkClaimedOutput']: AliasType<{
+    ids?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
@@ -1388,6 +1396,7 @@ columns and relationships of "circle_api_keys" */
     hash?: boolean | `@${string}`;
     name?: boolean | `@${string}`;
     read_circle?: boolean | `@${string}`;
+    read_discord?: boolean | `@${string}`;
     read_epochs?: boolean | `@${string}`;
     read_member_profiles?: boolean | `@${string}`;
     read_nominees?: boolean | `@${string}`;
@@ -1483,6 +1492,7 @@ columns and relationships of "circle_api_keys" */
     hash?: ValueTypes['String_comparison_exp'] | undefined | null;
     name?: ValueTypes['String_comparison_exp'] | undefined | null;
     read_circle?: ValueTypes['Boolean_comparison_exp'] | undefined | null;
+    read_discord?: ValueTypes['Boolean_comparison_exp'] | undefined | null;
     read_epochs?: ValueTypes['Boolean_comparison_exp'] | undefined | null;
     read_member_profiles?:
       | ValueTypes['Boolean_comparison_exp']
@@ -1517,6 +1527,7 @@ columns and relationships of "circle_api_keys" */
     hash?: string | undefined | null;
     name?: string | undefined | null;
     read_circle?: boolean | undefined | null;
+    read_discord?: boolean | undefined | null;
     read_epochs?: boolean | undefined | null;
     read_member_profiles?: boolean | undefined | null;
     read_nominees?: boolean | undefined | null;
@@ -1583,6 +1594,7 @@ columns and relationships of "circle_api_keys" */
     hash?: ValueTypes['order_by'] | undefined | null;
     name?: ValueTypes['order_by'] | undefined | null;
     read_circle?: ValueTypes['order_by'] | undefined | null;
+    read_discord?: ValueTypes['order_by'] | undefined | null;
     read_epochs?: ValueTypes['order_by'] | undefined | null;
     read_member_profiles?: ValueTypes['order_by'] | undefined | null;
     read_nominees?: ValueTypes['order_by'] | undefined | null;
@@ -1605,6 +1617,7 @@ columns and relationships of "circle_api_keys" */
     hash?: string | undefined | null;
     name?: string | undefined | null;
     read_circle?: boolean | undefined | null;
+    read_discord?: boolean | undefined | null;
     read_epochs?: boolean | undefined | null;
     read_member_profiles?: boolean | undefined | null;
     read_nominees?: boolean | undefined | null;
@@ -7152,6 +7165,10 @@ columns and relationships of "distributions" */
       ValueTypes['vouches']
     ];
     logoutUser?: ValueTypes['LogoutResponse'];
+    markClaimed?: [
+      { payload: ValueTypes['MarkClaimedInput'] },
+      ValueTypes['MarkClaimedOutput']
+    ];
     restoreCoordinape?: [
       { payload: ValueTypes['CoordinapeInput'] },
       ValueTypes['ConfirmationResponse']
@@ -16252,6 +16269,10 @@ export type ModelTypes = {
     /** An object relationship */
     profile: GraphQLTypes['profiles'];
   };
+  ['MarkClaimedInput']: GraphQLTypes['MarkClaimedInput'];
+  ['MarkClaimedOutput']: {
+    ids: Array<number>;
+  };
   /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
   ['String_comparison_exp']: GraphQLTypes['String_comparison_exp'];
   ['UpdateCircleInput']: GraphQLTypes['UpdateCircleInput'];
@@ -16520,6 +16541,7 @@ columns and relationships of "circle_api_keys" */
     hash: string;
     name: string;
     read_circle: boolean;
+    read_discord: boolean;
     read_epochs: boolean;
     read_member_profiles: boolean;
     read_nominees: boolean;
@@ -18955,6 +18977,7 @@ columns and relationships of "distributions" */
     /** insert a single row into the table: "vouches" */
     insert_vouches_one?: GraphQLTypes['vouches'] | undefined;
     logoutUser?: GraphQLTypes['LogoutResponse'] | undefined;
+    markClaimed?: GraphQLTypes['MarkClaimedOutput'] | undefined;
     restoreCoordinape?: GraphQLTypes['ConfirmationResponse'] | undefined;
     updateAllocations?: GraphQLTypes['AllocationsResponse'] | undefined;
     updateCircle?: GraphQLTypes['UpdateCircleOutput'] | undefined;
@@ -22056,6 +22079,14 @@ export type GraphQLTypes = {
     /** An object relationship */
     profile: GraphQLTypes['profiles'];
   };
+  ['MarkClaimedInput']: {
+    claim_id: number;
+    tx_hash: string;
+  };
+  ['MarkClaimedOutput']: {
+    __typename: 'MarkClaimedOutput';
+    ids: Array<number>;
+  };
   /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
   ['String_comparison_exp']: {
     _eq?: string | undefined;
@@ -22609,6 +22640,7 @@ columns and relationships of "circle_api_keys" */
     hash: string;
     name: string;
     read_circle: boolean;
+    read_discord: boolean;
     read_epochs: boolean;
     read_member_profiles: boolean;
     read_nominees: boolean;
@@ -22688,6 +22720,7 @@ columns and relationships of "circle_api_keys" */
     hash?: GraphQLTypes['String_comparison_exp'] | undefined;
     name?: GraphQLTypes['String_comparison_exp'] | undefined;
     read_circle?: GraphQLTypes['Boolean_comparison_exp'] | undefined;
+    read_discord?: GraphQLTypes['Boolean_comparison_exp'] | undefined;
     read_epochs?: GraphQLTypes['Boolean_comparison_exp'] | undefined;
     read_member_profiles?: GraphQLTypes['Boolean_comparison_exp'] | undefined;
     read_nominees?: GraphQLTypes['Boolean_comparison_exp'] | undefined;
@@ -22717,6 +22750,7 @@ columns and relationships of "circle_api_keys" */
     hash?: string | undefined;
     name?: string | undefined;
     read_circle?: boolean | undefined;
+    read_discord?: boolean | undefined;
     read_epochs?: boolean | undefined;
     read_member_profiles?: boolean | undefined;
     read_nominees?: boolean | undefined;
@@ -22783,6 +22817,7 @@ columns and relationships of "circle_api_keys" */
     hash?: GraphQLTypes['order_by'] | undefined;
     name?: GraphQLTypes['order_by'] | undefined;
     read_circle?: GraphQLTypes['order_by'] | undefined;
+    read_discord?: GraphQLTypes['order_by'] | undefined;
     read_epochs?: GraphQLTypes['order_by'] | undefined;
     read_member_profiles?: GraphQLTypes['order_by'] | undefined;
     read_nominees?: GraphQLTypes['order_by'] | undefined;
@@ -22805,6 +22840,7 @@ columns and relationships of "circle_api_keys" */
     hash?: string | undefined;
     name?: string | undefined;
     read_circle?: boolean | undefined;
+    read_discord?: boolean | undefined;
     read_epochs?: boolean | undefined;
     read_member_profiles?: boolean | undefined;
     read_nominees?: boolean | undefined;
@@ -26873,6 +26909,7 @@ columns and relationships of "distributions" */
     /** insert a single row into the table: "vouches" */
     insert_vouches_one?: GraphQLTypes['vouches'] | undefined;
     logoutUser?: GraphQLTypes['LogoutResponse'] | undefined;
+    markClaimed?: GraphQLTypes['MarkClaimedOutput'] | undefined;
     restoreCoordinape?: GraphQLTypes['ConfirmationResponse'] | undefined;
     updateAllocations?: GraphQLTypes['AllocationsResponse'] | undefined;
     updateCircle?: GraphQLTypes['UpdateCircleOutput'] | undefined;
@@ -31822,6 +31859,7 @@ export const enum circle_api_keys_select_column {
   hash = 'hash',
   name = 'name',
   read_circle = 'read_circle',
+  read_discord = 'read_discord',
   read_epochs = 'read_epochs',
   read_member_profiles = 'read_member_profiles',
   read_nominees = 'read_nominees',
@@ -31838,6 +31876,7 @@ export const enum circle_api_keys_update_column {
   hash = 'hash',
   name = 'name',
   read_circle = 'read_circle',
+  read_discord = 'read_discord',
   read_epochs = 'read_epochs',
   read_member_profiles = 'read_member_profiles',
   read_nominees = 'read_nominees',

--- a/api-test/hasura/actions/_handlers/markClaimed.test.ts
+++ b/api-test/hasura/actions/_handlers/markClaimed.test.ts
@@ -1,0 +1,90 @@
+import { AddressZero } from '@ethersproject/constants';
+
+import { adminClient } from '../../../../api-lib/gql/adminClient';
+import { updateClaims } from '../../../../api/hasura/actions/_handlers/markClaimed';
+import { Contracts } from '../../../../src/lib/vaults';
+import { chainId, provider } from '../../../../src/utils/testing/provider';
+
+jest.mock('../../../../api-lib/gql/adminClient', () => ({
+  adminClient: { mutate: jest.fn(), query: jest.fn() },
+}));
+
+const mockClient = {
+  query: adminClient.query as jest.Mock,
+  mutate: adminClient.mutate as jest.Mock,
+};
+
+const mockClaimData = (address?: string) => ({
+  distribution: {
+    id: 1,
+    vault: {
+      id: 2,
+      symbol: 'DAI',
+      chain_id: chainId,
+      decimals: 18,
+      vault_address: address || '0x1',
+      simple_token_address: AddressZero,
+    },
+    epoch: { circle_id: 1 },
+  },
+});
+
+test("don't update claim not owned by profile", async () => {
+  mockClient.query.mockImplementation(async () => ({
+    claims: [],
+  }));
+
+  expect(async () => {
+    await updateClaims(1, 2, '0xabc');
+  }).rejects.toThrow('no claim with id 2 & profile_id 1');
+});
+
+test('reject if no claims were updated', async () => {
+  mockClient.query.mockImplementation(async () => ({
+    claims: [mockClaimData()],
+  }));
+
+  mockClient.mutate.mockImplementation(async () => ({
+    update_claims: {
+      returning: [],
+    },
+  }));
+
+  expect(async () => {
+    await updateClaims(1, 2, '0xabc');
+  }).rejects.toThrow('updated 0 claims');
+});
+
+test('create interaction_event with unwrapped amount', async () => {
+  const contracts = new Contracts(chainId, provider);
+  const { address } = await contracts.createVault('DAI', true);
+  let actual;
+
+  mockClient.query.mockImplementation(async () => ({
+    claims: [mockClaimData(address)],
+  }));
+
+  mockClient.mutate.mockImplementation(async (query: any) => {
+    if (query.update_claims)
+      return {
+        update_claims: {
+          returning: [{ id: 17, new_amount: 10 }],
+        },
+      };
+
+    if (query.insert_interaction_events_one) {
+      actual = query.insert_interaction_events_one[0].object;
+      return {
+        insert_interaction_events_one: {
+          __typename: 'insert_interaction_events_one',
+        },
+      };
+    }
+  });
+
+  const result = await updateClaims(1, 2, '0xabc');
+  expect(result).toEqual([17]);
+  expect(actual.data.symbol).toBe('Yearn DAI');
+  const amount = actual.data.amount;
+  expect(amount).toBeGreaterThan(10);
+});

--- a/api/hasura/actions/_handlers/markClaimed.ts
+++ b/api/hasura/actions/_handlers/markClaimed.ts
@@ -109,7 +109,8 @@ export const updateClaims = async (
   }
 
   let amount = result?.returning.reduce((a, b) => a + b.new_amount, 0);
-  if (!hasSimpleToken({ simple_token_address })) {
+  const simple = hasSimpleToken({ simple_token_address });
+  if (!simple) {
     if (!contracts) {
       const provider = getProvider(chain_id);
       contracts = new Contracts(chain_id, provider, true);
@@ -131,7 +132,7 @@ export const updateClaims = async (
             profile_id: profileId,
             data: {
               vault_id,
-              symbol,
+              symbol: simple ? symbol : `Yearn ${symbol}`,
               tx_hash: txHash,
               circle_id,
               distribution_id,

--- a/api/hasura/actions/_handlers/markClaimed.ts
+++ b/api/hasura/actions/_handlers/markClaimed.ts
@@ -1,0 +1,149 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { z } from 'zod';
+
+import { adminClient } from '../../../../api-lib/gql/adminClient';
+import { getPropsWithUserSession } from '../../../../api-lib/handlerHelpers';
+import { UnprocessableError } from '../../../../api-lib/HttpError';
+import { getProvider } from '../../../../api-lib/provider';
+import { verifyHasuraRequestMiddleware } from '../../../../api-lib/validate';
+import { Contracts, hasSimpleToken } from '../../../../src/lib/vaults';
+
+const MarkClaimedInputSchema = z.object({
+  claim_id: z.number(),
+  tx_hash: z.string(),
+});
+
+async function handler(req: VercelRequest, res: VercelResponse) {
+  const {
+    session_variables: { hasuraProfileId },
+    input: {
+      payload: { tx_hash, claim_id },
+    },
+  } = getPropsWithUserSession(MarkClaimedInputSchema, req);
+
+  const ids = await updateClaims(hasuraProfileId, claim_id, tx_hash);
+  return res.json({ ids });
+}
+
+export default verifyHasuraRequestMiddleware(handler);
+
+export const updateClaims = async (
+  profileId: number,
+  claimId: number,
+  txHash: string,
+  contracts?: Contracts
+) => {
+  const {
+    claims: [claim],
+  } = await adminClient.query({
+    claims: [
+      {
+        where: {
+          id: { _eq: claimId },
+          profile_id: { _eq: profileId },
+        },
+        limit: 1,
+      },
+      {
+        distribution: {
+          id: true,
+          vault_id: true,
+          vault: {
+            symbol: true,
+            chain_id: true,
+            decimals: true,
+            vault_address: true,
+            simple_token_address: true,
+          },
+          epoch: { circle_id: true },
+        },
+      },
+    ],
+  });
+
+  if (!claim) {
+    throw new UnprocessableError(
+      `no claim with id ${claimId} & profile_id ${profileId}`
+    );
+  }
+
+  const {
+    distribution: {
+      id: distribution_id,
+      vault_id,
+      vault: {
+        vault_address,
+        decimals,
+        symbol,
+        simple_token_address,
+        chain_id,
+      },
+      epoch: { circle_id },
+    },
+  } = claim;
+
+  const { update_claims: result } = await adminClient.mutate({
+    update_claims: [
+      {
+        _set: { txHash },
+        where: {
+          txHash: { _is_null: true },
+          id: { _lte: claimId },
+          profile_id: { _eq: profileId },
+          distribution: {
+            vault_id: { _eq: vault_id },
+            epoch: { circle_id: { _eq: circle_id } },
+          },
+        },
+      },
+      { returning: { id: true, new_amount: true } },
+    ],
+    delete_pending_vault_transactions_by_pk: [
+      { tx_hash: txHash },
+      { __typename: true },
+    ],
+  });
+
+  if (!result?.returning.length) {
+    throw new UnprocessableError('updated 0 claims');
+  }
+
+  let amount = result?.returning.reduce((a, b) => a + b.new_amount, 0);
+  if (!hasSimpleToken({ simple_token_address })) {
+    if (!contracts) {
+      const provider = getProvider(chain_id);
+      contracts = new Contracts(chain_id, provider, true);
+    }
+    const pps = await contracts.getPricePerShare(
+      vault_address,
+      simple_token_address,
+      decimals
+    );
+    amount = amount * pps.toUnsafeFloat();
+  }
+
+  await adminClient.mutate(
+    {
+      insert_interaction_events_one: [
+        {
+          object: {
+            event_type: 'vault_claim',
+            profile_id: profileId,
+            data: {
+              vault_id,
+              symbol,
+              tx_hash: txHash,
+              circle_id,
+              distribution_id,
+              amount,
+            },
+          },
+        },
+        { __typename: true },
+      ],
+    },
+    { operationName: 'markClaimed' }
+  );
+
+  return result?.returning.map(x => x.id as number) || [];
+};

--- a/api/hasura/actions/_handlers/markClaimed.ts
+++ b/api/hasura/actions/_handlers/markClaimed.ts
@@ -5,6 +5,7 @@ import { adminClient } from '../../../../api-lib/gql/adminClient';
 import { getPropsWithUserSession } from '../../../../api-lib/handlerHelpers';
 import { UnprocessableError } from '../../../../api-lib/HttpError';
 import { getProvider } from '../../../../api-lib/provider';
+import { Awaited } from '../../../../api-lib/ts4.5shim';
 import { verifyHasuraRequestMiddleware } from '../../../../api-lib/validate';
 import { Contracts, hasSimpleToken } from '../../../../src/lib/vaults';
 
@@ -33,54 +34,25 @@ export const updateClaims = async (
   txHash: string,
   contracts?: Contracts
 ) => {
+  // 1. query: get data about the given claim
+
   const {
     claims: [claim],
-  } = await adminClient.query({
-    claims: [
-      {
-        where: {
-          id: { _eq: claimId },
-          profile_id: { _eq: profileId },
-        },
-        limit: 1,
-      },
-      {
-        distribution: {
-          id: true,
-          vault_id: true,
-          vault: {
-            symbol: true,
-            chain_id: true,
-            decimals: true,
-            vault_address: true,
-            simple_token_address: true,
-          },
-          epoch: { circle_id: true },
-        },
-      },
-    ],
-  });
-
-  if (!claim) {
+  } = await getClaimData(claimId, profileId);
+  if (!claim)
     throw new UnprocessableError(
       `no claim with id ${claimId} & profile_id ${profileId}`
     );
-  }
 
   const {
     distribution: {
       id: distribution_id,
-      vault_id,
-      vault: {
-        vault_address,
-        decimals,
-        symbol,
-        simple_token_address,
-        chain_id,
-      },
+      vault,
       epoch: { circle_id },
     },
   } = claim;
+
+  // 2. mutate: update all the matching claims with the tx hash
 
   const { update_claims: result } = await adminClient.mutate({
     update_claims: [
@@ -91,7 +63,7 @@ export const updateClaims = async (
           id: { _lte: claimId },
           profile_id: { _eq: profileId },
           distribution: {
-            vault_id: { _eq: vault_id },
+            vault_id: { _eq: vault.id },
             epoch: { circle_id: { _eq: circle_id } },
           },
         },
@@ -104,24 +76,14 @@ export const updateClaims = async (
     ],
   });
 
-  if (!result?.returning.length) {
+  if (!result?.returning.length)
     throw new UnprocessableError('updated 0 claims');
-  }
 
+  // 3. mutate: insert interaction event
+
+  const simple = hasSimpleToken(vault);
   let amount = result?.returning.reduce((a, b) => a + b.new_amount, 0);
-  const simple = hasSimpleToken({ simple_token_address });
-  if (!simple) {
-    if (!contracts) {
-      const provider = getProvider(chain_id);
-      contracts = new Contracts(chain_id, provider, true);
-    }
-    const pps = await contracts.getPricePerShare(
-      vault_address,
-      simple_token_address,
-      decimals
-    );
-    amount = amount * pps.toUnsafeFloat();
-  }
+  if (!simple) amount = await unwrap(amount, vault, contracts);
 
   await adminClient.mutate(
     {
@@ -131,8 +93,8 @@ export const updateClaims = async (
             event_type: 'vault_claim',
             profile_id: profileId,
             data: {
-              vault_id,
-              symbol: simple ? symbol : `Yearn ${symbol}`,
+              vault_id: vault.id,
+              symbol: simple ? vault.symbol : `Yearn ${vault.symbol}`,
               tx_hash: txHash,
               circle_id,
               distribution_id,
@@ -147,4 +109,51 @@ export const updateClaims = async (
   );
 
   return result?.returning.map(x => x.id as number) || [];
+};
+
+const getClaimData = (claimId: number, profileId: number) =>
+  adminClient.query({
+    claims: [
+      {
+        where: {
+          id: { _eq: claimId },
+          profile_id: { _eq: profileId },
+        },
+        limit: 1,
+      },
+      {
+        distribution: {
+          id: true,
+          vault: {
+            id: true,
+            symbol: true,
+            chain_id: true,
+            decimals: true,
+            vault_address: true,
+            simple_token_address: true,
+          },
+          epoch: { circle_id: true },
+        },
+      },
+    ],
+  });
+
+const unwrap = async (
+  amount: number,
+  vault: Awaited<
+    ReturnType<typeof getClaimData>
+  >['claims'][0]['distribution']['vault'],
+  contracts?: Contracts
+) => {
+  const { chain_id, vault_address, simple_token_address, decimals } = vault;
+  if (!contracts) {
+    const provider = getProvider(chain_id);
+    contracts = new Contracts(chain_id, provider, true);
+  }
+  const pps = await contracts.getPricePerShare(
+    vault_address,
+    simple_token_address,
+    decimals
+  );
+  return amount * pps.toUnsafeFloat();
 };

--- a/api/hasura/actions/actionManager.ts
+++ b/api/hasura/actions/actionManager.ts
@@ -19,6 +19,7 @@ import deleteEpoch from './_handlers/deleteEpoch';
 import deleteUser from './_handlers/deleteUser';
 import generateApiKey from './_handlers/generateApiKey';
 import logoutUser from './_handlers/logoutUser';
+import markClaimed from './_handlers/markClaimed';
 import restoreCoordinape from './_handlers/restoreCoordinape';
 import updateAllocations from './_handlers/updateAllocations';
 import updateCircle from './_handlers/updateCircle';
@@ -50,6 +51,7 @@ const HANDLERS: HandlerDict = {
   deleteUser,
   generateApiKey,
   logoutUser,
+  markClaimed,
   restoreCoordinape,
   updateAllocations,
   updateCircle,

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -63,6 +63,10 @@ type Mutation {
 }
 
 type Mutation {
+  markClaimed(payload: MarkClaimedInput!): MarkClaimedOutput
+}
+
+type Mutation {
   restoreCoordinape(payload: CoordinapeInput!): ConfirmationResponse
 }
 
@@ -324,6 +328,11 @@ input UpdateContributionInput {
   datetime_created: timestamptz!
 }
 
+input MarkClaimedInput {
+  claim_id: Int!
+  tx_hash: String!
+}
+
 type CreateCircleResponse {
   id: Int!
 }
@@ -409,6 +418,10 @@ type CircleLandingInfoResponse {
 
 type UpdateContributionResponse {
   id: ID!
+}
+
+type MarkClaimedOutput {
+  ids: [Int!]!
 }
 
 scalar timestamptz

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -149,6 +149,15 @@ actions:
           value_from_env: HASURA_EVENT_SECRET
     permissions:
       - role: user
+  - name: markClaimed
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_API_BASE_URL}}/actions/actionManager'
+      headers:
+        - name: verification_key
+          value_from_env: HASURA_EVENT_SECRET
+    permissions:
+      - role: user
   - name: restoreCoordinape
     definition:
       kind: synchronous
@@ -298,6 +307,7 @@ custom_types:
     - name: CreateUserWithTokenInput
     - name: DeleteContributionInput
     - name: UpdateContributionInput
+    - name: MarkClaimedInput
   objects:
     - name: CreateCircleResponse
       relationships:
@@ -472,5 +482,6 @@ custom_types:
           type: object
           field_mapping:
             id: id
+    - name: MarkClaimedOutput
   scalars:
     - name: timestamptz

--- a/scripts/generate_zeus.sh
+++ b/scripts/generate_zeus.sh
@@ -36,7 +36,7 @@ function generate() {
   if [[ "$PLATFORM" == "OSX" || "$PLATFORM" == "BSD" ]]; then
     sed -i "" 's,bigint"]:any,bigint"]:number,g' "$TMP_GEN_PATH"/zeus/index.ts
     sed -i "" 's,bigint"]:unknown,bigint"]:number,g' "$TMP_GEN_PATH"/zeus/index.ts
-    sed -i "" 's/console\.error(response)/\/\/ eslint-disable-next-line no-console\nconsole\.info(JSON\.stringify(response))/g' "$TMP_GEN_PATH"/zeus/index.ts
+    sed -i "" 's/console\.error(response)/\/\/ eslint-disable-next-line no-console\nconsole\.info(JSON\.stringify(response, null, 2))/g' "$TMP_GEN_PATH"/zeus/index.ts
   elif [ "$PLATFORM" == "LINUX" ]; then
     sed -i 's,bigint"]:any,bigint"]:number,g' "$TMP_GEN_PATH"/zeus/index.ts
     sed -i 's,bigint"]:unknown,bigint"]:number,g' "$TMP_GEN_PATH"/zeus/index.ts

--- a/src/lib/gql/__generated__/zeus/const.ts
+++ b/src/lib/gql/__generated__/zeus/const.ts
@@ -34,6 +34,7 @@ export const AllTypesProps: Record<string, any> = {
   GenerateApiKeyInput: {},
   Int_comparison_exp: {},
   LogVaultTxInput: {},
+  MarkClaimedInput: {},
   String_comparison_exp: {},
   UpdateCircleInput: {},
   UpdateContributionInput: {
@@ -1507,6 +1508,9 @@ export const AllTypesProps: Record<string, any> = {
     },
     insert_pending_vault_transactions_one: {
       object: 'pending_vault_transactions_insert_input',
+    },
+    markClaimed: {
+      payload: 'MarkClaimedInput',
     },
     restoreCoordinape: {
       payload: 'CoordinapeInput',
@@ -3421,6 +3425,9 @@ export const ReturnTypes: Record<string, any> = {
     id: 'Int',
     profile: 'profiles',
   },
+  MarkClaimedOutput: {
+    ids: 'Int',
+  },
   UpdateCircleOutput: {
     circle: 'circles',
     id: 'Int',
@@ -3996,6 +4003,7 @@ export const ReturnTypes: Record<string, any> = {
       'pending_vault_transactions_mutation_response',
     insert_pending_vault_transactions_one: 'pending_vault_transactions',
     logoutUser: 'LogoutResponse',
+    markClaimed: 'MarkClaimedOutput',
     restoreCoordinape: 'ConfirmationResponse',
     updateAllocations: 'AllocationsResponse',
     updateCircle: 'UpdateCircleOutput',

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -321,7 +321,7 @@ export class GraphQLError extends Error {
   constructor(public response: GraphQLResponse) {
     super('');
     // eslint-disable-next-line no-console
-    console.info(JSON.stringify(response));
+    console.info(JSON.stringify(response, null, 2));
   }
   toString() {
     return 'GraphQL Response Error';

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -321,7 +321,7 @@ export class GraphQLError extends Error {
   constructor(public response: GraphQLResponse) {
     super('');
     // eslint-disable-next-line no-console
-    console.info(JSON.stringify(response, null, 2));
+    console.info(JSON.stringify(response));
   }
   toString() {
     return 'GraphQL Response Error';
@@ -803,6 +803,14 @@ export type ValueTypes = {
     id?: boolean | `@${string}`;
     /** An object relationship */
     profile?: ValueTypes['profiles'];
+    __typename?: boolean | `@${string}`;
+  }>;
+  ['MarkClaimedInput']: {
+    claim_id: number;
+    tx_hash: string;
+  };
+  ['MarkClaimedOutput']: AliasType<{
+    ids?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
@@ -3832,6 +3840,10 @@ columns and relationships of "distributions" */
       ValueTypes['pending_vault_transactions']
     ];
     logoutUser?: ValueTypes['LogoutResponse'];
+    markClaimed?: [
+      { payload: ValueTypes['MarkClaimedInput'] },
+      ValueTypes['MarkClaimedOutput']
+    ];
     restoreCoordinape?: [
       { payload: ValueTypes['CoordinapeInput'] },
       ValueTypes['ConfirmationResponse']
@@ -8238,6 +8250,10 @@ export type ModelTypes = {
     /** An object relationship */
     profile: GraphQLTypes['profiles'];
   };
+  ['MarkClaimedInput']: GraphQLTypes['MarkClaimedInput'];
+  ['MarkClaimedOutput']: {
+    ids: Array<number>;
+  };
   /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
   ['String_comparison_exp']: GraphQLTypes['String_comparison_exp'];
   ['UpdateCircleInput']: GraphQLTypes['UpdateCircleInput'];
@@ -9288,6 +9304,7 @@ columns and relationships of "distributions" */
       | GraphQLTypes['pending_vault_transactions']
       | undefined;
     logoutUser?: GraphQLTypes['LogoutResponse'] | undefined;
+    markClaimed?: GraphQLTypes['MarkClaimedOutput'] | undefined;
     restoreCoordinape?: GraphQLTypes['ConfirmationResponse'] | undefined;
     updateAllocations?: GraphQLTypes['AllocationsResponse'] | undefined;
     updateCircle?: GraphQLTypes['UpdateCircleOutput'] | undefined;
@@ -10622,6 +10639,14 @@ export type GraphQLTypes = {
     id?: number | undefined;
     /** An object relationship */
     profile: GraphQLTypes['profiles'];
+  };
+  ['MarkClaimedInput']: {
+    claim_id: number;
+    tx_hash: string;
+  };
+  ['MarkClaimedOutput']: {
+    __typename: 'MarkClaimedOutput';
+    ids: Array<number>;
   };
   /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
   ['String_comparison_exp']: {
@@ -12971,6 +12996,7 @@ columns and relationships of "distributions" */
       | GraphQLTypes['pending_vault_transactions']
       | undefined;
     logoutUser?: GraphQLTypes['LogoutResponse'] | undefined;
+    markClaimed?: GraphQLTypes['MarkClaimedOutput'] | undefined;
     restoreCoordinape?: GraphQLTypes['ConfirmationResponse'] | undefined;
     updateAllocations?: GraphQLTypes['AllocationsResponse'] | undefined;
     updateCircle?: GraphQLTypes['UpdateCircleOutput'] | undefined;


### PR DESCRIPTION
## Motivation and Context

Track claims in interaction_events

## Description

interaction_events is only accessible from the backend, so we create a new Hasura action for claims. then we add the same mutation to it as we did for the other vault operations.