### PR TITLE
Suppress consoles during test runs

### DIFF
--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -11,6 +11,9 @@ global.TextEncoder = TextEncoder;
 // @ts-expect-error mismatched versions of typings
 global.TextDecoder = TextDecoder;
 
+global.console.info = jest.fn();
+global.console.log = jest.fn();
+
 jest.mock('uint8arrays', () => {
   return {
     compare: jest.fn(() => ({})),


### PR DESCRIPTION
## Motivation and Context

Console logs/infos in the backend are appearing unnecessarily that pollutes the test logs

## Description

Disable the logging in the jest setup

