### PR TITLE
Hide irrelevant epochs and integrated contributions

### DIFF
--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -608,26 +608,29 @@ const EpochGroup = React.memo(function EpochGroup({
 
 type ContributionListProps = {
   contributions: Array<LinkedElement<Contribution>>;
-};
+  epoch: LinkedElement<Epoch>;
+  userAddress?: string;
+} & SetActiveContributionProps;
 const ContributionList = ({
   epoch,
   contributions,
   setActiveContribution,
   currentContribution,
-  latestEpochEndDate,
   userAddress,
-}: ContributionListProps &
-  SetActiveContributionProps & {
-    epoch: LinkedElement<Epoch>;
-    latestEpochEndDate?: string;
-    userAddress?: string;
-  }) => {
-  const currentDateTime = useMemo(() => DateTime.now().toISO(), []);
-
+}: ContributionListProps) => {
+  // epochs are listed in chronologically descending order
+  // so the next epoch in the array is the epoch that ended
+  // before the one here
+  const priorEpoch = epoch.next();
   const integrationContributions = useContributions({
     address: userAddress || '',
-    startDate: epoch ? epoch.next()?.end_date : latestEpochEndDate,
-    endDate: epoch ? epoch.end_date : currentDateTime,
+    startDate: priorEpoch
+      ? priorEpoch.end_date
+      : // add a buffer of time before the start date if this is the first epoch
+        // Querying from epoch time 0 is apparently an unwelcome
+        // practice for some integrators
+        DateTime.fromISO(epoch.start_date).minus({ months: 1 }).toISO(),
+    endDate: epoch.end_date,
     mock: false,
   });
 

--- a/src/pages/ContributionsPage/queries.ts
+++ b/src/pages/ContributionsPage/queries.ts
@@ -1,7 +1,18 @@
 import { order_by } from 'lib/gql/__generated__/zeus';
 import { client } from 'lib/gql/client';
+import { DateTime } from 'luxon';
+
+import { IN_PRODUCTION } from 'config/env';
 
 import { Awaited } from 'types/shim';
+
+// avoid rendering any epochs from before the launch date
+// yesterday
+const endDateInProd = IN_PRODUCTION
+  ? {
+      _gt: DateTime.fromISO('2022-10-19T00:00:00Z').toISO(),
+    }
+  : undefined;
 
 export const getContributionsAndEpochs = async ({
   circleId,
@@ -39,6 +50,7 @@ export const getContributionsAndEpochs = async ({
         where: {
           circle_id: { _eq: circleId },
           id: epochId ? { _eq: epochId } : undefined,
+          end_date: endDateInProd,
         },
         order_by: [{ end_date: order_by.desc }],
       },


### PR DESCRIPTION
Integrator APIs can return errors if our filters are too large. Intead
of querying for all contributions since the beginning of time for an
initial epoch in a circle, we now query only back to the month before
the epoch started.

In the Contributions Page, Epochs that ended before the Contributions
feature was launched are now hidden.

Potential Future work: optionally hide all epochs with no contributions
