### PR TITLE
Create table to store api tokens for the discord bot

### DIFF
--- a/api-lib/config.ts
+++ b/api-lib/config.ts
@@ -72,6 +72,10 @@ export const MIXPANEL_PROJECT_TOKEN: string = getEnvValue(
   ''
 );
 
+export const HASURA_DISCORD_SECRET: string = getEnvValue(
+  'HASURA_DISCORD_SECRET'
+);
+
 export const DISCORD_BOT_CLIENT_ID: string = getEnvValue(
   'DISCORD_BOT_CLIENT_ID',
   'no_token'

--- a/api-lib/gql/__generated__/zeus/const.ts
+++ b/api-lib/gql/__generated__/zeus/const.ts
@@ -1564,6 +1564,67 @@ export const AllTypesProps: Record<string, any> = {
     _neq: 'date',
     _nin: 'date',
   },
+  discord_circle_api_tokens_aggregate_fields: {
+    count: {
+      columns: 'discord_circle_api_tokens_select_column',
+    },
+  },
+  discord_circle_api_tokens_bool_exp: {
+    _and: 'discord_circle_api_tokens_bool_exp',
+    _not: 'discord_circle_api_tokens_bool_exp',
+    _or: 'discord_circle_api_tokens_bool_exp',
+    channel_snowflake: 'String_comparison_exp',
+    circle_id: 'bigint_comparison_exp',
+    created_at: 'timestamptz_comparison_exp',
+    id: 'bigint_comparison_exp',
+    token: 'String_comparison_exp',
+  },
+  discord_circle_api_tokens_constraint: true,
+  discord_circle_api_tokens_inc_input: {
+    circle_id: 'bigint',
+    id: 'bigint',
+  },
+  discord_circle_api_tokens_insert_input: {
+    circle_id: 'bigint',
+    created_at: 'timestamptz',
+    id: 'bigint',
+  },
+  discord_circle_api_tokens_on_conflict: {
+    constraint: 'discord_circle_api_tokens_constraint',
+    update_columns: 'discord_circle_api_tokens_update_column',
+    where: 'discord_circle_api_tokens_bool_exp',
+  },
+  discord_circle_api_tokens_order_by: {
+    channel_snowflake: 'order_by',
+    circle_id: 'order_by',
+    created_at: 'order_by',
+    id: 'order_by',
+    token: 'order_by',
+  },
+  discord_circle_api_tokens_pk_columns_input: {
+    id: 'bigint',
+  },
+  discord_circle_api_tokens_select_column: true,
+  discord_circle_api_tokens_set_input: {
+    circle_id: 'bigint',
+    created_at: 'timestamptz',
+    id: 'bigint',
+  },
+  discord_circle_api_tokens_stream_cursor_input: {
+    initial_value: 'discord_circle_api_tokens_stream_cursor_value_input',
+    ordering: 'cursor_ordering',
+  },
+  discord_circle_api_tokens_stream_cursor_value_input: {
+    circle_id: 'bigint',
+    created_at: 'timestamptz',
+    id: 'bigint',
+  },
+  discord_circle_api_tokens_update_column: true,
+  discord_circle_api_tokens_updates: {
+    _inc: 'discord_circle_api_tokens_inc_input',
+    _set: 'discord_circle_api_tokens_set_input',
+    where: 'discord_circle_api_tokens_bool_exp',
+  },
   discord_roles_circles_aggregate_fields: {
     count: {
       columns: 'discord_roles_circles_select_column',
@@ -1577,7 +1638,7 @@ export const AllTypesProps: Record<string, any> = {
     circle_id: 'bigint_comparison_exp',
     created_at: 'timestamptz_comparison_exp',
     id: 'bigint_comparison_exp',
-    role: 'String_comparison_exp',
+    server_role: 'String_comparison_exp',
     updated_at: 'timestamptz_comparison_exp',
   },
   discord_roles_circles_constraint: true,
@@ -1602,7 +1663,7 @@ export const AllTypesProps: Record<string, any> = {
     circle_id: 'order_by',
     created_at: 'order_by',
     id: 'order_by',
-    role: 'order_by',
+    server_role: 'order_by',
     updated_at: 'order_by',
   },
   discord_roles_circles_pk_columns_input: {
@@ -2875,6 +2936,12 @@ export const AllTypesProps: Record<string, any> = {
     delete_contributions_by_pk: {
       id: 'bigint',
     },
+    delete_discord_circle_api_tokens: {
+      where: 'discord_circle_api_tokens_bool_exp',
+    },
+    delete_discord_circle_api_tokens_by_pk: {
+      id: 'bigint',
+    },
     delete_discord_roles_circles: {
       where: 'discord_roles_circles_bool_exp',
     },
@@ -3075,6 +3142,14 @@ export const AllTypesProps: Record<string, any> = {
     insert_contributions_one: {
       object: 'contributions_insert_input',
       on_conflict: 'contributions_on_conflict',
+    },
+    insert_discord_circle_api_tokens: {
+      objects: 'discord_circle_api_tokens_insert_input',
+      on_conflict: 'discord_circle_api_tokens_on_conflict',
+    },
+    insert_discord_circle_api_tokens_one: {
+      object: 'discord_circle_api_tokens_insert_input',
+      on_conflict: 'discord_circle_api_tokens_on_conflict',
     },
     insert_discord_roles_circles: {
       objects: 'discord_roles_circles_insert_input',
@@ -3402,6 +3477,19 @@ export const AllTypesProps: Record<string, any> = {
     },
     update_contributions_many: {
       updates: 'contributions_updates',
+    },
+    update_discord_circle_api_tokens: {
+      _inc: 'discord_circle_api_tokens_inc_input',
+      _set: 'discord_circle_api_tokens_set_input',
+      where: 'discord_circle_api_tokens_bool_exp',
+    },
+    update_discord_circle_api_tokens_by_pk: {
+      _inc: 'discord_circle_api_tokens_inc_input',
+      _set: 'discord_circle_api_tokens_set_input',
+      pk_columns: 'discord_circle_api_tokens_pk_columns_input',
+    },
+    update_discord_circle_api_tokens_many: {
+      updates: 'discord_circle_api_tokens_updates',
     },
     update_discord_roles_circles: {
       _inc: 'discord_roles_circles_inc_input',
@@ -4781,6 +4869,19 @@ export const AllTypesProps: Record<string, any> = {
     contributions_by_pk: {
       id: 'bigint',
     },
+    discord_circle_api_tokens: {
+      distinct_on: 'discord_circle_api_tokens_select_column',
+      order_by: 'discord_circle_api_tokens_order_by',
+      where: 'discord_circle_api_tokens_bool_exp',
+    },
+    discord_circle_api_tokens_aggregate: {
+      distinct_on: 'discord_circle_api_tokens_select_column',
+      order_by: 'discord_circle_api_tokens_order_by',
+      where: 'discord_circle_api_tokens_bool_exp',
+    },
+    discord_circle_api_tokens_by_pk: {
+      id: 'bigint',
+    },
     discord_roles_circles: {
       distinct_on: 'discord_roles_circles_select_column',
       order_by: 'discord_roles_circles_order_by',
@@ -4975,6 +5076,7 @@ export const AllTypesProps: Record<string, any> = {
     personal_access_tokens_by_pk: {
       id: 'bigint',
     },
+    price_per_share: {},
     profiles: {
       distinct_on: 'profiles_select_column',
       order_by: 'profiles_order_by',
@@ -5236,6 +5338,23 @@ export const AllTypesProps: Record<string, any> = {
     contributions_stream: {
       cursor: 'contributions_stream_cursor_input',
       where: 'contributions_bool_exp',
+    },
+    discord_circle_api_tokens: {
+      distinct_on: 'discord_circle_api_tokens_select_column',
+      order_by: 'discord_circle_api_tokens_order_by',
+      where: 'discord_circle_api_tokens_bool_exp',
+    },
+    discord_circle_api_tokens_aggregate: {
+      distinct_on: 'discord_circle_api_tokens_select_column',
+      order_by: 'discord_circle_api_tokens_order_by',
+      where: 'discord_circle_api_tokens_bool_exp',
+    },
+    discord_circle_api_tokens_by_pk: {
+      id: 'bigint',
+    },
+    discord_circle_api_tokens_stream: {
+      cursor: 'discord_circle_api_tokens_stream_cursor_input',
+      where: 'discord_circle_api_tokens_bool_exp',
     },
     discord_roles_circles: {
       distinct_on: 'discord_roles_circles_select_column',
@@ -8035,12 +8154,86 @@ export const ReturnTypes: Record<string, any> = {
     id: 'Float',
     user_id: 'Float',
   },
+  discord_circle_api_tokens: {
+    channel_snowflake: 'String',
+    circle_id: 'bigint',
+    created_at: 'timestamptz',
+    id: 'bigint',
+    token: 'String',
+  },
+  discord_circle_api_tokens_aggregate: {
+    aggregate: 'discord_circle_api_tokens_aggregate_fields',
+    nodes: 'discord_circle_api_tokens',
+  },
+  discord_circle_api_tokens_aggregate_fields: {
+    avg: 'discord_circle_api_tokens_avg_fields',
+    count: 'Int',
+    max: 'discord_circle_api_tokens_max_fields',
+    min: 'discord_circle_api_tokens_min_fields',
+    stddev: 'discord_circle_api_tokens_stddev_fields',
+    stddev_pop: 'discord_circle_api_tokens_stddev_pop_fields',
+    stddev_samp: 'discord_circle_api_tokens_stddev_samp_fields',
+    sum: 'discord_circle_api_tokens_sum_fields',
+    var_pop: 'discord_circle_api_tokens_var_pop_fields',
+    var_samp: 'discord_circle_api_tokens_var_samp_fields',
+    variance: 'discord_circle_api_tokens_variance_fields',
+  },
+  discord_circle_api_tokens_avg_fields: {
+    circle_id: 'Float',
+    id: 'Float',
+  },
+  discord_circle_api_tokens_max_fields: {
+    channel_snowflake: 'String',
+    circle_id: 'bigint',
+    created_at: 'timestamptz',
+    id: 'bigint',
+    token: 'String',
+  },
+  discord_circle_api_tokens_min_fields: {
+    channel_snowflake: 'String',
+    circle_id: 'bigint',
+    created_at: 'timestamptz',
+    id: 'bigint',
+    token: 'String',
+  },
+  discord_circle_api_tokens_mutation_response: {
+    affected_rows: 'Int',
+    returning: 'discord_circle_api_tokens',
+  },
+  discord_circle_api_tokens_stddev_fields: {
+    circle_id: 'Float',
+    id: 'Float',
+  },
+  discord_circle_api_tokens_stddev_pop_fields: {
+    circle_id: 'Float',
+    id: 'Float',
+  },
+  discord_circle_api_tokens_stddev_samp_fields: {
+    circle_id: 'Float',
+    id: 'Float',
+  },
+  discord_circle_api_tokens_sum_fields: {
+    circle_id: 'bigint',
+    id: 'bigint',
+  },
+  discord_circle_api_tokens_var_pop_fields: {
+    circle_id: 'Float',
+    id: 'Float',
+  },
+  discord_circle_api_tokens_var_samp_fields: {
+    circle_id: 'Float',
+    id: 'Float',
+  },
+  discord_circle_api_tokens_variance_fields: {
+    circle_id: 'Float',
+    id: 'Float',
+  },
   discord_roles_circles: {
     circle: 'circles',
     circle_id: 'bigint',
     created_at: 'timestamptz',
     id: 'bigint',
-    role: 'String',
+    server_role: 'String',
     updated_at: 'timestamptz',
   },
   discord_roles_circles_aggregate: {
@@ -8068,14 +8261,14 @@ export const ReturnTypes: Record<string, any> = {
     circle_id: 'bigint',
     created_at: 'timestamptz',
     id: 'bigint',
-    role: 'String',
+    server_role: 'String',
     updated_at: 'timestamptz',
   },
   discord_roles_circles_min_fields: {
     circle_id: 'bigint',
     created_at: 'timestamptz',
     id: 'bigint',
-    role: 'String',
+    server_role: 'String',
     updated_at: 'timestamptz',
   },
   discord_roles_circles_mutation_response: {
@@ -9162,6 +9355,9 @@ export const ReturnTypes: Record<string, any> = {
     delete_claims_by_pk: 'claims',
     delete_contributions: 'contributions_mutation_response',
     delete_contributions_by_pk: 'contributions',
+    delete_discord_circle_api_tokens:
+      'discord_circle_api_tokens_mutation_response',
+    delete_discord_circle_api_tokens_by_pk: 'discord_circle_api_tokens',
     delete_discord_roles_circles: 'discord_roles_circles_mutation_response',
     delete_discord_roles_circles_by_pk: 'discord_roles_circles',
     delete_discord_users: 'discord_users_mutation_response',
@@ -9229,6 +9425,9 @@ export const ReturnTypes: Record<string, any> = {
     insert_claims_one: 'claims',
     insert_contributions: 'contributions_mutation_response',
     insert_contributions_one: 'contributions',
+    insert_discord_circle_api_tokens:
+      'discord_circle_api_tokens_mutation_response',
+    insert_discord_circle_api_tokens_one: 'discord_circle_api_tokens',
     insert_discord_roles_circles: 'discord_roles_circles_mutation_response',
     insert_discord_roles_circles_one: 'discord_roles_circles',
     insert_discord_users: 'discord_users_mutation_response',
@@ -9315,6 +9514,11 @@ export const ReturnTypes: Record<string, any> = {
     update_contributions: 'contributions_mutation_response',
     update_contributions_by_pk: 'contributions',
     update_contributions_many: 'contributions_mutation_response',
+    update_discord_circle_api_tokens:
+      'discord_circle_api_tokens_mutation_response',
+    update_discord_circle_api_tokens_by_pk: 'discord_circle_api_tokens',
+    update_discord_circle_api_tokens_many:
+      'discord_circle_api_tokens_mutation_response',
     update_discord_roles_circles: 'discord_roles_circles_mutation_response',
     update_discord_roles_circles_by_pk: 'discord_roles_circles',
     update_discord_roles_circles_many:
@@ -10155,6 +10359,9 @@ export const ReturnTypes: Record<string, any> = {
     contributions: 'contributions',
     contributions_aggregate: 'contributions_aggregate',
     contributions_by_pk: 'contributions',
+    discord_circle_api_tokens: 'discord_circle_api_tokens',
+    discord_circle_api_tokens_aggregate: 'discord_circle_api_tokens_aggregate',
+    discord_circle_api_tokens_by_pk: 'discord_circle_api_tokens',
     discord_roles_circles: 'discord_roles_circles',
     discord_roles_circles_aggregate: 'discord_roles_circles_aggregate',
     discord_roles_circles_by_pk: 'discord_roles_circles',
@@ -10203,6 +10410,7 @@ export const ReturnTypes: Record<string, any> = {
     personal_access_tokens: 'personal_access_tokens',
     personal_access_tokens_aggregate: 'personal_access_tokens_aggregate',
     personal_access_tokens_by_pk: 'personal_access_tokens',
+    price_per_share: 'Float',
     profiles: 'profiles',
     profiles_aggregate: 'profiles_aggregate',
     profiles_by_pk: 'profiles',
@@ -10266,6 +10474,10 @@ export const ReturnTypes: Record<string, any> = {
     contributions_aggregate: 'contributions_aggregate',
     contributions_by_pk: 'contributions',
     contributions_stream: 'contributions',
+    discord_circle_api_tokens: 'discord_circle_api_tokens',
+    discord_circle_api_tokens_aggregate: 'discord_circle_api_tokens_aggregate',
+    discord_circle_api_tokens_by_pk: 'discord_circle_api_tokens',
+    discord_circle_api_tokens_stream: 'discord_circle_api_tokens',
     discord_roles_circles: 'discord_roles_circles',
     discord_roles_circles_aggregate: 'discord_roles_circles_aggregate',
     discord_roles_circles_by_pk: 'discord_roles_circles',
@@ -10976,6 +11188,7 @@ export const ReturnTypes: Record<string, any> = {
     id: 'bigint',
     org_id: 'bigint',
     organization: 'organizations',
+    price_per_share: 'Float',
     profile: 'profiles',
     simple_token_address: 'String',
     symbol: 'String',

--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -4618,6 +4618,205 @@ export type ValueTypes = {
     _neq?: ValueTypes['date'] | undefined | null;
     _nin?: Array<ValueTypes['date']> | undefined | null;
   };
+  /** tokens the discord bot uses to operate on circles */
+  ['discord_circle_api_tokens']: AliasType<{
+    channel_snowflake?: boolean | `@${string}`;
+    circle_id?: boolean | `@${string}`;
+    created_at?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    token?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregated selection of "discord.circle_api_tokens" */
+  ['discord_circle_api_tokens_aggregate']: AliasType<{
+    aggregate?: ValueTypes['discord_circle_api_tokens_aggregate_fields'];
+    nodes?: ValueTypes['discord_circle_api_tokens'];
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate fields of "discord.circle_api_tokens" */
+  ['discord_circle_api_tokens_aggregate_fields']: AliasType<{
+    avg?: ValueTypes['discord_circle_api_tokens_avg_fields'];
+    count?: [
+      {
+        columns?:
+          | Array<ValueTypes['discord_circle_api_tokens_select_column']>
+          | undefined
+          | null;
+        distinct?: boolean | undefined | null;
+      },
+      boolean | `@${string}`
+    ];
+    max?: ValueTypes['discord_circle_api_tokens_max_fields'];
+    min?: ValueTypes['discord_circle_api_tokens_min_fields'];
+    stddev?: ValueTypes['discord_circle_api_tokens_stddev_fields'];
+    stddev_pop?: ValueTypes['discord_circle_api_tokens_stddev_pop_fields'];
+    stddev_samp?: ValueTypes['discord_circle_api_tokens_stddev_samp_fields'];
+    sum?: ValueTypes['discord_circle_api_tokens_sum_fields'];
+    var_pop?: ValueTypes['discord_circle_api_tokens_var_pop_fields'];
+    var_samp?: ValueTypes['discord_circle_api_tokens_var_samp_fields'];
+    variance?: ValueTypes['discord_circle_api_tokens_variance_fields'];
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate avg on columns */
+  ['discord_circle_api_tokens_avg_fields']: AliasType<{
+    circle_id?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** Boolean expression to filter rows from the table "discord.circle_api_tokens". All fields are combined with a logical 'AND'. */
+  ['discord_circle_api_tokens_bool_exp']: {
+    _and?:
+      | Array<ValueTypes['discord_circle_api_tokens_bool_exp']>
+      | undefined
+      | null;
+    _not?: ValueTypes['discord_circle_api_tokens_bool_exp'] | undefined | null;
+    _or?:
+      | Array<ValueTypes['discord_circle_api_tokens_bool_exp']>
+      | undefined
+      | null;
+    channel_snowflake?: ValueTypes['String_comparison_exp'] | undefined | null;
+    circle_id?: ValueTypes['bigint_comparison_exp'] | undefined | null;
+    created_at?: ValueTypes['timestamptz_comparison_exp'] | undefined | null;
+    id?: ValueTypes['bigint_comparison_exp'] | undefined | null;
+    token?: ValueTypes['String_comparison_exp'] | undefined | null;
+  };
+  /** unique or primary key constraints on table "discord.circle_api_tokens" */
+  ['discord_circle_api_tokens_constraint']: discord_circle_api_tokens_constraint;
+  /** input type for incrementing numeric columns in table "discord.circle_api_tokens" */
+  ['discord_circle_api_tokens_inc_input']: {
+    circle_id?: ValueTypes['bigint'] | undefined | null;
+    id?: ValueTypes['bigint'] | undefined | null;
+  };
+  /** input type for inserting data into table "discord.circle_api_tokens" */
+  ['discord_circle_api_tokens_insert_input']: {
+    channel_snowflake?: string | undefined | null;
+    circle_id?: ValueTypes['bigint'] | undefined | null;
+    created_at?: ValueTypes['timestamptz'] | undefined | null;
+    id?: ValueTypes['bigint'] | undefined | null;
+    token?: string | undefined | null;
+  };
+  /** aggregate max on columns */
+  ['discord_circle_api_tokens_max_fields']: AliasType<{
+    channel_snowflake?: boolean | `@${string}`;
+    circle_id?: boolean | `@${string}`;
+    created_at?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    token?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate min on columns */
+  ['discord_circle_api_tokens_min_fields']: AliasType<{
+    channel_snowflake?: boolean | `@${string}`;
+    circle_id?: boolean | `@${string}`;
+    created_at?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    token?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** response of any mutation on the table "discord.circle_api_tokens" */
+  ['discord_circle_api_tokens_mutation_response']: AliasType<{
+    /** number of rows affected by the mutation */
+    affected_rows?: boolean | `@${string}`;
+    /** data from the rows affected by the mutation */
+    returning?: ValueTypes['discord_circle_api_tokens'];
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** on_conflict condition type for table "discord.circle_api_tokens" */
+  ['discord_circle_api_tokens_on_conflict']: {
+    constraint: ValueTypes['discord_circle_api_tokens_constraint'];
+    update_columns: Array<
+      ValueTypes['discord_circle_api_tokens_update_column']
+    >;
+    where?: ValueTypes['discord_circle_api_tokens_bool_exp'] | undefined | null;
+  };
+  /** Ordering options when selecting data from "discord.circle_api_tokens". */
+  ['discord_circle_api_tokens_order_by']: {
+    channel_snowflake?: ValueTypes['order_by'] | undefined | null;
+    circle_id?: ValueTypes['order_by'] | undefined | null;
+    created_at?: ValueTypes['order_by'] | undefined | null;
+    id?: ValueTypes['order_by'] | undefined | null;
+    token?: ValueTypes['order_by'] | undefined | null;
+  };
+  /** primary key columns input for table: discord.circle_api_tokens */
+  ['discord_circle_api_tokens_pk_columns_input']: {
+    id: ValueTypes['bigint'];
+  };
+  /** select columns of table "discord.circle_api_tokens" */
+  ['discord_circle_api_tokens_select_column']: discord_circle_api_tokens_select_column;
+  /** input type for updating data in table "discord.circle_api_tokens" */
+  ['discord_circle_api_tokens_set_input']: {
+    channel_snowflake?: string | undefined | null;
+    circle_id?: ValueTypes['bigint'] | undefined | null;
+    created_at?: ValueTypes['timestamptz'] | undefined | null;
+    id?: ValueTypes['bigint'] | undefined | null;
+    token?: string | undefined | null;
+  };
+  /** aggregate stddev on columns */
+  ['discord_circle_api_tokens_stddev_fields']: AliasType<{
+    circle_id?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate stddev_pop on columns */
+  ['discord_circle_api_tokens_stddev_pop_fields']: AliasType<{
+    circle_id?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate stddev_samp on columns */
+  ['discord_circle_api_tokens_stddev_samp_fields']: AliasType<{
+    circle_id?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** Streaming cursor of the table "discord_circle_api_tokens" */
+  ['discord_circle_api_tokens_stream_cursor_input']: {
+    /** Stream column input with initial value */
+    initial_value: ValueTypes['discord_circle_api_tokens_stream_cursor_value_input'];
+    /** cursor ordering */
+    ordering?: ValueTypes['cursor_ordering'] | undefined | null;
+  };
+  /** Initial value of the column from where the streaming should start */
+  ['discord_circle_api_tokens_stream_cursor_value_input']: {
+    channel_snowflake?: string | undefined | null;
+    circle_id?: ValueTypes['bigint'] | undefined | null;
+    created_at?: ValueTypes['timestamptz'] | undefined | null;
+    id?: ValueTypes['bigint'] | undefined | null;
+    token?: string | undefined | null;
+  };
+  /** aggregate sum on columns */
+  ['discord_circle_api_tokens_sum_fields']: AliasType<{
+    circle_id?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** update columns of table "discord.circle_api_tokens" */
+  ['discord_circle_api_tokens_update_column']: discord_circle_api_tokens_update_column;
+  ['discord_circle_api_tokens_updates']: {
+    /** increments the numeric columns with given value of the filtered values */
+    _inc?: ValueTypes['discord_circle_api_tokens_inc_input'] | undefined | null;
+    /** sets the columns of the filtered rows to the given values */
+    _set?: ValueTypes['discord_circle_api_tokens_set_input'] | undefined | null;
+    where: ValueTypes['discord_circle_api_tokens_bool_exp'];
+  };
+  /** aggregate var_pop on columns */
+  ['discord_circle_api_tokens_var_pop_fields']: AliasType<{
+    circle_id?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate var_samp on columns */
+  ['discord_circle_api_tokens_var_samp_fields']: AliasType<{
+    circle_id?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate variance on columns */
+  ['discord_circle_api_tokens_variance_fields']: AliasType<{
+    circle_id?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
   /** link a discord role to a circle  to control membership of the circle */
   ['discord_roles_circles']: AliasType<{
     /** An object relationship */
@@ -4625,7 +4824,7 @@ export type ValueTypes = {
     circle_id?: boolean | `@${string}`;
     created_at?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
-    role?: boolean | `@${string}`;
+    server_role?: boolean | `@${string}`;
     updated_at?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
@@ -4680,7 +4879,7 @@ export type ValueTypes = {
     circle_id?: ValueTypes['bigint_comparison_exp'] | undefined | null;
     created_at?: ValueTypes['timestamptz_comparison_exp'] | undefined | null;
     id?: ValueTypes['bigint_comparison_exp'] | undefined | null;
-    role?: ValueTypes['String_comparison_exp'] | undefined | null;
+    server_role?: ValueTypes['String_comparison_exp'] | undefined | null;
     updated_at?: ValueTypes['timestamptz_comparison_exp'] | undefined | null;
   };
   /** unique or primary key constraints on table "discord.roles_circles" */
@@ -4696,7 +4895,7 @@ export type ValueTypes = {
     circle_id?: ValueTypes['bigint'] | undefined | null;
     created_at?: ValueTypes['timestamptz'] | undefined | null;
     id?: ValueTypes['bigint'] | undefined | null;
-    role?: string | undefined | null;
+    server_role?: string | undefined | null;
     updated_at?: ValueTypes['timestamptz'] | undefined | null;
   };
   /** aggregate max on columns */
@@ -4704,7 +4903,7 @@ export type ValueTypes = {
     circle_id?: boolean | `@${string}`;
     created_at?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
-    role?: boolean | `@${string}`;
+    server_role?: boolean | `@${string}`;
     updated_at?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
@@ -4713,7 +4912,7 @@ export type ValueTypes = {
     circle_id?: boolean | `@${string}`;
     created_at?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
-    role?: boolean | `@${string}`;
+    server_role?: boolean | `@${string}`;
     updated_at?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
@@ -4737,7 +4936,7 @@ export type ValueTypes = {
     circle_id?: ValueTypes['order_by'] | undefined | null;
     created_at?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
-    role?: ValueTypes['order_by'] | undefined | null;
+    server_role?: ValueTypes['order_by'] | undefined | null;
     updated_at?: ValueTypes['order_by'] | undefined | null;
   };
   /** primary key columns input for table: discord.roles_circles */
@@ -4751,7 +4950,7 @@ export type ValueTypes = {
     circle_id?: ValueTypes['bigint'] | undefined | null;
     created_at?: ValueTypes['timestamptz'] | undefined | null;
     id?: ValueTypes['bigint'] | undefined | null;
-    role?: string | undefined | null;
+    server_role?: string | undefined | null;
     updated_at?: ValueTypes['timestamptz'] | undefined | null;
   };
   /** aggregate stddev on columns */
@@ -4784,7 +4983,7 @@ export type ValueTypes = {
     circle_id?: ValueTypes['bigint'] | undefined | null;
     created_at?: ValueTypes['timestamptz'] | undefined | null;
     id?: ValueTypes['bigint'] | undefined | null;
-    role?: string | undefined | null;
+    server_role?: string | undefined | null;
     updated_at?: ValueTypes['timestamptz'] | undefined | null;
   };
   /** aggregate sum on columns */
@@ -8135,6 +8334,17 @@ export type ValueTypes = {
       { id: ValueTypes['bigint'] },
       ValueTypes['contributions']
     ];
+    delete_discord_circle_api_tokens?: [
+      {
+        /** filter the rows which have to be deleted */
+        where: ValueTypes['discord_circle_api_tokens_bool_exp'];
+      },
+      ValueTypes['discord_circle_api_tokens_mutation_response']
+    ];
+    delete_discord_circle_api_tokens_by_pk?: [
+      { id: ValueTypes['bigint'] },
+      ValueTypes['discord_circle_api_tokens']
+    ];
     delete_discord_roles_circles?: [
       {
         /** filter the rows which have to be deleted */
@@ -8573,6 +8783,30 @@ export type ValueTypes = {
           | null;
       },
       ValueTypes['contributions']
+    ];
+    insert_discord_circle_api_tokens?: [
+      {
+        /** the rows to be inserted */
+        objects: Array<
+          ValueTypes['discord_circle_api_tokens_insert_input']
+        > /** upsert condition */;
+        on_conflict?:
+          | ValueTypes['discord_circle_api_tokens_on_conflict']
+          | undefined
+          | null;
+      },
+      ValueTypes['discord_circle_api_tokens_mutation_response']
+    ];
+    insert_discord_circle_api_tokens_one?: [
+      {
+        /** the row to be inserted */
+        object: ValueTypes['discord_circle_api_tokens_insert_input'] /** upsert condition */;
+        on_conflict?:
+          | ValueTypes['discord_circle_api_tokens_on_conflict']
+          | undefined
+          | null;
+      },
+      ValueTypes['discord_circle_api_tokens']
     ];
     insert_discord_roles_circles?: [
       {
@@ -9406,6 +9640,43 @@ export type ValueTypes = {
         updates: Array<ValueTypes['contributions_updates']>;
       },
       ValueTypes['contributions_mutation_response']
+    ];
+    update_discord_circle_api_tokens?: [
+      {
+        /** increments the numeric columns with given value of the filtered values */
+        _inc?:
+          | ValueTypes['discord_circle_api_tokens_inc_input']
+          | undefined
+          | null /** sets the columns of the filtered rows to the given values */;
+        _set?:
+          | ValueTypes['discord_circle_api_tokens_set_input']
+          | undefined
+          | null /** filter the rows which have to be updated */;
+        where: ValueTypes['discord_circle_api_tokens_bool_exp'];
+      },
+      ValueTypes['discord_circle_api_tokens_mutation_response']
+    ];
+    update_discord_circle_api_tokens_by_pk?: [
+      {
+        /** increments the numeric columns with given value of the filtered values */
+        _inc?:
+          | ValueTypes['discord_circle_api_tokens_inc_input']
+          | undefined
+          | null /** sets the columns of the filtered rows to the given values */;
+        _set?:
+          | ValueTypes['discord_circle_api_tokens_set_input']
+          | undefined
+          | null;
+        pk_columns: ValueTypes['discord_circle_api_tokens_pk_columns_input'];
+      },
+      ValueTypes['discord_circle_api_tokens']
+    ];
+    update_discord_circle_api_tokens_many?: [
+      {
+        /** updates to execute, in order */
+        updates: Array<ValueTypes['discord_circle_api_tokens_updates']>;
+      },
+      ValueTypes['discord_circle_api_tokens_mutation_response']
     ];
     update_discord_roles_circles?: [
       {
@@ -13323,6 +13594,62 @@ export type ValueTypes = {
       { id: ValueTypes['bigint'] },
       ValueTypes['contributions']
     ];
+    discord_circle_api_tokens?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['discord_circle_api_tokens_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['discord_circle_api_tokens_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?:
+          | ValueTypes['discord_circle_api_tokens_bool_exp']
+          | undefined
+          | null;
+      },
+      ValueTypes['discord_circle_api_tokens']
+    ];
+    discord_circle_api_tokens_aggregate?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['discord_circle_api_tokens_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['discord_circle_api_tokens_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?:
+          | ValueTypes['discord_circle_api_tokens_bool_exp']
+          | undefined
+          | null;
+      },
+      ValueTypes['discord_circle_api_tokens_aggregate']
+    ];
+    discord_circle_api_tokens_by_pk?: [
+      { id: ValueTypes['bigint'] },
+      ValueTypes['discord_circle_api_tokens']
+    ];
     discord_roles_circles?: [
       {
         /** distinct select on columns */
@@ -14120,6 +14447,10 @@ export type ValueTypes = {
     personal_access_tokens_by_pk?: [
       { id: ValueTypes['bigint'] },
       ValueTypes['personal_access_tokens']
+    ];
+    price_per_share?: [
+      { chain_id: number; token_address?: string | undefined | null },
+      boolean | `@${string}`
     ];
     profiles?: [
       {
@@ -15088,6 +15419,78 @@ export type ValueTypes = {
         where?: ValueTypes['contributions_bool_exp'] | undefined | null;
       },
       ValueTypes['contributions']
+    ];
+    discord_circle_api_tokens?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['discord_circle_api_tokens_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['discord_circle_api_tokens_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?:
+          | ValueTypes['discord_circle_api_tokens_bool_exp']
+          | undefined
+          | null;
+      },
+      ValueTypes['discord_circle_api_tokens']
+    ];
+    discord_circle_api_tokens_aggregate?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['discord_circle_api_tokens_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['discord_circle_api_tokens_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?:
+          | ValueTypes['discord_circle_api_tokens_bool_exp']
+          | undefined
+          | null;
+      },
+      ValueTypes['discord_circle_api_tokens_aggregate']
+    ];
+    discord_circle_api_tokens_by_pk?: [
+      { id: ValueTypes['bigint'] },
+      ValueTypes['discord_circle_api_tokens']
+    ];
+    discord_circle_api_tokens_stream?: [
+      {
+        /** maximum number of rows returned in a single batch */
+        batch_size: number /** cursor to stream the results returned by the query */;
+        cursor: Array<
+          | ValueTypes['discord_circle_api_tokens_stream_cursor_input']
+          | undefined
+          | null
+        > /** filter the rows returned */;
+        where?:
+          | ValueTypes['discord_circle_api_tokens_bool_exp']
+          | undefined
+          | null;
+      },
+      ValueTypes['discord_circle_api_tokens']
     ];
     discord_roles_circles?: [
       {
@@ -19189,6 +19592,7 @@ export type ValueTypes = {
     org_id?: boolean | `@${string}`;
     /** An object relationship */
     organization?: ValueTypes['organizations'];
+    price_per_share?: boolean | `@${string}`;
     /** An object relationship */
     profile?: ValueTypes['profiles'];
     simple_token_address?: boolean | `@${string}`;
@@ -21576,6 +21980,135 @@ export type ModelTypes = {
   ['date']: any;
   /** Boolean expression to compare columns of type "date". All fields are combined with logical 'AND'. */
   ['date_comparison_exp']: GraphQLTypes['date_comparison_exp'];
+  /** tokens the discord bot uses to operate on circles */
+  ['discord_circle_api_tokens']: {
+    channel_snowflake: string;
+    circle_id: GraphQLTypes['bigint'];
+    created_at: GraphQLTypes['timestamptz'];
+    id: GraphQLTypes['bigint'];
+    token?: string | undefined;
+  };
+  /** aggregated selection of "discord.circle_api_tokens" */
+  ['discord_circle_api_tokens_aggregate']: {
+    aggregate?:
+      | GraphQLTypes['discord_circle_api_tokens_aggregate_fields']
+      | undefined;
+    nodes: Array<GraphQLTypes['discord_circle_api_tokens']>;
+  };
+  /** aggregate fields of "discord.circle_api_tokens" */
+  ['discord_circle_api_tokens_aggregate_fields']: {
+    avg?: GraphQLTypes['discord_circle_api_tokens_avg_fields'] | undefined;
+    count: number;
+    max?: GraphQLTypes['discord_circle_api_tokens_max_fields'] | undefined;
+    min?: GraphQLTypes['discord_circle_api_tokens_min_fields'] | undefined;
+    stddev?:
+      | GraphQLTypes['discord_circle_api_tokens_stddev_fields']
+      | undefined;
+    stddev_pop?:
+      | GraphQLTypes['discord_circle_api_tokens_stddev_pop_fields']
+      | undefined;
+    stddev_samp?:
+      | GraphQLTypes['discord_circle_api_tokens_stddev_samp_fields']
+      | undefined;
+    sum?: GraphQLTypes['discord_circle_api_tokens_sum_fields'] | undefined;
+    var_pop?:
+      | GraphQLTypes['discord_circle_api_tokens_var_pop_fields']
+      | undefined;
+    var_samp?:
+      | GraphQLTypes['discord_circle_api_tokens_var_samp_fields']
+      | undefined;
+    variance?:
+      | GraphQLTypes['discord_circle_api_tokens_variance_fields']
+      | undefined;
+  };
+  /** aggregate avg on columns */
+  ['discord_circle_api_tokens_avg_fields']: {
+    circle_id?: number | undefined;
+    id?: number | undefined;
+  };
+  /** Boolean expression to filter rows from the table "discord.circle_api_tokens". All fields are combined with a logical 'AND'. */
+  ['discord_circle_api_tokens_bool_exp']: GraphQLTypes['discord_circle_api_tokens_bool_exp'];
+  /** unique or primary key constraints on table "discord.circle_api_tokens" */
+  ['discord_circle_api_tokens_constraint']: GraphQLTypes['discord_circle_api_tokens_constraint'];
+  /** input type for incrementing numeric columns in table "discord.circle_api_tokens" */
+  ['discord_circle_api_tokens_inc_input']: GraphQLTypes['discord_circle_api_tokens_inc_input'];
+  /** input type for inserting data into table "discord.circle_api_tokens" */
+  ['discord_circle_api_tokens_insert_input']: GraphQLTypes['discord_circle_api_tokens_insert_input'];
+  /** aggregate max on columns */
+  ['discord_circle_api_tokens_max_fields']: {
+    channel_snowflake?: string | undefined;
+    circle_id?: GraphQLTypes['bigint'] | undefined;
+    created_at?: GraphQLTypes['timestamptz'] | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    token?: string | undefined;
+  };
+  /** aggregate min on columns */
+  ['discord_circle_api_tokens_min_fields']: {
+    channel_snowflake?: string | undefined;
+    circle_id?: GraphQLTypes['bigint'] | undefined;
+    created_at?: GraphQLTypes['timestamptz'] | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    token?: string | undefined;
+  };
+  /** response of any mutation on the table "discord.circle_api_tokens" */
+  ['discord_circle_api_tokens_mutation_response']: {
+    /** number of rows affected by the mutation */
+    affected_rows: number;
+    /** data from the rows affected by the mutation */
+    returning: Array<GraphQLTypes['discord_circle_api_tokens']>;
+  };
+  /** on_conflict condition type for table "discord.circle_api_tokens" */
+  ['discord_circle_api_tokens_on_conflict']: GraphQLTypes['discord_circle_api_tokens_on_conflict'];
+  /** Ordering options when selecting data from "discord.circle_api_tokens". */
+  ['discord_circle_api_tokens_order_by']: GraphQLTypes['discord_circle_api_tokens_order_by'];
+  /** primary key columns input for table: discord.circle_api_tokens */
+  ['discord_circle_api_tokens_pk_columns_input']: GraphQLTypes['discord_circle_api_tokens_pk_columns_input'];
+  /** select columns of table "discord.circle_api_tokens" */
+  ['discord_circle_api_tokens_select_column']: GraphQLTypes['discord_circle_api_tokens_select_column'];
+  /** input type for updating data in table "discord.circle_api_tokens" */
+  ['discord_circle_api_tokens_set_input']: GraphQLTypes['discord_circle_api_tokens_set_input'];
+  /** aggregate stddev on columns */
+  ['discord_circle_api_tokens_stddev_fields']: {
+    circle_id?: number | undefined;
+    id?: number | undefined;
+  };
+  /** aggregate stddev_pop on columns */
+  ['discord_circle_api_tokens_stddev_pop_fields']: {
+    circle_id?: number | undefined;
+    id?: number | undefined;
+  };
+  /** aggregate stddev_samp on columns */
+  ['discord_circle_api_tokens_stddev_samp_fields']: {
+    circle_id?: number | undefined;
+    id?: number | undefined;
+  };
+  /** Streaming cursor of the table "discord_circle_api_tokens" */
+  ['discord_circle_api_tokens_stream_cursor_input']: GraphQLTypes['discord_circle_api_tokens_stream_cursor_input'];
+  /** Initial value of the column from where the streaming should start */
+  ['discord_circle_api_tokens_stream_cursor_value_input']: GraphQLTypes['discord_circle_api_tokens_stream_cursor_value_input'];
+  /** aggregate sum on columns */
+  ['discord_circle_api_tokens_sum_fields']: {
+    circle_id?: GraphQLTypes['bigint'] | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+  };
+  /** update columns of table "discord.circle_api_tokens" */
+  ['discord_circle_api_tokens_update_column']: GraphQLTypes['discord_circle_api_tokens_update_column'];
+  ['discord_circle_api_tokens_updates']: GraphQLTypes['discord_circle_api_tokens_updates'];
+  /** aggregate var_pop on columns */
+  ['discord_circle_api_tokens_var_pop_fields']: {
+    circle_id?: number | undefined;
+    id?: number | undefined;
+  };
+  /** aggregate var_samp on columns */
+  ['discord_circle_api_tokens_var_samp_fields']: {
+    circle_id?: number | undefined;
+    id?: number | undefined;
+  };
+  /** aggregate variance on columns */
+  ['discord_circle_api_tokens_variance_fields']: {
+    circle_id?: number | undefined;
+    id?: number | undefined;
+  };
   /** link a discord role to a circle  to control membership of the circle */
   ['discord_roles_circles']: {
     /** An object relationship */
@@ -21583,7 +22116,7 @@ export type ModelTypes = {
     circle_id: GraphQLTypes['bigint'];
     created_at: GraphQLTypes['timestamptz'];
     id: GraphQLTypes['bigint'];
-    role: string;
+    server_role: string;
     updated_at: GraphQLTypes['timestamptz'];
   };
   /** aggregated selection of "discord.roles_circles" */
@@ -21633,7 +22166,7 @@ export type ModelTypes = {
     circle_id?: GraphQLTypes['bigint'] | undefined;
     created_at?: GraphQLTypes['timestamptz'] | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
-    role?: string | undefined;
+    server_role?: string | undefined;
     updated_at?: GraphQLTypes['timestamptz'] | undefined;
   };
   /** aggregate min on columns */
@@ -21641,7 +22174,7 @@ export type ModelTypes = {
     circle_id?: GraphQLTypes['bigint'] | undefined;
     created_at?: GraphQLTypes['timestamptz'] | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
-    role?: string | undefined;
+    server_role?: string | undefined;
     updated_at?: GraphQLTypes['timestamptz'] | undefined;
   };
   /** response of any mutation on the table "discord.roles_circles" */
@@ -23301,6 +23834,14 @@ export type ModelTypes = {
       | undefined;
     /** delete single row from the table: "contributions" */
     delete_contributions_by_pk?: GraphQLTypes['contributions'] | undefined;
+    /** delete data from the table: "discord.circle_api_tokens" */
+    delete_discord_circle_api_tokens?:
+      | GraphQLTypes['discord_circle_api_tokens_mutation_response']
+      | undefined;
+    /** delete single row from the table: "discord.circle_api_tokens" */
+    delete_discord_circle_api_tokens_by_pk?:
+      | GraphQLTypes['discord_circle_api_tokens']
+      | undefined;
     /** delete data from the table: "discord.roles_circles" */
     delete_discord_roles_circles?:
       | GraphQLTypes['discord_roles_circles_mutation_response']
@@ -23497,6 +24038,14 @@ export type ModelTypes = {
       | undefined;
     /** insert a single row into the table: "contributions" */
     insert_contributions_one?: GraphQLTypes['contributions'] | undefined;
+    /** insert data into the table: "discord.circle_api_tokens" */
+    insert_discord_circle_api_tokens?:
+      | GraphQLTypes['discord_circle_api_tokens_mutation_response']
+      | undefined;
+    /** insert a single row into the table: "discord.circle_api_tokens" */
+    insert_discord_circle_api_tokens_one?:
+      | GraphQLTypes['discord_circle_api_tokens']
+      | undefined;
     /** insert data into the table: "discord.roles_circles" */
     insert_discord_roles_circles?:
       | GraphQLTypes['discord_roles_circles_mutation_response']
@@ -23741,6 +24290,21 @@ export type ModelTypes = {
     /** update multiples rows of table: "contributions" */
     update_contributions_many?:
       | Array<GraphQLTypes['contributions_mutation_response'] | undefined>
+      | undefined;
+    /** update data of the table: "discord.circle_api_tokens" */
+    update_discord_circle_api_tokens?:
+      | GraphQLTypes['discord_circle_api_tokens_mutation_response']
+      | undefined;
+    /** update single row of the table: "discord.circle_api_tokens" */
+    update_discord_circle_api_tokens_by_pk?:
+      | GraphQLTypes['discord_circle_api_tokens']
+      | undefined;
+    /** update multiples rows of table: "discord.circle_api_tokens" */
+    update_discord_circle_api_tokens_many?:
+      | Array<
+          | GraphQLTypes['discord_circle_api_tokens_mutation_response']
+          | undefined
+        >
       | undefined;
     /** update data of the table: "discord.roles_circles" */
     update_discord_roles_circles?:
@@ -25191,6 +25755,14 @@ export type ModelTypes = {
     contributions_aggregate: GraphQLTypes['contributions_aggregate'];
     /** fetch data from the table: "contributions" using primary key columns */
     contributions_by_pk?: GraphQLTypes['contributions'] | undefined;
+    /** fetch data from the table: "discord.circle_api_tokens" */
+    discord_circle_api_tokens: Array<GraphQLTypes['discord_circle_api_tokens']>;
+    /** fetch aggregated fields from the table: "discord.circle_api_tokens" */
+    discord_circle_api_tokens_aggregate: GraphQLTypes['discord_circle_api_tokens_aggregate'];
+    /** fetch data from the table: "discord.circle_api_tokens" using primary key columns */
+    discord_circle_api_tokens_by_pk?:
+      | GraphQLTypes['discord_circle_api_tokens']
+      | undefined;
     /** fetch data from the table: "discord.roles_circles" */
     discord_roles_circles: Array<GraphQLTypes['discord_roles_circles']>;
     /** fetch aggregated fields from the table: "discord.roles_circles" */
@@ -25295,6 +25867,7 @@ export type ModelTypes = {
     personal_access_tokens_by_pk?:
       | GraphQLTypes['personal_access_tokens']
       | undefined;
+    price_per_share: number;
     /** fetch data from the table: "profiles" */
     profiles: Array<GraphQLTypes['profiles']>;
     /** fetch aggregated fields from the table: "profiles" */
@@ -25419,6 +25992,18 @@ export type ModelTypes = {
     contributions_by_pk?: GraphQLTypes['contributions'] | undefined;
     /** fetch data from the table in a streaming manner : "contributions" */
     contributions_stream: Array<GraphQLTypes['contributions']>;
+    /** fetch data from the table: "discord.circle_api_tokens" */
+    discord_circle_api_tokens: Array<GraphQLTypes['discord_circle_api_tokens']>;
+    /** fetch aggregated fields from the table: "discord.circle_api_tokens" */
+    discord_circle_api_tokens_aggregate: GraphQLTypes['discord_circle_api_tokens_aggregate'];
+    /** fetch data from the table: "discord.circle_api_tokens" using primary key columns */
+    discord_circle_api_tokens_by_pk?:
+      | GraphQLTypes['discord_circle_api_tokens']
+      | undefined;
+    /** fetch data from the table in a streaming manner : "discord.circle_api_tokens" */
+    discord_circle_api_tokens_stream: Array<
+      GraphQLTypes['discord_circle_api_tokens']
+    >;
     /** fetch data from the table: "discord.roles_circles" */
     discord_roles_circles: Array<GraphQLTypes['discord_roles_circles']>;
     /** fetch aggregated fields from the table: "discord.roles_circles" */
@@ -26621,6 +27206,7 @@ export type ModelTypes = {
     org_id: GraphQLTypes['bigint'];
     /** An object relationship */
     organization: GraphQLTypes['organizations'];
+    price_per_share: number;
     /** An object relationship */
     profile: GraphQLTypes['profiles'];
     simple_token_address: string;
@@ -30331,6 +30917,206 @@ export type GraphQLTypes = {
     _neq?: GraphQLTypes['date'] | undefined;
     _nin?: Array<GraphQLTypes['date']> | undefined;
   };
+  /** tokens the discord bot uses to operate on circles */
+  ['discord_circle_api_tokens']: {
+    __typename: 'discord_circle_api_tokens';
+    channel_snowflake: string;
+    circle_id: GraphQLTypes['bigint'];
+    created_at: GraphQLTypes['timestamptz'];
+    id: GraphQLTypes['bigint'];
+    token?: string | undefined;
+  };
+  /** aggregated selection of "discord.circle_api_tokens" */
+  ['discord_circle_api_tokens_aggregate']: {
+    __typename: 'discord_circle_api_tokens_aggregate';
+    aggregate?:
+      | GraphQLTypes['discord_circle_api_tokens_aggregate_fields']
+      | undefined;
+    nodes: Array<GraphQLTypes['discord_circle_api_tokens']>;
+  };
+  /** aggregate fields of "discord.circle_api_tokens" */
+  ['discord_circle_api_tokens_aggregate_fields']: {
+    __typename: 'discord_circle_api_tokens_aggregate_fields';
+    avg?: GraphQLTypes['discord_circle_api_tokens_avg_fields'] | undefined;
+    count: number;
+    max?: GraphQLTypes['discord_circle_api_tokens_max_fields'] | undefined;
+    min?: GraphQLTypes['discord_circle_api_tokens_min_fields'] | undefined;
+    stddev?:
+      | GraphQLTypes['discord_circle_api_tokens_stddev_fields']
+      | undefined;
+    stddev_pop?:
+      | GraphQLTypes['discord_circle_api_tokens_stddev_pop_fields']
+      | undefined;
+    stddev_samp?:
+      | GraphQLTypes['discord_circle_api_tokens_stddev_samp_fields']
+      | undefined;
+    sum?: GraphQLTypes['discord_circle_api_tokens_sum_fields'] | undefined;
+    var_pop?:
+      | GraphQLTypes['discord_circle_api_tokens_var_pop_fields']
+      | undefined;
+    var_samp?:
+      | GraphQLTypes['discord_circle_api_tokens_var_samp_fields']
+      | undefined;
+    variance?:
+      | GraphQLTypes['discord_circle_api_tokens_variance_fields']
+      | undefined;
+  };
+  /** aggregate avg on columns */
+  ['discord_circle_api_tokens_avg_fields']: {
+    __typename: 'discord_circle_api_tokens_avg_fields';
+    circle_id?: number | undefined;
+    id?: number | undefined;
+  };
+  /** Boolean expression to filter rows from the table "discord.circle_api_tokens". All fields are combined with a logical 'AND'. */
+  ['discord_circle_api_tokens_bool_exp']: {
+    _and?:
+      | Array<GraphQLTypes['discord_circle_api_tokens_bool_exp']>
+      | undefined;
+    _not?: GraphQLTypes['discord_circle_api_tokens_bool_exp'] | undefined;
+    _or?: Array<GraphQLTypes['discord_circle_api_tokens_bool_exp']> | undefined;
+    channel_snowflake?: GraphQLTypes['String_comparison_exp'] | undefined;
+    circle_id?: GraphQLTypes['bigint_comparison_exp'] | undefined;
+    created_at?: GraphQLTypes['timestamptz_comparison_exp'] | undefined;
+    id?: GraphQLTypes['bigint_comparison_exp'] | undefined;
+    token?: GraphQLTypes['String_comparison_exp'] | undefined;
+  };
+  /** unique or primary key constraints on table "discord.circle_api_tokens" */
+  ['discord_circle_api_tokens_constraint']: discord_circle_api_tokens_constraint;
+  /** input type for incrementing numeric columns in table "discord.circle_api_tokens" */
+  ['discord_circle_api_tokens_inc_input']: {
+    circle_id?: GraphQLTypes['bigint'] | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+  };
+  /** input type for inserting data into table "discord.circle_api_tokens" */
+  ['discord_circle_api_tokens_insert_input']: {
+    channel_snowflake?: string | undefined;
+    circle_id?: GraphQLTypes['bigint'] | undefined;
+    created_at?: GraphQLTypes['timestamptz'] | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    token?: string | undefined;
+  };
+  /** aggregate max on columns */
+  ['discord_circle_api_tokens_max_fields']: {
+    __typename: 'discord_circle_api_tokens_max_fields';
+    channel_snowflake?: string | undefined;
+    circle_id?: GraphQLTypes['bigint'] | undefined;
+    created_at?: GraphQLTypes['timestamptz'] | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    token?: string | undefined;
+  };
+  /** aggregate min on columns */
+  ['discord_circle_api_tokens_min_fields']: {
+    __typename: 'discord_circle_api_tokens_min_fields';
+    channel_snowflake?: string | undefined;
+    circle_id?: GraphQLTypes['bigint'] | undefined;
+    created_at?: GraphQLTypes['timestamptz'] | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    token?: string | undefined;
+  };
+  /** response of any mutation on the table "discord.circle_api_tokens" */
+  ['discord_circle_api_tokens_mutation_response']: {
+    __typename: 'discord_circle_api_tokens_mutation_response';
+    /** number of rows affected by the mutation */
+    affected_rows: number;
+    /** data from the rows affected by the mutation */
+    returning: Array<GraphQLTypes['discord_circle_api_tokens']>;
+  };
+  /** on_conflict condition type for table "discord.circle_api_tokens" */
+  ['discord_circle_api_tokens_on_conflict']: {
+    constraint: GraphQLTypes['discord_circle_api_tokens_constraint'];
+    update_columns: Array<
+      GraphQLTypes['discord_circle_api_tokens_update_column']
+    >;
+    where?: GraphQLTypes['discord_circle_api_tokens_bool_exp'] | undefined;
+  };
+  /** Ordering options when selecting data from "discord.circle_api_tokens". */
+  ['discord_circle_api_tokens_order_by']: {
+    channel_snowflake?: GraphQLTypes['order_by'] | undefined;
+    circle_id?: GraphQLTypes['order_by'] | undefined;
+    created_at?: GraphQLTypes['order_by'] | undefined;
+    id?: GraphQLTypes['order_by'] | undefined;
+    token?: GraphQLTypes['order_by'] | undefined;
+  };
+  /** primary key columns input for table: discord.circle_api_tokens */
+  ['discord_circle_api_tokens_pk_columns_input']: {
+    id: GraphQLTypes['bigint'];
+  };
+  /** select columns of table "discord.circle_api_tokens" */
+  ['discord_circle_api_tokens_select_column']: discord_circle_api_tokens_select_column;
+  /** input type for updating data in table "discord.circle_api_tokens" */
+  ['discord_circle_api_tokens_set_input']: {
+    channel_snowflake?: string | undefined;
+    circle_id?: GraphQLTypes['bigint'] | undefined;
+    created_at?: GraphQLTypes['timestamptz'] | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    token?: string | undefined;
+  };
+  /** aggregate stddev on columns */
+  ['discord_circle_api_tokens_stddev_fields']: {
+    __typename: 'discord_circle_api_tokens_stddev_fields';
+    circle_id?: number | undefined;
+    id?: number | undefined;
+  };
+  /** aggregate stddev_pop on columns */
+  ['discord_circle_api_tokens_stddev_pop_fields']: {
+    __typename: 'discord_circle_api_tokens_stddev_pop_fields';
+    circle_id?: number | undefined;
+    id?: number | undefined;
+  };
+  /** aggregate stddev_samp on columns */
+  ['discord_circle_api_tokens_stddev_samp_fields']: {
+    __typename: 'discord_circle_api_tokens_stddev_samp_fields';
+    circle_id?: number | undefined;
+    id?: number | undefined;
+  };
+  /** Streaming cursor of the table "discord_circle_api_tokens" */
+  ['discord_circle_api_tokens_stream_cursor_input']: {
+    /** Stream column input with initial value */
+    initial_value: GraphQLTypes['discord_circle_api_tokens_stream_cursor_value_input'];
+    /** cursor ordering */
+    ordering?: GraphQLTypes['cursor_ordering'] | undefined;
+  };
+  /** Initial value of the column from where the streaming should start */
+  ['discord_circle_api_tokens_stream_cursor_value_input']: {
+    channel_snowflake?: string | undefined;
+    circle_id?: GraphQLTypes['bigint'] | undefined;
+    created_at?: GraphQLTypes['timestamptz'] | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    token?: string | undefined;
+  };
+  /** aggregate sum on columns */
+  ['discord_circle_api_tokens_sum_fields']: {
+    __typename: 'discord_circle_api_tokens_sum_fields';
+    circle_id?: GraphQLTypes['bigint'] | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+  };
+  /** update columns of table "discord.circle_api_tokens" */
+  ['discord_circle_api_tokens_update_column']: discord_circle_api_tokens_update_column;
+  ['discord_circle_api_tokens_updates']: {
+    /** increments the numeric columns with given value of the filtered values */
+    _inc?: GraphQLTypes['discord_circle_api_tokens_inc_input'] | undefined;
+    /** sets the columns of the filtered rows to the given values */
+    _set?: GraphQLTypes['discord_circle_api_tokens_set_input'] | undefined;
+    where: GraphQLTypes['discord_circle_api_tokens_bool_exp'];
+  };
+  /** aggregate var_pop on columns */
+  ['discord_circle_api_tokens_var_pop_fields']: {
+    __typename: 'discord_circle_api_tokens_var_pop_fields';
+    circle_id?: number | undefined;
+    id?: number | undefined;
+  };
+  /** aggregate var_samp on columns */
+  ['discord_circle_api_tokens_var_samp_fields']: {
+    __typename: 'discord_circle_api_tokens_var_samp_fields';
+    circle_id?: number | undefined;
+    id?: number | undefined;
+  };
+  /** aggregate variance on columns */
+  ['discord_circle_api_tokens_variance_fields']: {
+    __typename: 'discord_circle_api_tokens_variance_fields';
+    circle_id?: number | undefined;
+    id?: number | undefined;
+  };
   /** link a discord role to a circle  to control membership of the circle */
   ['discord_roles_circles']: {
     __typename: 'discord_roles_circles';
@@ -30339,7 +31125,7 @@ export type GraphQLTypes = {
     circle_id: GraphQLTypes['bigint'];
     created_at: GraphQLTypes['timestamptz'];
     id: GraphQLTypes['bigint'];
-    role: string;
+    server_role: string;
     updated_at: GraphQLTypes['timestamptz'];
   };
   /** aggregated selection of "discord.roles_circles" */
@@ -30388,7 +31174,7 @@ export type GraphQLTypes = {
     circle_id?: GraphQLTypes['bigint_comparison_exp'] | undefined;
     created_at?: GraphQLTypes['timestamptz_comparison_exp'] | undefined;
     id?: GraphQLTypes['bigint_comparison_exp'] | undefined;
-    role?: GraphQLTypes['String_comparison_exp'] | undefined;
+    server_role?: GraphQLTypes['String_comparison_exp'] | undefined;
     updated_at?: GraphQLTypes['timestamptz_comparison_exp'] | undefined;
   };
   /** unique or primary key constraints on table "discord.roles_circles" */
@@ -30404,7 +31190,7 @@ export type GraphQLTypes = {
     circle_id?: GraphQLTypes['bigint'] | undefined;
     created_at?: GraphQLTypes['timestamptz'] | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
-    role?: string | undefined;
+    server_role?: string | undefined;
     updated_at?: GraphQLTypes['timestamptz'] | undefined;
   };
   /** aggregate max on columns */
@@ -30413,7 +31199,7 @@ export type GraphQLTypes = {
     circle_id?: GraphQLTypes['bigint'] | undefined;
     created_at?: GraphQLTypes['timestamptz'] | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
-    role?: string | undefined;
+    server_role?: string | undefined;
     updated_at?: GraphQLTypes['timestamptz'] | undefined;
   };
   /** aggregate min on columns */
@@ -30422,7 +31208,7 @@ export type GraphQLTypes = {
     circle_id?: GraphQLTypes['bigint'] | undefined;
     created_at?: GraphQLTypes['timestamptz'] | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
-    role?: string | undefined;
+    server_role?: string | undefined;
     updated_at?: GraphQLTypes['timestamptz'] | undefined;
   };
   /** response of any mutation on the table "discord.roles_circles" */
@@ -30445,7 +31231,7 @@ export type GraphQLTypes = {
     circle_id?: GraphQLTypes['order_by'] | undefined;
     created_at?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
-    role?: GraphQLTypes['order_by'] | undefined;
+    server_role?: GraphQLTypes['order_by'] | undefined;
     updated_at?: GraphQLTypes['order_by'] | undefined;
   };
   /** primary key columns input for table: discord.roles_circles */
@@ -30459,7 +31245,7 @@ export type GraphQLTypes = {
     circle_id?: GraphQLTypes['bigint'] | undefined;
     created_at?: GraphQLTypes['timestamptz'] | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
-    role?: string | undefined;
+    server_role?: string | undefined;
     updated_at?: GraphQLTypes['timestamptz'] | undefined;
   };
   /** aggregate stddev on columns */
@@ -30492,7 +31278,7 @@ export type GraphQLTypes = {
     circle_id?: GraphQLTypes['bigint'] | undefined;
     created_at?: GraphQLTypes['timestamptz'] | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
-    role?: string | undefined;
+    server_role?: string | undefined;
     updated_at?: GraphQLTypes['timestamptz'] | undefined;
   };
   /** aggregate sum on columns */
@@ -33386,6 +34172,14 @@ export type GraphQLTypes = {
       | undefined;
     /** delete single row from the table: "contributions" */
     delete_contributions_by_pk?: GraphQLTypes['contributions'] | undefined;
+    /** delete data from the table: "discord.circle_api_tokens" */
+    delete_discord_circle_api_tokens?:
+      | GraphQLTypes['discord_circle_api_tokens_mutation_response']
+      | undefined;
+    /** delete single row from the table: "discord.circle_api_tokens" */
+    delete_discord_circle_api_tokens_by_pk?:
+      | GraphQLTypes['discord_circle_api_tokens']
+      | undefined;
     /** delete data from the table: "discord.roles_circles" */
     delete_discord_roles_circles?:
       | GraphQLTypes['discord_roles_circles_mutation_response']
@@ -33582,6 +34376,14 @@ export type GraphQLTypes = {
       | undefined;
     /** insert a single row into the table: "contributions" */
     insert_contributions_one?: GraphQLTypes['contributions'] | undefined;
+    /** insert data into the table: "discord.circle_api_tokens" */
+    insert_discord_circle_api_tokens?:
+      | GraphQLTypes['discord_circle_api_tokens_mutation_response']
+      | undefined;
+    /** insert a single row into the table: "discord.circle_api_tokens" */
+    insert_discord_circle_api_tokens_one?:
+      | GraphQLTypes['discord_circle_api_tokens']
+      | undefined;
     /** insert data into the table: "discord.roles_circles" */
     insert_discord_roles_circles?:
       | GraphQLTypes['discord_roles_circles_mutation_response']
@@ -33826,6 +34628,21 @@ export type GraphQLTypes = {
     /** update multiples rows of table: "contributions" */
     update_contributions_many?:
       | Array<GraphQLTypes['contributions_mutation_response'] | undefined>
+      | undefined;
+    /** update data of the table: "discord.circle_api_tokens" */
+    update_discord_circle_api_tokens?:
+      | GraphQLTypes['discord_circle_api_tokens_mutation_response']
+      | undefined;
+    /** update single row of the table: "discord.circle_api_tokens" */
+    update_discord_circle_api_tokens_by_pk?:
+      | GraphQLTypes['discord_circle_api_tokens']
+      | undefined;
+    /** update multiples rows of table: "discord.circle_api_tokens" */
+    update_discord_circle_api_tokens_many?:
+      | Array<
+          | GraphQLTypes['discord_circle_api_tokens_mutation_response']
+          | undefined
+        >
       | undefined;
     /** update data of the table: "discord.roles_circles" */
     update_discord_roles_circles?:
@@ -36256,6 +37073,14 @@ export type GraphQLTypes = {
     contributions_aggregate: GraphQLTypes['contributions_aggregate'];
     /** fetch data from the table: "contributions" using primary key columns */
     contributions_by_pk?: GraphQLTypes['contributions'] | undefined;
+    /** fetch data from the table: "discord.circle_api_tokens" */
+    discord_circle_api_tokens: Array<GraphQLTypes['discord_circle_api_tokens']>;
+    /** fetch aggregated fields from the table: "discord.circle_api_tokens" */
+    discord_circle_api_tokens_aggregate: GraphQLTypes['discord_circle_api_tokens_aggregate'];
+    /** fetch data from the table: "discord.circle_api_tokens" using primary key columns */
+    discord_circle_api_tokens_by_pk?:
+      | GraphQLTypes['discord_circle_api_tokens']
+      | undefined;
     /** fetch data from the table: "discord.roles_circles" */
     discord_roles_circles: Array<GraphQLTypes['discord_roles_circles']>;
     /** fetch aggregated fields from the table: "discord.roles_circles" */
@@ -36360,6 +37185,7 @@ export type GraphQLTypes = {
     personal_access_tokens_by_pk?:
       | GraphQLTypes['personal_access_tokens']
       | undefined;
+    price_per_share: number;
     /** fetch data from the table: "profiles" */
     profiles: Array<GraphQLTypes['profiles']>;
     /** fetch aggregated fields from the table: "profiles" */
@@ -36485,6 +37311,18 @@ export type GraphQLTypes = {
     contributions_by_pk?: GraphQLTypes['contributions'] | undefined;
     /** fetch data from the table in a streaming manner : "contributions" */
     contributions_stream: Array<GraphQLTypes['contributions']>;
+    /** fetch data from the table: "discord.circle_api_tokens" */
+    discord_circle_api_tokens: Array<GraphQLTypes['discord_circle_api_tokens']>;
+    /** fetch aggregated fields from the table: "discord.circle_api_tokens" */
+    discord_circle_api_tokens_aggregate: GraphQLTypes['discord_circle_api_tokens_aggregate'];
+    /** fetch data from the table: "discord.circle_api_tokens" using primary key columns */
+    discord_circle_api_tokens_by_pk?:
+      | GraphQLTypes['discord_circle_api_tokens']
+      | undefined;
+    /** fetch data from the table in a streaming manner : "discord.circle_api_tokens" */
+    discord_circle_api_tokens_stream: Array<
+      GraphQLTypes['discord_circle_api_tokens']
+    >;
     /** fetch data from the table: "discord.roles_circles" */
     discord_roles_circles: Array<GraphQLTypes['discord_roles_circles']>;
     /** fetch aggregated fields from the table: "discord.roles_circles" */
@@ -38694,6 +39532,7 @@ export type GraphQLTypes = {
     org_id: GraphQLTypes['bigint'];
     /** An object relationship */
     organization: GraphQLTypes['organizations'];
+    price_per_share: number;
     /** An object relationship */
     profile: GraphQLTypes['profiles'];
     simple_token_address: string;
@@ -39667,6 +40506,28 @@ export const enum cursor_ordering {
   ASC = 'ASC',
   DESC = 'DESC',
 }
+/** unique or primary key constraints on table "discord.circle_api_tokens" */
+export const enum discord_circle_api_tokens_constraint {
+  circle_api_tokens_circle_id_key = 'circle_api_tokens_circle_id_key',
+  circle_api_tokens_pkey = 'circle_api_tokens_pkey',
+  circle_api_tokens_token_key = 'circle_api_tokens_token_key',
+}
+/** select columns of table "discord.circle_api_tokens" */
+export const enum discord_circle_api_tokens_select_column {
+  channel_snowflake = 'channel_snowflake',
+  circle_id = 'circle_id',
+  created_at = 'created_at',
+  id = 'id',
+  token = 'token',
+}
+/** update columns of table "discord.circle_api_tokens" */
+export const enum discord_circle_api_tokens_update_column {
+  channel_snowflake = 'channel_snowflake',
+  circle_id = 'circle_id',
+  created_at = 'created_at',
+  id = 'id',
+  token = 'token',
+}
 /** unique or primary key constraints on table "discord.roles_circles" */
 export const enum discord_roles_circles_constraint {
   roles_circles_circle_id_key = 'roles_circles_circle_id_key',
@@ -39677,7 +40538,7 @@ export const enum discord_roles_circles_select_column {
   circle_id = 'circle_id',
   created_at = 'created_at',
   id = 'id',
-  role = 'role',
+  server_role = 'server_role',
   updated_at = 'updated_at',
 }
 /** update columns of table "discord.roles_circles" */
@@ -39685,7 +40546,7 @@ export const enum discord_roles_circles_update_column {
   circle_id = 'circle_id',
   created_at = 'created_at',
   id = 'id',
-  role = 'role',
+  server_role = 'server_role',
   updated_at = 'updated_at',
 }
 /** unique or primary key constraints on table "discord.users" */

--- a/api/hasura/auth.ts
+++ b/api/hasura/auth.ts
@@ -3,8 +3,13 @@ import assert from 'assert';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
 import { parseAuthHeader } from '../../api-lib/authHelpers';
-import { IS_LOCAL_ENV, IS_TEST_ENV } from '../../api-lib/config';
+import {
+  HASURA_DISCORD_SECRET,
+  IS_LOCAL_ENV,
+  IS_TEST_ENV,
+} from '../../api-lib/config';
 import { adminClient } from '../../api-lib/gql/adminClient';
+import { isFeatureEnabled } from '../../src/config/features';
 
 export const TEST_SKIP_AUTH = 'test-skip-auth';
 
@@ -30,6 +35,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         });
         return;
       }
+    }
+
+    if (
+      isFeatureEnabled('discord') &&
+      req.headers?.authorization === HASURA_DISCORD_SECRET
+    ) {
+      res.status(200).json({
+        'X-Hasura-Role': 'discord-bot',
+      });
     }
 
     assert(req.headers?.authorization, 'No token was provided');

--- a/hasura/metadata/databases/default/tables/discord_circle_api_tokens.yaml
+++ b/hasura/metadata/databases/default/tables/discord_circle_api_tokens.yaml
@@ -1,0 +1,25 @@
+table:
+  name: circle_api_tokens
+  schema: discord
+insert_permissions:
+  - role: discord-bot
+    permission:
+      check: {}
+      columns:
+        - channel_snowflake
+        - circle_id
+select_permissions:
+  - role: discord-bot
+    permission:
+      columns:
+        - channel_snowflake
+        - circle_id
+        - created_at
+        - id
+        - token
+      filter: {}
+delete_permissions:
+  - role: discord-bot
+    permission:
+      backend_only: false
+      filter: {}

--- a/hasura/metadata/databases/default/tables/discord_roles_circles.yaml
+++ b/hasura/metadata/databases/default/tables/discord_roles_circles.yaml
@@ -19,20 +19,20 @@ insert_permissions:
       set:
         circle_id: x-hasura-Circle-Id
       columns:
-        - role
+        - server_role
   - role: discord-bot
     permission:
       check: {}
       columns:
         - circle_id
-        - role
+        - server_role
 select_permissions:
   - role: api-user
     permission:
       columns:
         - circle_id
         - id
-        - role
+        - server_role
       filter:
         circle:
           api_keys:
@@ -46,7 +46,7 @@ select_permissions:
       columns:
         - circle_id
         - id
-        - role
+        - server_role
         - created_at
         - updated_at
       filter: {}
@@ -55,7 +55,7 @@ select_permissions:
       columns:
         - circle_id
         - id
-        - role
+        - server_role
         - created_at
         - updated_at
       filter:
@@ -71,7 +71,7 @@ update_permissions:
   - role: api-user
     permission:
       columns:
-        - role
+        - server_role
       filter:
         circle:
           api_keys:
@@ -85,13 +85,13 @@ update_permissions:
     permission:
       columns:
         - circle_id
-        - role
+        - server_role
       filter: {}
       check: null
   - role: user
     permission:
       columns:
-        - role
+        - server_role
       filter:
         circle:
           users:

--- a/hasura/metadata/databases/default/tables/discord_roles_circles.yaml
+++ b/hasura/metadata/databases/default/tables/discord_roles_circles.yaml
@@ -20,6 +20,12 @@ insert_permissions:
         circle_id: x-hasura-Circle-Id
       columns:
         - role
+  - role: discord-bot
+    permission:
+      check: {}
+      columns:
+        - circle_id
+        - role
 select_permissions:
   - role: api-user
     permission:
@@ -35,6 +41,15 @@ select_permissions:
                   _eq: X-Hasura-Api-Key-Hash
               - read_discord:
                   _eq: true
+  - role: discord-bot
+    permission:
+      columns:
+        - circle_id
+        - id
+        - role
+        - created_at
+        - updated_at
+      filter: {}
   - role: user
     permission:
       columns:
@@ -66,6 +81,13 @@ update_permissions:
               - update_circle:
                   _eq: true
       check: null
+  - role: discord-bot
+    permission:
+      columns:
+        - circle_id
+        - role
+      filter: {}
+      check: null
   - role: user
     permission:
       columns:
@@ -94,3 +116,7 @@ delete_permissions:
                   _eq: X-Hasura-Api-Key-Hash
               - update_circle:
                   _eq: true
+  - role: discord-bot
+    permission:
+      backend_only: false
+      filter: {}

--- a/hasura/metadata/databases/default/tables/discord_users.yaml
+++ b/hasura/metadata/databases/default/tables/discord_users.yaml
@@ -6,6 +6,12 @@ object_relationships:
     using:
       foreign_key_constraint_on: profile_id
 insert_permissions:
+  - role: discord-bot
+    permission:
+      check: {}
+      columns:
+        - profile_id
+        - user_snowflake
   - role: user
     permission:
       check: {}
@@ -34,6 +40,15 @@ select_permissions:
                       _eq: true
                   - read_member_profiles:
                       _eq: true
+  - role: discord-bot
+    permission:
+      columns:
+        - id
+        - profile_id
+        - user_snowflake
+        - created_at
+        - updated_at
+      filter: {}
   - role: user
     permission:
       columns:
@@ -47,6 +62,13 @@ select_permissions:
           id:
             _eq: X-Hasura-User-Id
 update_permissions:
+  - role: discord-bot
+    permission:
+      columns:
+        - profile_id
+        - user_snowflake
+      filter: {}
+      check: null
   - role: user
     permission:
       columns:
@@ -57,6 +79,10 @@ update_permissions:
             _eq: X-Hasura-User-Id
       check: null
 delete_permissions:
+  - role: discord-bot
+    permission:
+      backend_only: false
+      filter: {}
   - role: user
     permission:
       backend_only: false

--- a/hasura/metadata/databases/default/tables/public_circles.yaml
+++ b/hasura/metadata/databases/default/tables/public_circles.yaml
@@ -120,6 +120,12 @@ select_permissions:
             - read_circle:
                 _eq: true
       limit: 5
+  - role: discord-bot
+    permission:
+      columns:
+        - id
+        - name
+      filter: {}
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/public_profiles.yaml
+++ b/hasura/metadata/databases/default/tables/public_profiles.yaml
@@ -68,6 +68,11 @@ select_permissions:
                 - read_member_profiles:
                     _eq: true
       limit: 50
+  - role: discord-bot
+    permission:
+      columns:
+        - id
+      filter: {}
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/public_users.yaml
+++ b/hasura/metadata/databases/default/tables/public_users.yaml
@@ -113,6 +113,12 @@ select_permissions:
                       - read_member_profiles:
                           _eq: true
       limit: 50
+  - role: discord-bot
+    permission:
+      columns:
+        - circle_id
+        - role
+      filter: {}
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/tables.yaml
+++ b/hasura/metadata/databases/default/tables/tables.yaml
@@ -1,3 +1,4 @@
+- "!include discord_circle_api_tokens.yaml"
 - "!include discord_roles_circles.yaml"
 - "!include discord_users.yaml"
 - "!include public_burns.yaml"

--- a/hasura/migrations/default/1670355959284_create_table_discord_circle_api_tokens/down.sql
+++ b/hasura/migrations/default/1670355959284_create_table_discord_circle_api_tokens/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE "discord"."circle_api_tokens";

--- a/hasura/migrations/default/1670355959284_create_table_discord_circle_api_tokens/up.sql
+++ b/hasura/migrations/default/1670355959284_create_table_discord_circle_api_tokens/up.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "discord"."circle_api_tokens" (
+  "id" bigserial NOT NULL,
+  "token" text,
+  "channel_snowflake" text NOT NULL,
+  "circle_id" bigint NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY ("id"),
+  FOREIGN KEY ("circle_id") REFERENCES "public"."circles"("id") ON UPDATE restrict ON DELETE restrict,
+  UNIQUE ("token"),
+  UNIQUE ("circle_id"),
+  UNIQUE ("id")
+);
+COMMENT ON TABLE "discord"."circle_api_tokens" IS E'tokens the discord bot uses to operate on circles';

--- a/hasura/migrations/default/1670795162160_alter_table_discord_roles_circles_alter_column_role/down.sql
+++ b/hasura/migrations/default/1670795162160_alter_table_discord_roles_circles_alter_column_role/down.sql
@@ -1,0 +1,1 @@
+alter table "discord"."roles_circles" rename column "server_role" to "role";

--- a/hasura/migrations/default/1670795162160_alter_table_discord_roles_circles_alter_column_role/up.sql
+++ b/hasura/migrations/default/1670795162160_alter_table_discord_roles_circles_alter_column_role/up.sql
@@ -1,0 +1,1 @@
+alter table "discord"."roles_circles" rename column "role" to "server_role";

--- a/hasura/schema/admin/schema.graphql
+++ b/hasura/schema/admin/schema.graphql
@@ -6038,6 +6038,336 @@ input date_comparison_exp {
 }
 
 """
+tokens the discord bot uses to operate on circles
+"""
+type discord_circle_api_tokens {
+  channel_snowflake: String!
+  circle_id: bigint!
+  created_at: timestamptz!
+  id: bigint!
+  token: String
+}
+
+"""
+aggregated selection of "discord.circle_api_tokens"
+"""
+type discord_circle_api_tokens_aggregate {
+  aggregate: discord_circle_api_tokens_aggregate_fields
+  nodes: [discord_circle_api_tokens!]!
+}
+
+"""
+aggregate fields of "discord.circle_api_tokens"
+"""
+type discord_circle_api_tokens_aggregate_fields {
+  avg: discord_circle_api_tokens_avg_fields
+  count(
+    columns: [discord_circle_api_tokens_select_column!]
+    distinct: Boolean
+  ): Int!
+  max: discord_circle_api_tokens_max_fields
+  min: discord_circle_api_tokens_min_fields
+  stddev: discord_circle_api_tokens_stddev_fields
+  stddev_pop: discord_circle_api_tokens_stddev_pop_fields
+  stddev_samp: discord_circle_api_tokens_stddev_samp_fields
+  sum: discord_circle_api_tokens_sum_fields
+  var_pop: discord_circle_api_tokens_var_pop_fields
+  var_samp: discord_circle_api_tokens_var_samp_fields
+  variance: discord_circle_api_tokens_variance_fields
+}
+
+"""
+aggregate avg on columns
+"""
+type discord_circle_api_tokens_avg_fields {
+  circle_id: Float
+  id: Float
+}
+
+"""
+Boolean expression to filter rows from the table "discord.circle_api_tokens". All fields are combined with a logical 'AND'.
+"""
+input discord_circle_api_tokens_bool_exp {
+  _and: [discord_circle_api_tokens_bool_exp!]
+  _not: discord_circle_api_tokens_bool_exp
+  _or: [discord_circle_api_tokens_bool_exp!]
+  channel_snowflake: String_comparison_exp
+  circle_id: bigint_comparison_exp
+  created_at: timestamptz_comparison_exp
+  id: bigint_comparison_exp
+  token: String_comparison_exp
+}
+
+"""
+unique or primary key constraints on table "discord.circle_api_tokens"
+"""
+enum discord_circle_api_tokens_constraint {
+  """
+  unique or primary key constraint on columns "circle_id"
+  """
+  circle_api_tokens_circle_id_key
+
+  """
+  unique or primary key constraint on columns "id"
+  """
+  circle_api_tokens_pkey
+
+  """
+  unique or primary key constraint on columns "token"
+  """
+  circle_api_tokens_token_key
+}
+
+"""
+input type for incrementing numeric columns in table "discord.circle_api_tokens"
+"""
+input discord_circle_api_tokens_inc_input {
+  circle_id: bigint
+  id: bigint
+}
+
+"""
+input type for inserting data into table "discord.circle_api_tokens"
+"""
+input discord_circle_api_tokens_insert_input {
+  channel_snowflake: String
+  circle_id: bigint
+  created_at: timestamptz
+  id: bigint
+  token: String
+}
+
+"""
+aggregate max on columns
+"""
+type discord_circle_api_tokens_max_fields {
+  channel_snowflake: String
+  circle_id: bigint
+  created_at: timestamptz
+  id: bigint
+  token: String
+}
+
+"""
+aggregate min on columns
+"""
+type discord_circle_api_tokens_min_fields {
+  channel_snowflake: String
+  circle_id: bigint
+  created_at: timestamptz
+  id: bigint
+  token: String
+}
+
+"""
+response of any mutation on the table "discord.circle_api_tokens"
+"""
+type discord_circle_api_tokens_mutation_response {
+  """
+  number of rows affected by the mutation
+  """
+  affected_rows: Int!
+
+  """
+  data from the rows affected by the mutation
+  """
+  returning: [discord_circle_api_tokens!]!
+}
+
+"""
+on_conflict condition type for table "discord.circle_api_tokens"
+"""
+input discord_circle_api_tokens_on_conflict {
+  constraint: discord_circle_api_tokens_constraint!
+  update_columns: [discord_circle_api_tokens_update_column!]! = []
+  where: discord_circle_api_tokens_bool_exp
+}
+
+"""
+Ordering options when selecting data from "discord.circle_api_tokens".
+"""
+input discord_circle_api_tokens_order_by {
+  channel_snowflake: order_by
+  circle_id: order_by
+  created_at: order_by
+  id: order_by
+  token: order_by
+}
+
+"""
+primary key columns input for table: discord.circle_api_tokens
+"""
+input discord_circle_api_tokens_pk_columns_input {
+  id: bigint!
+}
+
+"""
+select columns of table "discord.circle_api_tokens"
+"""
+enum discord_circle_api_tokens_select_column {
+  """
+  column name
+  """
+  channel_snowflake
+
+  """
+  column name
+  """
+  circle_id
+
+  """
+  column name
+  """
+  created_at
+
+  """
+  column name
+  """
+  id
+
+  """
+  column name
+  """
+  token
+}
+
+"""
+input type for updating data in table "discord.circle_api_tokens"
+"""
+input discord_circle_api_tokens_set_input {
+  channel_snowflake: String
+  circle_id: bigint
+  created_at: timestamptz
+  id: bigint
+  token: String
+}
+
+"""
+aggregate stddev on columns
+"""
+type discord_circle_api_tokens_stddev_fields {
+  circle_id: Float
+  id: Float
+}
+
+"""
+aggregate stddev_pop on columns
+"""
+type discord_circle_api_tokens_stddev_pop_fields {
+  circle_id: Float
+  id: Float
+}
+
+"""
+aggregate stddev_samp on columns
+"""
+type discord_circle_api_tokens_stddev_samp_fields {
+  circle_id: Float
+  id: Float
+}
+
+"""
+Streaming cursor of the table "discord_circle_api_tokens"
+"""
+input discord_circle_api_tokens_stream_cursor_input {
+  """
+  Stream column input with initial value
+  """
+  initial_value: discord_circle_api_tokens_stream_cursor_value_input!
+
+  """
+  cursor ordering
+  """
+  ordering: cursor_ordering
+}
+
+"""
+Initial value of the column from where the streaming should start
+"""
+input discord_circle_api_tokens_stream_cursor_value_input {
+  channel_snowflake: String
+  circle_id: bigint
+  created_at: timestamptz
+  id: bigint
+  token: String
+}
+
+"""
+aggregate sum on columns
+"""
+type discord_circle_api_tokens_sum_fields {
+  circle_id: bigint
+  id: bigint
+}
+
+"""
+update columns of table "discord.circle_api_tokens"
+"""
+enum discord_circle_api_tokens_update_column {
+  """
+  column name
+  """
+  channel_snowflake
+
+  """
+  column name
+  """
+  circle_id
+
+  """
+  column name
+  """
+  created_at
+
+  """
+  column name
+  """
+  id
+
+  """
+  column name
+  """
+  token
+}
+
+input discord_circle_api_tokens_updates {
+  """
+  increments the numeric columns with given value of the filtered values
+  """
+  _inc: discord_circle_api_tokens_inc_input
+
+  """
+  sets the columns of the filtered rows to the given values
+  """
+  _set: discord_circle_api_tokens_set_input
+  where: discord_circle_api_tokens_bool_exp!
+}
+
+"""
+aggregate var_pop on columns
+"""
+type discord_circle_api_tokens_var_pop_fields {
+  circle_id: Float
+  id: Float
+}
+
+"""
+aggregate var_samp on columns
+"""
+type discord_circle_api_tokens_var_samp_fields {
+  circle_id: Float
+  id: Float
+}
+
+"""
+aggregate variance on columns
+"""
+type discord_circle_api_tokens_variance_fields {
+  circle_id: Float
+  id: Float
+}
+
+"""
 link a discord role to a circle  to control membership of the circle
 """
 type discord_roles_circles {
@@ -6048,7 +6378,7 @@ type discord_roles_circles {
   circle_id: bigint!
   created_at: timestamptz!
   id: bigint!
-  role: String!
+  server_role: String!
   updated_at: timestamptz!
 }
 
@@ -6099,7 +6429,7 @@ input discord_roles_circles_bool_exp {
   circle_id: bigint_comparison_exp
   created_at: timestamptz_comparison_exp
   id: bigint_comparison_exp
-  role: String_comparison_exp
+  server_role: String_comparison_exp
   updated_at: timestamptz_comparison_exp
 }
 
@@ -6134,7 +6464,7 @@ input discord_roles_circles_insert_input {
   circle_id: bigint
   created_at: timestamptz
   id: bigint
-  role: String
+  server_role: String
   updated_at: timestamptz
 }
 
@@ -6145,7 +6475,7 @@ type discord_roles_circles_max_fields {
   circle_id: bigint
   created_at: timestamptz
   id: bigint
-  role: String
+  server_role: String
   updated_at: timestamptz
 }
 
@@ -6156,7 +6486,7 @@ type discord_roles_circles_min_fields {
   circle_id: bigint
   created_at: timestamptz
   id: bigint
-  role: String
+  server_role: String
   updated_at: timestamptz
 }
 
@@ -6192,7 +6522,7 @@ input discord_roles_circles_order_by {
   circle_id: order_by
   created_at: order_by
   id: order_by
-  role: order_by
+  server_role: order_by
   updated_at: order_by
 }
 
@@ -6225,7 +6555,7 @@ enum discord_roles_circles_select_column {
   """
   column name
   """
-  role
+  server_role
 
   """
   column name
@@ -6240,7 +6570,7 @@ input discord_roles_circles_set_input {
   circle_id: bigint
   created_at: timestamptz
   id: bigint
-  role: String
+  server_role: String
   updated_at: timestamptz
 }
 
@@ -6290,7 +6620,7 @@ input discord_roles_circles_stream_cursor_value_input {
   circle_id: bigint
   created_at: timestamptz
   id: bigint
-  role: String
+  server_role: String
   updated_at: timestamptz
 }
 
@@ -6324,7 +6654,7 @@ enum discord_roles_circles_update_column {
   """
   column name
   """
-  role
+  server_role
 
   """
   column name
@@ -11391,6 +11721,21 @@ type mutation_root {
   delete_contributions_by_pk(id: bigint!): contributions
 
   """
+  delete data from the table: "discord.circle_api_tokens"
+  """
+  delete_discord_circle_api_tokens(
+    """
+    filter the rows which have to be deleted
+    """
+    where: discord_circle_api_tokens_bool_exp!
+  ): discord_circle_api_tokens_mutation_response
+
+  """
+  delete single row from the table: "discord.circle_api_tokens"
+  """
+  delete_discord_circle_api_tokens_by_pk(id: bigint!): discord_circle_api_tokens
+
+  """
   delete data from the table: "discord.roles_circles"
   """
   delete_discord_roles_circles(
@@ -12008,6 +12353,36 @@ type mutation_root {
     """
     on_conflict: contributions_on_conflict
   ): contributions
+
+  """
+  insert data into the table: "discord.circle_api_tokens"
+  """
+  insert_discord_circle_api_tokens(
+    """
+    the rows to be inserted
+    """
+    objects: [discord_circle_api_tokens_insert_input!]!
+
+    """
+    upsert condition
+    """
+    on_conflict: discord_circle_api_tokens_on_conflict
+  ): discord_circle_api_tokens_mutation_response
+
+  """
+  insert a single row into the table: "discord.circle_api_tokens"
+  """
+  insert_discord_circle_api_tokens_one(
+    """
+    the row to be inserted
+    """
+    object: discord_circle_api_tokens_insert_input!
+
+    """
+    upsert condition
+    """
+    on_conflict: discord_circle_api_tokens_on_conflict
+  ): discord_circle_api_tokens
 
   """
   insert data into the table: "discord.roles_circles"
@@ -13130,6 +13505,52 @@ type mutation_root {
     """
     updates: [contributions_updates!]!
   ): [contributions_mutation_response]
+
+  """
+  update data of the table: "discord.circle_api_tokens"
+  """
+  update_discord_circle_api_tokens(
+    """
+    increments the numeric columns with given value of the filtered values
+    """
+    _inc: discord_circle_api_tokens_inc_input
+
+    """
+    sets the columns of the filtered rows to the given values
+    """
+    _set: discord_circle_api_tokens_set_input
+
+    """
+    filter the rows which have to be updated
+    """
+    where: discord_circle_api_tokens_bool_exp!
+  ): discord_circle_api_tokens_mutation_response
+
+  """
+  update single row of the table: "discord.circle_api_tokens"
+  """
+  update_discord_circle_api_tokens_by_pk(
+    """
+    increments the numeric columns with given value of the filtered values
+    """
+    _inc: discord_circle_api_tokens_inc_input
+
+    """
+    sets the columns of the filtered rows to the given values
+    """
+    _set: discord_circle_api_tokens_set_input
+    pk_columns: discord_circle_api_tokens_pk_columns_input!
+  ): discord_circle_api_tokens
+
+  """
+  update multiples rows of table: "discord.circle_api_tokens"
+  """
+  update_discord_circle_api_tokens_many(
+    """
+    updates to execute, in order
+    """
+    updates: [discord_circle_api_tokens_updates!]!
+  ): [discord_circle_api_tokens_mutation_response]
 
   """
   update data of the table: "discord.roles_circles"
@@ -18926,6 +19347,71 @@ type query_root {
   contributions_by_pk(id: bigint!): contributions
 
   """
+  fetch data from the table: "discord.circle_api_tokens"
+  """
+  discord_circle_api_tokens(
+    """
+    distinct select on columns
+    """
+    distinct_on: [discord_circle_api_tokens_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [discord_circle_api_tokens_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: discord_circle_api_tokens_bool_exp
+  ): [discord_circle_api_tokens!]!
+
+  """
+  fetch aggregated fields from the table: "discord.circle_api_tokens"
+  """
+  discord_circle_api_tokens_aggregate(
+    """
+    distinct select on columns
+    """
+    distinct_on: [discord_circle_api_tokens_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [discord_circle_api_tokens_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: discord_circle_api_tokens_bool_exp
+  ): discord_circle_api_tokens_aggregate!
+
+  """
+  fetch data from the table: "discord.circle_api_tokens" using primary key columns
+  """
+  discord_circle_api_tokens_by_pk(id: bigint!): discord_circle_api_tokens
+
+  """
   fetch data from the table: "discord.roles_circles"
   """
   discord_roles_circles(
@@ -19954,6 +20440,7 @@ type query_root {
   fetch data from the table: "personal_access_tokens" using primary key columns
   """
   personal_access_tokens_by_pk(id: bigint!): personal_access_tokens
+  price_per_share(chain_id: Int!, token_address: String): Float!
 
   """
   fetch data from the table: "profiles"
@@ -21296,6 +21783,91 @@ type subscription_root {
     """
     where: contributions_bool_exp
   ): [contributions!]!
+
+  """
+  fetch data from the table: "discord.circle_api_tokens"
+  """
+  discord_circle_api_tokens(
+    """
+    distinct select on columns
+    """
+    distinct_on: [discord_circle_api_tokens_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [discord_circle_api_tokens_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: discord_circle_api_tokens_bool_exp
+  ): [discord_circle_api_tokens!]!
+
+  """
+  fetch aggregated fields from the table: "discord.circle_api_tokens"
+  """
+  discord_circle_api_tokens_aggregate(
+    """
+    distinct select on columns
+    """
+    distinct_on: [discord_circle_api_tokens_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [discord_circle_api_tokens_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: discord_circle_api_tokens_bool_exp
+  ): discord_circle_api_tokens_aggregate!
+
+  """
+  fetch data from the table: "discord.circle_api_tokens" using primary key columns
+  """
+  discord_circle_api_tokens_by_pk(id: bigint!): discord_circle_api_tokens
+
+  """
+  fetch data from the table in a streaming manner : "discord.circle_api_tokens"
+  """
+  discord_circle_api_tokens_stream(
+    """
+    maximum number of rows returned in a single batch
+    """
+    batch_size: Int!
+
+    """
+    cursor to stream the results returned by the query
+    """
+    cursor: [discord_circle_api_tokens_stream_cursor_input]!
+
+    """
+    filter the rows returned
+    """
+    where: discord_circle_api_tokens_bool_exp
+  ): [discord_circle_api_tokens!]!
 
   """
   fetch data from the table: "discord.roles_circles"
@@ -27159,6 +27731,7 @@ type vaults {
   An object relationship
   """
   organization: organizations!
+  price_per_share: Float!
 
   """
   An object relationship

--- a/hasura/schema/user/schema.graphql
+++ b/hasura/schema/user/schema.graphql
@@ -3444,7 +3444,7 @@ type discord_roles_circles {
   circle_id: bigint!
   created_at: timestamptz!
   id: bigint!
-  role: String!
+  server_role: String!
   updated_at: timestamptz!
 }
 
@@ -3459,7 +3459,7 @@ input discord_roles_circles_bool_exp {
   circle_id: bigint_comparison_exp
   created_at: timestamptz_comparison_exp
   id: bigint_comparison_exp
-  role: String_comparison_exp
+  server_role: String_comparison_exp
   updated_at: timestamptz_comparison_exp
 }
 
@@ -3486,7 +3486,7 @@ input discord_roles_circles_order_by {
   circle_id: order_by
   created_at: order_by
   id: order_by
-  role: order_by
+  server_role: order_by
   updated_at: order_by
 }
 
@@ -3519,7 +3519,7 @@ enum discord_roles_circles_select_column {
   """
   column name
   """
-  role
+  server_role
 
   """
   column name
@@ -3531,7 +3531,7 @@ enum discord_roles_circles_select_column {
 input type for updating data in table "discord.roles_circles"
 """
 input discord_roles_circles_set_input {
-  role: String
+  server_role: String
 }
 
 """
@@ -3556,7 +3556,7 @@ input discord_roles_circles_stream_cursor_value_input {
   circle_id: bigint
   created_at: timestamptz
   id: bigint
-  role: String
+  server_role: String
   updated_at: timestamptz
 }
 
@@ -8695,6 +8695,7 @@ type query_root {
   fetch data from the table: "pending_vault_transactions" using primary key columns
   """
   pending_vault_transactions_by_pk(tx_hash: String!): pending_vault_transactions
+  price_per_share(chain_id: Int!, token_address: String): Float!
 
   """
   fetch data from the table: "profiles"
@@ -12942,6 +12943,7 @@ type vaults {
   An object relationship
   """
   organization: organizations!
+  price_per_share: Float!
 
   """
   An object relationship

--- a/src/lib/gql/__generated__/zeus/const.ts
+++ b/src/lib/gql/__generated__/zeus/const.ts
@@ -1083,7 +1083,7 @@ export const AllTypesProps: Record<string, any> = {
     circle_id: 'bigint_comparison_exp',
     created_at: 'timestamptz_comparison_exp',
     id: 'bigint_comparison_exp',
-    role: 'String_comparison_exp',
+    server_role: 'String_comparison_exp',
     updated_at: 'timestamptz_comparison_exp',
   },
   discord_roles_circles_order_by: {
@@ -1091,7 +1091,7 @@ export const AllTypesProps: Record<string, any> = {
     circle_id: 'order_by',
     created_at: 'order_by',
     id: 'order_by',
-    role: 'order_by',
+    server_role: 'order_by',
     updated_at: 'order_by',
   },
   discord_roles_circles_pk_columns_input: {
@@ -2729,6 +2729,7 @@ export const AllTypesProps: Record<string, any> = {
       where: 'pending_vault_transactions_bool_exp',
     },
     pending_vault_transactions_by_pk: {},
+    price_per_share: {},
     profiles: {
       distinct_on: 'profiles_select_column',
       order_by: 'profiles_order_by',
@@ -4576,7 +4577,7 @@ export const ReturnTypes: Record<string, any> = {
     circle_id: 'bigint',
     created_at: 'timestamptz',
     id: 'bigint',
-    role: 'String',
+    server_role: 'String',
     updated_at: 'timestamptz',
   },
   discord_roles_circles_mutation_response: {
@@ -5128,6 +5129,7 @@ export const ReturnTypes: Record<string, any> = {
     pending_token_gifts_by_pk: 'pending_token_gifts',
     pending_vault_transactions: 'pending_vault_transactions',
     pending_vault_transactions_by_pk: 'pending_vault_transactions',
+    price_per_share: 'Float',
     profiles: 'profiles',
     profiles_by_pk: 'profiles',
     teammates: 'teammates',
@@ -5500,6 +5502,7 @@ export const ReturnTypes: Record<string, any> = {
     distributions_aggregate: 'distributions_aggregate',
     id: 'bigint',
     organization: 'organizations',
+    price_per_share: 'Float',
     profile: 'profiles',
     simple_token_address: 'String',
     symbol: 'String',

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -2948,7 +2948,7 @@ export type ValueTypes = {
     circle_id?: boolean | `@${string}`;
     created_at?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
-    role?: boolean | `@${string}`;
+    server_role?: boolean | `@${string}`;
     updated_at?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
@@ -2967,7 +2967,7 @@ export type ValueTypes = {
     circle_id?: ValueTypes['bigint_comparison_exp'] | undefined | null;
     created_at?: ValueTypes['timestamptz_comparison_exp'] | undefined | null;
     id?: ValueTypes['bigint_comparison_exp'] | undefined | null;
-    role?: ValueTypes['String_comparison_exp'] | undefined | null;
+    server_role?: ValueTypes['String_comparison_exp'] | undefined | null;
     updated_at?: ValueTypes['timestamptz_comparison_exp'] | undefined | null;
   };
   /** response of any mutation on the table "discord.roles_circles" */
@@ -2984,7 +2984,7 @@ export type ValueTypes = {
     circle_id?: ValueTypes['order_by'] | undefined | null;
     created_at?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
-    role?: ValueTypes['order_by'] | undefined | null;
+    server_role?: ValueTypes['order_by'] | undefined | null;
     updated_at?: ValueTypes['order_by'] | undefined | null;
   };
   /** primary key columns input for table: discord.roles_circles */
@@ -2995,7 +2995,7 @@ export type ValueTypes = {
   ['discord_roles_circles_select_column']: discord_roles_circles_select_column;
   /** input type for updating data in table "discord.roles_circles" */
   ['discord_roles_circles_set_input']: {
-    role?: string | undefined | null;
+    server_role?: string | undefined | null;
   };
   /** Streaming cursor of the table "discord_roles_circles" */
   ['discord_roles_circles_stream_cursor_input']: {
@@ -3009,7 +3009,7 @@ export type ValueTypes = {
     circle_id?: ValueTypes['bigint'] | undefined | null;
     created_at?: ValueTypes['timestamptz'] | undefined | null;
     id?: ValueTypes['bigint'] | undefined | null;
-    role?: string | undefined | null;
+    server_role?: string | undefined | null;
     updated_at?: ValueTypes['timestamptz'] | undefined | null;
   };
   ['discord_roles_circles_updates']: {
@@ -6589,6 +6589,10 @@ export type ValueTypes = {
       { tx_hash: string },
       ValueTypes['pending_vault_transactions']
     ];
+    price_per_share?: [
+      { chain_id: number; token_address?: string | undefined | null },
+      boolean | `@${string}`
+    ];
     profiles?: [
       {
         /** distinct select on columns */
@@ -9579,6 +9583,7 @@ export type ValueTypes = {
     id?: boolean | `@${string}`;
     /** An object relationship */
     organization?: ValueTypes['organizations'];
+    price_per_share?: boolean | `@${string}`;
     /** An object relationship */
     profile?: ValueTypes['profiles'];
     simple_token_address?: boolean | `@${string}`;
@@ -10718,7 +10723,7 @@ export type ModelTypes = {
     circle_id: GraphQLTypes['bigint'];
     created_at: GraphQLTypes['timestamptz'];
     id: GraphQLTypes['bigint'];
-    role: string;
+    server_role: string;
     updated_at: GraphQLTypes['timestamptz'];
   };
   /** Boolean expression to filter rows from the table "discord.roles_circles". All fields are combined with a logical 'AND'. */
@@ -11832,6 +11837,7 @@ export type ModelTypes = {
     pending_vault_transactions_by_pk?:
       | GraphQLTypes['pending_vault_transactions']
       | undefined;
+    price_per_share: number;
     /** fetch data from the table: "profiles" */
     profiles: Array<GraphQLTypes['profiles']>;
     /** fetch data from the table: "profiles" using primary key columns */
@@ -12547,6 +12553,7 @@ export type ModelTypes = {
     id: GraphQLTypes['bigint'];
     /** An object relationship */
     organization: GraphQLTypes['organizations'];
+    price_per_share: number;
     /** An object relationship */
     profile: GraphQLTypes['profiles'];
     simple_token_address: string;
@@ -14616,7 +14623,7 @@ export type GraphQLTypes = {
     circle_id: GraphQLTypes['bigint'];
     created_at: GraphQLTypes['timestamptz'];
     id: GraphQLTypes['bigint'];
-    role: string;
+    server_role: string;
     updated_at: GraphQLTypes['timestamptz'];
   };
   /** Boolean expression to filter rows from the table "discord.roles_circles". All fields are combined with a logical 'AND'. */
@@ -14628,7 +14635,7 @@ export type GraphQLTypes = {
     circle_id?: GraphQLTypes['bigint_comparison_exp'] | undefined;
     created_at?: GraphQLTypes['timestamptz_comparison_exp'] | undefined;
     id?: GraphQLTypes['bigint_comparison_exp'] | undefined;
-    role?: GraphQLTypes['String_comparison_exp'] | undefined;
+    server_role?: GraphQLTypes['String_comparison_exp'] | undefined;
     updated_at?: GraphQLTypes['timestamptz_comparison_exp'] | undefined;
   };
   /** response of any mutation on the table "discord.roles_circles" */
@@ -14645,7 +14652,7 @@ export type GraphQLTypes = {
     circle_id?: GraphQLTypes['order_by'] | undefined;
     created_at?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
-    role?: GraphQLTypes['order_by'] | undefined;
+    server_role?: GraphQLTypes['order_by'] | undefined;
     updated_at?: GraphQLTypes['order_by'] | undefined;
   };
   /** primary key columns input for table: discord.roles_circles */
@@ -14656,7 +14663,7 @@ export type GraphQLTypes = {
   ['discord_roles_circles_select_column']: discord_roles_circles_select_column;
   /** input type for updating data in table "discord.roles_circles" */
   ['discord_roles_circles_set_input']: {
-    role?: string | undefined;
+    server_role?: string | undefined;
   };
   /** Streaming cursor of the table "discord_roles_circles" */
   ['discord_roles_circles_stream_cursor_input']: {
@@ -14670,7 +14677,7 @@ export type GraphQLTypes = {
     circle_id?: GraphQLTypes['bigint'] | undefined;
     created_at?: GraphQLTypes['timestamptz'] | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
-    role?: string | undefined;
+    server_role?: string | undefined;
     updated_at?: GraphQLTypes['timestamptz'] | undefined;
   };
   ['discord_roles_circles_updates']: {
@@ -16898,6 +16905,7 @@ export type GraphQLTypes = {
     pending_vault_transactions_by_pk?:
       | GraphQLTypes['pending_vault_transactions']
       | undefined;
+    price_per_share: number;
     /** fetch data from the table: "profiles" */
     profiles: Array<GraphQLTypes['profiles']>;
     /** fetch data from the table: "profiles" using primary key columns */
@@ -18287,6 +18295,7 @@ export type GraphQLTypes = {
     id: GraphQLTypes['bigint'];
     /** An object relationship */
     organization: GraphQLTypes['organizations'];
+    price_per_share: number;
     /** An object relationship */
     profile: GraphQLTypes['profiles'];
     simple_token_address: string;
@@ -18747,7 +18756,7 @@ export const enum discord_roles_circles_select_column {
   circle_id = 'circle_id',
   created_at = 'created_at',
   id = 'id',
-  role = 'role',
+  server_role = 'server_role',
   updated_at = 'updated_at',
 }
 /** unique or primary key constraints on table "discord.users" */


### PR DESCRIPTION
The schema and permissions support the following flow:

1. The discord bot receives a request to administer a circle via the
   discord bot. This might entail the following:
   - adding or removing users via discord roles
   - assigning the circle to a channel
   - configure circle notifications in discord
2. the bot inserts a row in the discord.circle_api_tokens table
   containing a `circle_id` and the `channel_snowflake` and begins listening for the token to be added
   to that row via a subscription
3. the bot generates a link that will open the coordinape app on the
   discord route with the param `id` representing the row id in the
   circle_api_tokens table.
4. The user opens the link in a browser and authenticates or is
   authenticated with the address that has admin perms on the circle.
5. In the frontend, a circle api token is generated and passed into an
   action handler along with the circle_id provided, and the id of the
   token.
6. The handler attempts to update the row created by the bot with the
   new id. If no row exists with a null token field and the
   update fails, the key is deleted and an error is shown to the user
   in a toast on redirect.
7. If the update is successful, the user is notified the circle is
   linked to the channel in both the app in a toast and in discord
   because the subscription returns affirmatively.

We want to ensure the links generated to complete the flow are
single-use and do not cause unintended side-effects if the link is
accessed more than once. This flow guarantees that the links will be
single-use.


This schema and prescribed flow would not be possible for updating the
api token, so it's best to request all permissions the bot needs up
front, rather than having the permissions granted to the bot evolve
without compromising on the single-use aspect.

We could consider generating and passing around a single-use identifier
but the flow gets a bit more complex. This could also be added later
without much concern for additional lift. [YAGNI](https://builtin.com/software-engineering-perspectives/yagni) for now seems prudent
though

### Todos
- [ ] Update the Zeus schema
