### PR TITLE
Quick bugfixes for epoch statement and routing

### DIFF
--- a/src/pages/GivePage/EpochStatementDrawer.tsx
+++ b/src/pages/GivePage/EpochStatementDrawer.tsx
@@ -92,12 +92,17 @@ export const EpochStatementDrawer = ({
   const statementChanged = (newStatement: string) => {
     setStatement(newStatement);
     setSaving('buffering');
-    scheduleSaveStatement();
+    scheduleSaveStatement(saveStatement, newStatement);
   };
 
   // TODO: is this gonna not really debounce because of the statement dependency
   const scheduleSaveStatement = useCallback(
-    debounce(() => saveStatement(statement), DEBOUNCE_TIMEOUT),
+    debounce(
+      // pass in the latest instantiations so we're saving the
+      // newest state
+      (s: typeof saveStatement, statement: string) => s(statement),
+      DEBOUNCE_TIMEOUT
+    ),
     [saveStatement]
   );
 

--- a/src/pages/HistoryPage/CurrentEpochPanel.tsx
+++ b/src/pages/HistoryPage/CurrentEpochPanel.tsx
@@ -86,7 +86,7 @@ export const CurrentEpochPanel = ({
               ? `Allocate Your Remaining ${unallocated} ${tokenName}`
               : `No More ${tokenName} to Allocate`
           }
-          path={paths.allocation(circleId)}
+          path={paths.givebeta(circleId)}
           linkLabel="Allocate to Teammates"
         />
       </Flex>


### PR DESCRIPTION
the epoch statement save function was caching only on the backend
entrypoint and nothing else. This fixes that issue.

Additionally the "Allocate" button in the Current Epoch Panel was
pointing to the old allocations flow instead of givebeta
