### PR TITLE
bugfix: Contributions doesn't re-render when data changes

### DIFF
--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -278,7 +278,7 @@ const ContributionsPage = () => {
       returnData.epochs = createLinkedArray([currentEpoch, ...data.epochs]);
 
     return returnData;
-  }, [data?.epochs.length, data?.contributions.length, dataUpdatedAt]);
+  }, [dataUpdatedAt]);
 
   const activeContributionFn = useMemo(
     () =>

--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -104,7 +104,7 @@ const ContributionsPage = () => {
   const {
     data,
     refetch: refetchContributions,
-    isFetching,
+    dataUpdatedAt,
   } = useQuery(
     ['contributions', selectedCircle.id],
     () =>
@@ -166,32 +166,30 @@ const ContributionsPage = () => {
       },
     });
 
-  const {
-    mutate: mutateContribution,
-    status: updateStatus,
-    reset: resetUpdateMutation,
-  } = useMutation(updateContributionMutation, {
-    mutationKey: ['updateContribution', currentContribution?.contribution.id],
-    onError: (errors, { id }) => {
-      updateSaveStateForContribution(id, 'error');
-    },
-    onSuccess: ({ updateContribution }, { id }) => {
-      updateSaveStateForContribution(id, 'saved');
-      if (
-        currentContribution &&
-        updateContribution?.updateContribution_Contribution
-      )
-        setCurrentContribution({
-          ...currentContribution,
-          contribution: {
-            ...currentContribution.contribution,
-            description:
-              updateContribution.updateContribution_Contribution.description,
-          },
-        });
-      refetchContributions();
-    },
-  });
+  const { mutate: mutateContribution, reset: resetUpdateMutation } =
+    useMutation(updateContributionMutation, {
+      mutationKey: ['updateContribution', currentContribution?.contribution.id],
+      onError: (errors, { id }) => {
+        updateSaveStateForContribution(id, 'error');
+      },
+      onSuccess: ({ updateContribution }, { id }) => {
+        refetchContributions();
+        updateSaveStateForContribution(id, 'saved');
+        if (
+          currentContribution &&
+          updateContribution?.updateContribution_Contribution
+        ) {
+          setCurrentContribution({
+            ...currentContribution,
+            contribution: {
+              ...currentContribution.contribution,
+              description:
+                updateContribution.updateContribution_Contribution.description,
+            },
+          });
+        }
+      },
+    });
 
   const { mutate: deleteContribution } = useMutation(
     deleteContributionMutation,
@@ -280,11 +278,7 @@ const ContributionsPage = () => {
       returnData.epochs = createLinkedArray([currentEpoch, ...data.epochs]);
 
     return returnData;
-  }, [
-    data?.epochs.length,
-    data?.contributions.length,
-    updateStatus === 'success' && isFetching === false,
-  ]);
+  }, [data?.epochs.length, data?.contributions.length, dataUpdatedAt]);
 
   const activeContributionFn = useMemo(
     () =>


### PR DESCRIPTION
There was an edge case when if you switch between one selected Contribution to another selected Contribution BEFORE the mutation finished saving, the useMemo would not be invoked, and the page would show old state even though the save succeeded. We change from that pattern to use a dataUpdatedAt memo pattern that properly updates when new data is fetched.
