### PR TITLE
zIndex for AMDrawer popup

### DIFF
--- a/src/pages/AssetMapPage/AMDrawer.tsx
+++ b/src/pages/AssetMapPage/AMDrawer.tsx
@@ -218,7 +218,7 @@ export const AMDrawer = () => {
               <Filter size="lg" />
             </MUButton>
           )}
-          <Panel invertForm css={{ px: 0, gap: '$md' }}>
+          <Panel invertForm css={{ px: 0, gap: '$md', zIndex: 1 }}>
             <Select
               defaultValue={String(amEpochId)}
               options={epochOptions}


### PR DESCRIPTION
## Motivation and Context

<!-- Why is this change required? What problem does it solve? This can be omitted if a linked issue is provided
-->
this change adjust the zIndex for the popup menu in the AMDrawer
## Description

<!-- Describe your changes -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to; 
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):
<img width="1274" alt="Screenshot 2022-12-13 at 1 00 53 PM" src="https://user-images.githubusercontent.com/94828675/207301777-a6cb3608-4ca0-4f56-831d-3b97d7f92145.png">
<img width="1279" alt="Screenshot 2022-12-13 at 1 00 38 PM" src="https://user-images.githubusercontent.com/94828675/207301830-657ec4df-efc4-48a6-9ce4-6e608f40812a.png">

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

fixes #1761 