### PR TITLE
feat: Stories for `Modal`, `Tooltip`, `ToggleButton` and all the generated icons

### DIFF
--- a/src/ui/Modal.stories.tsx
+++ b/src/ui/Modal.stories.tsx
@@ -1,0 +1,55 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { Flex, Text, Button, Modal as ModalComponent } from './index';
+
+export default {
+  title: 'Design System/Components/Modal',
+  component: ModalComponent,
+  argTypes: {
+    children: {
+      table: {
+        disable: true,
+      },
+    },
+    onClose: {
+      table: {
+        disable: true,
+      },
+    },
+    onOpenChange: {
+      table: {
+        disable: true,
+      },
+    },
+    defaultOpen: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+} as ComponentMeta<typeof ModalComponent>;
+
+const Template: ComponentStory<typeof ModalComponent> = args => (
+  <ModalComponent {...args} />
+);
+
+export const Modal = Template.bind({});
+
+Modal.args = {
+  title: 'Modal Title',
+  showClose: true,
+  drawer: false,
+  open: true,
+  children: (
+    <Flex column alignItems="start" css={{ gap: '$md' }}>
+      <Text>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ut tortor
+        nec neque fringilla auctor ut eu augue. Mauris sem tellus, vehicula a
+        tincidunt quis, euismod eget sapien.
+      </Text>
+      <Button color="primary" onClick={() => {}}>
+        Button
+      </Button>
+    </Flex>
+  ),
+};

--- a/src/ui/SvgIcon.stories.tsx
+++ b/src/ui/SvgIcon.stories.tsx
@@ -1,47 +1,65 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
-import { ArrowLeft } from 'icons/__generated';
+import { theme } from '../stitches.config';
+import { X } from 'icons/__generated';
 
-import { Box, Text } from './index';
+import { Flex, Text } from './index';
 
 export default {
-  title: 'Design System/Components/SvgIcon',
-  component: Box,
-} as ComponentMeta<typeof Box>;
+  title: 'Design System/Components/Icons',
+  component: X,
+  argTypes: {
+    color: {
+      options: Object.keys(theme.colors),
+      control: { type: 'select' },
+      defaultValue: 'black',
+    },
+    size: {
+      options: ['xs', 'sm', 'md', 'lg', 'xl'],
+      control: { type: 'inline-radio' },
+      defaultValue: 'lg',
+    },
+    css: {
+      table: {
+        disable: true,
+      },
+    },
+    nostroke: { control: 'boolean', defaultValue: false },
+  },
+} as ComponentMeta<typeof X>;
 
