### PR TITLE
Update Receive Info on opt out change

### DIFF
--- a/src/components/ReceiveInfo.tsx
+++ b/src/components/ReceiveInfo.tsx
@@ -43,6 +43,9 @@ export const ReceiveInfo = () => {
   );
   const noEpoch =
     !data?.myReceived?.currentEpoch[0] && !data?.myReceived?.pastEpochs[0];
+  //handle if member was a receiver and no current epoch
+  const currentNonReceiver =
+    data?.user?.non_receiver && data?.myReceived?.currentEpoch[0];
   const gifts = data?.myReceived?.currentEpoch[0]
     ? data.myReceived.currentEpoch[0].receivedGifts ?? []
     : (data?.myReceived?.pastEpochs[0] &&
@@ -74,7 +77,7 @@ export const ReceiveInfo = () => {
             );
           }}
         >
-          {!data?.user?.non_receiver ? totalReceived : 0}{' '}
+          {!currentNonReceiver ? totalReceived : 0}{' '}
           {data?.myReceived?.token_name ?? 'GIVE'}
         </Button>
       </PopoverTrigger>
@@ -117,7 +120,7 @@ export const ReceiveInfo = () => {
               {noEpoch
                 ? 'No Epochs in this Circle'
                 : `You have received ${
-                    !data?.user?.non_receiver ? totalReceived : 0
+                    !currentNonReceiver ? totalReceived : 0
                   } ${data?.myReceived?.token_name ?? 'GIVE'}`}
             </Text>
           </PopoverClose>
@@ -140,7 +143,7 @@ export const ReceiveInfo = () => {
               >
                 <Flex css={{ justifyContent: 'space-between' }}>
                   <Text semibold css={{ mr: '$md' }}>
-                    {tokenGift.tokens > 0 && !data?.user?.non_receiver
+                    {tokenGift.tokens > 0 && !currentNonReceiver
                       ? `+${tokenGift.tokens} Received from `
                       : 'From '}
                     {tokenGift.sender?.name}

--- a/src/components/ReceiveInfo.tsx
+++ b/src/components/ReceiveInfo.tsx
@@ -38,9 +38,10 @@ export const ReceiveInfo = () => {
       //minmize background refetch
       refetchOnWindowFocus: false,
 
-      notifyOnChangeProps: ['data', 'error'],
+      notifyOnChangeProps: ['data'],
     }
   );
+
   const noEpoch = !circle?.currentEpoch[0] && !circle?.pastEpochs[0];
   const gifts = circle?.currentEpoch[0]
     ? circle.currentEpoch[0].receivedGifts ?? []
@@ -252,6 +253,5 @@ const getReceiveInfo = async (circleId: number, userId: number) => {
       operationName: 'getReceivedInfo',
     }
   );
-
   return gq.circles_by_pk;
 };

--- a/src/components/ReceiveInfo.tsx
+++ b/src/components/ReceiveInfo.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
 
 import iti from 'itiriri';
+import { order_by } from 'lib/gql/__generated__/zeus';
+import { client } from 'lib/gql/client';
 import { DateTime } from 'luxon';
+import { useQuery } from 'react-query';
 
