### PR TITLE
Refactor SavingIndicator; add retry to Allocations & Contributions

### DIFF
--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -16,13 +16,10 @@ import {
 import {
   DeworkColor,
   WonderColor,
-  Check,
-  AlertTriangle,
-  RefreshCcw,
   ChevronDown,
   ChevronUp,
 } from 'icons/__generated';
-import { SaveState } from 'pages/GivePage/SavingIndicator';
+import { SavingIndicator, SaveState } from 'pages/GivePage/SavingIndicator';
 import { Panel, Text, Box, Modal, Button, Flex } from 'ui';
 import { SingleColumnLayout } from 'ui/layouts';
 
@@ -178,7 +175,11 @@ const ContributionsPage = () => {
     reset: resetUpdateMutation,
   } = useMutation(updateContributionMutation, {
     mutationKey: ['updateContribution', currentContribution?.contribution.id],
-    onSettled: () => {
+    onSettled: e => {
+      updateSaveStateForContribution(
+        currentContribution?.contribution.id,
+        status
+      );
       //refetchContributions();
     },
     onSuccess: ({ updateContribution }) => {
@@ -525,34 +526,9 @@ const ContributionsPage = () => {
                     >
                       Delete
                     </Button>
-                    <Flex css={{ gap: '$sm' }}>
-                      <Text
-                        size="small"
-                        css={{ gap: '$sm' }}
-                        color={updateStatus === 'error' ? 'alert' : 'neutral'}
-                      >
-                        {(saveState[currentContribution.contribution.id] ===
-                          'saving' ||
-                          saveState[currentContribution.contribution.id] ===
-                            'scheduled') && (
-                          <>
-                            <RefreshCcw /> Saving...
-                          </>
-                        )}
-                        {saveState[currentContribution.contribution.id] ===
-                          'saved' && (
-                          <>
-                            <Check /> Saved
-                          </>
-                        )}
-                        {mutationStatus() === 'error' && isDirty && (
-                          <>
-                            <AlertTriangle />
-                            Error
-                          </>
-                        )}
-                      </Text>
-                    </Flex>
+                    <SavingIndicator
+                      saveState={saveState[currentContribution.contribution.id]}
+                    />
                   </Flex>
                 )}
               </Flex>

--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -19,9 +19,9 @@ import {
   ChevronDown,
   ChevronUp,
 } from 'icons/__generated';
-import { SavingIndicator, SaveState } from 'pages/GivePage/SavingIndicator';
 import { Panel, Text, Box, Modal, Button, Flex } from 'ui';
 import { SingleColumnLayout } from 'ui/layouts';
+import { SavingIndicator, SaveState } from 'ui/SavingIndicator';
 
 import {
   deleteContributionMutation,
@@ -139,35 +139,32 @@ const ContributionsPage = () => {
     control,
   });
 
-  const {
-    mutate: createContribution,
-    status: createStatus,
-    reset: resetCreateMutation,
-  } = useMutation(createContributionMutation, {
-    onSuccess: newContribution => {
-      refetchContributions();
-      if (newContribution.insert_contributions_one) {
-        updateSaveStateForContribution(0, 'stable');
-        updateSaveStateForContribution(
-          newContribution.insert_contributions_one.id,
-          'saved'
-        );
-        setCurrentContribution({
-          contribution: {
-            ...newContribution.insert_contributions_one,
-            description: descriptionField.value as string,
-            next: () => data?.contributions[0],
-            prev: () => undefined,
-            idx: 0,
-          },
-          epoch: getCurrentEpoch(data?.epochs ?? []),
-        });
-      } else {
-        updateSaveStateForContribution(0, 'stable');
-        resetCreateMutation();
-      }
-    },
-  });
+  const { mutate: createContribution, reset: resetCreateMutation } =
+    useMutation(createContributionMutation, {
+      onSuccess: newContribution => {
+        refetchContributions();
+        if (newContribution.insert_contributions_one) {
+          updateSaveStateForContribution(0, 'stable');
+          updateSaveStateForContribution(
+            newContribution.insert_contributions_one.id,
+            'saved'
+          );
+          setCurrentContribution({
+            contribution: {
+              ...newContribution.insert_contributions_one,
+              description: descriptionField.value as string,
+              next: () => data?.contributions[0],
+              prev: () => undefined,
+              idx: 0,
+            },
+            epoch: getCurrentEpoch(data?.epochs ?? []),
+          });
+        } else {
+          updateSaveStateForContribution(0, 'stable');
+          resetCreateMutation();
+        }
+      },
+    });
 
   const {
     mutate: mutateContribution,
@@ -175,18 +172,11 @@ const ContributionsPage = () => {
     reset: resetUpdateMutation,
   } = useMutation(updateContributionMutation, {
     mutationKey: ['updateContribution', currentContribution?.contribution.id],
-    onSettled: e => {
-      updateSaveStateForContribution(
-        currentContribution?.contribution.id,
-        status
-      );
-      //refetchContributions();
+    onError: (errors, { id }) => {
+      updateSaveStateForContribution(id, 'error');
     },
-    onSuccess: ({ updateContribution }) => {
-      updateSaveStateForContribution(
-        updateContribution?.updateContribution_Contribution?.id,
-        'saved'
-      );
+    onSuccess: ({ updateContribution }, { id }) => {
+      updateSaveStateForContribution(id, 'saved');
       if (
         currentContribution &&
         updateContribution?.updateContribution_Contribution
@@ -278,9 +268,6 @@ const ContributionsPage = () => {
     }
     resetUpdateMutation();
   }, [descriptionField.value, currentContribution?.contribution.id]);
-
-  const mutationStatus = () =>
-    currentContribution?.contribution.id === 0 ? createStatus : updateStatus;
 
   // prevents page re-renders when typing out a contribution
   // This seems pretty silly but it's actually a huge optimization
@@ -528,6 +515,10 @@ const ContributionsPage = () => {
                     </Button>
                     <SavingIndicator
                       saveState={saveState[currentContribution.contribution.id]}
+                      retry={() => {
+                        saveContribution(descriptionField.value);
+                        refetchContributions();
+                      }}
                     />
                   </Flex>
                 )}

--- a/src/pages/GivePage/EpochStatementDrawer.tsx
+++ b/src/pages/GivePage/EpochStatementDrawer.tsx
@@ -76,7 +76,7 @@ export const EpochStatementDrawer = ({
 
   const { mutate: updateEpochStatement } = useMutation(
     async (bio: string) => updateUser({ circle_id: member.circle_id, bio }),
-    { onSuccess: () => setSaving('saved') }
+    { onSettled: (data, error) => setSaving(error ? 'error' : 'saved') }
   );
 
   // update the statement in the to level page state
@@ -204,7 +204,12 @@ export const EpochStatementDrawer = ({
         <Flex
           css={{ justifyContent: 'flex-end', alignItems: 'center', mt: '$sm' }}
         >
-          <SavingIndicator saveState={saving} />
+          <SavingIndicator
+            saveState={saving}
+            retry={() => {
+              updateEpochStatement(statement);
+            }}
+          />
         </Flex>
       </Flex>
 

--- a/src/pages/GivePage/EpochStatementDrawer.tsx
+++ b/src/pages/GivePage/EpochStatementDrawer.tsx
@@ -17,11 +17,11 @@ import {
   ToggleButton,
 } from '../../ui';
 import { paths } from 'routes/paths';
+import { SaveState, SavingIndicator } from 'ui/SavingIndicator';
 
 import { Member } from './';
 import { Contribution } from './Contribution';
 import { getContributionsForEpoch } from './queries';
-import { SaveState, SavingIndicator } from './SavingIndicator';
 
 import { IMyUser } from 'types';
 

--- a/src/pages/GivePage/GiveDrawer.tsx
+++ b/src/pages/GivePage/GiveDrawer.tsx
@@ -4,13 +4,13 @@ import { useQuery } from 'react-query';
 
 import { ChevronDown, ChevronUp } from '../../icons/__generated';
 import { Avatar, Box, Button, Flex, Panel, Text, TextArea } from '../../ui';
+import { SaveState, SavingIndicator } from 'ui/SavingIndicator';
 
 import { Contribution } from './Contribution';
 import { ContributorButton } from './ContributorButton';
 import { GiveAllocator } from './GiveAllocator';
 import { Gift, Member } from './index';
 import { getContributionsForEpoch } from './queries';
-import { SaveState, SavingIndicator } from './SavingIndicator';
 
 type GiveDrawerProps = {
   member: Member;

--- a/src/pages/GivePage/GiveDrawer.tsx
+++ b/src/pages/GivePage/GiveDrawer.tsx
@@ -214,7 +214,12 @@ export const GiveDrawer = ({
           placeholder="Say thanks or give constructive feedback."
         />
         <Flex css={{ justifyContent: 'flex-end', alignItems: 'center' }}>
-          <SavingIndicator saveState={saveState} />
+          <SavingIndicator
+            saveState={saveState}
+            retry={() => {
+              saveNote({ ...gift }, note);
+            }}
+          />
         </Flex>
       </Box>
 

--- a/src/pages/GivePage/SavingIndicator.tsx
+++ b/src/pages/GivePage/SavingIndicator.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Check, RefreshCcw } from '../../icons/__generated';
+import { Check, RefreshCcw, AlertTriangle } from '../../icons/__generated';
 import { CSS } from '../../stitches.config';
 import { Flex, Text } from '../../ui';
 
@@ -9,7 +9,8 @@ export type SaveState =
   | 'buffering' // dirty, and we need to schedule
   | 'scheduled' // we are actually scheduled to save to backend
   | 'saving' // we are actively saving to backend
-  | 'saved'; // we just saved to backend
+  | 'saved' // we just saved to backend
+  | 'error'; // we received an error or unexpected state
 
 // stable->buffering = something was dirtied
 // buffering->scheduled =  dirty state causes scheduling
@@ -38,6 +39,12 @@ export const SavingIndicator = ({
         {saveState == 'saved' && (
           <>
             <Check /> Saved
+          </>
+        )}
+        {saveState == 'error' && (
+          <>
+            <AlertTriangle />
+            Error
           </>
         )}
       </Text>

--- a/src/pages/GivePage/index.tsx
+++ b/src/pages/GivePage/index.tsx
@@ -17,13 +17,13 @@ import { IEpoch, IMyUser } from '../../types';
 import { Box, Button, Flex, Modal, Panel, Text, Link } from '../../ui';
 import { SingleColumnLayout } from '../../ui/layouts';
 import { getPendingGiftsFrom } from '../AllocationPage/queries';
+import { SaveState, SavingIndicator } from 'ui/SavingIndicator';
 
 import { EpochStatementDrawer } from './EpochStatementDrawer';
 import { GiveDrawer } from './GiveDrawer';
 import { GiveRow } from './GiveRow';
 import { MyGiveRow } from './MyGiveRow';
 import { getMembersWithContributions, PotentialTeammate } from './queries';
-import { SaveState, SavingIndicator } from './SavingIndicator';
 
 export type Gift = Awaited<ReturnType<typeof getPendingGiftsFrom>>[number];
 

--- a/src/pages/GivePage/index.tsx
+++ b/src/pages/GivePage/index.tsx
@@ -173,11 +173,6 @@ const GivePage = () => {
           },
         ],
       });
-    } catch (e) {
-      showError(e);
-    } finally {
-      // errors don't cause us to retry save, this is an area for improvement later,
-      // https://github.com/coordinape/coordinape/issues/1400 -g
       setSaveState(prevState => {
         // this is to check if someone scheduled dirty changes while we were saving
         if (prevState == 'scheduled') {
@@ -186,7 +181,9 @@ const GivePage = () => {
         }
         return 'saved';
       });
-      // Do we need to try again? Error? Something happened while we were saving
+    } catch (e) {
+      setSaveState('error');
+      showError(e);
     }
   };
 
@@ -374,6 +371,7 @@ const GivePage = () => {
             myUser={myUser}
             maxedOut={totalGiveUsed >= myUser.starting_tokens}
             currentEpoch={currentEpoch}
+            retrySave={saveGifts}
           />
         )}
       </SingleColumnLayout>
@@ -395,6 +393,7 @@ type AllocateContentsProps = {
   myUser: IMyUser;
   maxedOut: boolean;
   currentEpoch?: IEpoch;
+  retrySave: () => void;
 };
 
 const AllocateContents = ({
@@ -409,6 +408,7 @@ const AllocateContents = ({
   myUser,
   maxedOut,
   currentEpoch,
+  retrySave,
 }: AllocateContentsProps) => {
   const { showError, showInfo } = useApeSnackbar();
 
@@ -654,7 +654,7 @@ const AllocateContents = ({
                   '@sm': { mb: '$sm' },
                 }}
               >
-                <SavingIndicator saveState={saveState} />
+                <SavingIndicator saveState={saveState} retry={retrySave} />
               </Flex>
             </Flex>
             <Flex

--- a/src/ui/SavingIndicator.stories.tsx
+++ b/src/ui/SavingIndicator.stories.tsx
@@ -1,0 +1,47 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { Box, Flex, TextArea } from 'ui';
+
+import { SavingIndicator } from './SavingIndicator';
+
+export default {
+  title: 'Design System/Components/SavingIndicator',
+  component: SavingIndicator,
+  argTypes: {
+    saveState: {
+      options: ['stable', 'buffered', 'scheduled', 'saving', 'saved', 'error'],
+      control: { type: 'radio' },
+    },
+    retry: {
+      control: 'function',
+    },
+  },
+  decorators: [
+    (Story: any) => (
+      <>
+        <Story />
+        <Box css={{ mt: '$md', p: '$md', background: '$surface' }}>
+          <TextArea css={{ width: '100%', background: 'white' }} />
+          <Flex css={{ justifyContent: 'flex-end', mt: '$md' }}>
+            <Story />
+          </Flex>
+        </Box>
+      </>
+    ),
+  ],
+} as ComponentMeta<typeof SavingIndicator>;
+
+const Template: ComponentStory<typeof SavingIndicator> = args => (
+  <SavingIndicator {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  saveState: 'saved',
+  retry: () => alert("Let's give it a retry!"),
+};
+export const ErrorWithRetry = Template.bind({});
+ErrorWithRetry.args = {
+  saveState: 'error',
+  retry: () => alert('Retried!'),
+};

--- a/src/ui/SavingIndicator.tsx
+++ b/src/ui/SavingIndicator.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
-import { Check, RefreshCcw, AlertTriangle } from '../../icons/__generated';
-import { CSS } from '../../stitches.config';
-import { Flex, Text } from '../../ui';
+import { CSS } from 'stitches.config';
+
+import { Check, RefreshCcw, AlertTriangle } from 'icons/__generated';
+import { Flex, Text } from 'ui';
 
 export type SaveState =
   | 'stable' // nothing needs to happen
@@ -26,9 +27,10 @@ export const SavingIndicator = ({
   saveState: SaveState;
   css?: CSS;
 }) => {
+  const color = saveState == 'error' ? 'alert' : 'neutral';
   return (
     <Flex css={{ ...css, minHeight: '$lg', alignItems: 'center' }}>
-      <Text size="small" color="neutral" css={{ gap: '$xs' }}>
+      <Text size="small" color={color} css={{ gap: '$xs' }}>
         {(saveState == 'saving' ||
           saveState == 'scheduled' ||
           saveState == 'buffering') && (
@@ -44,7 +46,7 @@ export const SavingIndicator = ({
         {saveState == 'error' && (
           <>
             <AlertTriangle />
-            Error
+            Error Saving
           </>
         )}
       </Text>

--- a/src/ui/SavingIndicator.tsx
+++ b/src/ui/SavingIndicator.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { CSS } from 'stitches.config';
 
 import { Check, RefreshCcw, AlertTriangle } from 'icons/__generated';
-import { Flex, Text } from 'ui';
+import { Button, Flex, Text } from 'ui';
 
 export type SaveState =
   | 'stable' // nothing needs to happen
@@ -23,9 +23,11 @@ export type SaveState =
 export const SavingIndicator = ({
   saveState,
   css,
+  retry,
 }: {
   saveState: SaveState;
   css?: CSS;
+  retry?: () => void;
 }) => {
   const color = saveState == 'error' ? 'alert' : 'neutral';
   return (
@@ -47,6 +49,11 @@ export const SavingIndicator = ({
           <>
             <AlertTriangle />
             Error Saving
+            {retry && (
+              <Button size="small" css={{ ml: '$xs' }} onClick={retry}>
+                Retry
+              </Button>
+            )}
           </>
         )}
       </Text>


### PR DESCRIPTION
Resolves #1400 

## What
*  Move SavingIndicator into a shared component
* Add error handling and retry support to SavingIndicator
* Update existing users of SavingIndicators to pass retry methods
  This list of uses includes:
  - Allocations Page
<img width="1508" alt="Screen Shot 2022-10-27 at 3 08 38 PM" src="https://user-images.githubusercontent.com/83605543/198408356-6fdb1a07-98ce-439b-b1ea-bd9fdea636e0.png">

<img width="663" alt="Screen Shot 2022-10-27 at 3 09 07 PM" src="https://user-images.githubusercontent.com/83605543/198408311-50588f21-733d-41b8-be29-dec85c362243.png">
<img width="1481" alt="Screen Shot 2022-10-27 at 3 08 56 PM" src="https://user-images.githubusercontent.com/83605543/198408340-5dd9bcda-372f-4e3e-a78c-8f18a016f246.png">

  - Contributions Page
<img width="634" alt="Screen Shot 2022-10-27 at 3 09 32 PM" src="https://user-images.githubusercontent.com/83605543/198408249-eb6700a8-5dd9-4413-b0ba-0a525c10ce4f.png">

  - Epoch Statement on New Give Page
<img width="641" alt="Screen Shot 2022-10-27 at 3 09 20 PM" src="https://user-images.githubusercontent.com/83605543/198408278-66d4331a-d2f5-4384-86cb-19016ef3ca2d.png">


Followup tasks:
- Add all this to storybook

## Testing

Test that all of these pages work as expected when requests don't error. And that when errors happen it properly shows the error state, and the retry functions work as expected.

This commit adds some helpers to introduce errors cases around these mutations: https://github.com/coordinape/coordinape/commit/0119ddddcf0258ee595dd8c23a5106f4e97b4c81
