### PR TITLE
Improve User profile picture upload pattern

### DIFF
--- a/src/components/AvatarUpload.tsx
+++ b/src/components/AvatarUpload.tsx
@@ -4,6 +4,7 @@ import { fileToBase64 } from 'lib/base64';
 import { updateProfileAvatar } from 'lib/gql/mutations';
 import { MAX_IMAGE_BYTES_LENGTH_BASE64 } from 'lib/images';
 
+import { LoadingModal } from 'components';
 import { useApeSnackbar, useApiBase } from 'hooks';
 import { Check } from 'icons/__generated';
 import { Avatar, Button, Flex, FormLabel, Text } from 'ui';
@@ -13,7 +14,7 @@ const VALID_FILE_TYPES = ['image/jpg', 'image/jpeg', 'image/png'];
 
 export const AvatarUpload = ({ original }: { original?: string }) => {
   const [uploadComplete, setUploadComplete] = useState<boolean>(false);
-  const [, setAvatarFile] = useState<File | undefined>(undefined);
+  const [avatarFile, setAvatarFile] = useState<File | undefined>(undefined);
 
   const [uploadedAvatarUrl, setUploadedAvatarUrl] = useState<
     undefined | string
@@ -67,6 +68,8 @@ export const AvatarUpload = ({ original }: { original?: string }) => {
       }
     }
   };
