### PR TITLE
Move web3 event handlers into global

### DIFF
--- a/src/features/auth/NetworkSelector.test.tsx
+++ b/src/features/auth/NetworkSelector.test.tsx
@@ -1,6 +1,8 @@
 import { act, render, screen } from '@testing-library/react';
 
 import { TestWrapper } from 'utils/testing';
+import { TestProvider } from 'utils/testing/ethereum';
+import { rpcUrl } from 'utils/testing/provider';
 
 import { NetworkSelector } from './NetworkSelector';
 
@@ -18,7 +20,9 @@ test('without window.ethereum, button is disabled', async () => {
   ).toBeDisabled();
 });
 
-const ethMock = jest.fn(() => '0xfa');
+const ethMock = new TestProvider(rpcUrl);
+ethMock.mockChainId = '0xfa';
+// (ethMock as any).request = jest.fn((...args) => console.log(args));
 
 describe('with metamask enabled', () => {
   beforeAll(() => {
@@ -51,6 +55,7 @@ describe('with metamask enabled', () => {
     });
 
     screen.getByText('Fantom Opera').click();
-    screen.getByText('Polygon');
+    screen.getByText('Polygon').click();
+    expect(ethMock.calls).toContain('wallet_switchEthereumChain');
   });
 });

--- a/src/features/auth/WalletAuthModal.test.tsx
+++ b/src/features/auth/WalletAuthModal.test.tsx
@@ -1,13 +1,15 @@
 import { act, render, screen } from '@testing-library/react';
 
 import { TestWrapper } from 'utils/testing';
+import { TestProvider } from 'utils/testing/ethereum';
+import { rpcUrl } from 'utils/testing/provider';
 
 import { WalletAuthModal } from './WalletAuthModal';
 
-const ethSpy = jest.fn(() => '0xfa');
+const ethMock = new TestProvider(rpcUrl);
 describe('with metamask enabled', () => {
   beforeAll(() => {
-    (window as any).ethereum = ethSpy;
+    (window as any).ethereum = ethMock;
   });
 
   afterAll(() => {

--- a/src/features/auth/WalletAuthModal.tsx
+++ b/src/features/auth/WalletAuthModal.tsx
@@ -64,16 +64,7 @@ export const WalletAuthModal = () => {
       // The "any" network will allow spontaneous network changes
 
       const provider = new Web3Provider(ethereum, 'any');
-
       updateChain(provider);
-      provider.on('network', (_, oldNetwork) => {
-        // When a Provider makes its initial connection, it emits a "network"
-        // event with a null oldNetwork along with the newNetwork. So, if the
-        // oldNetwork exists, it represents a changing network
-        if (oldNetwork) {
-          window.location.reload();
-        }
-      });
     }
   }, []);
 

--- a/src/utils/testing/ethereum.ts
+++ b/src/utils/testing/ethereum.ts
@@ -1,3 +1,10 @@
+/*
+This file was derived from the cypress TestProvider in `cypress/util/index.ts`.
+However, there were some issues getting all the tests to pass using one single implementation.
+
+This version should be used for all jest and non-cypress tests.
+*/
+
 /* eslint-disable no-console */
 import { HDNode } from '@ethersproject/hdnode';
 import Wallet from 'ethereumjs-wallet';

--- a/src/utils/testing/ethereum.ts
+++ b/src/utils/testing/ethereum.ts
@@ -1,0 +1,85 @@
+/* eslint-disable no-console */
+import { HDNode } from '@ethersproject/hdnode';
+import Wallet from 'ethereumjs-wallet';
+// @ts-expect-error
+import ProviderEngine from 'web3-provider-engine';
+// @ts-expect-error
+import FiltersSubprovider from 'web3-provider-engine/subproviders/filters';
+// @ts-expect-error
+import NonceSubprovider from 'web3-provider-engine/subproviders/nonce-tracker';
+// @ts-expect-error
+import RpcSubProvider from 'web3-provider-engine/subproviders/rpc';
+// @ts-expect-error
+import WalletSubprovider from 'web3-provider-engine/subproviders/wallet';
+
+import {
+  SEED_PHRASE as DEFAULT_SEED,
+  getAccountPath,
+} from '../../../scripts/util/eth';
+
+export class TestProvider {
+  engine: ProviderEngine;
+  mockChainId: string | undefined;
+  calls: string[];
+
+  constructor(url: string, accountIndex = 0, seed: string = DEFAULT_SEED) {
+    const privateKey = deriveAccount(accountIndex, seed).privateKey.substring(
+      2
+    );
+
+    this.calls = [];
+
+    this.engine = new ProviderEngine();
+    this.engine.addProvider(new FiltersSubprovider());
+    this.engine.addProvider(new NonceSubprovider());
+    this.engine.addProvider(
+      new WalletSubprovider(
+        //@ts-ignore
+        new Wallet(new Uint8Array(Buffer.from(privateKey, 'hex'))),
+        {}
+      )
+    );
+    this.engine.addProvider(new RpcSubProvider({ rpcUrl: url }));
+    this.engine.start();
+  }
+
+  sendAsync(params: any, callback: (error: any, result: any) => void) {
+    const { method } = params;
+    this.calls.push(method);
+    if (method === 'eth_chainId' && this.mockChainId) {
+      return callback(undefined, {
+        id: params.id,
+        jsonrpc: '2.0',
+        result: this.mockChainId,
+      });
+    }
+    if (method === 'personal_sign') {
+      // shim for ganache, which has a different name for this method
+      //args[0].method = 'eth_sign';
+    }
+    if (typeof method === 'object') {
+      this.engine.sendAsync([method]);
+      console.warn(
+        'Nested JSON-RPC command: ' + JSON.stringify(params, null, 2)
+      );
+      return;
+    }
+    this.engine.sendAsync(params, callback);
+  }
+
+  async request({ method, params }: { method: string; params: any[] }) {
+    return new Promise((res, rej) => {
+      this.sendAsync({ method, params }, (error, result) => {
+        if (error) rej(error);
+        else res(result.result);
+      });
+    });
+  }
+
+  on(...args: any[]) {
+    return this.engine.on(...args);
+  }
+}
+export const deriveAccount = (index = 0, seed: string = DEFAULT_SEED) => {
+  return HDNode.fromMnemonic(seed).derivePath(getAccountPath(index));
+};


### PR DESCRIPTION
We want the web3 event handlers to be setup globally, not just via the auth modal, so moving these into Web3React hook setup.

Additionally adding a reload on accountsChanged hook.
