### PR TITLE
refactor test provider code to work in Cypress

### DIFF
--- a/api-test/hasura/actions/_handlers/markClaimed.test.ts
+++ b/api-test/hasura/actions/_handlers/markClaimed.test.ts
@@ -57,7 +57,7 @@ test('reject if no claims were updated', async () => {
 });
 
 test('create interaction_event with unwrapped amount', async () => {
-  const contracts = new Contracts(chainId, provider);
+  const contracts = new Contracts(chainId, provider());
   const { address } = await contracts.createVault('DAI', true);
   let actual;
 

--- a/api-test/hasura/cron/recoverTransactions.test.ts
+++ b/api-test/hasura/cron/recoverTransactions.test.ts
@@ -28,7 +28,7 @@ test('mix of invalid & valid txs', async () => {
   } as unknown as VercelRequest;
   const res: any = { status: jest.fn(() => res), json: jest.fn() };
 
-  const contracts = new Contracts(chainId, provider);
+  const contracts = new Contracts(chainId, provider());
   const chain_id = Number(contracts.chainId);
   const daiAddress = contracts.getTokenAddress('DAI');
 

--- a/cypress/e2e/allocate.cy.ts
+++ b/cypress/e2e/allocate.cy.ts
@@ -4,8 +4,7 @@ let circleId;
 
 context('Coordinape', () => {
   before(() => {
-    const providerPort = Cypress.env('HARDHAT_GANACHE_PORT');
-    Cypress.on('window:before:load', injectWeb3(providerPort));
+    Cypress.on('window:before:load', injectWeb3());
     return gqlQuery({
       circles: [
         {

--- a/cypress/e2e/createEpoch.cy.ts
+++ b/cypress/e2e/createEpoch.cy.ts
@@ -4,8 +4,7 @@ let circleId, circleName;
 
 context('Coordinape', () => {
   before(() => {
-    const providerPort = Cypress.env('HARDHAT_GANACHE_PORT');
-    Cypress.on('window:before:load', injectWeb3(providerPort));
+    Cypress.on('window:before:load', injectWeb3());
     return gqlQuery({
       circles: [
         {

--- a/cypress/e2e/createNominee.cy.ts
+++ b/cypress/e2e/createNominee.cy.ts
@@ -4,8 +4,7 @@ let circleId;
 
 context('Coordinape', () => {
   before(() => {
-    const providerPort = Cypress.env('HARDHAT_GANACHE_PORT');
-    Cypress.on('window:before:load', injectWeb3(providerPort));
+    Cypress.on('window:before:load', injectWeb3());
     return gqlQuery({
       circles: [
         {

--- a/cypress/e2e/createUser.cy.ts
+++ b/cypress/e2e/createUser.cy.ts
@@ -4,8 +4,7 @@ let circleId;
 
 context('Coordinape', () => {
   before(() => {
-    const providerPort = Cypress.env('HARDHAT_GANACHE_PORT');
-    Cypress.on('window:before:load', injectWeb3(providerPort));
+    Cypress.on('window:before:load', injectWeb3());
     return gqlQuery({
       circles: [
         {

--- a/cypress/e2e/createVault.cy.ts
+++ b/cypress/e2e/createVault.cy.ts
@@ -4,9 +4,8 @@ let circleId;
 
 context('Coordinape', () => {
   before(() => {
-    const providerPort = Cypress.env('HARDHAT_GANACHE_PORT');
     const userAccount = deriveAccount().address;
-    Cypress.on('window:before:load', injectWeb3(providerPort));
+    Cypress.on('window:before:load', injectWeb3());
     return cy
       .mintErc20('USDC', userAccount, '20000')
       .then(() =>

--- a/cypress/e2e/updateCircle.cy.ts
+++ b/cypress/e2e/updateCircle.cy.ts
@@ -4,8 +4,7 @@ let circleId;
 
 context('Coordinape', () => {
   before(() => {
-    const providerPort = Cypress.env('HARDHAT_GANACHE_PORT');
-    Cypress.on('window:before:load', injectWeb3(providerPort));
+    Cypress.on('window:before:load', injectWeb3());
     return gqlQuery({
       circles: [
         {

--- a/cypress/e2e/updateUser.cy.ts
+++ b/cypress/e2e/updateUser.cy.ts
@@ -4,8 +4,7 @@ let circleId;
 
 context('Coordinape', () => {
   before(() => {
-    const providerPort = Cypress.env('HARDHAT_GANACHE_PORT');
-    Cypress.on('window:before:load', injectWeb3(providerPort));
+    Cypress.on('window:before:load', injectWeb3());
     return gqlQuery({
       circles: [
         {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -6,7 +6,14 @@
 // commands please read more here:
 // https://on.cypress.io/custom-commands
 // ***********************************************
+import { JsonRpcProvider } from '@ethersproject/providers';
+
 import { mintToken } from '../../src/utils/testing/mint';
+
+const provider = new JsonRpcProvider(
+  `http://localhost:${Cypress.env('HARDHAT_GANACHE_PORT')}`
+);
+
 Cypress.Commands.add('login', () => {
   cy.contains('Metamask').click();
 });
@@ -16,7 +23,7 @@ Cypress.Commands.add('login', () => {
 // Cypress' async context
 Cypress.Commands.add('mintErc20', (...args) => {
   cy.then(async () => {
-    await mintToken(...args);
+    await mintToken(...args, provider);
   });
 });
 

--- a/cypress/util/index.ts
+++ b/cypress/util/index.ts
@@ -56,9 +56,9 @@ export class TestProvider {
   }
 }
 
-export const injectWeb3 = (providerPort: string) => (win: any) => {
+export const injectWeb3 = () => (win: any) => {
   const provider = new Web3Provider(
-    new TestProvider('http://localhost:' + providerPort)
+    new TestProvider('http://localhost:' + Cypress.env('HARDHAT_GANACHE_PORT'))
   );
   if (!win.ethereum) {
     Object.defineProperty(win, 'ethereum', { value: provider });

--- a/src/lib/vaults/contracts.test.ts
+++ b/src/lib/vaults/contracts.test.ts
@@ -1,13 +1,13 @@
 import { AddressZero } from '@ethersproject/constants';
 
-import { chainId, provider } from 'utils/testing/provider';
+import { provider } from 'utils/testing';
 
 import { Contracts } from './contracts';
 
 let contracts: Contracts;
 
-beforeEach(() => {
-  contracts = new Contracts(chainId, provider);
+beforeEach(async () => {
+  contracts = await Contracts.fromProvider(provider());
 });
 
 test('getTokenAddress throws on unrecognized input', () => {

--- a/src/lib/vaults/contracts.ts
+++ b/src/lib/vaults/contracts.ts
@@ -78,6 +78,11 @@ export class Contracts {
     );
   }
 
+  static async fromProvider(provider: JsonRpcProvider) {
+    const { chainId } = await provider.getNetwork();
+    return new Contracts(chainId, provider);
+  }
+
   get signer() {
     assert(this._signer, 'Contracts instance is read-only');
     return this._signer;

--- a/src/lib/vaults/distributor.test.ts
+++ b/src/lib/vaults/distributor.test.ts
@@ -2,13 +2,17 @@ import { hexZeroPad } from '@ethersproject/bytes';
 import { AddressZero } from '@ethersproject/constants';
 import { parseUnits } from '@ethersproject/units';
 
+import { provider } from 'utils/testing';
 import { mint, tokens } from 'utils/testing/mint';
-import { chainId, provider } from 'utils/testing/provider';
 
 import { Contracts, encodeCircleId, getWrappedAmount } from '.';
 import { uploadEpochRoot } from './distributor';
 
-const contracts = new Contracts(chainId, provider);
+let contracts: Contracts;
+
+beforeAll(async () => {
+  contracts = await Contracts.fromProvider(provider());
+});
 
 describe('simple token', () => {
   beforeEach(async () => {

--- a/src/pages/ClaimsPage/useClaimAllocation.test.tsx
+++ b/src/pages/ClaimsPage/useClaimAllocation.test.tsx
@@ -60,7 +60,7 @@ const origError = console.error;
 
 beforeAll(async () => {
   snapshotId = await takeSnapshot();
-  const mainAccount = (await provider.listAccounts())[0];
+  const mainAccount = (await provider().listAccounts())[0];
   await mint({
     token: Asset.DAI,
     address: mainAccount,

--- a/src/pages/DistributionsPage/useSubmitDistribution.test.tsx
+++ b/src/pages/DistributionsPage/useSubmitDistribution.test.tsx
@@ -75,7 +75,7 @@ jest.mock('pages/DistributionsPage/mutations', () => {
 
 beforeAll(async () => {
   snapshotId = await takeSnapshot();
-  const mainAccount = (await provider.listAccounts())[0];
+  const mainAccount = (await provider().listAccounts())[0];
   await mint({
     token: Asset.DAI,
     address: mainAccount,

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -1,11 +1,5 @@
-import {
-  Web3Provider,
-  InfuraProvider,
-  JsonRpcProvider,
-} from '@ethersproject/providers';
+import { Web3Provider } from '@ethersproject/providers';
 import { ethers } from 'ethers';
-
-import { INFURA_PROJECT_ID, HARDHAT_GANACHE_PORT } from 'config/env';
 
 export const getSignature = async (data: string, provider?: Web3Provider) => {
   if (!provider) throw 'Missing provider for getSignature';
@@ -80,22 +74,5 @@ export function makeExplorerUrl(
       return '#' + txHash;
     default:
       console.warn(`No explorer for chain ID ${chainId}; tx Hash: ` + txHash);
-  }
-}
-
-export function getProviderForChain(chainId: number) {
-  switch (chainId) {
-    case 1: // mainnet
-      return new InfuraProvider('homestead', INFURA_PROJECT_ID);
-    case 5: // Goerli
-      return new InfuraProvider('goerli', INFURA_PROJECT_ID);
-    case 1337:
-    case 1338:
-      return new JsonRpcProvider(
-        'http://localhost:' + HARDHAT_GANACHE_PORT,
-        chainId
-      );
-    default:
-      throw new Error(`chainId ${chainId} is unsupported`);
   }
 }

--- a/src/utils/testing/index.tsx
+++ b/src/utils/testing/index.tsx
@@ -1,6 +1,6 @@
 import { ReactElement, Suspense, useEffect } from 'react';
 
-import { JsonRpcProvider, Web3Provider } from '@ethersproject/providers';
+import { Web3Provider } from '@ethersproject/providers';
 import { Web3ReactProvider, useWeb3React } from '@web3-react/core';
 import { NetworkConnector } from '@web3-react/network-connector';
 import { SnackbarProvider } from 'notistack';
@@ -12,7 +12,14 @@ import { ThemeProvider } from '@material-ui/styles';
 
 import { createTheme } from 'theme';
 
-import { chainId, rpcUrl } from './provider';
+import {
+  chainId,
+  rpcUrl,
+  provider,
+  takeSnapshot,
+  restoreSnapshot,
+} from './provider';
+export { provider, takeSnapshot, restoreSnapshot };
 
 const theme = createTheme();
 
@@ -67,20 +74,6 @@ export const TestWrapper = ({
       </QueryClientProvider>
     </RecoilRoot>
   );
-};
-
-export const provider = new JsonRpcProvider(rpcUrl);
-
-export const takeSnapshot = async (): Promise<string> => {
-  return (await provider.send('evm_snapshot', [])) as string;
-};
-
-export const restoreSnapshot = async (snapshotId?: string) => {
-  if (!snapshotId) {
-    console.error('No snapshot ID provided; not reverting.');
-    return;
-  }
-  return provider.send('evm_revert', [snapshotId]);
 };
 
 export * from './recoil';

--- a/src/utils/testing/provider.ts
+++ b/src/utils/testing/provider.ts
@@ -13,17 +13,32 @@ export const chainId = process.env.TEST_ON_HARDHAT_NODE
 const port = process.env.TEST_ON_HARDHAT_NODE
   ? HARDHAT_PORT
   : HARDHAT_GANACHE_PORT;
-export const rpcUrl = `http://localhost:${port}`;
-export const provider = new JsonRpcProvider(rpcUrl);
 
-export const takeSnapshot = async (): Promise<string> => {
-  return (await provider.send('evm_snapshot', [])) as string;
+export const rpcUrl = `http://localhost:${port}`;
+
+let _provider: JsonRpcProvider;
+
+export const provider = () => {
+  if (!_provider) _provider = new JsonRpcProvider(rpcUrl);
+  return _provider;
 };
 
-export const restoreSnapshot = async (snapshotId?: string) => {
+// These functions take optional provider args because the default provider may
+// not always be set up correctly, e.g. in Cypress
+
+export const takeSnapshot = async (
+  myProvider?: JsonRpcProvider
+): Promise<string> => {
+  return (await (myProvider || provider()).send('evm_snapshot', [])) as string;
+};
+
+export const restoreSnapshot = async (
+  snapshotId?: string,
+  myProvider?: JsonRpcProvider
+) => {
   if (!snapshotId) {
     console.error('No snapshot ID provided; not reverting.');
     return;
   }
-  return provider.send('evm_revert', [snapshotId]);
+  return (myProvider || provider()).send('evm_revert', [snapshotId]);
 };

--- a/src/utils/testing/unlockSigner.ts
+++ b/src/utils/testing/unlockSigner.ts
@@ -1,8 +1,14 @@
+import type { JsonRpcProvider } from '@ethersproject/providers';
 import { Signer } from 'ethers';
 
-import { provider } from './provider';
+import { provider as defaultProvider } from './provider';
 
-export async function unlockSigner(address: string): Promise<Signer> {
+export async function unlockSigner(
+  address: string,
+  provider?: JsonRpcProvider
+): Promise<Signer> {
+  if (!provider) provider = defaultProvider();
+
   if (!process.env.TEST_ON_HARDHAT_NODE) {
     await provider.send('evm_addAccount', [address, '']);
     await provider.send('personal_unlockAccount', [address, '', 0]);
@@ -10,6 +16,5 @@ export async function unlockSigner(address: string): Promise<Signer> {
   }
 
   await provider.send('hardhat_impersonateAccount', [address]);
-
   return provider.getSigner(address);
 }


### PR DESCRIPTION
These changes came out of work in #1540. They fix errors in Cypress when running ganache on a non-default port.