+
+  if (avatarFile) return <LoadingModal visible />;
 
   return (
     <Flex column css={{ alignItems: 'flex-start', gap: '$xs' }}>

--- a/src/components/AvatarUpload.tsx
+++ b/src/components/AvatarUpload.tsx
@@ -7,6 +7,7 @@ import { MAX_IMAGE_BYTES_LENGTH_BASE64 } from 'lib/images';
 import { useApeSnackbar, useApiBase } from 'hooks';
 import { Check } from 'icons/__generated';
 import { Avatar, Button, Flex, FormLabel, Text } from 'ui';
+import { formatBytes } from 'utils/presentationHelpers';
 
 const VALID_FILE_TYPES = ['image/jpg', 'image/jpeg', 'image/png'];
 
@@ -41,8 +42,7 @@ export const AvatarUpload = ({ original }: { original?: string }) => {
         showError(
           e.target.value +
             ' is too large, max file size is ' +
-            MAX_IMAGE_BYTES_LENGTH_BASE64 +
-            ' bytes'
+            formatBytes(MAX_IMAGE_BYTES_LENGTH_BASE64)
         );
       } else {
         setAvatarFile(e.target.files[0]);

--- a/src/components/AvatarUpload.tsx
+++ b/src/components/AvatarUpload.tsx
@@ -1,20 +1,12 @@
-import { makeStyles } from '@material-ui/core';
+import React, { useState } from 'react';
 
-import { FormFileUpload } from 'components/index';
-import { useImageUploader } from 'hooks';
-import { Avatar } from 'ui';
-import { getAvatarPath } from 'utils/domain';
+import { MAX_IMAGE_BYTES_LENGTH_BASE64 } from 'lib/images';
 
-const useStyles = makeStyles(() => ({
-  root: {
-    position: 'relative',
-  },
-  buttons: {
-    position: 'absolute',
-    bottom: 0,
-    right: 0,
-  },
-}));
+import { useApeSnackbar } from 'hooks';
+import { Check } from 'icons/__generated';
+import { Avatar, Button, Flex, FormLabel, Text } from 'ui';
+
+const VALID_FILE_TYPES = ['image/jpg', 'image/jpeg', 'image/png'];
 
 export const AvatarUpload = ({
   original,
@@ -23,22 +15,112 @@ export const AvatarUpload = ({
   original?: string;
   commit: (file: File) => Promise<any>;
 }) => {
-  const classes = useStyles();
+  const [uploadComplete, setUploadComplete] = useState<boolean>(false);
+  const [, setAvatarFile] = useState<File | undefined>(undefined);
 
-  const { imageUrl, formFileUploadProps } = useImageUploader(
-    getAvatarPath(original)
-  );
+  const [uploadedAvatarUrl, setUploadedAvatarUrl] = useState<
+    undefined | string
+  >(undefined);
+
+  const fileInput = React.createRef<HTMLInputElement>();
+
+  const { showError } = useApeSnackbar();
+
+  const onInputChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files.length) {
+      if (!VALID_FILE_TYPES.includes(e.target.files[0].type)) {
+        showError(
+          e.target.value +
+            ' is invalid, allowed files are: ' +
+            VALID_FILE_TYPES.join(', ')
+        );
+        setAvatarFile(undefined);
+      } else if (e.target.files[0].size > MAX_IMAGE_BYTES_LENGTH_BASE64) {
+        showError(
+          e.target.value +
+            ' is too large, max file size is ' +
+            MAX_IMAGE_BYTES_LENGTH_BASE64 +
+            ' bytes'
+        );
+      } else {
+        setAvatarFile(e.target.files[0]);
+        const newAvatar = e.target.files[0];
+        if (newAvatar === undefined) {
+          return;
+        }
+        let response = undefined;
+        try {
+          response = await commit(newAvatar);
+        } catch (e: any) {
+          showError(e);
+          setAvatarFile(undefined);
+          return;
+        }
+        setUploadedAvatarUrl(response.uploadProfileAvatar?.profile.avatar);
+        setAvatarFile(undefined);
+        setUploadComplete(true);
+      }
+    }
+  };
 
   return (
-    <div className={classes.root}>
-      <Avatar path={imageUrl} size="large" />
-      <FormFileUpload
-        className={classes.buttons}
-        commit={commit}
-        {...formFileUploadProps}
-        accept="image/gif, image/jpeg, image/png"
-        style={{ zIndex: 1 }}
-      />
-    </div>
+    <Flex column css={{ alignItems: 'flex-start', gap: '$xs' }}>
+      <Flex
+        css={{
+          alignItems: 'center',
+          gap: '$sm',
+          width: '100%',
+        }}
+      >
+        <Avatar
+          size="medium"
+          margin="none"
+          path={uploadedAvatarUrl ? uploadedAvatarUrl : original}
+          name={'me'}
+        />
+        <FormLabel htmlFor="upload-avatar-button" css={{ flexGrow: '1' }}>
+          <Flex
+            css={{
+              alignItems: 'center',
+              gap: '$sm',
+            }}
+          >
+            <Button
+              id="upload-avatar-button"
+              color="primary"
+              outlined
+              as="span"
+              css={{
+                display: 'inline-flex',
+              }}
+              onClick={() => {
+                setUploadComplete(false);
+                fileInput.current?.click?.();
+              }}
+            >
+              Select File
+            </Button>
+            {uploadComplete && (
+              <Text
+                size="small"
+                color="neutral"
+                css={{
+                  gap: '$xs',
+                }}
+              >
+                <Check /> Avatar Saved!
+              </Text>
+            )}
+            <input
+              ref={fileInput}
+              accept={VALID_FILE_TYPES.join(', ')}
+              onChange={onInputChange}
+              style={{ display: 'none' }}
+              type="file"
+            />
+          </Flex>
+        </FormLabel>
+      </Flex>
+    </Flex>
   );
 };

--- a/src/components/AvatarUpload.tsx
+++ b/src/components/AvatarUpload.tsx
@@ -59,6 +59,8 @@ export const AvatarUpload = ({ original }: { original?: string }) => {
           return;
         }
         setUploadedAvatarUrl(response.uploadProfileAvatar?.profile.avatar);
+
+        //to be fixed when profile data is fetched separately
         await fetchManifest();
         setAvatarFile(undefined);
         setUploadComplete(true);

--- a/src/components/EditProfileModal.tsx
+++ b/src/components/EditProfileModal.tsx
@@ -51,7 +51,7 @@ export const EditProfileModal = ({
   const classes = useStyles();
 
   const myProfile = useMyProfile();
-  const { updateMyProfile, updateAvatar } = useApiWithProfile();
+  const { updateMyProfile } = useApiWithProfile();
 
   return (
     <EditProfileForm.FormController
@@ -85,7 +85,7 @@ export const EditProfileModal = ({
           size="large"
         >
           <h2 className={classes.sectionHeader}>Profile Image</h2>
-          <AvatarUpload original={myProfile.avatar} commit={updateAvatar} />
+          <AvatarUpload original={myProfile.avatar} />
 
           <h2 className={classes.sectionHeader}>Select Your Skills</h2>
           <div className={classes.skillsContainer}>

--- a/src/hooks/useApiWithProfile.ts
+++ b/src/hooks/useApiWithProfile.ts
@@ -21,17 +21,6 @@ export const useApiWithProfile = () => {
     []
   );
 
-  const updateAvatar = useRecoilLoadCatch(
-    () => async (newAvatar: File) => {
-      // TODO: ideally we would use useTypedMutation instead of this but I couldn't get the variables to work w/ mutation -CryptoGraffe
-      const image_data_base64 = await fileToBase64(newAvatar);
-      await mutations.updateProfileAvatar(image_data_base64);
-      // FIXME fetchManifest instead of updating the changed field is wasteful
-      await fetchManifest();
-    },
-    []
-  );
-
   const updateBackground = useRecoilLoadCatch(
     () => async (newAvatar: File) => {
       const image_data_base64 = await fileToBase64(newAvatar);
@@ -64,7 +53,6 @@ export const useApiWithProfile = () => {
 
   return {
     createCircle,
-    updateAvatar,
     updateBackground,
     updateMyProfile,
   };

--- a/src/lib/gql/mutations.ts
+++ b/src/lib/gql/mutations.ts
@@ -20,7 +20,11 @@ export const updateProfileAvatar = async (image_data_base64: string) => {
     {
       uploadProfileAvatar: [
         { payload: { image_data_base64: variables.$('image_data_base64') } },
-        { id: true },
+        {
+          profile: {
+            avatar: true,
+          },
+        },
       ],
     },
     {

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -3,4 +3,4 @@
 const base64Buffer = 4 / 3;
 export const MAX_IMAGE_BYTES_LENGTH = 10 * 1024 * 1024; // 10MB+buffer
 export const MAX_IMAGE_BYTES_LENGTH_BASE64 =
-  MAX_IMAGE_BYTES_LENGTH * base64Buffer;
+  MAX_IMAGE_BYTES_LENGTH / base64Buffer;

--- a/src/pages/OrganizationSettingsPage/OrganizationSettingsPage.tsx
+++ b/src/pages/OrganizationSettingsPage/OrganizationSettingsPage.tsx
@@ -32,6 +32,7 @@ import {
   Tooltip,
 } from 'ui';
 import { SingleColumnLayout } from 'ui/layouts';
+import { formatBytes } from 'utils/presentationHelpers';
 
 import { updateOrg } from './mutations';
 
@@ -101,8 +102,7 @@ export const OrganizationSettingsPage = () => {
         showError(
           e.target.value +
             ' is too large, max file size is ' +
-            MAX_IMAGE_BYTES_LENGTH_BASE64 +
-            ' bytes'
+            formatBytes(MAX_IMAGE_BYTES_LENGTH_BASE64)
         );
       } else {
         setLogoFile(e.target.files[0]);

--- a/src/utils/presentationHelpers.test.ts
+++ b/src/utils/presentationHelpers.test.ts
@@ -1,0 +1,11 @@
+import { formatBytes } from './presentationHelpers';
+
+describe('formatBytes', () => {
+  test('it displays a pretty short size correctly', () => {
+    expect(formatBytes(1024 ** 1)).toEqual('1 KB');
+    expect(formatBytes(1024 ** 2)).toEqual('1 MB');
+    expect(formatBytes(1024 ** 3)).toEqual('1 GB');
+    expect(formatBytes(1024 ** 1 + 100)).toEqual('1.1 KB');
+    expect(formatBytes(1024 ** 2 + 90000)).toEqual('1.09 MB');
+  });
+});

--- a/src/utils/presentationHelpers.ts
+++ b/src/utils/presentationHelpers.ts
@@ -1,0 +1,10 @@
+export const formatBytes = (bytes: number, decimals = 2) => {
+  if (bytes === 0) return '0 Bytes';
+
+  const k = 1024;
+  const dm = decimals < 0 ? 0 : decimals;
+  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
+};


### PR DESCRIPTION
## Motivation and Context
resolves #1496

## Description
Update AvatarUpload.tsx to follow org logo upload in OrganizationSettingsPage.tsx
- Button to upload new Image
- Auto-save Image after selected
- Error state
- While the image is uploading please give an indication that it's loading where the image saved text is "Saving..."

Update updateProfileAvatar mutation to return the avatar to display after upload

#### Note:
I kept the same way of fetching the data by recoil. I think it needs a separate issue because there will be many changes in profile page

## Test and Deployment Plan
1- Go to your profile page
2- click edit profile
3- use correct image format to check the uploaded avatar
4- use large size photo or wrong format to check the error message

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/34943689/195558989-93b1154b-72f2-4679-9472-b7905368a56b.png)


![image](https://user-images.githubusercontent.com/34943689/195552771-15162edb-837a-4880-b44e-110532d8a4d4.png)


## Related Issue

