### PR TITLE
Remove unneccessary Box in SavingIndicator

### DIFF
--- a/src/pages/GivePage/SavingIndicator.tsx
+++ b/src/pages/GivePage/SavingIndicator.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Check, RefreshCcw } from '../../icons/__generated';
 import { CSS } from '../../stitches.config';
-import { Box, Flex, Text } from '../../ui';
+import { Flex, Text } from '../../ui';
 
 // SavingIndicator indicates whether state is stable, being saved, or has recently been saved
 export const SavingIndicator = ({
@@ -14,16 +14,16 @@ export const SavingIndicator = ({
 }) => {
   return (
     <Flex css={{ ...css, minHeight: '$lg', alignItems: 'center' }}>
-      <Text size="small" color="neutral">
+      <Text size="small" color="neutral" css={{ gap: '$xs' }}>
         {needToSave === true && (
-          <Box>
+          <>
             <RefreshCcw /> Saving Changes
-          </Box>
+          </>
         )}
         {needToSave === false && (
-          <Box>
+          <>
             <Check /> Changes Saved!
-          </Box>
+          </>
         )}
       </Text>
     </Flex>

--- a/src/ui/Button/Button.tsx
+++ b/src/ui/Button/Button.tsx
@@ -25,6 +25,7 @@ export const Button = styled('button', {
   '&[disabled]': {
     opacity: 0.4,
     cursor: 'default',
+    pointerEvents: 'none',
   },
 
   variants: {


### PR DESCRIPTION
@wingfeatherwave 

Remove unncesssary Box, use CSS on the Text. Not sure if the "Saving Changes" spacing is perfect... but matches what is on `main`.

<img width="186" alt="Screen Shot 2022-10-07 at 5 26 08 PM" src="https://user-images.githubusercontent.com/83605543/194678612-f3a12563-b47a-4e15-9d88-6dba2f5e7345.png">
<img width="201" alt="Screen Shot 2022-10-07 at 5 26 07 PM" src="https://user-images.githubusercontent.com/83605543/194678613-1e092d93-cd97-40e7-af9d-1c98fbae1368.png">
