### PR TITLE
Fix members table and member settings rendering

### DIFF
--- a/src/hooks/gql/useCircleOrg.ts
+++ b/src/hooks/gql/useCircleOrg.ts
@@ -2,24 +2,31 @@ import { client } from 'lib/gql/client';
 import { useQuery } from 'react-query';
 
 export function useCircleOrg(circleId: number) {
-  return useQuery(['circle-org', circleId], async () => {
-    const res = await client.query(
-      {
-        circles_by_pk: [
-          { id: circleId },
-          {
-            id: true,
-            organization: {
+  return useQuery(
+    ['circle-org', circleId],
+    async () => {
+      const res = await client.query(
+        {
+          circles_by_pk: [
+            { id: circleId },
+            {
               id: true,
+              organization: {
+                id: true,
+              },
             },
-          },
-        ],
-      },
-      {
-        operationName: 'circle_integrations',
-      }
-    );
+          ],
+        },
+        {
+          operationName: 'circle_integrations',
+        }
+      );
 
-    return res.circles_by_pk?.organization;
-  });
+      return res.circles_by_pk?.organization;
+    },
+    {
+      enabled: !!circleId,
+      refetchOnWindowFocus: false,
+    }
+  );
 }

--- a/src/hooks/gql/useCircleOrg.ts
+++ b/src/hooks/gql/useCircleOrg.ts
@@ -27,6 +27,7 @@ export function useCircleOrg(circleId: number) {
     {
       enabled: !!circleId,
       refetchOnWindowFocus: false,
+      notifyOnChangeProps: ['data'],
     }
   );
 }

--- a/src/hooks/gql/useVaults.ts
+++ b/src/hooks/gql/useVaults.ts
@@ -83,6 +83,7 @@ export function useVaults({
         });
       },
       refetchOnWindowFocus: false,
+      notifyOnChangeProps: ['data'],
     }
   );
 }

--- a/src/hooks/gql/useVaults.ts
+++ b/src/hooks/gql/useVaults.ts
@@ -82,6 +82,7 @@ export function useVaults({
           return v;
         });
       },
+      refetchOnWindowFocus: false,
     }
   );
 }

--- a/src/pages/DistributionsPage/DistributionsPage.tsx
+++ b/src/pages/DistributionsPage/DistributionsPage.tsx
@@ -54,6 +54,8 @@ export function DistributionsPage() {
           );
         return d;
       },
+      refetchOnWindowFocus: false,
+      notifyOnChangeProps: ['data'],
     }
   );
 

--- a/src/pages/MembersPage/MembersTable.tsx
+++ b/src/pages/MembersPage/MembersTable.tsx
@@ -278,12 +278,11 @@ const MemberRow = ({
         setShowOptOutChangeWarning(false);
         updateUser(user.address, { ...data, role: data.role ? 1 : 0 })
           .then(() => {
+            showInfo('Saved changes');
             queryClient.invalidateQueries(QUERY_KEY_FIXED_PAYMENT);
           })
           .catch(console.warn);
       }
-
-      showInfo('Saved changes');
     } catch (e) {
       console.warn(e);
     }

