### PR TITLE
Configure Eslint Warnings to fail CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "test": "./scripts/ci/manager.sh test --jest -i",
     "test:ci": "./scripts/ci/manager.sh test --all",
     "test:up": "./scripts/ci/manager.sh up",
-    "lint:check": "eslint \"{{api,api-lib,cypress,hasura,src}/**/*.{js,ts,tsx,graphql},*.{js,ts,tsx,graphql}}\"",
+    "lint:check": "eslint \"{{api,api-lib,cypress,hasura,src}/**/*.{js,ts,tsx,graphql},*.{js,ts,tsx,graphql}}\" --max-warnings 0",
     "lint:fix": "yarn lint:check --fix",
     "prettier": "prettier \"{{api,api-lib,cypress,hasura,src}/**/*.{js,ts,tsx,graphql,json},*.{js,ts,tsx,graphql,json}}\"",
     "prettier:check": "yarn prettier --check",


### PR DESCRIPTION
This change updates the repo lint:check script to return an error state
when one or more warnings are encountered.

Nothing else changes, but this error state will cause CI to fail when
warnings are encountered, ideally forcing devs to address the lint
problems so they don't get merged to main
