### PR TITLE
Bugfix console warnings nested `button` and `anchor`

### DIFF
--- a/src/components/MainLayout/OverviewMenu.tsx
+++ b/src/components/MainLayout/OverviewMenu.tsx
@@ -22,7 +22,6 @@ import {
   PopoverTrigger,
   PopoverContent,
   PopoverClose,
-  // PopoverAnchor,
   POPOVER_TIMEOUT,
 } from 'ui';
 
@@ -111,7 +110,6 @@ export const OverviewMenu = ({
         }}
       >
         {overviewMenuTrigger}
-        {/* <PopoverAnchor /> */}
       </PopoverTrigger>
       <PopoverContent
         onKeyDown={e => {

--- a/src/components/MainLayout/OverviewMenu.tsx
+++ b/src/components/MainLayout/OverviewMenu.tsx
@@ -22,7 +22,7 @@ import {
   PopoverTrigger,
   PopoverContent,
   PopoverClose,
-  PopoverAnchor,
+  // PopoverAnchor,
   POPOVER_TIMEOUT,
 } from 'ui';
 
@@ -58,7 +58,7 @@ export const OverviewMenu = ({
     ? 'CoVaults'
     : 'Overview';
   const overviewMenuTrigger = (
-    <Link
+    <Text
       css={navLinkStyle}
       className={
         location.pathname === paths.circles ||
@@ -67,13 +67,12 @@ export const OverviewMenu = ({
           ? 'active'
           : ''
       }
-      href="#"
     >
       {overviewMenuTriggerText}
       <Box css={{ marginLeft: '$xs', display: 'flex' }}>
         <ChevronDown size="lg" />
       </Box>
-    </Link>
+    </Text>
   );
 
   const [mouseEnterPopover, setMouseEnterPopover] = useState(false);
@@ -112,7 +111,7 @@ export const OverviewMenu = ({
         }}
       >
         {overviewMenuTrigger}
-        <PopoverAnchor />
+        {/* <PopoverAnchor /> */}
       </PopoverTrigger>
       <PopoverContent
         onKeyDown={e => {

--- a/src/components/MainLayout/OverviewMenu.tsx
+++ b/src/components/MainLayout/OverviewMenu.tsx
@@ -85,8 +85,8 @@ export const OverviewMenu = ({
   return (
     <Popover open={mouseEnterPopover}>
       <PopoverTrigger
-        tabIndex={-1}
-        css={{ outline: 'none !important' }}
+        tabIndex={0}
+        css={{ borderRadius: '$pill' }}
         ref={triggerRef}
         onKeyDown={e => {
           if (e.key === 'Enter' || e.key === ' ') {

--- a/src/components/MainLayout/OverviewMenu.tsx
+++ b/src/components/MainLayout/OverviewMenu.tsx
@@ -132,11 +132,11 @@ export const OverviewMenu = ({
           outline: 'none',
           position: 'relative',
           left: '$xl',
-          top: 'calc($xxs - $3xl)',
-          mb: '$lg',
-          zIndex: 2,
           // 1px border position bugfix:
           pl: '1px',
+          top: 'calc($xxs - $3xl + 1px)',
+          mb: '$lg',
+          zIndex: 2,
         }}
       >
         <Box

--- a/src/components/MyAvatarMenu/MyAvatarMenu.tsx
+++ b/src/components/MyAvatarMenu/MyAvatarMenu.tsx
@@ -14,7 +14,6 @@ import {
   Box,
   Link,
   Popover,
-  PopoverAnchor,
   PopoverTrigger,
   PopoverContent,
   PopoverClose,
@@ -73,7 +72,6 @@ export const MyAvatarMenu = ({ walletStatus }: Props) => {
             <Link href="#">
               <Avatar path={myProfile.avatar} name="me" />
             </Link>
-            <PopoverAnchor />
           </PopoverTrigger>
           <PopoverContent
             onKeyDown={e => {

--- a/src/components/ReceiveInfo.tsx
+++ b/src/components/ReceiveInfo.tsx
@@ -61,6 +61,7 @@ export const ReceiveInfo = () => {
   return (
     <Popover open={mouseEnterPopover}>
       <PopoverTrigger
+        tabIndex={0}
         onKeyDown={e => {
           if (e.key === 'Enter' || e.key === ' ') {
             clearTimeout(timeoutId);

--- a/src/components/ReceiveInfo.tsx
+++ b/src/components/ReceiveInfo.tsx
@@ -79,7 +79,7 @@ export const ReceiveInfo = () => {
           );
         }}
       >
-        <Button tabIndex={-1} size="small" color="surface">
+        <Button as="div" tabIndex={-1} size="small" color="surface">
           {!currentNonReceiver ? totalReceived : 0}{' '}
           {data?.myReceived?.token_name ?? 'GIVE'}
         </Button>

--- a/src/pages/GivePage/GiveRow.tsx
+++ b/src/pages/GivePage/GiveRow.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 
 import { FileText } from '../../icons/__generated';
 import { CSS } from '../../stitches.config';
-import { Button, Box, Flex, Text } from '../../ui';
+import { Box, Flex, Text } from '../../ui';
 import useMobileDetect from 'hooks/useMobileDetect';
 
 import { AvatarAndName } from './AvatarAndName';
@@ -41,7 +41,7 @@ export const GiveRow = ({
   // noteComplete indicates that this member has a note
   const noteComplete = gift.note && gift.note.length > 0;
   const { isMobile } = useMobileDetect();
-  const newRef = useRef<HTMLButtonElement>(null);
+  const newRef = useRef<HTMLDivElement>(null);
   const [lastSelected, setLastSelected] = useState<boolean>(false);
   useEffect(() => {
     if (selected) {
@@ -54,12 +54,19 @@ export const GiveRow = ({
     }
   }, [selected, lastSelected]);
   return (
-    <Button
+    <Box
+      tabIndex={0}
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
       onClick={() => setSelectedMember(member)}
+      onKeyDown={e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          setSelectedMember(member);
+          e.preventDefault();
+        }
+      }}
       color="transparent"
-      css={{ p: 0 }}
+      css={{ p: 0, borderRadius: '$3' }}
       ref={newRef}
     >
       <GiveRowGrid selected={(selected || docExample) ?? false} css={css}>
@@ -183,6 +190,6 @@ export const GiveRow = ({
           />
         </Flex>
       </GiveRowGrid>
-    </Button>
+    </Box>
   );
 };

--- a/src/pages/GivePage/MyGiveRow.tsx
+++ b/src/pages/GivePage/MyGiveRow.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import { ApeInfoTooltip } from '../../components';
 import { Check, X } from '../../icons/__generated';
 import { IMyUser } from '../../types';
-import { Box, Button, Flex, Text, ToggleButton } from 'ui';
+import { Box, Flex, Text, ToggleButton } from 'ui';
 
 import { AvatarAndName } from './AvatarAndName';
 import { GiveRowGrid } from './GiveRowGrid';
@@ -33,7 +33,7 @@ export const MyGiveRow = ({
   statementCompelete: boolean;
   selected: boolean;
 }) => {
-  const newRef = useRef<HTMLButtonElement>(null);
+  const newRef = useRef<HTMLDivElement>(null);
   const [lastSelected, setLastSelected] = useState<boolean>(false);
 
   useEffect(() => {
@@ -47,10 +47,18 @@ export const MyGiveRow = ({
     }
   }, [selected, lastSelected]);
   return (
-    <Button
+    <Box
+      tabIndex={0}
       onClick={openEpochStatement}
+      onKeyDown={e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          openEpochStatement();
+          e.preventDefault();
+          e.stopPropagation();
+        }
+      }}
       color="transparent"
-      css={{ p: 0, width: '100%' }}
+      css={{ p: 0, width: '100%', borderRadius: '$3' }}
       ref={newRef}
     >
       <GiveRowGrid
@@ -176,6 +184,6 @@ export const MyGiveRow = ({
         tokenName={myUser.circle.tokenName}
         give_token_received={myUser.give_token_received}
       />
-    </Button>
+    </Box>
   );
 };

--- a/src/ui/Popover/Popover.stories.tsx
+++ b/src/ui/Popover/Popover.stories.tsx
@@ -7,7 +7,6 @@ import { Box, Button } from 'ui';
 
 import {
   Popover as PopoverComponent,
-  PopoverAnchor,
   PopoverClose,
   PopoverContent,
   PopoverTrigger,
@@ -45,7 +44,6 @@ const Template: ComponentStory<typeof PopoverComponent> = () => {
         >
           Popover Trigger
         </Button>
-        <PopoverAnchor />
       </PopoverTrigger>
       <PopoverContent
         onMouseEnter={onMouseEnter}

--- a/src/ui/Popover/Popover.tsx
+++ b/src/ui/Popover/Popover.tsx
@@ -1,10 +1,6 @@
 import * as PopoverPrimitive from '@radix-ui/react-popover';
 import { styled } from 'stitches.config';
 
-const StyledTrigger = styled(PopoverPrimitive.Trigger, {
-  outline: 'none !important',
-});
-
 const StyledContent = styled(PopoverPrimitive.Content, {
   padding: 0,
   borderRadius: '$3',
@@ -17,8 +13,7 @@ const StyledContent = styled(PopoverPrimitive.Content, {
 
 export const POPOVER_TIMEOUT = 300;
 export const Popover = PopoverPrimitive.Root;
-// export const PopoverTrigger = styled(PopoverPrimitive.Trigger, {});
-export const PopoverTrigger = StyledTrigger;
+export const PopoverTrigger = styled(PopoverPrimitive.Trigger, {});
 export const PopoverAnchor = PopoverPrimitive.Anchor;
 export const PopoverPortal = PopoverPrimitive.Portal;
 export const PopoverContent = StyledContent;


### PR DESCRIPTION
* Console log was getting filled with improper nesting warnings.  Fixed.
* Remove Popover anchor, as it's not actually needed.  I thought it would be helpful in making positioning easier, but the new version of Radix popover makes the positioning easier without `PopoverAnchor`, which can be used if you want the popover to appear someplace different than the trigger.

