### PR TITLE
adding 45s timeout to all adminClient graphql calls

### DIFF
--- a/api-lib/gql/adminClient.ts
+++ b/api-lib/gql/adminClient.ts
@@ -8,6 +8,9 @@ const thunder = makeThunder({
     'x-hasura-admin-secret': HASURA_GRAPHQL_ADMIN_SECRET,
     'Hasura-Client-Name': 'serverless-function',
   },
+  // 45 sec - vercel has a 60s timeout and we are trying to figure out why we are hitting it
+  // so setting this lower might help us -g
+  timeout: 45 * 1000,
 });
 
 export const adminClient = {

--- a/api-lib/gql/makeThunder.ts
+++ b/api-lib/gql/makeThunder.ts
@@ -3,9 +3,10 @@ import { apiFetch, Thunder } from './__generated__/zeus';
 type ThunderOptions = {
   url: string;
   headers: Record<string, string>;
+  timeout?: number;
 };
 
-export const makeThunder = ({ url, headers }: ThunderOptions) =>
+export const makeThunder = ({ url, headers, timeout = 0 }: ThunderOptions) =>
   Thunder(async (...params) =>
-    apiFetch([url, { method: 'POST', headers }])(...params)
+    apiFetch([url, { method: 'POST', headers, timeout: timeout }])(...params)
   );


### PR DESCRIPTION
## Motivation and Context

We are getting 60s timeouts in vercel and it's a bit unclear why. If we timeout the zeus calls back to hasura at 45s maybe we will find some meaning. 

## Description

Adding 45s timeout to adminClient

## Test plan

Test out on a dev vercel instance and make sure some custom actions work ok (eg allocating)

