### PR TITLE
Fix user nodes select on mobile

### DIFF
--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -22,7 +22,6 @@ export const Drawer = ({ open, setOpen, children }: IProps) => {
           position: 'absolute',
           top: 0,
           bottom: 0,
-          zIndex: 1,
           flexDirection: 'column',
         }}
       >


### PR DESCRIPTION
## Motivation and Context

fixes #1489

## Description

Removed zIndex from the Circle Map header text 

## Test and Deployment Plan

Go to Map page on mobile and touch a node to select it or to drag it

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/34943689/195172940-41faff56-b965-4da9-a3de-d27239700e20.png)
