### PR TITLE
feat: Add `RadioGroup` story

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -21,3 +21,21 @@ export const parameters = {
     },
   },
 };
+
+export const argTypes = {
+  as: {
+    table: {
+      disable: true,
+    },
+  },
+  asChild: {
+    table: {
+      disable: true,
+    },
+  },
+  css: {
+    table: {
+      disable: true,
+    },
+  },
+};

--- a/src/ui/RadioGroup/RadioGroup.stories.tsx
+++ b/src/ui/RadioGroup/RadioGroup.stories.tsx
@@ -1,0 +1,61 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { withDesign } from 'storybook-addon-designs';
+
+import { Flex, FormLabel } from 'ui';
+
+import {
+  RadioGroupIndicator,
+  RadioGroupRadio,
+  RadioGroupRoot as RadioGroupRootComponent,
+} from './RadioGroup';
+
+export default {
+  title: 'Design System/Components/RadioGroup',
+  component: RadioGroupRootComponent,
+  decorators: [withDesign, Story => <Story />],
+  argTypes: {
+    asChild: {
+      table: {
+        disable: true,
+      },
+    },
+    css: {
+      table: {
+        disable: true,
+      },
+    },
+    as: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+} as ComponentMeta<typeof RadioGroupRootComponent>;
+
+const options = [
+  { value: 'apple', label: 'Apple' },
+  { value: 'banana', label: 'Banana' },
+  { value: 'orange', label: 'Orange' },
+];
+
+const Template: ComponentStory<typeof RadioGroupRootComponent> = args => (
+  <RadioGroupRootComponent
+    css={{
+      display: 'flex',
+      gap: '$md',
+    }}
+    defaultValue={options[0].value}
+    {...args}
+  >
+    {options.map(({ value, label }) => (
+      <Flex key={value} css={{ alignItems: 'center', gap: '$xs' }}>
+        <RadioGroupRadio value={value}>
+          <RadioGroupIndicator />
+        </RadioGroupRadio>
+        <FormLabel type="radioLabel">{label}</FormLabel>
+      </Flex>
+    ))}
+  </RadioGroupRootComponent>
+);
+
+export const RadioGroup = Template.bind({});

--- a/src/ui/RadioGroup/RadioGroup.stories.tsx
+++ b/src/ui/RadioGroup/RadioGroup.stories.tsx
@@ -1,5 +1,4 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { withDesign } from 'storybook-addon-designs';
 
 import { Flex, FormLabel } from 'ui';
 
@@ -10,26 +9,7 @@ import {
 } from './RadioGroup';
 
 export default {
-  title: 'Design System/Components/RadioGroup',
   component: RadioGroupRootComponent,
-  decorators: [withDesign, Story => <Story />],
-  argTypes: {
-    asChild: {
-      table: {
-        disable: true,
-      },
-    },
-    css: {
-      table: {
-        disable: true,
-      },
-    },
-    as: {
-      table: {
-        disable: true,
-      },
-    },
-  },
 } as ComponentMeta<typeof RadioGroupRootComponent>;
 
 const options = [


### PR DESCRIPTION
## Motivation and Context

<!-- Why is this change required? What problem does it solve? This can be omitted if a linked issue is provided
-->

Add all our current components into Storybook via stories.

## Description

<!-- Describe your changes -->

Implements a story for the `RadioGroup.tsx` component.

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->

Ran storybook locally and observed the story, refer to the screenshot below:

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

<img width="1582" alt="Screenshot 2022-10-29 at 10 55 15" src="https://user-images.githubusercontent.com/78794805/198820686-84fdf9c6-cf25-4b6b-848b-9ea624a7cab4.png">

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

@crabsinger 

## Related Issue

<!-- Please link to the issue here -->

https://github.com/coordinape/coordinape/issues/1570
