### PR TITLE
Hide changes saved/saving while writing notes in new Give page

### DIFF
--- a/src/pages/GivePage/GiveDrawer.tsx
+++ b/src/pages/GivePage/GiveDrawer.tsx
@@ -79,6 +79,7 @@ export const GiveDrawer = ({
 
   // noteChanged schedules a save to the underlying state in the parent component, clearing any pending save
   const noteChanged = (newNote: string) => {
+    setNeedToSave(undefined);
     setNote(newNote);
     if (saveTimeout) {
       clearTimeout(saveTimeout);


### PR DESCRIPTION
## Motivation and Context
fixes #1479 

## Description

set setNeedToSave to undefined upon changing notes

## Test and Deployment Plan

Go to new give page on active epoch and give feedback to one of the team mates 
While writing notes saving indicator should be hidden.
after finishing saving changes then changes saved should appear

## Screenshots (if appropriate):
while typing
![image](https://user-images.githubusercontent.com/34943689/195719096-67ce78e6-aef0-4771-b200-3d1e8b367994.png)

