### PR TITLE
Convert GiveBeta page to default allocations flow

### DIFF
--- a/src/components/MainLayout/CircleNav.tsx
+++ b/src/components/MainLayout/CircleNav.tsx
@@ -32,7 +32,7 @@ export const CircleNav = () => {
     assert(circleId);
     const l: [string, string, string[]?][] = [
       [
-        paths.allocation(circleId),
+        paths.givebeta(circleId),
         'Allocate',
         [paths.epoch(circleId), paths.team(circleId), paths.give(circleId)],
       ],

--- a/src/pages/CirclesPage/CirclesPage.tsx
+++ b/src/pages/CirclesPage/CirclesPage.tsx
@@ -181,7 +181,7 @@ const buttons: [
   ((c: QueryCircle) => boolean)?
 ][] = [
   [paths.history, 'Epoch Overview'],
-  [paths.allocation, 'Allocation'],
+  [paths.givebeta, 'Allocation'],
   [paths.map, 'Map'],
   [paths.members, 'Members'],
   [paths.circleAdmin, 'Admin', (c: QueryCircle) => c.users[0]?.role !== 1],

--- a/src/pages/GivePage/index.tsx
+++ b/src/pages/GivePage/index.tsx
@@ -10,8 +10,9 @@ import useConnectedAddress from '../../hooks/useConnectedAddress';
 import { client } from '../../lib/gql/client';
 import { epochTimeUpcoming } from '../../lib/time';
 import { useSelectedCircle } from '../../recoilState';
+import { paths } from '../../routes/paths';
 import { IEpoch, IMyUser } from '../../types';
-import { Box, Button, Flex, Modal, Panel, Text } from '../../ui';
+import { Box, Button, Flex, Modal, Panel, Text, AppLink } from '../../ui';
 import { SingleColumnLayout } from '../../ui/layouts';
 import { getPendingGiftsFrom } from '../AllocationPage/queries';
 
@@ -285,66 +286,79 @@ const GivePage = () => {
   }
 
   return (
-    <SingleColumnLayout>
-      <Helmet>
-        <title>Give - {selectedCircle.name} - Coordinape</title>
-      </Helmet>
-      <Box>
-        <Box css={{ mb: '$md' }}>
-          <Text h1 semibold inline>
-            GIVE
+    <Box css={{ width: '100%' }}>
+      <Flex
+        css={{ background: '$info', justifyContent: 'center', py: '$md' }}
+        alignItems="center"
+      >
+        <Text>Not ready for the new GIVE experience?</Text>
+        <AppLink to={paths.allocation(selectedCircle.id)}>
+          <Button outlined color="primary" css={{ ml: '$md' }}>
+            Go Back
+          </Button>
+        </AppLink>
+      </Flex>
+      <SingleColumnLayout>
+        <Helmet>
+          <title>Give - {selectedCircle.name} - Coordinape</title>
+        </Helmet>
+        <Box>
+          <Box css={{ mb: '$md' }}>
+            <Text h1 semibold inline>
+              GIVE
+            </Text>
+            {currentEpoch && (
+              <Text inline h1 normal css={{ ml: '$md' }}>
+                Epoch {currentEpoch.number}:{' '}
+                {currentEpoch.startDate.toFormat('MMM d')} -{' '}
+                {currentEpoch.endDate.toFormat(
+                  currentEpoch.endDate.month === currentEpoch.startDate.month
+                    ? 'd'
+                    : 'MMM d'
+                )}
+              </Text>
+            )}
+          </Box>
+          <Text css={{ mb: '$md' }}>
+            Reward &amp; thank your teammates for their contributions
           </Text>
-          {currentEpoch && (
-            <Text inline h1 normal css={{ ml: '$md' }}>
-              Epoch {currentEpoch.number}:{' '}
-              {currentEpoch.startDate.toFormat('MMM d')} -{' '}
-              {currentEpoch.endDate.toFormat(
-                currentEpoch.endDate.month === currentEpoch.startDate.month
-                  ? 'd'
-                  : 'MMM d'
+        </Box>
+        {!currentEpoch && (
+          <Panel>
+            <Text semibold inline>
+              Allocations happen during active epochs.{' '}
+              {nextEpoch ? (
+                <Text inline>
+                  Allocation begins in {epochTimeUpcoming(nextEpoch.startDate)}.
+                  {nextEpoch.repeat === 1
+                    ? ' (repeats weekly)'
+                    : nextEpoch.repeat === 2
+                    ? ' (repeats monthly)'
+                    : ''}
+                </Text>
+              ) : (
+                <Text inline>No upcoming epochs scheduled.</Text>
               )}
             </Text>
-          )}
-        </Box>
-        <Text css={{ mb: '$md' }}>
-          Reward &amp; thank your teammates for their contributions
-        </Text>
-      </Box>
-      {!currentEpoch && (
-        <Panel>
-          <Text semibold inline>
-            Allocations happen during active epochs.{' '}
-            {nextEpoch ? (
-              <Text inline>
-                Allocation begins in {epochTimeUpcoming(nextEpoch.startDate)}.
-                {nextEpoch.repeat === 1
-                  ? ' (repeats weekly)'
-                  : nextEpoch.repeat === 2
-                  ? ' (repeats monthly)'
-                  : ''}
-              </Text>
-            ) : (
-              <Text inline>No upcoming epochs scheduled.</Text>
-            )}
-          </Text>
-        </Panel>
-      )}
-      {data && pendingGiftsFrom && (
-        <AllocateContents
-          members={members}
-          updateTeammate={updateTeammate}
-          gifts={gifts}
-          updateNote={updateNote}
-          adjustGift={adjustGift}
-          needToSave={needToSave}
-          setNeedToSave={setNeedToSave}
-          totalGiveUsed={totalGiveUsed}
-          myUser={myUser}
-          maxedOut={totalGiveUsed >= myUser.starting_tokens}
-          currentEpoch={currentEpoch}
-        />
-      )}
-    </SingleColumnLayout>
+          </Panel>
+        )}
+        {data && pendingGiftsFrom && (
+          <AllocateContents
+            members={members}
+            updateTeammate={updateTeammate}
+            gifts={gifts}
+            updateNote={updateNote}
+            adjustGift={adjustGift}
+            needToSave={needToSave}
+            setNeedToSave={setNeedToSave}
+            totalGiveUsed={totalGiveUsed}
+            myUser={myUser}
+            maxedOut={totalGiveUsed >= myUser.starting_tokens}
+            currentEpoch={currentEpoch}
+          />
+        )}
+      </SingleColumnLayout>
+    </Box>
   );
 };
 


### PR DESCRIPTION

## Motivation and Context

<!-- Why is this change required? What problem does it solve? This can be omitted if a linked issue is provided
-->
This is the last step need to ship contributions: defaulting to GiveBeta so contributions are visible during the allocation process.

## Description

<!-- Describe your changes -->
An opt-out button has been added to a banner so folks can go back to the
original allocations flow if they want.

The Nav bar `Allocations` button directs to GiveBeta and the `CircleRow`
button for Allocations also now links to GiveBeta. Please let me know if
I'm missing anything else.


## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
This should be merged  before #1518.
n.b. #1516 also should be merged before #1518.

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->
![image](https://user-images.githubusercontent.com/17910833/196517062-e599d82b-e3aa-4bca-812a-50b96c20adf0.png)


## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->
@CryptoGraffe 

## Related Issue

<!-- Please link to the issue here -->
