### PR TITLE
show Loading modal during image uploads

### DIFF
--- a/src/components/LoadingModal.tsx
+++ b/src/components/LoadingModal.tsx
@@ -18,10 +18,10 @@ const useStyles = makeStyles(theme => ({
     textAlign: 'center',
   },
   title: {
-    fontSize: 30,
-    lineHeight: '22px',
-    color: theme.colors.surface,
+    fontSize: 16,
     textAlign: 'center',
+    color: theme.colors.secondaryText,
+    fontWeight: 500,
     marginTop: 16,
   },
 }));

--- a/src/pages/OrganizationSettingsPage/OrganizationSettingsPage.tsx
+++ b/src/pages/OrganizationSettingsPage/OrganizationSettingsPage.tsx
@@ -70,7 +70,7 @@ export const OrganizationSettingsPage = () => {
   const [uploadComplete, setUploadComplete] = useState<boolean>(false);
   const org = data?.organizations_by_pk;
 
-  const [, setLogoFile] = useState<File | undefined>(undefined);
+  const [logoFile, setLogoFile] = useState<File | undefined>(undefined);
 
   const onSubmit: SubmitHandler<OrgAdminFormSchema> = async data => {
     try {
@@ -144,8 +144,8 @@ export const OrganizationSettingsPage = () => {
     },
   });
 
-  if (isLoading || isIdle || isRefetching)
-    return <LoadingModal visible note="OrganizationPage" />;
+  if (isLoading || isIdle || isRefetching || logoFile)
+    return <LoadingModal visible note="OrganizationPage" text="Saving..." />;
 
   if (!org) {
     navigate(paths.circles);


### PR DESCRIPTION
On the Organization Settings Page, there is no state indication as the image uploads. This PR sets the loading modal to true during image upload.

<img width="1154" alt="Screen Shot 2022-10-11 at 3 16 42 PM" src="https://user-images.githubusercontent.com/83605543/195208494-656ec115-486c-46a2-992d-06872e407a48.png">

Show loading state during image uploads
