### PR TITLE
Fix For New Contributions Spam

### DIFF
--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -140,24 +140,19 @@ const ContributionsPage = () => {
   } = useMutation(createContributionMutation, {
     onSuccess: newContribution => {
       refetchContributions();
-      if (
-        newContribution.insert_contributions_one?.id ===
-        currentContribution?.contribution.id
-      ) {
-        if (newContribution.insert_contributions_one) {
-          resetField('description', {
-            defaultValue: newContribution.insert_contributions_one.description,
-          });
-          setCurrentContribution({
-            contribution: {
-              ...newContribution.insert_contributions_one,
-              next: () => data?.contributions[1],
-              prev: () => undefined,
-              idx: 0,
-            },
-            epoch: getCurrentEpoch(data?.epochs ?? []),
-          });
-        }
+      if (newContribution.insert_contributions_one) {
+        resetField('description', {
+          defaultValue: newContribution.insert_contributions_one.description,
+        });
+        setCurrentContribution({
+          contribution: {
+            ...newContribution.insert_contributions_one,
+            next: () => data?.contributions[0],
+            prev: () => undefined,
+            idx: 0,
+          },
+          epoch: getCurrentEpoch(data?.epochs ?? []),
+        });
       } else {
         resetCreateMutation();
       }
@@ -239,7 +234,6 @@ const ContributionsPage = () => {
       );
     }
     resetUpdateMutation();
-    resetCreateMutation();
   }, [descriptionField.value, currentContribution?.contribution.id]);
 
   const mutationStatus = () =>

--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -425,7 +425,7 @@ const ContributionsPage = () => {
                   name="description"
                   control={control}
                   defaultValue={currentContribution.contribution.description}
-                  areaProps={{ rows: 18 }}
+                  areaProps={{ rows: 18, autoFocus: true }}
                   disabled={!isEpochCurrent(currentContribution.epoch)}
                   textArea
                 />


### PR DESCRIPTION
## Description

The new contributions drawer had this regression where each modification
to the text generated a new contribution.

Normal behavior is now restored, and the new contribution drawer
seamlessly converts to "edit contribution" behavior after the initial
save.

## Test plan

Create a contribution and let it save. Ensure that any changes after the
initial save modify the newly created contribution and don't create any
more new contributions

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->
![Peek 2022-10-19 09-44](https://user-images.githubusercontent.com/17910833/196724028-12c3aa3b-4f0b-44dd-97f8-536c6aa1ab4b.gif)

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->
@wingfeatherwave 
