### PR TITLE
Allow admin to populate contribution text fields

### DIFF
--- a/src/components/FormInputField.tsx
+++ b/src/components/FormInputField.tsx
@@ -106,6 +106,7 @@ export const FormInputField = <TFieldValues extends FieldValues>(
           id={id}
           error={!!fieldState.error}
           disabled={disabled}
+          placeholder={placeholder}
         ></TextField>
       )}
       {textArea && (

--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -62,8 +62,8 @@ const schema = z.object({
 
     .string()
     .max(500)
-    .refine(val => val.trim().length >= 40, {
-      message: 'Please write at least 40 characters.',
+    .refine(val => val.trim().length >= 1, {
+      message: 'Please write something.',
     }),
 });
 type contributionTextSchema = z.infer<typeof schema>;
@@ -423,56 +423,70 @@ const ContributionsPage = () => {
           }}
         >
           <Text h1>Contributions</Text>
-          {!editHelpText ? (
-            isAdmin && (
+        </Flex>
+        {!editHelpText ? (
+          <Flex css={{ gap: '$md', alignContent: 'center' }}>
+            <Text>
+              {updatedTeamSelText
+                ? updatedTeamSelText
+                : data?.circles_by_pk?.team_sel_text
+                ? data?.circles_by_pk?.team_sel_text
+                : 'What have you been working on?'}
+            </Text>
+            {isAdmin && (
               <Button
                 outlined
                 color="primary"
                 type="submit"
+                size="small"
                 onClick={() => {
                   setEditHelpText(true);
                 }}
               >
                 Edit Help Text
               </Button>
-            )
-          ) : (
-            <Button
-              outlined
-              color="primary"
-              type="submit"
-              onClick={handleSubmit(onSubmit)}
-            >
-              Save
-            </Button>
-          )}
-        </Flex>
-        <Box>
-          {!editHelpText ? (
-            updatedTeamSelText ||
-            data?.circles_by_pk?.team_sel_text || (
-              <>
-                <Text p>What have you been working on?</Text>
-                {(memoizedEpochData.contributions || []).length >= 0 && (
-                  <ContributionIntro />
-                )}
-              </>
-            )
-          ) : (
+            )}
+          </Flex>
+        ) : (
+          <Flex css={{ gap: '$md', alignItems: 'flex-start' }}>
             <FormInputField
               name="team_sel_text"
               id="finish_work"
               control={contributionTextControl}
               defaultValue={data?.circles_by_pk?.team_sel_text}
               label="Contribution Help Text"
+              placeholder="Default: 'What have you been working on?'"
               infoTooltip="Change the text that contributors see on this page."
               showFieldErrors
               css={{
                 width: '50%',
+                '@sm': { width: '100%' },
               }}
             />
-          )}
-        </Box>
+            <Flex css={{ gap: '$sm', mt: '$lg' }}>
+              <Button
+                outlined
+                color="primary"
+                type="submit"
+                onClick={handleSubmit(onSubmit)}
+              >
+                Save
+              </Button>
+              <Button
+                outlined
+                color="destructive"
+                onClick={() => {
+                  setEditHelpText(false);
+                }}
+              >
+                Cancel
+              </Button>
+            </Flex>
+          </Flex>
+        )}
+        {(memoizedEpochData.contributions || []).length >= 0 && (
+          <ContributionIntro />
+        )}
         <EpochGroup
           contributions={memoizedEpochData.contributions || []}
           epochs={memoizedEpochData.epochs || []}
@@ -819,6 +833,7 @@ const EpochGroup = React.memo(function EpochGroup({
         <Box key={epoch.id}>
           <Box>
             <Flex
+              alignItems="center"
               css={{
                 justifyContent: 'space-between',
                 flexWrap: 'wrap',

--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -28,7 +28,7 @@ import {
   Edit,
 } from 'icons/__generated';
 import { QUERY_KEY_ALLOCATE_CONTRIBUTIONS } from 'pages/GivePage/EpochStatementDrawer';
-import { Panel, Text, Box, Modal, Button, Flex,MarkdownPreview  } from 'ui';
+import { Panel, Text, Box, Modal, Button, Flex, MarkdownPreview } from 'ui';
 import { SingleColumnLayout } from 'ui/layouts';
 import { SavingIndicator, SaveState } from 'ui/SavingIndicator';
 
@@ -444,22 +444,18 @@ const ContributionsPage = () => {
             </Button>
           )}
         </Flex>
-        <Box
-          css={{
-            justifyContent: 'space-between',
-            alignItems: 'flex-end',
-            flexWrap: 'wrap',
-            gap: '$md',
-          }}
-        >
+        <Box>
           {!editHelpText ? (
-            <p>
-              {data?.circles_by_pk?.team_sel_text ??
-                'What have you been working on?'}
-            </p>
-          {(memoizedEpochData.contributions || []).length >= 0 && (
-          <ContributionIntro />
-        )}
+            <>
+              <Text p>
+                {data?.circles_by_pk?.team_sel_text ??
+                  'What have you been working on?'}
+              </Text>
+
+              {(memoizedEpochData.contributions || []).length >= 0 && (
+                <ContributionIntro />
+              )}
+            </>
           ) : (
             <FormInputField
               name="team_sel_text"
@@ -820,7 +816,13 @@ const EpochGroup = React.memo(function EpochGroup({
       {epochs.map((epoch, idx, epochArray) => (
         <Box key={epoch.id}>
           <Box>
-            <Flex css={{ justifyContent: 'space-between' }}>
+            <Flex
+              css={{
+                justifyContent: 'space-between',
+                flexWrap: 'wrap',
+                gap: '$md',
+              }}
+            >
               <Text h2 bold css={{ gap: '$md' }}>
                 {epoch.id === 0 ? 'Latest' : renderEpochDate(epoch)}
                 {getEpochLabel(epoch)}

--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -161,7 +161,7 @@ const ContributionsPage = () => {
   );
   const [updatedTeamSelText, setUpdatedTeamSelText] = useState<
     string | undefined
-  >(data?.circles_by_pk?.team_sel_text);
+  >();
 
   const { control, reset, resetField, setValue } = useForm({ mode: 'all' });
   const { control: contributionTextControl, handleSubmit } =
@@ -451,7 +451,9 @@ const ContributionsPage = () => {
           {!editHelpText ? (
             <>
             <Text p>
-              {updatedTeamSelText || 'What have you been working on?'}
+              {updatedTeamSelText ||
+                data?.circles_by_pk?.team_sel_text ||
+                'What have you been working on?'}
             </Text>
               {(memoizedEpochData.contributions || []).length >= 0 && (
                 <ContributionIntro />

--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -449,16 +449,15 @@ const ContributionsPage = () => {
         </Flex>
         <Box>
           {!editHelpText ? (
-            <>
-            <Text p>
-              {updatedTeamSelText ||
-                data?.circles_by_pk?.team_sel_text ||
-                'What have you been working on?'}
-            </Text>
-              {(memoizedEpochData.contributions || []).length >= 0 && (
-                <ContributionIntro />
-              )}
-            </>
+            updatedTeamSelText ||
+            data?.circles_by_pk?.team_sel_text || (
+              <>
+                <Text p>What have you been working on?</Text>
+                {(memoizedEpochData.contributions || []).length >= 0 && (
+                  <ContributionIntro />
+                )}
+              </>
+            )
           ) : (
             <FormInputField
               name="team_sel_text"

--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -1,10 +1,13 @@
 import React, { useEffect, useMemo, useState } from 'react';
 
+import { zodResolver } from '@hookform/resolvers/zod';
 import dedent from 'dedent';
+import { updateCircle } from 'lib/gql/mutations';
 import { debounce } from 'lodash';
 import { DateTime } from 'luxon';
-import { useForm, useController } from 'react-hook-form';
+import { useForm, SubmitHandler, useController } from 'react-hook-form';
 import { useQuery, useMutation, useQueryClient } from 'react-query';
+import * as z from 'zod';
 
 import useConnectedAddress from '../../hooks/useConnectedAddress';
 import { useSelectedCircle } from '../../recoilState';
@@ -23,7 +26,7 @@ import {
   Edit,
 } from 'icons/__generated';
 import { QUERY_KEY_ALLOCATE_CONTRIBUTIONS } from 'pages/GivePage/EpochStatementDrawer';
-import { Panel, Text, Box, Modal, Button, Flex, MarkdownPreview } from 'ui';
+import { Panel, Text, Box, Modal, Button, Flex, Form,MarkdownPreview } from 'ui';
 import { SingleColumnLayout } from 'ui/layouts';
 import { SavingIndicator, SaveState } from 'ui/SavingIndicator';
 
@@ -51,6 +54,17 @@ import {
   jumpToEpoch,
   isEpochCurrentOrLater,
 } from './util';
+
+const schema = z.object({
+  team_sel_text: z
+
+    .string()
+    .max(500)
+    .refine(val => val.trim().length >= 40, {
+      message: 'At least 40 characters must be writen',
+    }),
+});
+type contributionTextSchema = z.infer<typeof schema>;
 
 const DEBOUNCE_TIMEOUT = 1000;
 
@@ -105,6 +119,7 @@ const ContributionsPage = () => {
   const address = useConnectedAddress();
   const { circle: selectedCircle } = useSelectedCircle();
   const [modalOpen, setModalOpen] = useState(false);
+  const [editHelpText, setEditHelpText] = useState(true);
   const [saveState, setSaveState] = useState<{ [key: number]: SaveState }>({});
   const [currentContribution, setCurrentContribution] =
     useState<CurrentContribution | null>(null);
@@ -142,6 +157,25 @@ const ContributionsPage = () => {
   );
 
   const { control, reset, resetField, setValue } = useForm({ mode: 'all' });
+  const { control: contributionTextControl, handleSubmit } =
+    useForm<contributionTextSchema>({
+      resolver: zodResolver(schema),
+      mode: 'all',
+    });
+
+  const onSubmit: SubmitHandler<contributionTextSchema> = async data => {
+    try {
+      await updateCircle({
+        circle_id: selectedCircle.id,
+        team_sel_text: data.team_sel_text,
+      });
+
+      refetchContributions();
+    } catch (e) {
+      console.warn(e);
+    }
+    setEditHelpText(true);
+  };
 
   useEffect(() => {
     // once we become buffering, we need to schedule
@@ -345,7 +379,6 @@ const ContributionsPage = () => {
   if (!memoizedEpochData) {
     return <LoadingModal visible />;
   }
-
   const currentUserId: number = memoizedEpochData.users[0]?.id;
 
   const closeDrawer = () => {
@@ -383,20 +416,66 @@ const ContributionsPage = () => {
           }}
         >
           <Text h1>Contributions</Text>
-          <Button outlined color="primary" onClick={newContribution}>
-            Add Contribution
-          </Button>
+          {editHelpText ? (
+            <Button
+              outlined
+              color="primary"
+              type="submit"
+              onClick={() => {
+                setEditHelpText(false);
+              }}
+            >
+              Edit Help Text
+            </Button>
+          ) : (
+            <Button
+              outlined
+              color="primary"
+              type="submit"
+              onClick={handleSubmit(onSubmit)}
+            >
+              Save
+            </Button>
+          )}
         </Flex>
-        <Text p>What have you been working on?</Text>
-        {(memoizedEpochData.contributions || []).length >= 0 && (
+        <Form
+          css={{
+            justifyContent: 'space-between',
+            alignItems: 'flex-end',
+            flexWrap: 'wrap',
+            gap: '$md',
+          }}
+        >
+          {editHelpText ? (
+            <p>
+              {data?.circles_by_pk?.team_sel_text ??
+                'What have you been working on ?'}
+            </p>
+          {(memoizedEpochData.contributions || []).length >= 0 && (
           <ContributionIntro />
         )}
+          ) : (
+            <FormInputField
+              name="team_sel_text"
+              id="finish_work"
+              control={contributionTextControl}
+              defaultValue={data?.circles_by_pk?.team_sel_text}
+              label="Contribution Help Text"
+              infoTooltip="Write what you been working on "
+              showFieldErrors
+              css={{
+                width: '700px',
+              }}
+            />
+          )}
+        </Form>
         <EpochGroup
           contributions={memoizedEpochData.contributions || []}
           epochs={memoizedEpochData.epochs || []}
           currentContribution={currentContribution}
           setActiveContribution={activeContributionFn}
           userAddress={address}
+          addContributionClickHandler={newContribution}
         />
       </SingleColumnLayout>
       <Modal
@@ -724,17 +803,32 @@ const EpochGroup = React.memo(function EpochGroup({
   currentContribution,
   setActiveContribution,
   userAddress,
+  addContributionClickHandler,
 }: Omit<LinkedContributionsAndEpochs, 'users'> &
-  SetActiveContributionProps & { userAddress?: string }) {
+  SetActiveContributionProps & {
+    userAddress?: string;
+    addContributionClickHandler: () => void;
+  }) {
   return (
     <Flex column css={{ gap: '$1xl' }}>
       {epochs.map((epoch, idx, epochArray) => (
         <Box key={epoch.id}>
           <Box>
-            <Text h2 bold css={{ gap: '$md' }}>
-              {epoch.id === 0 ? 'Latest' : renderEpochDate(epoch)}
-              {getEpochLabel(epoch)}
-            </Text>
+            <Flex css={{ justifyContent: 'space-between' }}>
+              <Text h2 bold css={{ gap: '$md' }}>
+                {epoch.id === 0 ? 'Latest' : renderEpochDate(epoch)}
+                {getEpochLabel(epoch)}
+              </Text>
+              {idx === 0 && (
+                <Button
+                  outlined
+                  color="primary"
+                  onClick={addContributionClickHandler}
+                >
+                  Add Contribution
+                </Button>
+              )}
+            </Flex>
           </Box>
           <ContributionPanel>
             <ContributionList

--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -464,7 +464,7 @@ const ContributionsPage = () => {
               control={contributionTextControl}
               defaultValue={data?.circles_by_pk?.team_sel_text}
               label="Contribution Help Text"
-              infoTooltip="Change the default text contributors see on contributions page"
+              infoTooltip="Change the text that contributors see on this page."
               showFieldErrors
               css={{
                 width: '50%',

--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -122,6 +122,7 @@ const ContributionsPage = () => {
   const { circle: selectedCircle, myUser: me } = useSelectedCircle();
   const [modalOpen, setModalOpen] = useState(false);
   const [editHelpText, setEditHelpText] = useState(false);
+
   const [saveState, setSaveState] = useState<{ [key: number]: SaveState }>({});
   const [currentContribution, setCurrentContribution] =
     useState<CurrentContribution | null>(null);
@@ -158,6 +159,9 @@ const ContributionsPage = () => {
       },
     }
   );
+  const [updatedTeamSelText, setUpdatedTeamSelText] = useState<
+    string | undefined
+  >(data?.circles_by_pk?.team_sel_text);
 
   const { control, reset, resetField, setValue } = useForm({ mode: 'all' });
   const { control: contributionTextControl, handleSubmit } =
@@ -172,8 +176,7 @@ const ContributionsPage = () => {
         circle_id: selectedCircle.id,
         team_sel_text: data.team_sel_text,
       });
-
-      refetchContributions();
+      setUpdatedTeamSelText(data.team_sel_text);
     } catch (e) {
       showError(e);
       console.warn(e);
@@ -447,11 +450,9 @@ const ContributionsPage = () => {
         <Box>
           {!editHelpText ? (
             <>
-              <Text p>
-                {data?.circles_by_pk?.team_sel_text ??
-                  'What have you been working on?'}
-              </Text>
-
+            <Text p>
+              {updatedTeamSelText || 'What have you been working on?'}
+            </Text>
               {(memoizedEpochData.contributions || []).length >= 0 && (
                 <ContributionIntro />
               )}

--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import dedent from 'dedent';
 import { updateCircle } from 'lib/gql/mutations';
+import { isUserAdmin } from 'lib/users';
 import { debounce } from 'lodash';
 import { DateTime } from 'luxon';
 import { useForm, SubmitHandler, useController } from 'react-hook-form';
@@ -117,7 +118,7 @@ const contributionSource = (source: string) => {
 };
 const ContributionsPage = () => {
   const address = useConnectedAddress();
-  const { circle: selectedCircle } = useSelectedCircle();
+  const { circle: selectedCircle, myUser: me } = useSelectedCircle();
   const [modalOpen, setModalOpen] = useState(false);
   const [editHelpText, setEditHelpText] = useState(true);
   const [saveState, setSaveState] = useState<{ [key: number]: SaveState }>({});
@@ -162,7 +163,7 @@ const ContributionsPage = () => {
       resolver: zodResolver(schema),
       mode: 'all',
     });
-
+  const isAdmin = isUserAdmin(me);
   const onSubmit: SubmitHandler<contributionTextSchema> = async data => {
     try {
       await updateCircle({
@@ -417,16 +418,20 @@ const ContributionsPage = () => {
         >
           <Text h1>Contributions</Text>
           {editHelpText ? (
-            <Button
-              outlined
-              color="primary"
-              type="submit"
-              onClick={() => {
-                setEditHelpText(false);
-              }}
-            >
-              Edit Help Text
-            </Button>
+            <>
+              {isAdmin && (
+                <Button
+                  outlined
+                  color="primary"
+                  type="submit"
+                  onClick={() => {
+                    setEditHelpText(false);
+                  }}
+                >
+                  Edit Help Text
+                </Button>
+              )}
+            </>
           ) : (
             <Button
               outlined

--- a/src/pages/ContributionsPage/queries.ts
+++ b/src/pages/ContributionsPage/queries.ts
@@ -62,6 +62,14 @@ export const getContributionsAndEpochs = async ({
         ended: true,
       },
     ],
+    circles_by_pk: [
+      {
+        id: circleId,
+      },
+      {
+        team_sel_text: true,
+      },
+    ],
   });
 
 export type ContributionsAndEpochs = Awaited<


### PR DESCRIPTION
## Motivation and Context

resolves #1566 


## Description

Allow admin to to Edit help text to the contribution page 

## Test and Deployment Plan

go to Contribution page--> contribution --> click edit edit text and change text-->click save and check saved text

## Screenshots (if appropriate):
 as an admin
![image](https://user-images.githubusercontent.com/73297706/200139050-e032d07a-fd48-41e7-9031-241dd1e3ede2.png)
as non admin
![image](https://user-images.githubusercontent.com/73297706/200139075-2577d4a8-cb0e-462c-9ed3-013923fda169.png)

## Reviewers
@reeserj 
@sshmm 
## Related Issue
https://github.com/coordinape/coordinape/issues/1566
