### PR TITLE
bugfix: contribution text resets on save

### DIFF
--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -149,7 +149,11 @@ const ContributionsPage = () => {
   } = useMutation(createContributionMutation, {
     onSuccess: newContribution => {
       refetchContributions();
-      if (newContribution.insert_contributions_one) {
+      if (
+        newContribution.insert_contributions_one &&
+        newContribution.insert_contributions_one.id ===
+          currentContribution?.contribution.id
+      ) {
         setSaveState('saved');
         setCurrentContribution({
           contribution: {
@@ -162,7 +166,6 @@ const ContributionsPage = () => {
           epoch: getCurrentEpoch(data?.epochs ?? []),
         });
       } else {
-        setSaveState('stable');
         resetCreateMutation();
       }
     },
@@ -179,7 +182,12 @@ const ContributionsPage = () => {
     },
     onSuccess: ({ updateContribution }) => {
       setSaveState('saved');
-      if (currentContribution && updateContribution)
+      if (
+        currentContribution &&
+        updateContribution &&
+        updateContribution.updateContribution_Contribution.id ===
+          currentContribution?.contribution.id
+      )
         setCurrentContribution({
           ...currentContribution,
           contribution: {
@@ -386,6 +394,7 @@ const ContributionsPage = () => {
                         prevContribution.datetime_created
                       ),
                     });
+                    setSaveState('stable');
                     resetField('description', {
                       defaultValue: prevContribution.description,
                     });
@@ -414,6 +423,7 @@ const ContributionsPage = () => {
                         nextContribution.datetime_created
                       ),
                     });
+                    setSaveState('stable');
                     resetField('description', {
                       defaultValue: nextContribution.description,
                     });


### PR DESCRIPTION
When auto-saving contribution text on a higher-latency connection, the
textarea was resetting to the saved state, even if the user had entered
more text after the save request was initiated.

This has been remedied by simply not resetting the textArea's "dirty"
state check on save anymore.

Additionally, the save state info text now more closely behaves like
that of the Give Page.

## Test Plan:
This is most easily tested by logging out the `saveState` variable in
ContributionsPage.ts to the browser console, and adding a delay to
actionManager.ts, eg:
```js
const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
```
Add a `delay` call right before the handler is invoked on line 85

1. type some text and wait for the `saveState` variable to log as `saving`
2. type more text during the `saving` period
3. observe that text area state does not revert to the text string that
   was saved
4. ensure the save state text in the UI behaves as expected
