### PR TITLE
add markdown support for allocation notes

### DIFF
--- a/src/components/MainLayout/OverviewMenu.tsx
+++ b/src/components/MainLayout/OverviewMenu.tsx
@@ -137,7 +137,7 @@ export const OverviewMenu = ({
           left: '$xl',
           top: 'calc($xxs - $3xl)',
           mb: '$lg',
-          zIndex: 2,
+          zIndex: 4,
           // 1px border position bugfix:
           pl: '1px',
         }}

--- a/src/components/ReceiveInfo.tsx
+++ b/src/components/ReceiveInfo.tsx
@@ -20,6 +20,7 @@ import {
   PopoverContent,
   Text,
   POPOVER_TIMEOUT,
+  MarkdownPreview,
 } from 'ui';
 
 export const QUERY_KEY_RECEIVE_INFO = 'getReceiveInfo';
@@ -108,6 +109,10 @@ export const ReceiveInfo = () => {
         align="end"
         sideOffset={-38}
         alignOffset={-1}
+        css={{
+          maxHeight: '$smallScreen',
+          overflowY: 'scroll',
+        }}
       >
         <Box
           css={{
@@ -180,9 +185,7 @@ export const ReceiveInfo = () => {
                     name={tokenGift.sender.name}
                   />
                   {tokenGift.gift_private?.note ? (
-                    <Text p as="p" size="small">
-                      {tokenGift.gift_private.note}
-                    </Text>
+                    <MarkdownPreview source={tokenGift.gift_private.note} />
                   ) : (
                     <Text color="neutral">-- Empty Note --</Text>
                   )}

--- a/src/components/ReceiveInfo.tsx
+++ b/src/components/ReceiveInfo.tsx
@@ -112,6 +112,7 @@ export const ReceiveInfo = () => {
         css={{
           maxHeight: '$smallScreen',
           overflowY: 'scroll',
+          zIndex: 4,
         }}
       >
         <Box

--- a/src/pages/GivePage/GiveDrawer.tsx
+++ b/src/pages/GivePage/GiveDrawer.tsx
@@ -68,6 +68,8 @@ export const GiveDrawer = ({
     }
   );
 
+  const [showMarkdown, setShowMarkDown] = useState<boolean>(true);
+
   // note is the current state of the note
   const [note, setNote] = useState(gift.note);
 
@@ -89,6 +91,9 @@ export const GiveDrawer = ({
       // reset the need to save indicator so it doesnt say 'Changes Saved' when
       // it has already moved to 'Saved'.
 
+      if (!note || (note.length === 0 && showMarkdown)) {
+        setShowMarkDown(false);
+      }
       if (saveState == 'saved') {
         setNeedToSave(false);
       }
@@ -219,21 +224,66 @@ export const GiveDrawer = ({
           {/*  Giving Feedback in Web3*/}
           {/*</ApeInfoTooltip>*/}
         </Box>
-        <TextArea
-          autoSize
-          css={{
-            backgroundColor: 'white',
-            width: '100%',
-            mt: '$xs',
-            mb: '$md',
-            fontSize: '$medium',
-          }}
-          // eslint-disable-next-line jsx-a11y/no-autofocus
-          autoFocus={true}
-          value={note ?? ''}
-          onChange={e => noteChanged(e.target.value)}
-          placeholder="Say thanks or give constructive feedback."
-        />
+        {showMarkdown ? (
+          <Box
+            tabIndex={0}
+            css={{ borderRadius: '$3' }}
+            onClick={() => {
+              setShowMarkDown(false);
+            }}
+            onKeyDown={e => {
+              e.stopPropagation();
+              if (e.key === 'Enter' || e.key === ' ') {
+                setShowMarkDown(false);
+              }
+            }}
+          >
+            <MarkdownPreview source={note} />
+          </Box>
+        ) : (
+          <Box css={{ position: 'relative' }}>
+            <TextArea
+              autoSize
+              css={{
+                backgroundColor: 'white',
+                width: '100%',
+                mt: '$xs',
+                mb: '$md',
+                pb: '$xl',
+                fontSize: '$medium',
+                resize: 'vertical',
+                minHeight: 'calc($2xl * 2)',
+              }}
+              // eslint-disable-next-line jsx-a11y/no-autofocus
+              autoFocus={true}
+              value={note ?? ''}
+              onChange={e => noteChanged(e.target.value)}
+              onBlur={() => {
+                if (note && note?.length > 0) setShowMarkDown(true);
+              }}
+              onFocus={e => {
+                e.currentTarget.setSelectionRange(
+                  e.currentTarget.value.length,
+                  e.currentTarget.value.length
+                );
+              }}
+              placeholder="Say thanks or give constructive feedback."
+            />
+            <Text
+              inline
+              size="small"
+              color="secondary"
+              css={{
+                position: 'absolute',
+                right: '$sm',
+                bottom: '$sm',
+              }}
+            >
+              Markdown Supported
+            </Text>
+          </Box>
+        )}
+
         <Flex css={{ justifyContent: 'flex-end', mt: '$md' }}>
           <Button
             color="primary"

--- a/src/pages/GivePage/GiveDrawer.tsx
+++ b/src/pages/GivePage/GiveDrawer.tsx
@@ -289,6 +289,8 @@ export const GiveDrawer = ({
             color="primary"
             disabled={selectedMemberIdx == totalMembers - 1}
             onClick={() => nextMember(true)}
+            // adding onMouseDown because the onBlur event on the markdown-ready textarea was preventing onClick
+            onMouseDown={() => nextMember(true)}
           >
             <Edit />
             Next

--- a/src/pages/HistoryPage/EpochPanel.tsx
+++ b/src/pages/HistoryPage/EpochPanel.tsx
@@ -9,7 +9,16 @@ import { CSS } from 'stitches.config';
 import isFeatureEnabled from 'config/features';
 import { useApiAdminCircle } from 'hooks';
 import { paths } from 'routes/paths';
-import { Avatar, Box, Panel, Text, Button, AppLink, Flex } from 'ui';
+import {
+  Avatar,
+  Box,
+  Panel,
+  Text,
+  Button,
+  AppLink,
+  Flex,
+  MarkdownPreview,
+} from 'ui';
 
 import type { QueryPastEpoch, QueryDistribution } from './getHistoryData';
 
@@ -300,12 +309,27 @@ const NotesItem = ({
 
   const note = gift.gift_private?.note;
   return (
-    <Box css={{ display: 'flex', my: '$sm' }}>
+    <Box
+      css={{
+        display: 'grid',
+        gridTemplateColumns: '1fr 15fr',
+        my: '$sm',
+      }}
+    >
       <Box css={{ mr: '$md' }}>
         <Avatar path={other.profile?.avatar} name={other.name} size="medium" />
       </Box>
       <Box css={!note ? { alignItems: 'center', display: 'flex' } : {}}>
-        {note && <Text css={{ mb: '$xs', lineHeight: 'normal' }}>{note}</Text>}
+        {note && (
+          <MarkdownPreview
+            css={{
+              mb: '$xs',
+              borderColor: '$borderMedium !important',
+              borderRadius: '$1',
+            }}
+            source={note}
+          />
+        )}
         <Box css={{ fontSize: '$small', color: '$secondaryText' }}>
           {gift.tokens} {tokenName} {received ? 'received from ' : 'sent to '}
           {other.name}

--- a/src/pages/HistoryPage/EpochPanel.tsx
+++ b/src/pages/HistoryPage/EpochPanel.tsx
@@ -323,9 +323,7 @@ const NotesItem = ({
         {note && (
           <MarkdownPreview
             css={{
-              mb: '$xs',
-              borderColor: '$borderMedium !important',
-              borderRadius: '$1',
+              p: 0,
             }}
             source={note}
           />


### PR DESCRIPTION
## Motivation and Context
 
resolves #1561

## Description

1- Allow user send markdown notes
2- display markdown in ReceiveInfo popover and EpochPanel

## Test and Deployment Plan
preocondition: Active Epoch
1- Go to Allocation page and click on the user that you want to allocate to 'another wallet of users so that you can view the notes
2-  write markdown note to that user
3- Switch to the other user to view the markdown note on the give popover
4- wait for the epoch to end to be able to view it on EpochPanel

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/34943689/202569737-9fb4ebaf-513c-43e9-b951-322f9b365e5e.png)
scrollable popover
![image](https://user-images.githubusercontent.com/34943689/202569833-7441907d-8ce1-438f-a784-fb436f84cf54.png)
![image](https://user-images.githubusercontent.com/34943689/202570041-1f0a9a85-5274-4686-a83c-22cd24dbf097.png)
![image](https://user-images.githubusercontent.com/34943689/202569967-db830369-6b43-4574-9e2c-b96f88263217.png)

