### PR TITLE
bugfix: stop querying contributions from time 0

### DIFF
--- a/src/components/ProfileCard/ProfileCard.tsx
+++ b/src/components/ProfileCard/ProfileCard.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { DateTime } from 'luxon';
+
 import { makeStyles, Button } from '@material-ui/core';
 
 import { ReactComponent as EditProfileSVG } from 'assets/svgs/button/edit-profile.svg';
@@ -126,10 +128,16 @@ const ProfileCardInner = ({
     (userBioTextLength > 93 && skillsLength > 2) || userBioTextLength > 270;
 
   const epochs = useSelectedCircle().circleEpochsStatus;
+  const now = DateTime.now().toISO();
   const contributions = useContributions({
     address: user.address,
-    startDate: epochs.previousEpochEndedOn,
-    endDate: epochs.currentEpoch?.end_date,
+    // run a query that will return nothing if no epoch is active
+    startDate:
+      epochs.previousEpochEndedOn ||
+      (epochs.currentEpoch?.startDate &&
+        epochs.currentEpoch.startDate.minus({ months: 1 }).toISO()) ||
+      now,
+    endDate: epochs.currentEpoch?.end_date || now,
   });
 
   const updateGift = ({ note, tokens }: { note?: string; tokens?: number }) => {

--- a/src/hooks/useContributions.ts
+++ b/src/hooks/useContributions.ts
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 
-import { DateTime } from 'luxon';
 import { useQueries } from 'react-query';
 
 import {
@@ -155,14 +154,14 @@ export function useContributionUsers(timeInput: TimeInput): UserContributions {
 
 export function useContributions(input: {
   address: string;
-  startDate?: string;
-  endDate?: string;
+  startDate: string;
+  endDate: string;
   mock?: boolean;
 }): Array<Contribution> | undefined {
   const { address, startDate, endDate, mock } = input;
   const userToContribution = useContributionUsers({
-    startDate: startDate ?? DateTime.fromMillis(0).toISO(),
-    endDate: endDate ?? DateTime.now().toISO(),
+    startDate,
+    endDate,
   });
   const ret = useMemo(
     () => (address ? userToContribution[address.toLowerCase()] : undefined),


### PR DESCRIPTION
Contribution providers do not want to support multi-year queries due to
adversarial concerns such as scraping. Our contribution hook would fall
back to epoch timestamp zero if no start date for the query was
supplied. This is now fixed and the query falls back to a month before
the current epochs start date if no prior epoch exists.

I've also tightened up the API to make the dates required params so that
no hidden fallbacks are possible. This is at the expense of the legacy
code in the ProfileCard, which utilizes recoil and irresponsibly tries
to render a result even if no epoch is currently active.

It'd be preferable to pass in a required epoch prop or two that the
component can rely on, but given that this is a legacy view, it's not
worth the maintenance. The solution, then is nominally unreachable hack
that would yield a minimally impactful query for integrated
contributions
