### PR TITLE
Update datamodel for read/create contributions API

### DIFF
--- a/hasura/metadata/databases/default/tables/public_circle_api_keys.yaml
+++ b/hasura/metadata/databases/default/tables/public_circle_api_keys.yaml
@@ -1,6 +1,6 @@
 table:
-  schema: public
   name: circle_api_keys
+  schema: public
 object_relationships:
   - name: circle
     using:
@@ -13,29 +13,29 @@ select_permissions:
     permission:
       columns:
         - circle_id
-        - created_by
+        - create_contributions
         - create_vouches
+        - created_at
+        - created_by
+        - hash
+        - name
         - read_circle
+        - read_contributions
         - read_epochs
         - read_member_profiles
         - read_nominees
         - read_pending_token_gifts
         - update_circle
         - update_pending_token_gifts
-        - hash
-        - name
-        - created_at
       filter:
         circle:
           users:
-            _and:
-              - role:
-                  _eq: 1
-              - address:
-                  _eq: X-Hasura-Address
+            address:
+              _eq: X-Hasura-Address
 delete_permissions:
   - role: user
     permission:
+      backend_only: false
       filter:
         circle:
           users:

--- a/hasura/metadata/databases/default/tables/public_contributions.yaml
+++ b/hasura/metadata/databases/default/tables/public_contributions.yaml
@@ -1,14 +1,34 @@
 table:
-  schema: public
   name: contributions
+  schema: public
 object_relationships:
   - name: circle
     using:
       foreign_key_constraint_on: circle_id
+  - name: created_with_api_key
+    using:
+      foreign_key_constraint_on: created_with_api_key_hash
   - name: user
     using:
       foreign_key_constraint_on: user_id
 insert_permissions:
+  - role: api-user
+    permission:
+      check:
+        circle:
+          api_keys:
+            _and:
+              - hash:
+                  _eq: X-Hasura-Api-Key-Hash
+              - create_contributions:
+                  _eq: true
+      set:
+        circle_id: x-hasura--Circle-Id
+        created_with_api_key_hash: x-hasura-Api-Key-Hash
+      columns:
+        - datetime_created
+        - description
+        - user_id
   - role: user
     permission:
       check:
@@ -27,16 +47,38 @@ insert_permissions:
         - description
         - user_id
 select_permissions:
+  - role: api-user
+    permission:
+      columns:
+        - circle_id
+        - created_at
+        - datetime_created
+        - description
+        - id
+        - updated_at
+        - user_id
+      filter:
+        _and:
+          - circle:
+              api_keys:
+                _and:
+                  - hash:
+                      _eq: X-Hasura-Api-Key-Hash
+                  - read_contributions:
+                      _eq: true
+          - deleted_at:
+              _is_null: true
   - role: user
     permission:
       columns:
         - circle_id
-        - id
-        - user_id
-        - description
         - created_at
+        - created_with_api_key_hash
         - datetime_created
+        - description
+        - id
         - updated_at
+        - user_id
       filter:
         _and:
           - circle:

--- a/hasura/migrations/default/1667278140823_contributions_api/down.sql
+++ b/hasura/migrations/default/1667278140823_contributions_api/down.sql
@@ -1,0 +1,8 @@
+
+alter table "public"."contributions" drop constraint "contributions_created_with_api_key_hash_fkey";
+
+alter table "public"."contributions" drop column "created_with_api_key_hash";
+
+alter table "public"."circle_api_keys" drop column "create_contributions";
+
+alter table "public"."circle_api_keys" drop column "read_contributions";

--- a/hasura/migrations/default/1667278140823_contributions_api/up.sql
+++ b/hasura/migrations/default/1667278140823_contributions_api/up.sql
@@ -1,0 +1,15 @@
+
+alter table "public"."circle_api_keys" add column "read_contributions" boolean
+ not null default 'false';
+
+alter table "public"."circle_api_keys" add column "create_contributions" boolean
+ not null default 'false';
+
+alter table "public"."contributions" add column "created_with_api_key_hash" text
+ null;
+
+alter table "public"."contributions"
+  add constraint "contributions_created_with_api_key_hash_fkey"
+  foreign key ("created_with_api_key_hash")
+  references "public"."circle_api_keys"
+  ("hash") on update restrict on delete no action;


### PR DESCRIPTION
## Motivation and Context

Allows 3rd party integrators / api users to programatically read and create contributions for a given circle.

## Description

Added columns and appropriate permissions in Hasura for the `api-user` role to create and read contributions. Also added a new column to contributions that tracks which API key was used to create the contribution (if any).

## Test and Deployment Plan

Ensure permissions are correctly configured and contributions created with a given API key are marked as such.

## Reviewers

@topocount @zashton 

## Related Issue

#1545 
