### PR TITLE
cache docker images in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -76,6 +76,11 @@ jobs:
           path: '**/hardhat/node_modules'
           key: hardhatNodeModules-${{ runner.os }}-${{ hashFiles('**/hardhat/yarn.lock') }}
 
+      - name: Cache Docker images
+        uses: ScribeMD/docker-cache@0.2.6
+        with:
+          key: docker-${{ runner.os }}-${{ hashFiles('**/docker-compose.yml') }}
+
       - run: yarn --frozen-lockfile
       - run: yarn cypress install
       - run: yarn cypress verify


### PR DESCRIPTION
Attempt to speed up CI Github Actions a bit by caching Docker images. If this works correctly, we should see many `Downloading...` and `Extracting...` log lines ([e.g.](https://github.com/coordinape/coordinape/actions/runs/3417769084/jobs/5689286607)) go away