### PR TITLE
fix: Invalidate 'allocate-contributions' query on add/remove contribution

### DIFF
--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -19,6 +19,7 @@ import {
   ChevronDown,
   ChevronUp,
 } from 'icons/__generated';
+import { QUERY_KEY_ALLOCATE_CONTRIBUTIONS } from 'pages/GivePage/EpochStatementDrawer';
 import { Panel, Text, Box, Modal, Button, Flex } from 'ui';
 import { SingleColumnLayout } from 'ui/layouts';
 import { SavingIndicator, SaveState } from 'ui/SavingIndicator';
@@ -162,7 +163,9 @@ const ContributionsPage = () => {
     useMutation(createContributionMutation, {
       onSuccess: newContribution => {
         refetchContributions();
-        queryClient.invalidateQueries({ queryKey: ['allocate-contributions'] });
+        queryClient.invalidateQueries({
+          queryKey: [QUERY_KEY_ALLOCATE_CONTRIBUTIONS],
+        });
         if (newContribution.insert_contributions_one) {
           updateSaveStateForContribution(NEW_CONTRIBUTION_ID, 'stable');
           setCurrentContribution({
@@ -237,7 +240,9 @@ const ContributionsPage = () => {
         refetchContributions();
         updateSaveStateForContribution(data.contribution_id, 'stable');
         reset();
-        queryClient.invalidateQueries({ queryKey: ['allocate-contributions'] });
+        queryClient.invalidateQueries({
+          queryKey: [QUERY_KEY_ALLOCATE_CONTRIBUTIONS],
+        });
       },
     }
   );

--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -4,7 +4,7 @@ import dedent from 'dedent';
 import { debounce } from 'lodash';
 import { DateTime } from 'luxon';
 import { useForm, useController } from 'react-hook-form';
-import { useQuery, useMutation } from 'react-query';
+import { useQuery, useMutation, useQueryClient } from 'react-query';
 
 import useConnectedAddress from '../../hooks/useConnectedAddress';
 import { useSelectedCircle } from '../../recoilState';
@@ -103,6 +103,8 @@ const ContributionsPage = () => {
   const [currentIntContribution, setCurrentIntContribution] =
     useState<CurrentIntContribution | null>(null);
 
+  const queryClient = useQueryClient();
+
   const {
     data,
     refetch: refetchContributions,
@@ -160,6 +162,7 @@ const ContributionsPage = () => {
     useMutation(createContributionMutation, {
       onSuccess: newContribution => {
         refetchContributions();
+        queryClient.invalidateQueries({ queryKey: ['allocate-contributions'] });
         if (newContribution.insert_contributions_one) {
           updateSaveStateForContribution(NEW_CONTRIBUTION_ID, 'stable');
           setCurrentContribution({
@@ -234,6 +237,7 @@ const ContributionsPage = () => {
         refetchContributions();
         updateSaveStateForContribution(data.contribution_id, 'stable');
         reset();
+        queryClient.invalidateQueries({ queryKey: ['allocate-contributions'] });
       },
     }
   );

--- a/src/pages/GivePage/EpochStatementDrawer.tsx
+++ b/src/pages/GivePage/EpochStatementDrawer.tsx
@@ -27,6 +27,8 @@ import { IMyUser } from 'types';
 
 const DEBOUNCE_TIMEOUT = 1000;
 
+export const QUERY_KEY_ALLOCATE_CONTRIBUTIONS = 'allocate-contributions';
+
 type StatementDrawerProps = {
   myUser: IMyUser;
   member: Member;
@@ -55,7 +57,7 @@ export const EpochStatementDrawer = ({
 }: StatementDrawerProps) => {
   // fetch the contributions for this particular member
   const { data: contributions } = useQuery(
-    ['allocate-contributions', member.id],
+    [QUERY_KEY_ALLOCATE_CONTRIBUTIONS, member.id],
     () =>
       getContributionsForEpoch({
         circleId: member.circle_id,

--- a/src/pages/GivePage/GiveDrawer.tsx
+++ b/src/pages/GivePage/GiveDrawer.tsx
@@ -8,6 +8,7 @@ import { SaveState, SavingIndicator } from 'ui/SavingIndicator';
 
 import { Contribution } from './Contribution';
 import { ContributorButton } from './ContributorButton';
+import { QUERY_KEY_ALLOCATE_CONTRIBUTIONS } from './EpochStatementDrawer';
 import { GiveAllocator } from './GiveAllocator';
 import { Gift, Member } from './index';
 import { getContributionsForEpoch } from './queries';
@@ -49,7 +50,7 @@ export const GiveDrawer = ({
 }: GiveDrawerProps) => {
   // fetch the contributions for this particular member
   const { data: contributions, refetch } = useQuery(
-    ['allocate-contributions', member.id],
+    [QUERY_KEY_ALLOCATE_CONTRIBUTIONS, member.id],
     () =>
       getContributionsForEpoch({
         circleId: member.circle_id,


### PR DESCRIPTION
## Motivation and Context

<!-- Why is this change required? What problem does it solve? This can be omitted if a linked issue is provided
-->

Contributions do not reload on add/remove allocation

## Description

<!-- Describe your changes -->

Invalidate `'allocate-contributions'` query on 

* createContributionMutation
* deleteContributionMutation

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->

Ran locally and recorded a screencast, see below

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

https://user-images.githubusercontent.com/78794805/199474641-56223d6f-5f48-47d3-869a-89191c1d3c85.mov

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

@CryptoGraffe 

## Related Issue

<!-- Please link to the issue here -->

Fixes https://github.com/coordinape/coordinape/issues/1608