### PR TITLE
resolving react-refresh to 0.11.0 to fix import issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "zod": "3.17.3"
   },
   "resolutions": {
-    "canvas-color-tracker": "file:./canvas-color-tracker"
+    "canvas-color-tracker": "file:./canvas-color-tracker",
+    "react-refresh": "^0.11.0"
   },
   "scripts": {
     "setup": "./scripts/setup.sh",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19276,12 +19276,7 @@ react-query@3.34.8:
     broadcast-channel "^3.4.1"
     match-sorter "^6.0.2"
 
-react-refresh@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.10.0.tgz#2f536c9660c0b9b1d500684d9e52a65e7404f7e3"
-  integrity sha512-PgidR3wST3dDYKr6b4pJoqQFpPGNKDSCDx4cZoshjXipw3LzO7mG1My2pwEzz2JVkF+inx3xRpDeQLFQGH/hsQ==
-
-react-refresh@^0.11.0:
+react-refresh@^0.10.0, react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==


### PR DESCRIPTION
## Motivation and Context

We have conflicting dependencies on react-refresh brought about by upgrading storybook. This resolves it to 0.11.0 . 


