### PR TITLE
use price_per_share from remote schema

### DIFF
--- a/api-test/hasura/remote/vaults.test.ts
+++ b/api-test/hasura/remote/vaults.test.ts
@@ -1,0 +1,80 @@
+import { AddressZero } from '@ethersproject/constants';
+import faker from 'faker';
+
+import { adminClient } from '../../../api-lib/gql/adminClient';
+import { createOrganization, createProfile } from '../../helpers';
+
+const daiAddress = '0x6B175474E89094C44Da98b954EedeAC495271d0F';
+
+describe('pricePerShare', () => {
+  // we set up one vault record and then change its values to simulate different
+  // conditions for different tests
+  const vault_address = '0x112dcc3a7caa40c7e4d1a5d3b579ee1a1e499a45';
+
+  beforeAll(async () => {
+    const org = await createOrganization(adminClient);
+    const profile = await createProfile(adminClient);
+    await adminClient.mutate({
+      insert_vaults_one: [
+        {
+          object: {
+            symbol: 'DAI',
+            chain_id: 1,
+            vault_address,
+            token_address: AddressZero,
+            simple_token_address: AddressZero,
+            org_id: org.id,
+            decimals: 18,
+            created_by: profile.id,
+          },
+        },
+        { id: true },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await adminClient.mutate({
+      delete_vaults: [
+        { where: { vault_address: { _eq: vault_address } } },
+        { affected_rows: true },
+      ],
+    });
+  });
+
+  const setTokens = (token_address, simple_token_address) =>
+    adminClient.mutate({
+      update_vaults: [
+        {
+          where: { vault_address: { _eq: vault_address } },
+          _set: { token_address, simple_token_address },
+        },
+        { affected_rows: true },
+      ],
+    });
+
+  const getPrice = () =>
+    adminClient
+      .query({
+        vaults: [
+          { where: { vault_address: { _eq: vault_address } } },
+          { price_per_share: true },
+        ],
+      })
+      .then(res => res.vaults?.[0]?.price_per_share);
+
+  test('invalid token address', async () => {
+    await setTokens(faker.finance.ethereumAddress(), AddressZero);
+    expect(await getPrice()).toBe(1);
+  });
+
+  test('simple vault', async () => {
+    await setTokens(AddressZero, daiAddress);
+    expect(await getPrice()).toBe(1);
+  });
+
+  test('Yearn vault', async () => {
+    await setTokens(daiAddress, AddressZero);
+    expect(await getPrice()).toBeGreaterThan(1);
+  });
+});

--- a/api-test/hasura/remote/vaults.test.ts
+++ b/api-test/hasura/remote/vaults.test.ts
@@ -53,15 +53,21 @@ describe('pricePerShare', () => {
       ],
     });
 
-  const getPrice = () =>
-    adminClient
-      .query({
-        vaults: [
-          { where: { vault_address: { _eq: vault_address } } },
-          { price_per_share: true },
-        ],
-      })
-      .then(res => res.vaults?.[0]?.price_per_share);
+  const getPrice = async () => {
+    try {
+      return await adminClient
+        .query({
+          vaults: [
+            { where: { vault_address: { _eq: vault_address } } },
+            { price_per_share: true },
+          ],
+        })
+        .then(res => res.vaults?.[0]?.price_per_share);
+    } catch (err: any) {
+      if (!err.message) err.message = err.response?.errors.map(e => e.message);
+      console.error(err);
+    }
+  };
 
   test('invalid token address', async () => {
     await setTokens(faker.finance.ethereumAddress(), AddressZero);

--- a/api-test/helpers/organizations.ts
+++ b/api-test/helpers/organizations.ts
@@ -1,3 +1,5 @@
+import faker from 'faker';
+
 import { createOrganizationSchemaInput } from '../../src/lib/zod';
 
 import type { GQLClientType } from './common';
@@ -6,14 +8,16 @@ type OrganizationInput = typeof createOrganizationSchemaInput['_type'];
 
 export async function createOrganization(
   client: GQLClientType,
-  object: OrganizationInput
+  object?: OrganizationInput
 ) {
   const { insert_organizations_one } = await client.mutate({
     insert_organizations_one: [
       {
-        object,
+        object: object || {
+          name: faker.company.companyName(),
+        },
       },
-      { id: true },
+      { id: true, name: true },
     ],
   });
 

--- a/api-test/helpers/profiles.ts
+++ b/api-test/helpers/profiles.ts
@@ -6,7 +6,7 @@ type ProfileInput = { address: string; name?: string };
 
 export async function createProfile(
   client: GQLClientType,
-  object: ProfileInput
+  object?: ProfileInput
 ): Promise<{ id: number }> {
   if (!object) {
     object = {

--- a/api/hasura/actions/_handlers/allocationCsv.test.ts
+++ b/api/hasura/actions/_handlers/allocationCsv.test.ts
@@ -1,5 +1,4 @@
 import { VercelRequest } from '@vercel/node';
-import { FixedNumber } from 'ethers';
 import { DateTime } from 'luxon';
 
 import { DISTRIBUTION_TYPE } from '../../../../api-lib/constants';
@@ -70,13 +69,13 @@ function getMockCircleDistribution(
           },
         },
         tx_hash: '0x',
-        pricePerShare: FixedNumber.from(1),
         vault: {
           symbol: 'DAI',
           chain_id: 1,
           vault_address: '0x1',
           simple_token_address: '0x0',
           decimals: 18,
+          price_per_share: 1,
         },
         claims: [
           { address: '0x1', profile_id: 1, new_amount: 150 },
@@ -89,13 +88,13 @@ function getMockCircleDistribution(
         distribution_type: DISTRIBUTION_TYPE.GIFT,
         distribution_json: {},
         tx_hash: '0x',
-        pricePerShare: FixedNumber.from(1),
         vault: {
           symbol: 'DAI',
           chain_id: 1,
           vault_address: '0x1',
           simple_token_address: '0x0',
           decimals: 18,
+          price_per_share: 1,
         },
         claims: [
           { address: '0x1', profile_id: 1, new_amount: 150 },
@@ -113,13 +112,13 @@ function getMockCircleDistribution(
           },
         },
         tx_hash: '0x',
-        pricePerShare: FixedNumber.from(1),
         vault: {
           symbol: 'DAI',
           chain_id: 1,
           vault_address: '0x1',
           simple_token_address: '0x0',
           decimals: 18,
+          price_per_share: 1,
         },
         claims: [
           { address: '0x1', profile_id: 1, new_amount: 250 },

--- a/api/hasura/actions/_handlers/allocationCsv.ts
+++ b/api/hasura/actions/_handlers/allocationCsv.ts
@@ -9,12 +9,10 @@ import { formatCustomDate } from '../../../../api-lib/dateTimeHelpers';
 import { adminClient } from '../../../../api-lib/gql/adminClient';
 import { getEpoch } from '../../../../api-lib/gql/queries';
 import { errorResponseWithStatusCode } from '../../../../api-lib/HttpError';
-import { getProvider } from '../../../../api-lib/provider';
 import { uploadCsv } from '../../../../api-lib/s3';
 import { Awaited } from '../../../../api-lib/ts4.5shim';
 import { claimsUnwrappedAmount } from '../../../../src/common-lib/distributions';
 import { isFeatureEnabled } from '../../../../src/config/features';
-import { Contracts } from '../../../../src/lib/vaults';
 import {
   allocationCsvInput,
   composeHasuraActionRequestBody,
@@ -128,10 +126,10 @@ export function generateCsvValues(
         address: u.address,
         fixedDistDecimals: fixedDist?.vault.decimals,
         fixedGifts: fixedDist?.distribution_json.fixedGifts,
-        fixedDistPricePerShare: fixedDist?.pricePerShare,
+        fixedDistPricePerShare: fixedDist?.vault.price_per_share,
         circleDistDecimals: circleDist?.vault.decimals,
         circleDistClaimAmount: claimAmt,
-        circleDistPricePerShare: circleDist?.pricePerShare,
+        circleDistPricePerShare: circleDist?.vault.price_per_share,
       });
       const received = u.received_gifts.length
         ? u.received_gifts
@@ -200,6 +198,7 @@ export async function getCircleDetails(circle_id: number, epochId: number) {
                     vault_address: true,
                     simple_token_address: true,
                     decimals: true,
+                    price_per_share: true,
                   },
                   claims: [
                     {},
@@ -240,22 +239,11 @@ export async function getCircleDetails(circle_id: number, epochId: number) {
     },
     { operationName: 'allocationCsv_getGifts' }
   );
-  const chainId =
-    circles_by_pk?.epochs[0]?.distributions[0]?.vault.chain_id || 1;
-  const provider = getProvider(chainId);
-  const contracts = new Contracts(chainId, provider, true);
-  const distributions = await Promise.all(
-    circles_by_pk?.epochs[0]?.distributions.map(async dist => ({
-      ...dist,
-      pricePerShare: await contracts.getPricePerShare(
-        dist.vault.vault_address,
-        dist.vault.simple_token_address,
-        dist.vault.decimals
-      ),
-    })) || []
-  );
   const epoch = circles_by_pk?.epochs[0];
-  return { ...circles_by_pk, epochs: [{ ...epoch, distributions }] };
+  return {
+    ...circles_by_pk,
+    epochs: [{ ...epoch, distributions: epoch?.distributions || [] }],
+  };
 }
 
 export default authCircleAdminMiddleware(handler);

--- a/scripts/ci/manager.sh
+++ b/scripts/ci/manager.sh
@@ -56,6 +56,11 @@ start_services() {
       exit 1
     fi
   done
+
+  # handle race condition: if hasura started up before the web server, it needs
+  # to reload metadata to enable the remote schema
+  yarn hasura metadata reload
+  
   echo "All services are ready."
 }
 

--- a/src/common-lib/distributions.test.ts
+++ b/src/common-lib/distributions.test.ts
@@ -1,5 +1,3 @@
-import { FixedNumber } from 'ethers';
-
 import { claimsUnwrappedAmount } from './distributions';
 
 describe('claimsUnwrappedAmount', () => {
@@ -9,7 +7,7 @@ describe('claimsUnwrappedAmount', () => {
       circleDistDecimals: 18,
       // the new_amount col includes fixed payment values as well
       circleDistClaimAmount: 300,
-      circleDistPricePerShare: FixedNumber.from('1'),
+      circleDistPricePerShare: 1,
       circleFixedGifts: { '0x1': '100000000000000000000' },
     });
     expect(circleClaimed).toEqual(200);
@@ -20,9 +18,9 @@ describe('claimsUnwrappedAmount', () => {
       address: '0x1',
       circleDistDecimals: 18,
       circleDistClaimAmount: 200,
-      circleDistPricePerShare: FixedNumber.from('1'),
+      circleDistPricePerShare: 1,
       fixedGifts: { '0x1': '50000000000000000000' },
-      fixedDistPricePerShare: FixedNumber.from('1'),
+      fixedDistPricePerShare: 1,
       fixedDistDecimals: 18,
     });
     expect(circleClaimed).toEqual(200);
@@ -33,9 +31,9 @@ describe('claimsUnwrappedAmount', () => {
       address: '0x1',
       circleDistDecimals: 18,
       circleDistClaimAmount: 200,
-      circleDistPricePerShare: FixedNumber.from('1.2'),
+      circleDistPricePerShare: 1.2,
       fixedGifts: { '0x1': '50000000000000000000' },
-      fixedDistPricePerShare: FixedNumber.from('2'),
+      fixedDistPricePerShare: 2,
       fixedDistDecimals: 18,
     });
     expect(circleClaimed).toEqual(240);

--- a/src/common-lib/distributions.ts
+++ b/src/common-lib/distributions.ts
@@ -1,26 +1,4 @@
-import { FixedNumber } from 'ethers';
 import { formatUnits } from 'ethers/lib/utils';
-
-const calc = ({
-  address,
-  decimals,
-  fixedGifts,
-  pricePerShare,
-}: {
-  address: string;
-  decimals: number;
-  fixedGifts?: Record<string, string>;
-  pricePerShare?: FixedNumber;
-}) => {
-  return {
-    fixedPaymentAmt: getUserClaimedFixedPaymentAmt({
-      decimals,
-      fixedGifts,
-      address,
-    }),
-    pricePerShare: pricePerShare?.toUnsafeFloat() || 1,
-  };
-};
 
 const getUserClaimedFixedPaymentAmt = ({
   decimals,
@@ -36,24 +14,25 @@ const getUserClaimedFixedPaymentAmt = ({
     ? Number(formatUnits(fixedGifts[address], decimals))
     : 0;
 };
+
 export const claimsUnwrappedAmount = ({
   address,
   fixedGifts,
   fixedDistDecimals = 18,
-  fixedDistPricePerShare,
+  fixedDistPricePerShare = 1,
   circleDistDecimals = 18,
   circleDistClaimAmount = 0,
-  circleDistPricePerShare,
+  circleDistPricePerShare = 1,
   circleFixedGifts,
 }: {
   address?: string;
   fixedDistDecimals?: number;
   fixedDistClaimAmount?: number;
   fixedGifts?: Record<string, string>;
-  fixedDistPricePerShare?: FixedNumber;
+  fixedDistPricePerShare?: number;
   circleDistDecimals?: number;
   circleDistClaimAmount?: number;
-  circleDistPricePerShare?: FixedNumber;
+  circleDistPricePerShare?: number;
   circleFixedGifts?: Record<string, string>;
 }) => {
   let fixedPayment = 0,
@@ -62,28 +41,23 @@ export const claimsUnwrappedAmount = ({
 
   if (circleDistClaimAmount) {
     const claimAmt = circleDistClaimAmount || 0;
-    const { fixedPaymentAmt, pricePerShare } = calc({
+    const fixedPaymentAmt = getUserClaimedFixedPaymentAmt({
       address,
       decimals: circleDistDecimals,
       fixedGifts: circleFixedGifts,
-      pricePerShare: circleDistPricePerShare,
     });
-    fixedPayment = fixedPaymentAmt * pricePerShare;
-    circleClaimed = (claimAmt - fixedPaymentAmt) * pricePerShare;
+    fixedPayment = fixedPaymentAmt * fixedDistPricePerShare;
+    circleClaimed = (claimAmt - fixedPaymentAmt) * circleDistPricePerShare;
   }
 
   if (fixedGifts) {
-    const { fixedPaymentAmt, pricePerShare } = calc({
+    const fixedPaymentAmt = getUserClaimedFixedPaymentAmt({
       address,
       decimals: fixedDistDecimals,
       fixedGifts,
-      pricePerShare: fixedDistPricePerShare,
     });
-    fixedPayment = fixedPaymentAmt * pricePerShare;
+    fixedPayment = fixedPaymentAmt * fixedDistPricePerShare;
   }
 
-  return {
-    fixedPayment,
-    circleClaimed,
-  };
+  return { fixedPayment, circleClaimed };
 };

--- a/src/pages/ClaimsPage/queries.ts
+++ b/src/pages/ClaimsPage/queries.ts
@@ -1,6 +1,6 @@
 import { order_by } from 'lib/gql/__generated__/zeus';
 import { client } from 'lib/gql/client';
-import { Contracts, getUnwrappedAmount } from 'lib/vaults';
+import { Contracts } from 'lib/vaults';
 
 import type { Awaited } from 'types/shim';
 
@@ -45,6 +45,7 @@ export const getClaims = async (
               simple_token_address: true,
               symbol: true,
               decimals: true,
+              price_per_share: true,
             },
             epoch: {
               id: true,
@@ -74,21 +75,12 @@ export const getClaims = async (
   };
 
   for (const claim of claims) {
-    const { distribution } = claim;
-    const pricePerShare = await contracts.getPricePerShare(
-      distribution.vault.vault_address,
-      distribution.vault.simple_token_address,
-      distribution.vault.decimals
-    );
+    const { price_per_share } = claim.distribution.vault;
 
-    const unwrappedAmount = getUnwrappedAmount(claim.amount, pricePerShare);
-    const unwrappedNewAmount = getUnwrappedAmount(
-      claim.new_amount,
-      pricePerShare
-    );
-
-    (claim as ClaimWithUnwrappedAmount).unwrappedAmount = unwrappedAmount;
-    (claim as ClaimWithUnwrappedAmount).unwrappedNewAmount = unwrappedNewAmount;
+    (claim as ClaimWithUnwrappedAmount).unwrappedAmount =
+      claim.amount * price_per_share;
+    (claim as ClaimWithUnwrappedAmount).unwrappedNewAmount =
+      claim.new_amount * price_per_share;
   }
   return claims;
 };

--- a/src/pages/ClaimsPage/useClaimAllocation.test.tsx
+++ b/src/pages/ClaimsPage/useClaimAllocation.test.tsx
@@ -150,7 +150,16 @@ test('claim single successfully', async () => {
                 organization: { id: 3, name: 'org' },
               },
             },
-            vault,
+            vault: {
+              ...vault,
+              price_per_share: (
+                await contracts.getPricePerShare(
+                  vault.vault_address,
+                  vault.simple_token_address,
+                  vault.decimals
+                )
+              ).toUnsafeFloat(),
+            },
           },
           claimIds: [1],
           amount,

--- a/src/pages/DistributionsPage/DistributionsPage.test.tsx
+++ b/src/pages/DistributionsPage/DistributionsPage.test.tsx
@@ -1,6 +1,5 @@
 import { AddressZero } from '@ethersproject/constants';
 import { act, render, screen, waitFor } from '@testing-library/react';
-import { FixedNumber } from 'ethers';
 import { Contracts } from 'lib/vaults';
 import pick from 'lodash/pick';
 import { DateTime } from 'luxon';
@@ -122,10 +121,12 @@ test('render with a distribution', async () => {
           total_amount: '10000000',
           gift_amount: 500,
           fixed_amount: 5000,
-          pricePerShare: FixedNumber.from('1.08'),
           distribution_type: 1,
           distribution_json: {},
-          vault: mockEpochData.circle.organization.vaults[0],
+          vault: {
+            ...mockEpochData.circle.organization.vaults[0],
+            price_per_share: 1.08,
+          },
           claims: [
             {
               address: '0x63c389CB2C573dd3c9239A13a3eb65935Ddb5e2e',

--- a/src/pages/DistributionsPage/DistributionsPage.tsx
+++ b/src/pages/DistributionsPage/DistributionsPage.tsx
@@ -14,7 +14,7 @@ import { useSelectedCircle } from '../../recoilState';
 import { paths } from '../../routes/paths';
 import { LoadingModal } from 'components';
 import { QUERY_KEY_MAIN_HEADER } from 'components/MainLayout/getMainHeaderData';
-import { useApiAdminCircle, useContracts } from 'hooks';
+import { useApiAdminCircle } from 'hooks';
 import useConnectedAddress from 'hooks/useConnectedAddress';
 import { AppLink, BackButton, Box, Text } from 'ui';
 import { SingleColumnLayout } from 'ui/layouts';
@@ -27,7 +27,6 @@ import { getEpochData } from './queries';
 export function DistributionsPage() {
   const { epochId } = useParams();
   const address = useConnectedAddress();
-  const contracts = useContracts();
   const queryClient = useQueryClient();
 
   const {
@@ -39,7 +38,7 @@ export function DistributionsPage() {
     refetch: refetchDistributions,
   } = useQuery(
     ['distributions', epochId],
-    () => getEpochData(Number.parseInt(epochId || '0'), address, contracts),
+    () => getEpochData(Number.parseInt(epochId || '0'), address),
     {
       enabled: !!address,
       retry: false,
@@ -124,10 +123,10 @@ export function DistributionsPage() {
         address: user.address,
         fixedDistDecimals: fixedDist?.vault.decimals,
         fixedGifts: fixedDist?.distribution_json.fixedGifts,
-        fixedDistPricePerShare: fixedDist?.pricePerShare,
+        fixedDistPricePerShare: fixedDist?.vault.price_per_share,
         circleDistDecimals: circleDist?.vault.decimals,
         circleDistClaimAmount,
-        circleDistPricePerShare: circleDist?.pricePerShare,
+        circleDistPricePerShare: circleDist?.vault.price_per_share,
         circleFixedGifts: circleDist?.distribution_json.fixedGifts,
       });
       return {


### PR DESCRIPTION
In #1520 and #1624 we added a Hasura remote schema so the frontend can get pricePerShare values for vaults in a Hasura query instead of having to directly query the blockchain. This PR changes the distributions & claims code to use that.
