### PR TITLE
fix for error seen by user where the tokenGift.sender is null

### DIFF
--- a/src/components/ReceiveInfo.tsx
+++ b/src/components/ReceiveInfo.tsx
@@ -126,7 +126,9 @@ export const ReceiveInfo = () => {
           </PopoverClose>
           {gifts
             ?.filter(
-              tokenGift => tokenGift.tokens > 0 || tokenGift.gift_private?.note
+              tokenGift =>
+                tokenGift.sender &&
+                (tokenGift.tokens > 0 || tokenGift.gift_private?.note)
             )
             ?.sort(
               (a, b) => +new Date(b.dts_created) - +new Date(a.dts_created)


### PR DESCRIPTION
## Motivation and Context

User hitting error with deleted user as sender in tokenGift

## Description

workaround this in UI for now by checking for null
