### PR TITLE
Deletion of pending distribution records

### DIFF
--- a/hasura/migrations/default/1665330873631_set_fk_public_claims_distribution_id/down.sql
+++ b/hasura/migrations/default/1665330873631_set_fk_public_claims_distribution_id/down.sql
@@ -1,0 +1,5 @@
+alter table "public"."claims" drop constraint "claims_distribution_id_fkey",
+  add constraint "claims_distribution_id_fkey"
+  foreign key ("distribution_id")
+  references "public"."distributions"
+  ("id") on update no action on delete no action;

--- a/hasura/migrations/default/1665330873631_set_fk_public_claims_distribution_id/up.sql
+++ b/hasura/migrations/default/1665330873631_set_fk_public_claims_distribution_id/up.sql
@@ -1,0 +1,5 @@
+alter table "public"."claims" drop constraint "claims_distribution_id_fkey",
+  add constraint "claims_distribution_id_fkey"
+  foreign key ("distribution_id")
+  references "public"."distributions"
+  ("id") on update no action on delete cascade;


### PR DESCRIPTION
## Motivation and Context

Distribution & claims are records are remaining in the DB even if user rejects the tx.

## Description

Use the cron to handle cleanup of the records that are not attached to any `tx_hash` + at least 5 minutes old and cascade delete the associated claim records

## Test and Deployment Plan

Attempt to make a distribution but reject the tx, wait for 5 minutes to pass an for the cron to run (should be every 2 minutes) make sure the distribution record is being deleted together with the claim records
