### PR TITLE
Fixup/contributions allocations UI fixes

### DIFF
--- a/src/components/FormInputField.tsx
+++ b/src/components/FormInputField.tsx
@@ -20,6 +20,7 @@ type TFormInputField<TFieldValues extends FieldValues> = {
   textArea?: boolean;
   infoTooltip?: string;
   description?: string;
+  placeholder?: string;
   inputProps?: TextFieldProps;
   areaProps?: TextAreaProps;
   control: Control<TFieldValues>;
@@ -47,6 +48,7 @@ export const FormInputField = <TFieldValues extends FieldValues>(
     css,
     number,
     showFieldErrors,
+    placeholder,
   } = props;
 
   const { field, fieldState } = useController({
@@ -119,6 +121,7 @@ export const FormInputField = <TFieldValues extends FieldValues>(
           {...areaProps}
           error={!!fieldState.error}
           disabled={disabled}
+          placeholder={placeholder}
         />
       )}
       {showFieldErrors && fieldState.error && (

--- a/src/components/MainLayout/MainHeader.tsx
+++ b/src/components/MainLayout/MainHeader.tsx
@@ -66,6 +66,9 @@ const NormalHeader = ({ inCircle }: { inCircle: boolean }) => {
           justifyContent: 'space-between',
           alignItems: 'center',
           position: 'relative',
+          '@md': {
+            a: { fontSize: '$md' },
+          },
         }}
       >
         <OverviewMenu data={query.data} />
@@ -87,7 +90,14 @@ const NormalHeader = ({ inCircle }: { inCircle: boolean }) => {
         </Box>
         {inCircle && (
           <Suspense fallback={null}>
-            <Box css={{ mr: '$md' }}>
+            <Box
+              css={{
+                mr: '$md',
+                '@md': {
+                  button: { fontSize: '$xs' },
+                },
+              }}
+            >
               <ReceiveInfo />
             </Box>
           </Suspense>

--- a/src/components/MainLayout/MainHeader.tsx
+++ b/src/components/MainLayout/MainHeader.tsx
@@ -94,7 +94,7 @@ const NormalHeader = ({ inCircle }: { inCircle: boolean }) => {
               css={{
                 mr: '$md',
                 '@md': {
-                  button: { fontSize: '$xs' },
+                  scale: 0.8,
                 },
               }}
             >

--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -21,6 +21,7 @@ import {
   Save,
   ChevronDown,
   ChevronUp,
+  RefreshCcw,
 } from 'icons/__generated';
 import { Panel, Text, Box, Modal, Button, Flex } from 'ui';
 import { SingleColumnLayout } from 'ui/layouts';
@@ -426,70 +427,84 @@ const ContributionsPage = () => {
                   ).toFormat('LLL dd')}
                 </Text>
               </Text>
-              {isEpochCurrent(currentContribution.epoch) ? (
-                <FormInputField
-                  id="description"
-                  name="description"
-                  control={control}
-                  defaultValue={currentContribution.contribution.description}
-                  areaProps={{ rows: 18, autoFocus: true }}
-                  disabled={!isEpochCurrent(currentContribution.epoch)}
-                  textArea
-                />
-              ) : (
-                <Panel nested>
-                  <Text p>{currentContribution.contribution.description}</Text>
-                </Panel>
-              )}
-              {isEpochCurrent(currentContribution.epoch) && (
-                <Flex
-                  css={{
-                    justifyContent: 'space-between',
-                    mt: '$lg',
-                    flexDirection: 'row-reverse',
-                  }}
-                >
-                  <Flex css={{ gap: '$md' }}>
-                    <Text
-                      css={{ gap: '$sm' }}
-                      color={updateStatus === 'error' ? 'alert' : 'neutral'}
-                    >
-                      {mutationStatus() === 'loading' && (
-                        <>
-                          <Save />
-                          Saving...
-                        </>
-                      )}
-                      {(updateStatus === 'success' ||
-                        (createStatus === 'success' &&
-                          updateStatus === 'idle')) && (
-                        <>
-                          <Check /> Changes Saved
-                        </>
-                      )}
-                      {mutationStatus() === 'error' && isDirty && (
-                        <>
-                          <AlertTriangle />
-                          Error
-                        </>
-                      )}
+              <Flex column css={{ gap: '$sm' }}>
+                <Text inline semibold size="large">
+                  Contribution
+                </Text>
+                {isEpochCurrent(currentContribution.epoch) ? (
+                  <FormInputField
+                    id="description"
+                    name="description"
+                    control={control}
+                    defaultValue={currentContribution.contribution.description}
+                    areaProps={{ autoFocus: true }}
+                    disabled={!isEpochCurrent(currentContribution.epoch)}
+                    placeholder="What have you been working on?"
+                    textArea
+                  />
+                ) : (
+                  <Panel nested>
+                    <Text p>
+                      {currentContribution.contribution.description}
                     </Text>
-                  </Flex>
-                  <Button
-                    outlined
-                    color="destructive"
-                    size="medium"
-                    onClick={() => {
-                      handleDebouncedDescriptionChange.cancel();
-                      deleteContribution({
-                        contribution_id: currentContribution.contribution.id,
-                      });
+                  </Panel>
+                )}
+                {isEpochCurrent(currentContribution.epoch) && (
+                  <Flex
+                    css={{
+                      justifyContent: 'space-between',
+                      mt: '$sm',
                     }}
                   >
-                    Delete
-                  </Button>
-                </Flex>
-              )}
+                    <Button
+                      outlined
+                      color="destructive"
+                      size="small"
+                      onClick={() => {
+                        handleDebouncedDescriptionChange.cancel();
+                        deleteContribution({
+                          contribution_id: currentContribution.contribution.id,
+                        });
+                      }}
+                    >
+                      Delete
+                    </Button>
+                    <Flex css={{ gap: '$sm' }}>
+                      <Text
+                        size="small"
+                        css={{ gap: '$sm' }}
+                        color={updateStatus === 'error' ? 'alert' : 'neutral'}
+                      >
+                        {updateStatus === 'idle' && (
+                          <>
+                            <RefreshCcw />
+                            Autosave Enabled
+                          </>
+                        )}
+                        {mutationStatus() === 'loading' && (
+                          <>
+                            <Save />
+                            Saving...
+                          </>
+                        )}
+                        {(updateStatus === 'success' ||
+                          (createStatus === 'success' &&
+                            updateStatus === 'idle')) && (
+                          <>
+                            <Check /> Changes Saved
+                          </>
+                        )}
+                        {mutationStatus() === 'error' && isDirty && (
+                          <>
+                            <AlertTriangle />
+                            Error
+                          </>
+                        )}
+                      </Text>
+                    </Flex>
+                  </Flex>
+                )}
+              </Flex>
             </>
           ) : currentIntContribution ? (
             <>
@@ -644,6 +659,7 @@ const ContributionList = ({
                     ? '2px solid $link'
                     : '2px solid $border',
                 cursor: 'pointer',
+                transition: 'background-color 0.3s, border-color 0.3s',
                 background:
                   currentContribution?.contribution.id === c.id
                     ? '$highlight'

--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -415,21 +415,41 @@ const ContributionsPage = () => {
                   <ChevronDown size="lg" />
                 </Button>
               </Flex>
-              <Text h2 css={{ gap: '$md', my: '$xl' }}>
-                {currentContribution.epoch.id
-                  ? renderEpochDate(currentContribution.epoch)
-                  : 'Latest'}
+              <Flex
+                css={{
+                  alignItems: 'center',
+                  my: '$xl',
+                }}
+              >
+                <Text
+                  h3
+                  semibold
+                  css={{
+                    mr: '$md',
+                  }}
+                >
+                  {currentContribution.epoch.id
+                    ? renderEpochDate(currentContribution.epoch)
+                    : 'Latest'}
+                </Text>
                 {getEpochLabel(currentContribution.epoch)}
-                <Text p>
-                  {DateTime.fromISO(
-                    currentContribution.contribution.datetime_created
-                  ).toFormat('LLL dd')}
-                </Text>
-              </Text>
+              </Flex>
               <Flex column css={{ gap: '$sm' }}>
-                <Text inline semibold size="large">
-                  Contribution
-                </Text>
+                <Flex
+                  css={{
+                    justifyContent: 'space-between',
+                    alignItems: 'flex-end',
+                  }}
+                >
+                  <Text inline semibold size="medium">
+                    Contribution
+                  </Text>
+                  <Text variant="label">
+                    {DateTime.fromISO(
+                      currentContribution.contribution.datetime_created
+                    ).toFormat('LLL dd')}
+                  </Text>
+                </Flex>
                 {isEpochCurrent(currentContribution.epoch) ? (
                   <FormInputField
                     id="description"

--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -481,8 +481,7 @@ const ContributionsPage = () => {
                           </>
                         )}
                         {(updateStatus === 'success' ||
-                          (currentContribution.contribution.description.length >
-                            0 &&
+                          (createStatus === 'success' &&
                             updateStatus === 'idle')) && (
                           <>
                             <Check /> Saved

--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -21,7 +21,6 @@ import {
   Save,
   ChevronDown,
   ChevronUp,
-  RefreshCcw,
 } from 'icons/__generated';
 import { Panel, Text, Box, Modal, Button, Flex } from 'ui';
 import { SingleColumnLayout } from 'ui/layouts';
@@ -475,12 +474,6 @@ const ContributionsPage = () => {
                         css={{ gap: '$sm' }}
                         color={updateStatus === 'error' ? 'alert' : 'neutral'}
                       >
-                        {updateStatus === 'idle' && (
-                          <>
-                            <RefreshCcw />
-                            Autosave Enabled
-                          </>
-                        )}
                         {mutationStatus() === 'loading' && (
                           <>
                             <Save />
@@ -488,10 +481,11 @@ const ContributionsPage = () => {
                           </>
                         )}
                         {(updateStatus === 'success' ||
-                          (createStatus === 'success' &&
+                          (currentContribution.contribution.description.length >
+                            0 &&
                             updateStatus === 'idle')) && (
                           <>
-                            <Check /> Changes Saved
+                            <Check /> Saved
                           </>
                         )}
                         {mutationStatus() === 'error' && isDirty && (

--- a/src/pages/GivePage/Contribution.tsx
+++ b/src/pages/GivePage/Contribution.tsx
@@ -1,4 +1,5 @@
-import { Panel, Text } from '../../ui';
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { Box, Panel, Text } from '../../ui';
 
 import { Contributions } from './queries';
 
@@ -9,10 +10,16 @@ export const Contribution = ({
   contribution: Contributions[number];
 }) => {
   return (
-    <Panel background css={{ mb: '$md', padding: '$sm' }}>
-      <Panel nested>
-        <Text p>{contribution.description}</Text>
-      </Panel>
-    </Panel>
+    <Box
+      css={{
+        mb: '$xs',
+        p: '$md $sm',
+        borderBottom: '1px solid $border',
+      }}
+    >
+      <Text p css={{ lineHeight: '$shorter' }}>
+        {contribution.description}
+      </Text>
+    </Box>
   );
 };

--- a/src/pages/GivePage/EpochStatementDrawer.tsx
+++ b/src/pages/GivePage/EpochStatementDrawer.tsx
@@ -200,8 +200,13 @@ export const EpochStatementDrawer = ({
           onChange={e => statementChanged(e.target.value)}
           placeholder="Summarize your Contributions"
         />
-        <Flex css={{ justifyContent: 'flex-end', alignItems: 'center' }}>
-          <SavingIndicator saveState={saving} css={{ mr: '$md' }} />
+        <Flex
+          css={{ justifyContent: 'flex-end', alignItems: 'center', mt: '$sm' }}
+        >
+          {statement && statement?.length > 0 && (
+            <SavingIndicator saveState={saving} />
+          )}
+          &nbsp;
         </Flex>
       </Flex>
 

--- a/src/pages/GivePage/EpochStatementDrawer.tsx
+++ b/src/pages/GivePage/EpochStatementDrawer.tsx
@@ -203,10 +203,7 @@ export const EpochStatementDrawer = ({
         <Flex
           css={{ justifyContent: 'flex-end', alignItems: 'center', mt: '$sm' }}
         >
-          {statement && statement?.length > 0 && (
-            <SavingIndicator saveState={saving} />
-          )}
-          &nbsp;
+          <SavingIndicator saveState={saving} />
         </Flex>
       </Flex>
 

--- a/src/pages/GivePage/EpochStatementDrawer.tsx
+++ b/src/pages/GivePage/EpochStatementDrawer.tsx
@@ -186,21 +186,15 @@ export const EpochStatementDrawer = ({
           </Flex>
         </Flex>
       </Flex>
-      <Box css={{ mt: '$xl' }}>
-        <Box>
-          <Text inline semibold size="large" css={{ mr: '$xs' }}>
-            Epoch Statement
-          </Text>
-          {/*<ApeInfoTooltip>*/}
-          {/*  Not sure what goes here yet */}
-          {/*</ApeInfoTooltip>*/}
-        </Box>
+      <Flex css={{ flexDirection: 'column', mt: '$xl', gap: '$sm' }}>
+        <Text inline semibold size="large">
+          Epoch Statement
+        </Text>
         <TextArea
           css={{
             backgroundColor: 'white',
             width: '100%',
-            mt: '$xs',
-            mb: '$md',
+            fontSize: '$medium',
           }}
           value={statement}
           onChange={e => statementChanged(e.target.value)}
@@ -209,7 +203,7 @@ export const EpochStatementDrawer = ({
         <Flex css={{ justifyContent: 'flex-end', alignItems: 'center' }}>
           <SavingIndicator saveState={saving} css={{ mr: '$md' }} />
         </Flex>
-      </Box>
+      </Flex>
 
       <Box
         css={{

--- a/src/pages/GivePage/GiveDrawer.tsx
+++ b/src/pages/GivePage/GiveDrawer.tsx
@@ -214,10 +214,7 @@ export const GiveDrawer = ({
           placeholder="Say thanks or give constructive feedback."
         />
         <Flex css={{ justifyContent: 'flex-end', alignItems: 'center' }}>
-          {note && note?.length > 0 && (
-            <SavingIndicator saveState={saveState} />
-          )}
-          &nbsp;
+          <SavingIndicator saveState={saveState} />
         </Flex>
       </Box>
 

--- a/src/pages/GivePage/GiveDrawer.tsx
+++ b/src/pages/GivePage/GiveDrawer.tsx
@@ -207,6 +207,7 @@ export const GiveDrawer = ({
             width: '100%',
             mt: '$xs',
             mb: '$md',
+            fontSize: '$medium',
           }}
           value={note ?? ''}
           onChange={e => noteChanged(e.target.value)}
@@ -230,7 +231,7 @@ export const GiveDrawer = ({
               Epoch Statement
             </Text>
             <Box css={{ mt: '$sm', pb: '$lg' }}>
-              <Panel nested css={{ mb: '$md' }}>
+              <Panel nested css={{ mb: '$md', p: '$sm' }}>
                 <Text p>{member.bio}</Text>
               </Panel>
             </Box>

--- a/src/pages/GivePage/GiveDrawer.tsx
+++ b/src/pages/GivePage/GiveDrawer.tsx
@@ -214,7 +214,10 @@ export const GiveDrawer = ({
           placeholder="Say thanks or give constructive feedback."
         />
         <Flex css={{ justifyContent: 'flex-end', alignItems: 'center' }}>
-          <SavingIndicator saveState={saveState} css={{ mr: '$md' }} />
+          {note && note?.length > 0 && (
+            <SavingIndicator saveState={saveState} />
+          )}
+          &nbsp;
         </Flex>
       </Box>
 

--- a/src/pages/GivePage/SavingIndicator.tsx
+++ b/src/pages/GivePage/SavingIndicator.tsx
@@ -26,14 +26,14 @@ export const SavingIndicator = ({
   css?: CSS;
 }) => {
   return (
-    <Flex css={{ ...css, alignItems: 'center' }}>
+    <Flex css={{ ...css, minHeight: '$lg', alignItems: 'center' }}>
       <Text size="small" color="neutral" css={{ gap: '$xs' }}>
         {(saveState == 'saving' || saveState == 'scheduled') && (
           <>
             <RefreshCcw /> Saving Changes
           </>
         )}
-        {(saveState == 'saved' || saveState == 'stable') && (
+        {saveState == 'saved' && (
           <>
             <Check /> Saved
           </>

--- a/src/pages/GivePage/SavingIndicator.tsx
+++ b/src/pages/GivePage/SavingIndicator.tsx
@@ -26,16 +26,16 @@ export const SavingIndicator = ({
   css?: CSS;
 }) => {
   return (
-    <Flex css={{ ...css, minHeight: '$lg', alignItems: 'center' }}>
+    <Flex css={{ ...css, alignItems: 'center' }}>
       <Text size="small" color="neutral" css={{ gap: '$xs' }}>
         {(saveState == 'saving' || saveState == 'scheduled') && (
           <>
             <RefreshCcw /> Saving Changes
           </>
         )}
-        {saveState == 'saved' && (
+        {(saveState == 'saved' || saveState == 'stable') && (
           <>
-            <Check /> Changes Saved!
+            <Check /> Saved
           </>
         )}
       </Text>

--- a/src/ui/Text/Text.tsx
+++ b/src/ui/Text/Text.tsx
@@ -31,16 +31,24 @@ export const Text = styled('span', {
     inline: { true: { display: 'inline !important' } },
 
     h1: {
-      true: { fontSize: '$h1', color: '$headingText', fontWeight: '$semibold' },
+      true: {
+        fontSize: '$h1',
+        color: '$headingText',
+        fontWeight: '$semibold',
+        '@sm': { fontSize: '$h2' },
+      },
     },
     h2: {
       true: {
         fontSize: '$h2',
         fontWeight: '$semibold',
         lineHeight: '$shorter',
+        '@sm': { fontSize: '$h3' },
       },
     },
-    h3: { true: { fontSize: '$h3' } },
+    h3: {
+      true: { fontSize: '$h3', '@sm': { fontSize: '$large' } },
+    },
 
     size: {
       small: { fontSize: '$small !important', lineHeight: '$shorter' },


### PR DESCRIPTION
UI fixes for allocations and contributions

* line height and font size unification / dialing for drawer fields
~~* persistent `✔ Saved` indicator for when text has been saved in the past (ie: not blank)~~
* css animations for hover states 
* remove double panel bubbles for contributions in give drawer.  use separator lines instead

TBD: adding an `Autosave` hint text beneath the initial form field to be edited.
