### PR TITLE
Add chainId to `login` interaction event

### DIFF
--- a/api/login.ts
+++ b/api/login.ts
@@ -186,6 +186,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     await insertInteractionEvents({
       event_type: 'login',
       profile_id: profile.id,
+      data: {
+        chainId,
+      },
     });
     return res
       .status(200)


### PR DESCRIPTION
We added this to `first_login` but not all `login` events.
