### PR TITLE
fix bug: Allocation countdown

### DIFF
--- a/src/lib/time.test.ts
+++ b/src/lib/time.test.ts
@@ -2,76 +2,74 @@ import epochTimeUpcoming from 'lib/time';
 import { DateTime } from 'luxon';
 
 // epochTimeUpcoming generates a human friendly string about when an epoch will start
-test('epoch Time Upcoming 1', async () => {
-  const epoch = epochTimeUpcoming(
-    DateTime.now().plus({
-      hours: 3,
-      minutes: 59,
-      seconds: 59,
-      milliseconds: 10,
-    })
-  );
-  expect(epoch).toEqual('3 hrs, 59 mins');
-});
+test('epochTimeUpcoming', async () => {
+  expect(
+    epochTimeUpcoming(
+      DateTime.now().plus({
+        hours: 3,
+        minutes: 59,
+        seconds: 59,
+        milliseconds: 10,
+      })
+    )
+  ).toEqual('3 hrs, 59 mins');
 
-test('epoch Time Upcoming 2', async () => {
-  const epoch = epochTimeUpcoming(
-    DateTime.now().plus({
-      hours: 1,
-      minutes: 21,
-      seconds: 0,
-      milliseconds: 10,
-    })
-  );
-  expect(epoch).toEqual('1 hr, 21 mins');
-});
-test('epoch Time Upcoming 3', async () => {
-  const epoch = epochTimeUpcoming(
-    DateTime.now().plus({
-      days: 1,
-      hours: 0,
-      minutes: 59,
-      seconds: 59,
-      milliseconds: 10,
-    })
-  );
-  expect(epoch).toEqual('1 day, 59 mins');
-});
+  expect(
+    epochTimeUpcoming(
+      DateTime.now().plus({
+        hours: 1,
+        minutes: 21,
+        seconds: 0,
+        milliseconds: 10,
+      })
+    )
+  ).toEqual('1 hr, 21 mins');
 
-test('epoch Time Upcoming 4', async () => {
-  const epoch = epochTimeUpcoming(
-    DateTime.now().plus({
-      days: 10,
-      hours: 20,
-      minutes: 15,
-      seconds: 59,
-      milliseconds: 10,
-    })
-  );
-  expect(epoch).toEqual('10 days, 20 hrs, 15 mins');
-});
-test('epoch Time Upcoming 5', async () => {
-  const epoch = epochTimeUpcoming(
-    DateTime.now().plus({
-      days: 0,
-      hours: 0,
-      minutes: 0,
-      seconds: 59,
-      milliseconds: 10,
-    })
-  );
-  expect(epoch).toEqual('a minute');
-});
+  expect(
+    epochTimeUpcoming(
+      DateTime.now().plus({
+        days: 1,
+        hours: 0,
+        minutes: 59,
+        seconds: 59,
+        milliseconds: 10,
+      })
+    )
+  ).toEqual('1 day, 59 mins');
 
-test('epoch Time Upcoming 6', async () => {
-  const epoch = epochTimeUpcoming(
-    DateTime.now().plus({
-      days: 0,
-      hours: 20,
-      minutes: 0,
-      seconds: 59,
-      milliseconds: 10,
-    })
-  );
-  expect(epoch).toEqual('20 hrs');
+  expect(
+    epochTimeUpcoming(
+      DateTime.now().plus({
+        days: 10,
+        hours: 20,
+        minutes: 15,
+        seconds: 59,
+        milliseconds: 10,
+      })
+    )
+  ).toEqual('10 days, 20 hrs, 15 mins');
+
+  expect(
+    epochTimeUpcoming(
+      DateTime.now().plus({
+        days: 0,
+        hours: 0,
+        minutes: 0,
+        seconds: 59,
+        milliseconds: 10,
+      })
+    )
+  ).toEqual('a minute');
+
+  expect(
+    epochTimeUpcoming(
+      DateTime.now().plus({
+        days: 0,
+        hours: 20,
+        minutes: 0,
+        seconds: 59,
+        milliseconds: 10,
+      })
+    )
+  ).toEqual('20 hrs');
 });

--- a/src/lib/time.test.ts
+++ b/src/lib/time.test.ts
@@ -1,0 +1,77 @@
+import epochTimeUpcoming from 'lib/time';
+import { DateTime } from 'luxon';
+
+// epochTimeUpcoming generates a human friendly string about when an epoch will start
+test('epoch Time Upcoming 1', async () => {
+  const epoch = epochTimeUpcoming(
+    DateTime.now().plus({
+      hours: 3,
+      minutes: 59,
+      seconds: 59,
+      milliseconds: 10,
+    })
+  );
+  expect(epoch).toEqual('3 hrs, 59 mins');
+});
+
+test('epoch Time Upcoming 2', async () => {
+  const epoch = epochTimeUpcoming(
+    DateTime.now().plus({
+      hours: 1,
+      minutes: 21,
+      seconds: 0,
+      milliseconds: 10,
+    })
+  );
+  expect(epoch).toEqual('1 hr, 21 mins');
+});
+test('epoch Time Upcoming 3', async () => {
+  const epoch = epochTimeUpcoming(
+    DateTime.now().plus({
+      days: 1,
+      hours: 0,
+      minutes: 59,
+      seconds: 59,
+      milliseconds: 10,
+    })
+  );
+  expect(epoch).toEqual('1 day, 59 mins');
+});
+
+test('epoch Time Upcoming 4', async () => {
+  const epoch = epochTimeUpcoming(
+    DateTime.now().plus({
+      days: 10,
+      hours: 20,
+      minutes: 15,
+      seconds: 59,
+      milliseconds: 10,
+    })
+  );
+  expect(epoch).toEqual('10 days, 20 hrs, 15 mins');
+});
+test('epoch Time Upcoming 5', async () => {
+  const epoch = epochTimeUpcoming(
+    DateTime.now().plus({
+      days: 0,
+      hours: 0,
+      minutes: 0,
+      seconds: 59,
+      milliseconds: 10,
+    })
+  );
+  expect(epoch).toEqual('a minute');
+});
+
+test('epoch Time Upcoming 6', async () => {
+  const epoch = epochTimeUpcoming(
+    DateTime.now().plus({
+      days: 0,
+      hours: 20,
+      minutes: 0,
+      seconds: 59,
+      milliseconds: 10,
+    })
+  );
+  expect(epoch).toEqual('20 hrs');
+});

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -4,6 +4,6 @@ import { DateTime } from 'luxon';
 export const epochTimeUpcoming = (startDate: DateTime) => {
   return startDate
     .diffNow(['days', 'hours', 'minutes'])
-    .toHuman({ unitDisplay: 'short', notation: 'compact' })
+    .toFormat("d' days, 'h' hr, 'm' mins'")
     .replace(/(0 days, |0 hr, )/g, '');
 };

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -2,8 +2,19 @@ import { DateTime } from 'luxon';
 
 // epochTimeUpcoming generates a human friendly string about when an epoch will start
 export const epochTimeUpcoming = (startDate: DateTime) => {
-  return startDate
-    .diffNow(['days', 'hours', 'minutes'])
-    .toFormat("d' days, 'h' hr, 'm' mins'")
-    .replace(/(0 days, |0 hr, )/g, '');
+  const dateTime = startDate.diffNow(['days', 'hours', 'minutes']);
+  if (dateTime.days < 1 && dateTime.hours < 1 && dateTime.minutes <= 1) {
+    return 'a minute';
+  } else {
+    return dateTime
+      .toFormat(
+        ` d' ${dateTime.days >= 2 ? 'days' : 'day'}, 'h' ${
+          dateTime.hours >= 2 ? 'hrs' : 'hr'
+        }, 'm' ${dateTime.minutes >= 2 ? 'mins' : 'min'}'`
+      )
+      .replace(/( 0 day,| 0 hr,|, 0 min)/g, '')
+      .replace(/(, 0 min)/g, '')
+      .trim();
+  }
 };
+export default epochTimeUpcoming;

--- a/src/pages/HistoryPage/NextEpoch.tsx
+++ b/src/pages/HistoryPage/NextEpoch.tsx
@@ -26,7 +26,7 @@ export const NextEpoch = ({
     const diff = epochTimeUpcoming(startDate);
     return (
       <Flex css={{ flexWrap: 'wrap', gap: '$md' }}>
-        <Text inline bold color="neutral" css={{ minWidth: '180px' }}>
+        <Text inline bold color="neutral">
           {`${startDate.toFormat('LLL d')} - ${
             startDate.month === endDate.month
               ? endDate.day


### PR DESCRIPTION
## Motivation and Context

resolves #1719 

## Description

-Allow time of the created Epochs to be shown correctly 

## Test and Deployment Plan

open any circle --> create an epoch --> set a time that you like -->check Allocation countdown in (Epoch Overview, give)

## Screenshots (if appropriate):

![Screenshot from 2022-12-07 15-53-36](https://user-images.githubusercontent.com/73297706/206197413-16123506-f210-4c14-921e-df01191b2536.png)
![Screenshot from 2022-12-07 15-53-30](https://user-images.githubusercontent.com/73297706/206197427-a135a39b-6edf-4bd6-98ce-5f21a5553869.png)

## Reviewers

@levity 


## Related Issue

#1719 
