### PR TITLE
upgrade github actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v4
+        uses: fkirc/skip-duplicate-actions@v5.2.0
         with:
           concurrent_skipping: 'same_content_newer'
           skip_after_successful_duplicate: false
@@ -21,17 +21,17 @@ jobs:
     env:
       CI: true
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3.1.0
+      - uses: actions/setup-node@v3.5.1
         with:
           node-version: 16.x
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3.0.11
         with:
           path: '**/node_modules'
           key: nodeModules-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3.0.11
         with:
           path: '/home/runner/.cache'
           key: nodeModules-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
@@ -59,19 +59,19 @@ jobs:
       REACT_APP_FEATURE_FLAG_FIXED_PAYMENTS: true
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3.1.0
+      - uses: actions/setup-node@v3.5.1
         with:
           node-version: 16.x
 
       - name: Cache node_modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3.0.11
         with:
           path: '**/node_modules'
           key: nodeModules-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 
       - name: Cache hardhat/node_modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3.0.11
         with:
           path: '**/hardhat/node_modules'
           key: hardhatNodeModules-${{ runner.os }}-${{ hashFiles('**/hardhat/yarn.lock') }}
@@ -83,7 +83,7 @@ jobs:
       - run: ./scripts/ci/manager.sh test --all
 
       - name: Save Cypress artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.1
         if: failure()
         with:
           name: cy-artifacts
@@ -98,7 +98,7 @@ jobs:
           ./codecov
 
       - name: Save coverage report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.1
         with:
           name: coverage
           path: ./coverage


### PR DESCRIPTION
to deal with warnings about the set-output and save-state commands being deprecated

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