-const Template: ComponentStory<typeof Box> = args => (
-  <Box
-    css={{
-      display: 'flex',
-      flexDirection: 'column',
-      gap: '$sm',
-    }}
-  >
-    {args.children}
-  </Box>
+const context = require.context('../icons/__generated', true, /.tsx$/);
+const components = context.keys().reduce((accum, path) => {
+  const name = path.substring(2).replace('.tsx', '');
+  return {
+    ...accum,
+    [name]: context(path),
+  };
+}, {});
+
+const Template: ComponentStory<typeof X> = args => (
+  <Flex css={{ flexWrap: 'wrap', gap: '$lg' }}>
+    {Object.keys(components).map(name => {
+      const Icon = (components as any)[name].default;
+      return (
+        <Flex
+          key={name}
+          css={{
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: '$sm',
+          }}
+        >
+          <Icon
+            {...args}
+            size={args.size ?? 'lg'}
+            color={args.color ?? 'black'}
+          />
+          <Text size="small">{name}</Text>
+        </Flex>
+      );
+    })}
+  </Flex>
 );
 
-export const SingleArrowLeft = Template.bind({});
-
-SingleArrowLeft.args = {
-  children: (
-    <>
-      <Box css={{ display: 'flex', gap: '$sm' }}>
-        <Text>xs (10px)</Text>
-        <ArrowLeft size="xs" />
-      </Box>
-      <Box css={{ display: 'flex', gap: '$sm' }}>
-        <Text>sm (12px)</Text>
-        <ArrowLeft size="sm" />
-      </Box>
-      <Box css={{ display: 'flex', gap: '$sm' }}>
-        <Text>md (16px)</Text>
-        <ArrowLeft size="md" />
-      </Box>
-      <Box css={{ display: 'flex', gap: '$sm' }}>
-        <Text>lg (24px)</Text>
-        <ArrowLeft size="lg" />
-      </Box>
-    </>
-  ),
-};
+export const Icons = Template.bind({});

--- a/src/ui/ToggleButton.stories.tsx
+++ b/src/ui/ToggleButton.stories.tsx
@@ -1,0 +1,92 @@
+import { useState } from 'react';
+
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { Check, Slash, X } from 'icons/__generated';
+
+import { Flex, ToggleButton as ToggleButtonComponent } from './index';
+
+export default {
+  title: 'Design System/Components/Toggle Button',
+  component: ToggleButtonComponent,
+  argTypes: {
+    children: {
+      table: {
+        disable: true,
+      },
+    },
+    ref: {
+      table: {
+        disable: true,
+      },
+    },
+    as: {
+      table: {
+        disable: true,
+      },
+    },
+    css: {
+      table: {
+        disable: true,
+      },
+    },
+    color: {
+      table: {
+        disable: true,
+      },
+    },
+    active: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+} as ComponentMeta<typeof ToggleButtonComponent>;
+
+const Template: ComponentStory<typeof ToggleButtonComponent> = () => {
+  const [index, setIndex] = useState(0);
+
+  return (
+    <Flex css={{ flexWrap: 'wrap', gap: '$sm' }}>
+      <ToggleButtonComponent
+        color="complete"
+        active={index === 0}
+        name={'yes'}
+        onClick={e => {
+          e.preventDefault();
+          setIndex(0);
+        }}
+      >
+        <Check size="lg" /> Yes
+      </ToggleButtonComponent>
+      <ToggleButtonComponent
+        color="destructive"
+        active={index === 1}
+        name={'no'}
+        onClick={e => {
+          e.preventDefault();
+          setIndex(1);
+        }}
+      >
+        <X size="lg" /> No
+      </ToggleButtonComponent>
+      <ToggleButtonComponent
+        color="destructive"
+        active={index === 2}
+        name={'cancel'}
+        onClick={e => {
+          e.preventDefault();
+          setIndex(2);
+        }}
+      >
+        <Slash size="lg" /> Cancel
+      </ToggleButtonComponent>
+    </Flex>
+  );
+};
+
+export const ToggleButton = Template.bind({});
+
+ToggleButton.parameters = {
+  controls: { hideNoControlsWarning: true },
+};

--- a/src/ui/Tooltip/Tooltip.stories.tsx
+++ b/src/ui/Tooltip/Tooltip.stories.tsx
@@ -8,6 +8,23 @@ import { Tooltip as TooltipComponent } from './Tooltip';
 export default {
   title: 'Design System/Components/Tooltip',
   component: TooltipComponent,
+  argTypes: {
+    children: {
+      table: {
+        disable: true,
+      },
+    },
+    css: {
+      table: {
+        disable: true,
+      },
+    },
+    content: {
+      table: {
+        disable: true,
+      },
+    },
+  },
 } as ComponentMeta<typeof TooltipComponent>;
 
 const Template: ComponentStory<typeof TooltipComponent> = () => (
@@ -24,3 +41,6 @@ const Template: ComponentStory<typeof TooltipComponent> = () => (
 );
 
 export const Tooltip = Template.bind({});
+Tooltip.parameters = {
+  controls: { hideNoControlsWarning: true },
+};

--- a/src/ui/Tooltip/Tooltip.stories.tsx
+++ b/src/ui/Tooltip/Tooltip.stories.tsx
@@ -1,0 +1,26 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { Text } from '../Text/Text';
+import { Info } from 'icons/__generated';
+
+import { Tooltip as TooltipComponent } from './Tooltip';
+
+export default {
+  title: 'Design System/Components/Tooltip',
+  component: TooltipComponent,
+} as ComponentMeta<typeof TooltipComponent>;
+
+const Template: ComponentStory<typeof TooltipComponent> = () => (
+  <TooltipComponent
+    content={
+      <Text>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer
+        lobortis consequat orci, quis feugiat sem suscipit sed.
+      </Text>
+    }
+  >
+    <Info />
+  </TooltipComponent>
+);
+
+export const Tooltip = Template.bind({});


### PR DESCRIPTION
## Motivation and Context

<!-- Why is this change required? What problem does it solve? This can be omitted if a linked issue is provided
-->

To support faster development and designing, there should be more stories added to Storybook

## Description

<!-- Describe your changes -->

Added a story for the following components `Modal`, `Tooltip`, `ToggleButton` and all the generated icons

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->

Ran storybook and played with the stories, refer to the screenshots below

## Screenshots (if appropriate):

Preview link https://coordinape-storybook-git-fork-karelianpie-issue-1462-coordinape.vercel.app/?path=/story/design-system-components-modal--modal

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

### Modal story
<img width="2352" alt="Screen Shot 2022-10-05 at 12 15 26 pm" src="https://user-images.githubusercontent.com/78794805/194025818-87450fda-a73e-47b6-8c75-5d07d40061c0.png">

### Tooltip story
<img width="2352" alt="Screen Shot 2022-10-05 at 12 15 37 pm" src="https://user-images.githubusercontent.com/78794805/194025823-8eda3ebc-17bc-4d79-a422-86eaeb4b86d5.png">

### Toggle Button story
<img width="2352" alt="Screen Shot 2022-10-05 at 12 15 46 pm" src="https://user-images.githubusercontent.com/78794805/194025826-b2d5ba88-c070-40c9-b001-308cda3cb2c3.png">

### Icons story
<img width="2352" alt="Screen Shot 2022-10-05 at 12 16 11 pm" src="https://user-images.githubusercontent.com/78794805/194025833-02f9ba5b-e9bd-45d3-b791-7a1bec515335.png">


## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

@crabsinger

## Related Issue

<!-- Please link to the issue here -->

Closes https://github.com/coordinape/coordinape/issues/1462
