### PR TITLE
fixing flaky tests that were failing due to data from other tests

### DIFF
--- a/cypress/e2e/give.cy.ts
+++ b/cypress/e2e/give.cy.ts
@@ -23,8 +23,8 @@ context('Coordinape', () => {
     cy.contains('thank your teammates').click();
   });
   it('can select teammates', () => {
-    cy.get('[data-testid=give-row]')
-      .eq(2)
+    cy.contains('Bruce')
+      .parents('[data-testid=give-row]')
       .trigger('mouseover')
       .within(() => {
         cy.get('[data-testid=collaborator-button]').within(() => {
@@ -37,8 +37,8 @@ context('Coordinape', () => {
       });
   });
   it('can allocate to teammates', () => {
-    cy.get('[data-testid=give-row]')
-      .eq(2)
+    cy.contains('Bruce')
+      .parents('[data-testid=give-row]')
       .within(() => {
         cy.get('[data-testid=increment]').multiClick(5);
         cy.contains('Empty Note').click().wait(1000);
@@ -52,14 +52,14 @@ context('Coordinape', () => {
       .wait(1000)
       .type('{esc}');
 
-    cy.get('[data-testid=give-row]')
-      .eq(2)
+    cy.contains('Bruce')
+      .parents('[data-testid=give-row]')
       .within(() => {
         cy.contains('Note Complete').wait(1000);
       });
 
-    cy.get('[data-testid=give-row]')
-      .eq(5)
+    cy.contains('Kasey')
+      .parents('[data-testid=give-row]')
       .within(() => {
         cy.get('[data-testid=tokenCount]')
           .click()
@@ -75,8 +75,8 @@ context('Coordinape', () => {
       .wait(1000)
       .type('{esc}');
 
-    cy.get('[data-testid=give-row]')
-      .eq(5)
+    cy.contains('Kasey')
+      .parents('[data-testid=give-row]')
       .within(() => {
         cy.contains('Note Complete').wait(1000);
       });

--- a/scripts/ci/manager.sh
+++ b/scripts/ci/manager.sh
@@ -133,6 +133,8 @@ elif [ "${OTHERARGS[0]}" = "test" ]; then
 
 elif [ "${OTHERARGS[0]}" = "combine-coverage" ]; then
   combine_coverage
+elif [ "${OTHERARGS[0]}" = "seed" ]; then
+  clean_hasura
 
 else
   echo "No command given. Expected one of: up, down, logs, test"


### PR DESCRIPTION
## Motivation and Context

Test was using indexes instead of user names to fetch rows in the give page. Switched to using names which is more reliable after other tests goof with the users in this circle. 

