### PR TITLE
 Bug: Dework tasks not showing up on Allocations card view

### DIFF
--- a/src/pages/GivePage/EpochStatementDrawer.tsx
+++ b/src/pages/GivePage/EpochStatementDrawer.tsx
@@ -6,7 +6,14 @@ import { useMutation, useQuery } from 'react-query';
 import { NavLink } from 'react-router-dom';
 
 import { ApeInfoTooltip } from '../../components';
-import { Check, ChevronsRight, X } from 'icons/__generated';
+import { useContributions } from 'hooks/useContributions';
+import {
+  Check,
+  ChevronsRight,
+  DeworkColor,
+  WonderColor,
+  X,
+} from 'icons/__generated';
 import { paths } from 'routes/paths';
 import {
   Avatar,
@@ -30,6 +37,15 @@ import { IMyUser } from 'types';
 const DEBOUNCE_TIMEOUT = 1000;
 
 export const QUERY_KEY_ALLOCATE_CONTRIBUTIONS = 'allocate-contributions';
+
+const contributionIcon = (source: string) => {
+  switch (source) {
+    case 'wonder':
+      return <WonderColor css={{ mr: '$md' }} />;
+    default:
+      return <DeworkColor css={{ mr: '$md' }} />;
+  }
+};
 
 type StatementDrawerProps = {
   myUser: IMyUser;
@@ -76,6 +92,12 @@ export const EpochStatementDrawer = ({
       staleTime: Infinity,
     }
   );
+  const integrationContributions = useContributions({
+    address: member.address || '',
+    startDate: start_date.toISOString(),
+    endDate: end_date.toISOString(),
+    mock: false,
+  });
 
   // saveTimeout is the timeout handle for the buffered async saving
   const [saving, setSaving] = useState<SaveState>('stable');
@@ -307,7 +329,9 @@ export const EpochStatementDrawer = ({
             <Box>Loading...</Box>
           )}
           {contributions &&
-            (contributions.length == 0 ? (
+            (contributions.length === 0 &&
+            (!integrationContributions ||
+              integrationContributions?.length === 0) ? (
               <>
                 <Box>
                   <Text inline color="neutral">
@@ -319,6 +343,34 @@ export const EpochStatementDrawer = ({
               contributions.map(c => (
                 <Contribution key={c.id} contribution={c} />
               ))
+            ))}
+          {integrationContributions &&
+            integrationContributions.length > 0 &&
+            integrationContributions.map(c => (
+              <Box
+                key={c.link}
+                css={{
+                  p: '$md $sm',
+                  borderBottom: '1px solid $border',
+                }}
+              >
+                <Text
+                  ellipsis
+                  css={{
+                    cursor: 'default',
+                    backgroundColor: 'rgb(225 229 232) !important',
+                    borderColor: '$borderMedium !important',
+                    boxShadow: '$shadow1',
+                    border: '1px solid transparent',
+                    minHeight: 0,
+                    borderRadius: '$1',
+                    p: '$md',
+                  }}
+                >
+                  {contributionIcon(c.source)}
+                  {c.title}
+                </Text>
+              </Box>
             ))}
         </Box>
       </Box>

--- a/src/pages/GivePage/GiveDrawer.tsx
+++ b/src/pages/GivePage/GiveDrawer.tsx
@@ -2,7 +2,15 @@ import { useEffect, useState } from 'react';
 
 import { useQuery } from 'react-query';
 
-import { ChevronDown, ChevronsRight, ChevronUp, Edit } from 'icons/__generated';
+import { useContributions } from 'hooks/useContributions';
+import {
+  ChevronDown,
+  ChevronsRight,
+  ChevronUp,
+  Edit,
+  DeworkColor,
+  WonderColor,
+} from 'icons/__generated';
 import { Avatar, Box, Button, Flex, Text, TextArea, MarkdownPreview } from 'ui';
 import { SaveState, SavingIndicator } from 'ui/SavingIndicator';
 
@@ -30,7 +38,14 @@ type GiveDrawerProps = {
   updateTeammate(id: number, teammate: boolean): void;
   closeDrawer: () => void;
 };
-
+const contributionIcon = (source: string) => {
+  switch (source) {
+    case 'wonder':
+      return <WonderColor css={{ mr: '$md' }} />;
+    default:
+      return <DeworkColor css={{ mr: '$md' }} />;
+  }
+};
 // GiveDrawer is the focused modal drawer to give/note/view contributions for one member
 export const GiveDrawer = ({
   // show,
@@ -67,6 +82,12 @@ export const GiveDrawer = ({
       staleTime: Infinity,
     }
   );
+  const integrationContributions = useContributions({
+    address: member.address || '',
+    startDate: start_date.toISOString(),
+    endDate: end_date.toISOString(),
+    mock: false,
+  });
 
   const [showMarkdown, setShowMarkDown] = useState<boolean>(true);
 
@@ -333,7 +354,9 @@ export const GiveDrawer = ({
               <Box>Loading...</Box>
             )}
             {contributions &&
-              (contributions.length == 0 ? (
+              (contributions.length === 0 &&
+              (!integrationContributions ||
+                integrationContributions?.length === 0) ? (
                 <>
                   <Box>
                     <Text inline color="neutral">
@@ -348,6 +371,34 @@ export const GiveDrawer = ({
                 contributions.map(c => (
                   <Contribution key={c.id} contribution={c} />
                 ))
+              ))}
+            {integrationContributions &&
+              integrationContributions.length > 0 &&
+              integrationContributions.map(c => (
+                <Box
+                  key={c.link}
+                  css={{
+                    p: '$md $sm',
+                    borderBottom: '1px solid $border',
+                  }}
+                >
+                  <Text
+                    ellipsis
+                    css={{
+                      cursor: 'default',
+                      backgroundColor: 'rgb(225 229 232) !important',
+                      borderColor: '$borderMedium !important',
+                      boxShadow: '$shadow1',
+                      border: '1px solid transparent',
+                      minHeight: 0,
+                      borderRadius: '$1',
+                      p: '$md',
+                    }}
+                  >
+                    {contributionIcon(c.source)}
+                    {c.title}
+                  </Text>
+                </Box>
               ))}
           </Box>
         </Flex>

--- a/src/pages/GivePage/index.tsx
+++ b/src/pages/GivePage/index.tsx
@@ -659,6 +659,7 @@ const AllocateContents = ({
     fixed_non_receiver: true,
     non_receiver: true,
     teammate: false,
+    address: '0x23f24381cf8518c4fafdaeeac5c0f7c92b7ae678',
     circle_id: -1,
     contributions_aggregate: {
       aggregate: {

--- a/src/pages/GivePage/index.tsx
+++ b/src/pages/GivePage/index.tsx
@@ -4,6 +4,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { updateUser, updateCircle } from 'lib/gql/mutations';
 import { isUserAdmin } from 'lib/users';
 import debounce from 'lodash/debounce';
+import { DateTime } from 'luxon';
 import { Helmet } from 'react-helmet';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
@@ -546,6 +547,7 @@ const GivePage = () => {
             currentEpoch={currentEpoch}
             retrySave={saveGifts}
             gridView={gridView}
+            previousEpochEndDate={previousEpoch?.endDate}
           />
         )}
       </SingleColumnLayout>
@@ -569,6 +571,7 @@ type AllocateContentsProps = {
   currentEpoch?: IEpoch;
   retrySave: () => void;
   gridView: boolean;
+  previousEpochEndDate?: DateTime;
 };
 
 const AllocateContents = ({
@@ -585,6 +588,7 @@ const AllocateContents = ({
   currentEpoch,
   retrySave,
   gridView,
+  previousEpochEndDate,
 }: AllocateContentsProps) => {
   const { showError, showInfo } = useApeSnackbar();
 
@@ -1019,7 +1023,13 @@ const AllocateContents = ({
               userIsOptedOut={userIsOptedOut}
               updateNonReceiver={updateNonReceiver}
               isNonReceiverMutationLoading={isNonReceiverMutationLoading}
-              start_date={currentEpoch.startDate.toJSDate()}
+              start_date={
+                previousEpochEndDate
+                  ? previousEpochEndDate.toJSDate()
+                  : DateTime.fromISO(currentEpoch.start_date)
+                      .minus({ months: 1 })
+                      .toJSDate()
+              }
               end_date={currentEpoch.endDate.toJSDate()}
               statement={statement}
               setStatement={setStatement}
@@ -1044,7 +1054,13 @@ const AllocateContents = ({
               }
             }
             maxedOut={maxedOut}
-            start_date={currentEpoch.startDate.toJSDate()}
+            start_date={
+              previousEpochEndDate
+                ? previousEpochEndDate.toJSDate()
+                : DateTime.fromISO(currentEpoch.start_date)
+                    .minus({ months: 1 })
+                    .toJSDate()
+            }
             end_date={currentEpoch.endDate.toJSDate()}
             saveState={saveState}
             setNeedToSave={setNeedToSave}

--- a/src/pages/GivePage/queries.ts
+++ b/src/pages/GivePage/queries.ts
@@ -56,6 +56,7 @@ export const getMembersWithContributions = async (
           bio: true,
           non_receiver: true,
           fixed_non_receiver: true,
+          address: true,
           profile: {
             avatar: true,
             id: true,


### PR DESCRIPTION
## Motivation and Context

resolves #1691 

## Description

-Allow Dework and wonder tasks to show up on allocations card view 
-the start date of the epoch GiveDrawer and EpochStatementDrawer is the end of the previous epoch like ContributionsPage


## Test and Deployment Plan
Test 1 
open circle --> create epoch --> add tasks from (wonderverse Or Dework) connection --> check Allocations card view
test 2
open circle --> go to contributions page -->check the letest contribution and date  --> go to Allocations card view and check


## Screenshots (if appropriate):
test 1
![Screenshot from 2022-11-28 17-38-52](https://user-images.githubusercontent.com/73297706/204320147-d97e4ec1-baa1-4c86-8e4f-4e4ce9bfabd5.png)
![Screenshot from 2022-11-28 17-38-43](https://user-images.githubusercontent.com/73297706/204320161-a8a754ac-0cce-4bf0-976c-99d08d1996c0.png)
![Screenshot from 2022-11-28 17-37-02](https://user-images.githubusercontent.com/73297706/204320169-4c0c7e87-dd0b-4ad0-bbd0-e1211d8e96f5.png)

test 2
![Screenshot from 2022-11-28 17-51-45](https://user-images.githubusercontent.com/73297706/204321947-1510ca7a-d27d-41dd-98be-facc68b7a0b2.png)
![Screenshot from 2022-11-28 17-51-35](https://user-images.githubusercontent.com/73297706/204321956-165a2576-fb59-4417-b04b-8548a256c015.png)
![Screenshot from 2022-11-28 17-51-26](https://user-images.githubusercontent.com/73297706/204321964-cf087165-b847-4e22-b27a-02f2f4f5a65b.png)
![Screenshot from 2022-11-28 17-51-17](https://user-images.githubusercontent.com/73297706/204321968-967ba5ce-06a6-4cca-bee5-eec4d5ec838c.png)


## Reviewers

@levity 
@sshmm 

## Related Issue

#1691 
