### PR TITLE
fix: Chromatic stories

### DIFF
--- a/src/ui/Image/Image.stories.tsx
+++ b/src/ui/Image/Image.stories.tsx
@@ -13,5 +13,6 @@ const Template: ComponentStory<typeof ImageComponent> = args => (
 export const Image = Template.bind({});
 Image.args = {
   alt: 'Alt property',
-  src: 'https://picsum.photos/200/300',
+  src: '../imgs/avatar/placeholder.jpg',
+  width: 250,
 };

--- a/src/ui/Table/Table.stories.tsx
+++ b/src/ui/Table/Table.stories.tsx
@@ -14,16 +14,21 @@ type User = {
   jobTitle: string;
 };
 
-const generateUser = (): User => ({
-  userId: faker.datatype.uuid(),
-  firstName: faker.name.firstName(),
-  lastName: faker.name.lastName(),
-  jobTitle: faker.name.jobTitle(),
-});
+const generateUser = ({ index }: { value: unknown; index: number }): User => {
+  faker.seed(index);
+  return {
+    userId: faker.datatype.uuid(),
+    firstName: faker.name.firstName(),
+    lastName: faker.name.lastName(),
+    jobTitle: faker.name.jobTitle(),
+  };
+};
 
 const headers: string[] = ['userId', 'firstName', 'lastName', 'jobTitle'];
 
-const data = Array.from({ length: 8 }).map(generateUser);
+const data = Array.from({ length: 8 }).map(
+  (value: unknown, index: number): User => generateUser({ value, index })
+);
 
 const Template: ComponentStory<typeof TableComponent> = args => (
   <TableComponent {...args}>

--- a/src/ui/Table/Table.stories.tsx
+++ b/src/ui/Table/Table.stories.tsx
@@ -14,21 +14,17 @@ type User = {
   jobTitle: string;
 };
 
-const generateUser = ({ index }: { value: unknown; index: number }): User => {
-  faker.seed(index);
-  return {
-    userId: faker.datatype.uuid(),
-    firstName: faker.name.firstName(),
-    lastName: faker.name.lastName(),
-    jobTitle: faker.name.jobTitle(),
-  };
-};
+const generateUser = (): User => ({
+  userId: faker.datatype.uuid(),
+  firstName: faker.name.firstName(),
+  lastName: faker.name.lastName(),
+  jobTitle: faker.name.jobTitle(),
+});
 
 const headers: string[] = ['userId', 'firstName', 'lastName', 'jobTitle'];
 
-const data = Array.from({ length: 8 }).map(
-  (value: unknown, index: number): User => generateUser({ value, index })
-);
+faker.seed(1);
+const data = Array.from({ length: 8 }).map(generateUser);
 
 const Template: ComponentStory<typeof TableComponent> = args => (
   <TableComponent {...args}>


### PR DESCRIPTION
## Motivation and Context

<!-- Why is this change required? What problem does it solve? This can be omitted if a linked issue is provided
-->

Randomising data does not work well with Chromatic as it detects it as a change

## Description

<!-- Describe your changes -->

Serve always the same assets and data for the `Image` and `Table` stories.

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->

Ran storybook locally and observed always the same image being served as well as the same data for the table

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

<img width="1582" alt="Screenshot 2022-11-07 at 9 40 50" src="https://user-images.githubusercontent.com/78794805/200254777-eabc43ed-25a6-4999-92ff-262bb10e2f78.png">
<img width="1582" alt="Screenshot 2022-11-07 at 9 50 40" src="https://user-images.githubusercontent.com/78794805/200254822-530e2377-ad7f-49ab-8fd1-a574fa245dde.png">

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

@levity 

## Related Issue

<!-- Please link to the issue here -->
