### PR TITLE
Bugfix / Markdown interactions

### DIFF
--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -410,7 +410,7 @@ const ContributionsPage = () => {
           closeDrawer();
         }}
       >
-        <Panel invertForm css={{ p: 0, '& textarea': { resize: 'vertical' } }}>
+        <Panel invertForm css={{ p: 0 }}>
           {currentContribution ? (
             <>
               <Flex
@@ -540,14 +540,6 @@ const ContributionsPage = () => {
                 >
                   <Text inline semibold size="large">
                     Contribution
-                    <Text
-                      inline
-                      size="small"
-                      color="neutral"
-                      css={{ ml: '$sm' }}
-                    >
-                      Markdown Supported
-                    </Text>
                   </Text>
                   <Text variant="label">
                     {DateTime.fromISO(
@@ -573,50 +565,73 @@ const ContributionsPage = () => {
                       <MarkdownPreview source={descriptionField.value} />
                     </Box>
                   ) : (
-                    <FormInputField
-                      id="description"
-                      name="description"
-                      control={control}
-                      defaultValue={
-                        currentContribution.contribution.description
-                      }
-                      areaProps={{
-                        autoFocus: true,
-                        onChange: e => {
-                          setValue('description', e.target.value);
-                          // Don't schedule a new save if a createContribution
-                          // request is inflight, since this will create
-                          // a duplicate contribution
-                          if (
-                            !(
-                              currentContribution.contribution.id ===
-                                NEW_CONTRIBUTION_ID &&
-                              saveState[currentContribution.contribution.id] ==
-                                'saving'
+                    <>
+                      <FormInputField
+                        id="description"
+                        name="description"
+                        control={control}
+                        css={{
+                          textarea: {
+                            resize: 'vertical',
+                            pb: '$1xl',
+                          },
+                        }}
+                        defaultValue={
+                          currentContribution.contribution.description
+                        }
+                        areaProps={{
+                          autoFocus: true,
+                          onChange: e => {
+                            setValue('description', e.target.value);
+                            // Don't schedule a new save if a createContribution
+                            // request is inflight, since this will create
+                            // a duplicate contribution
+                            if (
+                              !(
+                                currentContribution.contribution.id ===
+                                  NEW_CONTRIBUTION_ID &&
+                                saveState[
+                                  currentContribution.contribution.id
+                                ] == 'saving'
+                              )
                             )
-                          )
-                            updateSaveStateForContribution(
-                              currentContribution.contribution.id,
-                              'buffering'
+                              updateSaveStateForContribution(
+                                currentContribution.contribution.id,
+                                'buffering'
+                              );
+                          },
+                          onBlur: () => {
+                            if (descriptionField.value.length > 0)
+                              setShowMarkDown(true);
+                          },
+                          onFocus: e => {
+                            e.currentTarget.setSelectionRange(
+                              e.currentTarget.value.length,
+                              e.currentTarget.value.length
                             );
-                        },
-                        onBlur: () => {
-                          if (descriptionField.value.length > 0)
-                            setShowMarkDown(true);
-                        },
-                        onFocus: e => {
-                          e.currentTarget.setSelectionRange(
-                            e.currentTarget.value.length,
-                            e.currentTarget.value.length
-                          );
-                        },
-                      }}
-                      disabled={
-                        !isEpochCurrentOrLater(currentContribution.epoch)
-                      }
-                      placeholder="What have you been working on?"
-                      textArea
-                    />
+                          },
+                        }}
+                        disabled={
+                          !isEpochCurrentOrLater(currentContribution.epoch)
+                        }
+                        placeholder="What have you been working on?"
+                        textArea
+                      />
+                      <Text
+                        inline
+                        size="small"
+                        color="neutral"
+                        css={{
+                          mx: '$sm',
+                          mt: '-$xl',
+                          textAlign: 'right',
+                          // to match the browser placeholder color
+                          opacity: '0.7',
+                        }}
+                      >
+                        Markdown Supported
+                      </Text>
+                    </>
                   )
                 ) : (
                   <Panel nested>
@@ -625,10 +640,12 @@ const ContributionsPage = () => {
                     />
                   </Panel>
                 )}
+
                 <Flex css={{ justifyContent: 'flex-end', mt: '$md' }}>
                   <Button
                     color="primary"
-                    onClick={() => {
+                    // using onMouseDown because the onBlur event on the markdown-ready textarea was preventing onClick
+                    onMouseDown={() => {
                       setCurrentContribution({
                         contribution: getNewContribution(
                           currentUserId,

--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -624,13 +624,11 @@ const ContributionsPage = () => {
                       <Text
                         inline
                         size="small"
-                        color="neutral"
+                        color="secondary"
                         css={{
                           position: 'absolute',
                           right: '$sm',
                           bottom: '$sm',
-                          // to match the browser placeholder color
-                          opacity: '0.7',
                         }}
                       >
                         Markdown Supported

--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -634,6 +634,7 @@ const ContributionsPage = () => {
                       resetField('description', { defaultValue: '' });
                       resetCreateMutation();
                       setModalOpen(true);
+                      setShowMarkDown(false);
                     }}
                   >
                     <Edit />

--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -357,6 +357,19 @@ const ContributionsPage = () => {
     resetUpdateMutation();
     reset();
   };
+  const newContribution = () => {
+    setCurrentContribution({
+      contribution: getNewContribution(
+        currentUserId,
+        memoizedEpochData.contributions[0]
+      ),
+      epoch: getCurrentEpoch(memoizedEpochData.epochs),
+    });
+    resetField('description', { defaultValue: '' });
+    resetCreateMutation();
+    setModalOpen(true);
+    setShowMarkDown(false);
+  };
 
   return (
     <>
@@ -374,17 +387,7 @@ const ContributionsPage = () => {
             outlined
             color="primary"
             onClick={() => {
-              setCurrentContribution({
-                contribution: getNewContribution(
-                  currentUserId,
-                  memoizedEpochData.contributions[0]
-                ),
-                epoch: getCurrentEpoch(memoizedEpochData.epochs),
-              });
-              resetField('description', { defaultValue: '' });
-              resetCreateMutation();
-              setModalOpen(true);
-              setShowMarkDown(false);
+              newContribution();
             }}
           >
             Add Contribution
@@ -573,7 +576,7 @@ const ContributionsPage = () => {
                       <MarkdownPreview source={descriptionField.value} />
                     </Box>
                   ) : (
-                    <>
+                    <Box css={{ position: 'relative' }}>
                       <FormInputField
                         id="description"
                         name="description"
@@ -581,7 +584,8 @@ const ContributionsPage = () => {
                         css={{
                           textarea: {
                             resize: 'vertical',
-                            pb: '$1xl',
+                            pb: '$xl',
+                            minHeight: 'calc($2xl * 2)',
                           },
                         }}
                         defaultValue={
@@ -630,16 +634,16 @@ const ContributionsPage = () => {
                         size="small"
                         color="neutral"
                         css={{
-                          mx: '$sm',
-                          mt: '-$xl',
-                          textAlign: 'right',
+                          position: 'absolute',
+                          right: '$sm',
+                          bottom: '$sm',
                           // to match the browser placeholder color
                           opacity: '0.7',
                         }}
                       >
                         Markdown Supported
                       </Text>
-                    </>
+                    </Box>
                   )
                 ) : (
                   <Panel nested>
@@ -652,19 +656,12 @@ const ContributionsPage = () => {
                 <Flex css={{ justifyContent: 'flex-end', mt: '$md' }}>
                   <Button
                     color="primary"
-                    // using onMouseDown because the onBlur event on the markdown-ready textarea was preventing onClick
+                    onClick={() => {
+                      newContribution();
+                    }}
+                    // adding onMouseDown because the onBlur event on the markdown-ready textarea was preventing onClick
                     onMouseDown={() => {
-                      setCurrentContribution({
-                        contribution: getNewContribution(
-                          currentUserId,
-                          memoizedEpochData.contributions[0]
-                        ),
-                        epoch: getCurrentEpoch(memoizedEpochData.epochs),
-                      });
-                      resetField('description', { defaultValue: '' });
-                      resetCreateMutation();
-                      setModalOpen(true);
-                      setShowMarkDown(false);
+                      newContribution();
                     }}
                   >
                     <Edit />

--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -617,7 +617,10 @@ const ContributionsPage = () => {
                     />
                   </Panel>
                 )}
-                <Flex css={{ justifyContent: 'flex-end', mt: '$md' }}>
+                <Text size="small" color="neutral" css={{ ml: '$xs' }}>
+                  Markdown Supported
+                </Text>
+                <Flex css={{ justifyContent: 'flex-end', mt: '$xs' }}>
                   <Button
                     color="primary"
                     onClick={() => {

--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -538,8 +538,16 @@ const ContributionsPage = () => {
                     alignItems: 'flex-end',
                   }}
                 >
-                  <Text inline semibold size="medium">
+                  <Text inline semibold size="large">
                     Contribution
+                    <Text
+                      inline
+                      size="small"
+                      color="neutral"
+                      css={{ ml: '$sm' }}
+                    >
+                      Markdown Supported
+                    </Text>
                   </Text>
                   <Text variant="label">
                     {DateTime.fromISO(
@@ -617,10 +625,7 @@ const ContributionsPage = () => {
                     />
                   </Panel>
                 )}
-                <Text size="small" color="neutral" css={{ ml: '$xs' }}>
-                  Markdown Supported
-                </Text>
-                <Flex css={{ justifyContent: 'flex-end', mt: '$xs' }}>
+                <Flex css={{ justifyContent: 'flex-end', mt: '$md' }}>
                   <Button
                     color="primary"
                     onClick={() => {

--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -543,14 +543,6 @@ const ContributionsPage = () => {
                 >
                   <Text inline semibold size="large">
                     Contribution
-                    <Text
-                      inline
-                      size="small"
-                      color="neutral"
-                      css={{ ml: '$sm' }}
-                    >
-                      Markdown Supported
-                    </Text>
                   </Text>
                   <Text variant="label">
                     {DateTime.fromISO(

--- a/src/pages/GivePage/EpochStatementDrawer.tsx
+++ b/src/pages/GivePage/EpochStatementDrawer.tsx
@@ -17,6 +17,7 @@ import {
   TextArea,
   ToggleButton,
   MarkdownPreview,
+  Panel,
 } from 'ui';
 import { SaveState, SavingIndicator } from 'ui/SavingIndicator';
 
@@ -199,57 +200,82 @@ export const EpochStatementDrawer = ({
           )}
         </Flex>
       </Flex>
-      <Flex column css={{ mt: '$xl', gap: '$sm' }}>
-        <Text inline semibold size="large">
-          Epoch Statement
-          <Text inline size="small" color="neutral" css={{ ml: '$sm' }}>
-            Markdown Supported
+      <Flex column css={{ mt: '$xl' }}>
+        <Panel invertForm css={{ p: 0, gap: '$sm' }}>
+          <Text inline semibold size="large">
+            Epoch Statement
           </Text>
-        </Text>
-        {showMarkdown ? (
-          <Box
-            onClick={() => {
-              setShowMarkDown(false);
+          {showMarkdown ? (
+            <Box
+              tabIndex={0}
+              css={{ borderRadius: '$3' }}
+              onClick={() => {
+                setShowMarkDown(false);
+              }}
+              onKeyDown={e => {
+                e.stopPropagation();
+                if (e.key === 'Enter' || e.key === ' ') {
+                  setShowMarkDown(false);
+                }
+              }}
+            >
+              <MarkdownPreview source={statement} />
+            </Box>
+          ) : (
+            <>
+              <TextArea
+                id="epoch_statement"
+                autoSize
+                css={{
+                  resize: 'vertical',
+                  pb: '$1xl',
+                }}
+                value={statement}
+                onChange={e => statementChanged(e.target.value)}
+                placeholder="Summarize your Contributions"
+                // eslint-disable-next-line jsx-a11y/no-autofocus
+                autoFocus={true}
+                onBlur={() => {
+                  if (statement.length > 0) setShowMarkDown(true);
+                }}
+                onFocus={e => {
+                  e.currentTarget.setSelectionRange(
+                    e.currentTarget.value.length,
+                    e.currentTarget.value.length
+                  );
+                }}
+              />
+              <Text
+                inline
+                size="small"
+                color="neutral"
+                css={{
+                  mx: '$sm',
+                  mt: '-$xl',
+                  textAlign: 'right',
+                  // to match the browser placeholder color
+                  opacity: '0.7',
+                }}
+              >
+                Markdown Supported
+              </Text>
+            </>
+          )}
+          <Flex
+            css={{
+              justifyContent: 'flex-end',
+              alignItems: 'center',
+              mt: '$sm',
             }}
           >
-            <MarkdownPreview source={statement} />
-          </Box>
-        ) : (
-          <TextArea
-            id="epoch_statement"
-            autoSize
-            css={{
-              backgroundColor: 'white',
-              width: '100%',
-              fontSize: '$medium',
-              whiteSpace: 'pre-wrap',
-            }}
-            value={statement}
-            onChange={e => statementChanged(e.target.value)}
-            placeholder="Summarize your Contributions"
-            // eslint-disable-next-line jsx-a11y/no-autofocus
-            autoFocus={true}
-            onBlur={() => {
-              if (statement.length > 0) setShowMarkDown(true);
-            }}
-            onFocus={e => {
-              e.currentTarget.setSelectionRange(
-                e.currentTarget.value.length,
-                e.currentTarget.value.length
-              );
-            }}
-          />
-        )}
-        <Flex
-          css={{ justifyContent: 'flex-end', alignItems: 'center', mt: '$sm' }}
-        >
-          <SavingIndicator
-            saveState={saving}
-            retry={() => {
-              updateEpochStatement(statement);
-            }}
-          />
-        </Flex>
+            <SavingIndicator
+              saveState={saving}
+              retry={() => {
+                updateEpochStatement(statement);
+              }}
+            />
+          </Flex>
+        </Panel>
       </Flex>
 
       <Box

--- a/src/pages/GivePage/EpochStatementDrawer.tsx
+++ b/src/pages/GivePage/EpochStatementDrawer.tsx
@@ -250,13 +250,11 @@ export const EpochStatementDrawer = ({
               <Text
                 inline
                 size="small"
-                color="neutral"
+                color="secondary"
                 css={{
                   position: 'absolute',
                   right: '$sm',
                   bottom: '$sm',
-                  // to match the browser placeholder color
-                  opacity: '0.7',
                 }}
               >
                 Markdown Supported

--- a/src/pages/GivePage/EpochStatementDrawer.tsx
+++ b/src/pages/GivePage/EpochStatementDrawer.tsx
@@ -202,6 +202,9 @@ export const EpochStatementDrawer = ({
       <Flex column css={{ mt: '$xl', gap: '$sm' }}>
         <Text inline semibold size="large">
           Epoch Statement
+          <Text inline size="small" color="neutral" css={{ ml: '$sm' }}>
+            Markdown Supported
+          </Text>
         </Text>
         {showMarkdown ? (
           <Box

--- a/src/pages/GivePage/EpochStatementDrawer.tsx
+++ b/src/pages/GivePage/EpochStatementDrawer.tsx
@@ -222,13 +222,13 @@ export const EpochStatementDrawer = ({
               <MarkdownPreview source={statement} />
             </Box>
           ) : (
-            <Box css={{ position: 'relative', width: '100%' }}>
+            <Box css={{ position: 'relative' }}>
               <TextArea
                 id="epoch_statement"
                 autoSize
                 css={{
                   resize: 'vertical',
-                  pb: '$1xl',
+                  pb: '$xl',
                   width: '100%',
                   minHeight: 'calc($2xl * 2)',
                 }}

--- a/src/ui/TextArea/TextArea.tsx
+++ b/src/ui/TextArea/TextArea.tsx
@@ -7,6 +7,8 @@ import { styled } from '../../stitches.config';
 import { modifyVariantsForStory } from '../type-utils';
 
 const StyledTextArea = styled('textarea', {
+  fontSize: '$medium',
+  whiteSpace: 'pre-wrap',
   background: '$surface',
   border: '1px solid transparent',
   '&:focus': {


### PR DESCRIPTION
Dialing the markdown hint text a bit more...

* add `markdown supported` hint text overlay to the textarea
* hide for rendered markdown view
* bugfix onBlur / onClick bug

<img width="645" alt="Screenshot 2022-11-14 at 5 14 22 PM" src="https://user-images.githubusercontent.com/100873710/201802270-47253f4f-1c68-4e54-877c-fce77021d97e.png">
<img width="646" alt="Screenshot 2022-11-14 at 5 17 27 PM" src="https://user-images.githubusercontent.com/100873710/201802695-4c983ee3-4a75-4fb3-b9d4-4904ce51cd90.png">
<img width="643" alt="Screenshot 2022-11-14 at 5 17 40 PM" src="https://user-images.githubusercontent.com/100873710/201802703-87362849-c660-47fa-ad0e-bf37d9f52b2a.png">