-import { useUserGifts } from 'recoilState/allocation';
 import { useSelectedCircle } from 'recoilState/app';
 import { paths } from 'routes/paths';
 import {
@@ -20,18 +22,29 @@ import {
   POPOVER_TIMEOUT,
 } from 'ui';
 
+export const QUERY_KEY_RECEIVE_INFO = 'getReceiveInfo';
+
 export const ReceiveInfo = () => {
   const {
-    myUser,
-    circle: selectedCircle,
-    circleEpochsStatus: { currentEpoch, previousEpoch },
+    myUser: { id: userId },
+    circleId,
   } = useSelectedCircle();
-  const { forUserByEpoch: myReceived } = useUserGifts(myUser.id);
 
-  const noEpoch = !currentEpoch && !previousEpoch;
-  const gifts = currentEpoch
-    ? myReceived.get(currentEpoch.id) ?? []
-    : (previousEpoch && myReceived.get(previousEpoch.id)) ?? [];
+  const { data: circle } = useQuery(
+    [QUERY_KEY_RECEIVE_INFO, circleId, userId],
+    () => getReceiveInfo(circleId, userId),
+    {
+      enabled: !!userId && !!circleId,
+      //minmize background refetch
+      refetchOnWindowFocus: false,
+
+      notifyOnChangeProps: ['data', 'error'],
+    }
+  );
+  const noEpoch = !circle?.currentEpoch[0] && !circle?.pastEpochs[0];
+  const gifts = circle?.currentEpoch[0]
+    ? circle.currentEpoch[0].receivedGifts ?? []
+    : (circle?.pastEpochs[0] && circle?.pastEpochs[0].receivedGifts) ?? [];
   const totalReceived = (gifts && iti(gifts).sum(({ tokens }) => tokens)) || 0;
   const [mouseEnterPopover, setMouseEnterPopover] = useState(false);
   const closePopover = () => {
@@ -58,7 +71,7 @@ export const ReceiveInfo = () => {
             );
           }}
         >
-          {totalReceived} {selectedCircle?.tokenName}
+          {totalReceived} {circle?.token_name ?? 'GIVE'}
         </Button>
       </PopoverTrigger>
       <PopoverContent
@@ -100,12 +113,14 @@ export const ReceiveInfo = () => {
               {noEpoch
                 ? 'No Epochs in this Circle'
                 : `You have received ${totalReceived ?? 0} ${
-                    selectedCircle?.tokenName
+                    circle?.token_name ?? 'GIVE'
                   }`}
             </Text>
           </PopoverClose>
           {gifts
-            ?.filter(tokenGift => tokenGift.tokens > 0 || tokenGift.note)
+            ?.filter(
+              tokenGift => tokenGift.tokens > 0 || tokenGift.gift_private?.note
+            )
             ?.sort(
               (a, b) => +new Date(b.dts_created) - +new Date(a.dts_created)
             )
@@ -143,9 +158,9 @@ export const ReceiveInfo = () => {
                     path={tokenGift.sender.profile.avatar}
                     name={tokenGift.sender.name}
                   />
-                  {tokenGift.note ? (
+                  {tokenGift.gift_private?.note ? (
                     <Text p as="p" size="small">
-                      {tokenGift.note}
+                      {tokenGift.gift_private.note}
                     </Text>
                   ) : (
                     <Text color="neutral">-- Empty Note --</Text>
@@ -154,12 +169,89 @@ export const ReceiveInfo = () => {
               </Box>
             ))}
           <Text css={{ mt: '$md' }}>
-            <AppLink to={paths.history(selectedCircle.id)}>
-              View Epoch Overview
-            </AppLink>
+            <AppLink to={paths.history(circleId)}>View Epoch Overview</AppLink>
           </Text>
         </Box>
       </PopoverContent>
     </Popover>
   );
+};
+
+const getReceiveInfo = async (circleId: number, userId: number) => {
+  const gq = await client.query(
+    {
+      circles_by_pk: [
+        { id: circleId },
+        {
+          token_name: true,
+          __alias: {
+            currentEpoch: {
+              epochs: [
+                {
+                  where: { ended: { _eq: false }, start_date: { _lt: 'now' } },
+                  limit: 1,
+                },
+                {
+                  id: true,
+                  start_date: true,
+                  __alias: {
+                    receivedGifts: {
+                      epoch_pending_token_gifts: [
+                        { where: { recipient_id: { _eq: userId } } },
+                        {
+                          id: true,
+                          tokens: true,
+                          sender: { name: true, profile: { avatar: true } },
+                          gift_private: { note: true },
+                          dts_created: true,
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+            },
+            pastEpochs: {
+              epochs: [
+                {
+                  where: { ended: { _eq: true } },
+                  order_by: [{ start_date: order_by.desc }],
+                  limit: 1,
+                },
+                {
+                  id: true,
+                  number: true,
+                  start_date: true,
+                  end_date: true,
+                  token_gifts_aggregate: [
+                    {},
+                    { aggregate: { sum: { tokens: true } } },
+                  ],
+                  __alias: {
+                    receivedGifts: {
+                      token_gifts: [
+                        { where: { recipient_id: { _eq: userId } } },
+                        {
+                          id: true,
+                          tokens: true,
+                          sender: { name: true, profile: { avatar: true } },
+                          gift_private: { note: true },
+                          dts_created: true,
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ],
+    },
+    {
+      operationName: 'getReceivedInfo',
+    }
+  );
+
+  return gq.circles_by_pk;
 };

--- a/src/pages/AllocationPage/AllocationEpoch.tsx
+++ b/src/pages/AllocationPage/AllocationEpoch.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 import capitalize from 'lodash/capitalize';
+import { useQueryClient } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 
 import { makeStyles } from '@material-ui/core';
@@ -8,7 +9,7 @@ import { makeStyles } from '@material-ui/core';
 import { useApiWithSelectedCircle } from '../../hooks';
 import { STEP_ALLOCATION, STEP_MY_TEAM } from '../../routes/allocation';
 import { IAllocationStep } from '../../types';
-import { OptInput, ApeInfoTooltip } from 'components';
+import { OptInput, ApeInfoTooltip, QUERY_KEY_RECEIVE_INFO } from 'components';
 import { MAX_BIO_LENGTH } from 'config/constants';
 import { useSelectedCircle } from 'recoilState/app';
 import { Button, Flex, Text, Modal } from 'ui';
@@ -127,6 +128,8 @@ const AllocationEpoch = ({
     myUser,
   } = useSelectedCircle();
 
+  const queryClient = useQueryClient();
+
   const [epochBio, setEpochBio] = useState('');
   const fixedNonReceiver = myUser.fixed_non_receiver;
   const [nonReceiver, setNonReceiver] = useState(false);
@@ -159,6 +162,7 @@ const AllocationEpoch = ({
         setActiveStep(_nextStep.key);
         navigate(_nextStep.pathFn(circleId));
       }
+      queryClient.invalidateQueries(QUERY_KEY_RECEIVE_INFO);
     } catch (e) {
       console.warn('handleSaveEpoch', e);
     }

--- a/src/pages/GivePage/index.tsx
+++ b/src/pages/GivePage/index.tsx
@@ -6,7 +6,7 @@ import { Helmet } from 'react-helmet';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 
 import { Awaited } from '../../../api-lib/ts4.5shim';
-import { LoadingModal } from '../../components';
+import { LoadingModal, QUERY_KEY_RECEIVE_INFO } from '../../components';
 import { useApeSnackbar } from '../../hooks';
 import useConnectedAddress from '../../hooks/useConnectedAddress';
 import { client } from '../../lib/gql/client';
@@ -431,6 +431,8 @@ const AllocateContents = ({
   // fetching the manifest.
   const [userIsOptedOut, setUserIsOptedOut] = useState(myUser.non_receiver);
 
+  const queryClient = useQueryClient();
+
   const { mutate: updateNonReceiver, isLoading: isNonReceiverMutationLoading } =
     useMutation(
       async (nonReceiver: boolean) =>
@@ -440,7 +442,11 @@ const AllocateContents = ({
         }),
       {
         onSuccess: data => {
-          if (data) setUserIsOptedOut(data.UserResponse.non_receiver);
+          queryClient.invalidateQueries(QUERY_KEY_RECEIVE_INFO);
+
+          if (data) {
+            setUserIsOptedOut(data.UserResponse.non_receiver);
+          }
         },
         onError: e => {
           console.error(e);


### PR DESCRIPTION
## Motivation and Context
resolves #1475 

## Description
1- Fetch the receive data by react-query
2- refetch the data and rerender on opt-out change
3- used user.non_receiver to handle corner cases for the current epoch because gift data won't be ready from hasura immediately after opt out

## Test and Deployment Plan
1- opt out by old and new give after receiving gives from another user
expected: received gives should change to 0 immediately
2- Check last epoch received gives if there is no current epoch and still opted in
3- Check last epoch received gives if there is no current epoch and opted out after



## Screenshots (if appropriate):
![Screenshot from 2022-10-17 12-28-04](https://user-images.githubusercon
![Screenshot from 2022-10-17 12-28-16](https://user-images.githubusercontent.com/34943689/196160372-44ebcd4f-7a6f-4233-ab91-eb576cba6bc5.png)
tent.com/34943689/196160370-db76f988-4bf6-4116-a6a6-e5a078184ce0.png)