--- a/src/pages/MembersPage/MembersTable.tsx
+++ b/src/pages/MembersPage/MembersTable.tsx
@@ -882,6 +882,7 @@ export const MembersTable = ({
   return (
     <>
       <MemberTable
+        key={circle.id}
         headers={headers}
         data={view}
         startingSortIndex={0}

--- a/src/pages/MembersPage/index.tsx
+++ b/src/pages/MembersPage/index.tsx
@@ -71,7 +71,13 @@ const MembersPage = () => {
     circleEpochsStatus,
   } = useSelectedCircle();
 
-  const { data: circle } = useQuery(
+  const {
+    isLoading: circleSettingsLoading,
+    isError: circleSettingshasError,
+    isIdle: circleSettingsIdle,
+    error: circleSettingsError,
+    data: circle,
+  } = useQuery(
     [QUERY_KEY_CIRCLE_SETTINGS, circleId],
     () => getCircleSettings(circleId),
     {
@@ -83,19 +89,11 @@ const MembersPage = () => {
     }
   );
 
-  const { deleteUser } = useApiAdminCircle(circleId);
-
-  const onChangeKeyword = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setKeyword(event.target.value);
-  };
-
-  const isAdmin = isUserAdmin(me);
-
   const {
-    isLoading,
-    isError,
-    isIdle,
-    error,
+    isLoading: activeNomineesLoading,
+    isError: activeNomineeshasError,
+    isIdle: activeNomineesIdle,
+    error: activeNomineesError,
     data: activeNominees,
     refetch: refetchNominees,
   } = useQuery(
@@ -107,12 +105,18 @@ const MembersPage = () => {
 
       //minmize background refetch
       refetchOnWindowFocus: false,
-
+      staleTime: Infinity,
       notifyOnChangeProps: ['data'],
     }
   );
 
-  const { data: fixedPayment } = useQuery(
+  const {
+    isLoading: fixedPaymentLoading,
+    isError: fixedPaymenthasError,
+    isIdle: fixedPaymentIdle,
+    error: fixedPaymentError,
+    data: fixedPayment,
+  } = useQuery(
     [QUERY_KEY_FIXED_PAYMENT, circleId],
     () => getFixedPayment(circleId),
     {
@@ -120,14 +124,20 @@ const MembersPage = () => {
       enabled: !!circleId,
       //minmize background refetch
       refetchOnWindowFocus: false,
-
       staleTime: Infinity,
       notifyOnChangeProps: ['data'],
     }
   );
 
+  const onChangeKeyword = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setKeyword(event.target.value);
+  };
+
+  const isAdmin = isUserAdmin(me);
+
   const contracts = useContracts();
   const orgQuery = useCircleOrg(circleId);
+  const { deleteUser } = useApiAdminCircle(circleId);
 
   const vaultsQuery = useVaults({
     orgId: orgQuery.data?.id,
@@ -208,10 +218,28 @@ const MembersPage = () => {
     formatUnits(maxGiftTokens, getDecimals(stringifiedVaultId()))
   );
 
-  if (isLoading || isIdle) return <LoadingModal visible />;
-  if (isError) {
-    if (error instanceof Error) {
-      console.warn(error.message);
+  if (
+    activeNomineesLoading ||
+    activeNomineesIdle ||
+    circleSettingsLoading ||
+    circleSettingsIdle ||
+    fixedPaymentLoading ||
+    fixedPaymentIdle
+  )
+    return <LoadingModal visible />;
+  if (activeNomineeshasError) {
+    if (activeNomineesError instanceof Error) {
+      console.warn(activeNomineesError.message);
+    }
+  }
+  if (circleSettingshasError) {
+    if (circleSettingsError instanceof Error) {
+      console.warn(circleSettingsError.message);
+    }
+  }
+  if (fixedPaymenthasError) {
+    if (fixedPaymentError instanceof Error) {
+      console.warn(fixedPaymentError.message);
     }
   }
   return (

--- a/src/pages/MembersPage/index.tsx
+++ b/src/pages/MembersPage/index.tsx
@@ -9,7 +9,7 @@ import { NavLink } from 'react-router-dom';
 import { disabledStyle } from 'stitches.config';
 
 import { LoadingModal } from 'components';
-import { useApiAdminCircle, useContracts } from 'hooks';
+import { useApeSnackbar, useApiAdminCircle, useContracts } from 'hooks';
 import { useCircleOrg } from 'hooks/gql/useCircleOrg';
 import { useVaults } from 'hooks/gql/useVaults';
 import useMobileDetect from 'hooks/useMobileDetect';
@@ -45,6 +45,7 @@ export interface IDeleteUser {
 
 const MembersPage = () => {
   const { isMobile } = useMobileDetect();
+  const { showError } = useApeSnackbar();
 
   const [keyword, setKeyword] = useState<string>('');
   const [deleteUserDialog, setDeleteUserDialog] = useState<
@@ -72,9 +73,7 @@ const MembersPage = () => {
   } = useSelectedCircle();
 
   const {
-    isLoading: circleSettingsLoading,
-    isError: circleSettingshasError,
-    isIdle: circleSettingsIdle,
+    isError: circleSettingsHasError,
     error: circleSettingsError,
     data: circle,
   } = useQuery(
@@ -90,9 +89,7 @@ const MembersPage = () => {
   );
 
   const {
-    isLoading: activeNomineesLoading,
-    isError: activeNomineeshasError,
-    isIdle: activeNomineesIdle,
+    isError: activeNomineesHasError,
     error: activeNomineesError,
     data: activeNominees,
     refetch: refetchNominees,
@@ -111,9 +108,7 @@ const MembersPage = () => {
   );
 
   const {
-    isLoading: fixedPaymentLoading,
-    isError: fixedPaymenthasError,
-    isIdle: fixedPaymentIdle,
+    isError: fixedPaymentHasError,
     error: fixedPaymentError,
     data: fixedPayment,
   } = useQuery(
@@ -218,28 +213,22 @@ const MembersPage = () => {
     formatUnits(maxGiftTokens, getDecimals(stringifiedVaultId()))
   );
 
-  if (
-    activeNomineesLoading ||
-    activeNomineesIdle ||
-    circleSettingsLoading ||
-    circleSettingsIdle ||
-    fixedPaymentLoading ||
-    fixedPaymentIdle
-  )
+  if (!activeNominees || !circle || !fixedPayment)
     return <LoadingModal visible />;
-  if (activeNomineeshasError) {
+
+  if (activeNomineesHasError) {
     if (activeNomineesError instanceof Error) {
-      console.warn(activeNomineesError.message);
+      showError(activeNomineesError.message);
     }
   }
-  if (circleSettingshasError) {
+  if (circleSettingsHasError) {
     if (circleSettingsError instanceof Error) {
-      console.warn(circleSettingsError.message);
+      showError(circleSettingsError.message);
     }
   }
-  if (fixedPaymenthasError) {
+  if (fixedPaymentHasError) {
     if (fixedPaymentError instanceof Error) {
-      console.warn(fixedPaymentError.message);
+      showError(fixedPaymentError.message);
     }
   }
   return (


### PR DESCRIPTION
## Motivation and Context

fixes #1618

## Description
1-MembersPage have many useQuery's and some of them are defined inside custom hooks causing refetching and rerendering of Members Page solved by adding refetchOnWindowFocus: false to MembersPage queries
2- show saved changes only after saving the changes only
3- Handle the errors and Loading for main queries in MembersPage

## Test and Deployment Plan

follow the steps in the bug description #1618 the buggy behaviour should disappear

