### PR TITLE
Minor UI fixes: leave circle error notification, button colors

### DIFF
--- a/src/pages/MembersPage/LeaveCircleModal.tsx
+++ b/src/pages/MembersPage/LeaveCircleModal.tsx
@@ -43,7 +43,6 @@ export const LeaveCircleModal = ({
     reset,
     formState: { isValid },
   } = useForm<LeaveCircleFormSchema>({
-    shouldUseNativeValidation: false,
     mode: 'all',
     resolver: zodResolver(schema),
   });

--- a/src/pages/MembersPage/LeaveCircleModal.tsx
+++ b/src/pages/MembersPage/LeaveCircleModal.tsx
@@ -48,7 +48,7 @@ export const LeaveCircleModal = ({
     reset,
     formState: { errors, isDirty },
   } = useForm<LeaveCircleFormSchema>({
-    shouldUseNativeValidation: true,
+    shouldUseNativeValidation: false,
     mode: 'all',
     resolver: zodResolver(schema),
   });
@@ -92,6 +92,7 @@ export const LeaveCircleModal = ({
             control={control}
             label="Enter the team`s name to leave it"
             css={{ width: '100%' }}
+            showFieldErrors
           ></FormInputField>
           <Flex css={{ width: '100%', gap: '$lg' }}>
             <Button

--- a/src/pages/MembersPage/LeaveCircleModal.tsx
+++ b/src/pages/MembersPage/LeaveCircleModal.tsx
@@ -81,8 +81,8 @@ export const LeaveCircleModal = ({
               {circleName} Circle
             </Text>
             {epochIsActive
-              ? ' . Opting out during an in-progress epoch will result in any GIVEs you have received being returned to senders. Are you sure you wish to proceed? This cannot be undone.'
-              : '. Leaving this circle, You will no longer have access to any of the information in the circle.'}
+              ? '? Opting out during an in-progress epoch will result in any GIVEs you have received being returned to senders. Are you sure you wish to proceed? This cannot be undone.'
+              : '? Leaving this circle, You will no longer have access to any of the information in the circle.'}
           </Text>
 
           <FormInputField
@@ -90,7 +90,7 @@ export const LeaveCircleModal = ({
             name="circle_name"
             defaultValue=""
             control={control}
-            label="Enter the team`s name to leave it"
+            label="Enter the team's name to leave it"
             css={{ width: '100%' }}
             showFieldErrors
           ></FormInputField>

--- a/src/pages/MembersPage/LeaveCircleModal.tsx
+++ b/src/pages/MembersPage/LeaveCircleModal.tsx
@@ -1,6 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { deleteUser } from 'lib/gql/mutations';
-import isEmpty from 'lodash/isEmpty';
 import { useForm } from 'react-hook-form';
 import { useQueryClient } from 'react-query';
 import { useNavigate } from 'react-router';
@@ -28,13 +27,9 @@ export const LeaveCircleModal = ({
 }) => {
   const schema = z
     .object({
-      circle_name: z
-        .string({
-          required_error: 'Please enter the circle name',
-        })
-        .refine(c => c === circleName, {
-          message: 'Please match the circle name',
-        }),
+      circle_name: z.string().refine(c => c === circleName, {
+        message: "Circle name doesn't match",
+      }),
     })
     .strict();
   type LeaveCircleFormSchema = z.infer<typeof schema>;
@@ -46,7 +41,7 @@ export const LeaveCircleModal = ({
     handleSubmit,
     control,
     reset,
-    formState: { errors, isDirty },
+    formState: { isValid },
   } = useForm<LeaveCircleFormSchema>({
     shouldUseNativeValidation: false,
     mode: 'all',
@@ -67,34 +62,39 @@ export const LeaveCircleModal = ({
   return (
     <Modal
       open={!!leaveCircleDialog}
-      title={'Are you sure ?'}
+      title={`Leave the ${circleName} Circle?`}
       onClose={() => {
         reset();
         setLeaveCircleDialog(undefined);
       }}
     >
       <Form onSubmit={handleSubmit(onSubmit)}>
-        <Flex column alignItems="start" css={{ gap: '$xl' }}>
-          <Text inline size="medium">
-            Are you sure you want to leave the{' '}
-            <Text inline bold>
-              {circleName} Circle
-            </Text>
+        <Flex column alignItems="start" css={{ gap: '$md' }}>
+          <Text p>
             {epochIsActive
-              ? '? Opting out during an in-progress epoch will result in any GIVEs you have received being returned to senders. Are you sure you wish to proceed? This cannot be undone.'
-              : '? Leaving this circle, You will no longer have access to any of the information in the circle.'}
+              ? 'This circle has an in-progress epoch. If you leave now, you will forfeit all GIVE received this epoch.'
+              : 'If you leave this circle you will no longer have access to any circle information or future epochs.'}
           </Text>
-
+          <Text p>
+            Are you sure you wish to proceed? This cannot be undone.
+          </Text>
+          <Text p>
+            Please type the circle name{' '}
+            <Text bold inline>
+              {circleName}
+            </Text>{' '}
+            to confirm.
+          </Text>
           <FormInputField
             id="circle_name"
             name="circle_name"
             defaultValue=""
             control={control}
-            label="Enter the team's name to leave it"
-            css={{ width: '100%' }}
+            label="Circle name"
+            css={{ width: '100%', mt: '$md' }}
             showFieldErrors
           ></FormInputField>
-          <Flex css={{ width: '100%', gap: '$lg' }}>
+          <Flex css={{ width: '100%', gap: '$lg', mt: '$md' }}>
             <Button
               onClick={() => {
                 reset();
@@ -111,7 +111,7 @@ export const LeaveCircleModal = ({
               color="destructive"
               size="large"
               css={{ width: '50%' }}
-              disabled={!isEmpty(errors) || !isDirty}
+              disabled={!isValid}
               type="submit"
             >
               Leave Circle

--- a/src/pages/MembersPage/MembersTable.tsx
+++ b/src/pages/MembersPage/MembersTable.tsx
@@ -316,7 +316,7 @@ const MemberRow = ({
               }}
             >
               {!user.non_giver ? (
-                <Check color="complete" />
+                <Check size="lg" color="complete" />
               ) : (
                 <X size="lg" color="neutral" />
               )}
@@ -350,7 +350,7 @@ const MemberRow = ({
           }}
         >
           {user.role === USER_ROLE_ADMIN ? (
-            <Check color="complete" />
+            <Check size="lg" color="complete" />
           ) : (
             <X size="lg" color="neutral" />
           )}
@@ -426,7 +426,7 @@ const MemberRow = ({
             user.id === me.id && (
               <Button
                 color="destructive"
-                size="medium"
+                size="small"
                 outlined
                 css={{
                   mr: 0,

--- a/src/ui/Button/Button.tsx
+++ b/src/ui/Button/Button.tsx
@@ -153,13 +153,10 @@ export const Button = styled('button', {
           height: '$lg',
           width: '$lg',
         },
-        '&:hover': {
-          color: '$secondary',
-          background: '$surface',
-        },
-        '&:focus': {
-          color: '$secondary',
-          background: '$surface',
+        '&:hover, &:focus': {
+          filter: 'saturate(1)',
+          color: '$primary',
+          background: '$background',
         },
         '&:disabled': {
           color: '$text',
@@ -232,7 +229,7 @@ export const Button = styled('button', {
       color: 'neutral',
       outlined: true,
       css: {
-        color: '$text',
+        color: '$neutral',
         borderColor: '$neutral',
         '&:hover, &:focus': {
           color: '$white',


### PR DESCRIPTION
Using our below-field errors instead of the native html5 error popover
<img width="709" alt="Screen Shot 2022-10-25 at 11 14 22 AM" src="https://user-images.githubusercontent.com/100873710/197850413-65962ede-9dd9-480a-a136-cc002f277db8.png">
