### PR TITLE
Use 4mb image limit to respect vercel's payload size

### DIFF
--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -1,6 +1,6 @@
 // this buffer is because the base64 size of the file is larger, base64 takes 4 chars to encode 3 bytes of data
 // and the client limits file to 10MB - we need to make sure we have enough room to handle the base64 overhead
 const base64Buffer = 4 / 3;
-export const MAX_IMAGE_BYTES_LENGTH = 10 * 1024 * 1024; // 10MB+buffer
+export const MAX_IMAGE_BYTES_LENGTH = 4 * 1024 * 1024; // 4MB+buffer
 export const MAX_IMAGE_BYTES_LENGTH_BASE64 =
   MAX_IMAGE_BYTES_LENGTH / base64Buffer;


### PR DESCRIPTION
Seems the root cause of the image upload woes are that Vercel has a 4.5mb payload size limit, which we've been exceeding. Update FE UIs validation to support this limit.

https://vercel.com/docs/concepts/limits/overview#serverless-function-payload-size-limit