### PR TITLE
link to create a real circle in the sample org alert bar

### DIFF
--- a/src/components/MainLayout/SampleOrgIndicator.tsx
+++ b/src/components/MainLayout/SampleOrgIndicator.tsx
@@ -1,3 +1,6 @@
+import { NavLink } from 'react-router-dom';
+
+import { paths } from '../../routes/paths';
 import { Flex, Text } from '../../ui';
 
 export const SampleOrgIndicator = () => (
@@ -8,16 +11,63 @@ export const SampleOrgIndicator = () => (
       justifyContent: 'center',
     }}
   >
+    <Flex css={{ flex: 1, marginRight: 'auto', '@sm': { display: 'none' } }}>
+      &nbsp;
+    </Flex>
     <Text
       semibold
       color="active"
       css={{
+        display: 'flex',
+        flex: 1,
+        justifyContent: 'center',
         '@sm': {
           fontSize: '$small',
+          justifyContent: 'flex-start',
+          pl: '$md',
         },
       }}
     >
       Sample Organization
     </Text>
+    <Flex
+      css={{
+        flex: 1,
+        marginLeft: 'auto',
+        justifyContent: 'flex-end',
+        pr: '$md',
+      }}
+    >
+      <NavLink to={paths.createCircle} style={{ textDecoration: 'none' }}>
+        <Flex
+          css={{
+            flexDirection: 'column',
+            justifyItems: 'center',
+          }}
+        >
+          <Text
+            css={{
+              color: '$tagDark',
+              textDecoration: 'none',
+              mb: '$xs',
+              justifyContent: 'center',
+            }}
+            size="small"
+          >
+            Done Testing?
+          </Text>
+          <Text
+            css={{
+              textDecoration: 'underline',
+              color: '$tagDark',
+            }}
+            semibold
+            size="small"
+          >
+            Create a Circle
+          </Text>
+        </Flex>
+      </NavLink>
+    </Flex>
   </Flex>
 );


### PR DESCRIPTION
## Motivation and Context
Users have expressed that they don't know how to "leave" or "progress out of" the sample circle experience.

## Description

New "Create real Circle" button in the sample org header
