### PR TITLE
fix: Set up your GitHub Actions workflow with a specific version of node.js

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -7,10 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Install dependencies
-        run: yarn
+      - uses: actions/setup-node@v3
         with:
           node-version: 14.x
+      - name: Install dependencies
+        run: yarn
       - name: Publish to Chromatic
         uses: chromaui/action@v1
         with:


### PR DESCRIPTION
We are getting the following [error](https://github.com/coordinape/coordinape/actions/runs/3195021921):

> Invalid workflow file: .github/workflows/chromatic.yml#L12
> The workflow is not valid. .github/workflows/chromatic.yml (Line: 12, Col: 9): Unexpected value 'with'

Set up your GitHub Actions workflow with a specific version of node.js