### PR TITLE
Create Hasura Role for the discord bot

### DIFF
--- a/api-lib/config.ts
+++ b/api-lib/config.ts
@@ -72,6 +72,10 @@ export const MIXPANEL_PROJECT_TOKEN: string = getEnvValue(
   ''
 );
 
+export const HASURA_DISCORD_SECRET: string = getEnvValue(
+  'HASURA_DISCORD_SECRET'
+);
+
 export const DISCORD_BOT_CLIENT_ID: string = getEnvValue(
   'DISCORD_BOT_CLIENT_ID',
   'no_token'

--- a/api/hasura/auth.ts
+++ b/api/hasura/auth.ts
@@ -3,8 +3,13 @@ import assert from 'assert';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
 import { parseAuthHeader } from '../../api-lib/authHelpers';
-import { IS_LOCAL_ENV, IS_TEST_ENV } from '../../api-lib/config';
+import {
+  HASURA_DISCORD_SECRET,
+  IS_LOCAL_ENV,
+  IS_TEST_ENV,
+} from '../../api-lib/config';
 import { adminClient } from '../../api-lib/gql/adminClient';
+import { isFeatureEnabled } from '../../src/config/features';
 
 export const TEST_SKIP_AUTH = 'test-skip-auth';
 
@@ -30,6 +35,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         });
         return;
       }
+    }
+
+    if (
+      isFeatureEnabled('discord') &&
+      req.headers?.authorization === HASURA_DISCORD_SECRET
+    ) {
+      res.status(200).json({
+        'X-Hasura-Role': 'discord-bot',
+      });
     }
 
     assert(req.headers?.authorization, 'No token was provided');

--- a/hasura/metadata/databases/default/tables/discord_roles_circles.yaml
+++ b/hasura/metadata/databases/default/tables/discord_roles_circles.yaml
@@ -20,6 +20,12 @@ insert_permissions:
         circle_id: x-hasura-Circle-Id
       columns:
         - role
+  - role: discord-bot
+    permission:
+      check: {}
+      columns:
+        - circle_id
+        - role
 select_permissions:
   - role: api-user
     permission:
@@ -35,6 +41,15 @@ select_permissions:
                   _eq: X-Hasura-Api-Key-Hash
               - read_discord:
                   _eq: true
+  - role: discord-bot
+    permission:
+      columns:
+        - circle_id
+        - id
+        - role
+        - created_at
+        - updated_at
+      filter: {}
   - role: user
     permission:
       columns:
@@ -66,6 +81,13 @@ update_permissions:
               - update_circle:
                   _eq: true
       check: null
+  - role: discord-bot
+    permission:
+      columns:
+        - circle_id
+        - role
+      filter: {}
+      check: null
   - role: user
     permission:
       columns:
@@ -94,3 +116,7 @@ delete_permissions:
                   _eq: X-Hasura-Api-Key-Hash
               - update_circle:
                   _eq: true
+  - role: discord-bot
+    permission:
+      backend_only: false
+      filter: {}

--- a/hasura/metadata/databases/default/tables/discord_users.yaml
+++ b/hasura/metadata/databases/default/tables/discord_users.yaml
@@ -6,6 +6,12 @@ object_relationships:
     using:
       foreign_key_constraint_on: profile_id
 insert_permissions:
+  - role: discord-bot
+    permission:
+      check: {}
+      columns:
+        - profile_id
+        - user_snowflake
   - role: user
     permission:
       check: {}
@@ -34,6 +40,15 @@ select_permissions:
                       _eq: true
                   - read_member_profiles:
                       _eq: true
+  - role: discord-bot
+    permission:
+      columns:
+        - id
+        - profile_id
+        - user_snowflake
+        - created_at
+        - updated_at
+      filter: {}
   - role: user
     permission:
       columns:
@@ -47,6 +62,13 @@ select_permissions:
           id:
             _eq: X-Hasura-User-Id
 update_permissions:
+  - role: discord-bot
+    permission:
+      columns:
+        - profile_id
+        - user_snowflake
+      filter: {}
+      check: null
   - role: user
     permission:
       columns:
@@ -57,6 +79,10 @@ update_permissions:
             _eq: X-Hasura-User-Id
       check: null
 delete_permissions:
+  - role: discord-bot
+    permission:
+      backend_only: false
+      filter: {}
   - role: user
     permission:
       backend_only: false

--- a/hasura/metadata/databases/default/tables/public_circles.yaml
+++ b/hasura/metadata/databases/default/tables/public_circles.yaml
@@ -120,6 +120,12 @@ select_permissions:
             - read_circle:
                 _eq: true
       limit: 5
+  - role: discord-bot
+    permission:
+      columns:
+        - id
+        - name
+      filter: {}
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/public_profiles.yaml
+++ b/hasura/metadata/databases/default/tables/public_profiles.yaml
@@ -68,6 +68,11 @@ select_permissions:
                 - read_member_profiles:
                     _eq: true
       limit: 50
+  - role: discord-bot
+    permission:
+      columns:
+        - id
+      filter: {}
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/public_users.yaml
+++ b/hasura/metadata/databases/default/tables/public_users.yaml
@@ -113,6 +113,12 @@ select_permissions:
                       - read_member_profiles:
                           _eq: true
       limit: 50
+  - role: discord-bot
+    permission:
+      columns:
+        - circle_id
+        - role
+      filter: {}
   - role: user
     permission:
       columns:


### PR DESCRIPTION
This role formalizes the access the discord bot will have to the db,
     since it's administering an adjacent schema to persist state.

Specifically, the discord bot is now able to find all circles a user is
an admin of after they link their discord account to their coordinape
account. This is needed for the circle-linking flow.
