### PR TITLE
Re-enable webpack stdout to console

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,6 +1,14 @@
 {
-  "watch": ["api/", "api-lib/", "scripts/", "src/lib", "src/common-lib"],
+  "watch": [
+    "api/",
+    "api-lib/",
+    "scripts/",
+    "src/lib",
+    "src/common-lib",
+    "*.json"
+  ],
   "delay": 300,
+  "verbose": true,
   "execMap": {
     "ts": "ts-node --swc"
   },

--- a/package.json
+++ b/package.json
@@ -193,6 +193,7 @@
     "@web3-react/network-connector": "^6.2.9",
     "assert": "2.0.0",
     "buffer": "6.0.3",
+    "chalk": "4.1.2",
     "chromatic": "6.10.1",
     "crypto-browserify": "3.12.0",
     "cypress": "10.2.0",

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -9,7 +9,7 @@ esac; shift; done
 
 PROXY_PORT=$(( $RANDOM % 900 + 3100 ))
 
-BROWSER=none PORT=$PROXY_PORT yarn craco start >/dev/null & CRACO_PID=$!
+BROWSER=none PORT=$PROXY_PORT yarn craco start & CRACO_PID=$!
 
 trap 'kill $CRACO_PID' EXIT
 

--- a/scripts/serve_dev.ts
+++ b/scripts/serve_dev.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk';
 import express from 'express';
 import { createProxyMiddleware } from 'http-proxy-middleware';
 import morgan from 'morgan';
@@ -54,12 +55,21 @@ app.get('/stats/js/script.js', (req, res) => {
 
 app.use(
   '/',
-  createProxyMiddleware({ target: `http://localhost:${proxyPort}` })
+  createProxyMiddleware({
+    target: `http://localhost:${proxyPort}`,
+    logLevel: 'warn',
+  })
 );
 
 app.listen(port, () => {
+  /* eslint-disable */
   console.log(`==========================================================`);
   console.log(`Development server has started successfully!`);
-  console.log(`Visit http://localhost:${port} to view the Coordinape app.`);
+  console.log(
+    `Visit`,
+    chalk.bold(`http://localhost:${port}`),
+    `to view the Coordinape app.`
+  );
   console.log(`==========================================================`);
+  /* eslint-enable */
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -9474,6 +9474,14 @@ ccount@^1.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.1.0.tgz#246687debb6014735131be8abab2d93898f8d043"
   integrity sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==
 
+chalk@4.1.2, chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -9487,14 +9495,6 @@ chalk@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
   integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
-
-chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
-  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"


### PR DESCRIPTION
I've run into some frustrating situations where I can't tell what
webpack is doing to my machine. to compensate for re-enabling the
logging of misleading URLs that we proxy, I've changed our
call to action link to bold.

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->
![image](https://user-images.githubusercontent.com/17910833/196457632-1a904d89-a7d8-499b-8d8f-d409553ee09e.png)

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->
