### PR TITLE
Fixup/markdown interactions

### DIFF
--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -634,6 +634,7 @@ const ContributionsPage = () => {
                       resetField('description', { defaultValue: '' });
                       resetCreateMutation();
                       setModalOpen(true);
+                      setShowMarkDown(false);
                     }}
                   >
                     <Edit />

--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -617,7 +617,10 @@ const ContributionsPage = () => {
                     />
                   </Panel>
                 )}
-                <Flex css={{ justifyContent: 'flex-end', mt: '$md' }}>
+                <Text size="small" color="neutral" css={{ ml: '$xs' }}>
+                  Markdown Supported
+                </Text>
+                <Flex css={{ justifyContent: 'flex-end', mt: '$xs' }}>
                   <Button
                     color="primary"
                     onClick={() => {

--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -538,8 +538,16 @@ const ContributionsPage = () => {
                     alignItems: 'flex-end',
                   }}
                 >
-                  <Text inline semibold size="medium">
+                  <Text inline semibold size="large">
                     Contribution
+                    <Text
+                      inline
+                      size="small"
+                      color="neutral"
+                      css={{ ml: '$sm' }}
+                    >
+                      Markdown Supported
+                    </Text>
                   </Text>
                   <Text variant="label">
                     {DateTime.fromISO(
@@ -617,10 +625,7 @@ const ContributionsPage = () => {
                     />
                   </Panel>
                 )}
-                <Text size="small" color="neutral" css={{ ml: '$xs' }}>
-                  Markdown Supported
-                </Text>
-                <Flex css={{ justifyContent: 'flex-end', mt: '$xs' }}>
+                <Flex css={{ justifyContent: 'flex-end', mt: '$md' }}>
                   <Button
                     color="primary"
                     onClick={() => {

--- a/src/pages/GivePage/EpochStatementDrawer.tsx
+++ b/src/pages/GivePage/EpochStatementDrawer.tsx
@@ -202,6 +202,9 @@ export const EpochStatementDrawer = ({
       <Flex column css={{ mt: '$xl', gap: '$sm' }}>
         <Text inline semibold size="large">
           Epoch Statement
+          <Text inline size="small" color="neutral" css={{ ml: '$sm' }}>
+            Markdown Supported
+          </Text>
         </Text>
         {showMarkdown ? (
           <Box


### PR DESCRIPTION
<img width="646" alt="Screenshot 2022-11-14 at 12 32 11 PM" src="https://user-images.githubusercontent.com/100873710/201770225-f1861d7b-9903-4064-ba6f-26db943bc889.png">
 Motivation and Context

* Add `Markdown Supported` tag to textarea labels on contributions form and epoch statement form
* fix `New` textarea focus bug
* fix blank contribution bug