### PR TITLE
wide text for ReceiveInfo 

### DIFF
--- a/src/components/ReceiveInfo.tsx
+++ b/src/components/ReceiveInfo.tsx
@@ -130,6 +130,7 @@ export const ReceiveInfo = () => {
             display: 'flex',
             flexDirection: 'column',
             fontSize: '$small',
+            width: '30rem',
             p: '$md',
           }}
         >
@@ -188,7 +189,7 @@ export const ReceiveInfo = () => {
                   css={{
                     gap: '$sm',
                     mt: '$sm',
-                    maxWidth: '30rem',
+                    maxWidth: '100%',
                   }}
                 >
                   <Avatar

--- a/src/components/ReceiveInfo.tsx
+++ b/src/components/ReceiveInfo.tsx
@@ -188,7 +188,7 @@ export const ReceiveInfo = () => {
                   css={{
                     gap: '$sm',
                     mt: '$sm',
-                    maxWidth: '20rem',
+                    maxWidth: '30rem',
                   }}
                 >
                   <Avatar


### PR DESCRIPTION
## Motivation and Context

<!-- Why is this change required? What problem does it solve? This can be omitted if a linked issue is provided
-->
this change widen the text area in the dropdown for RecieveInfo 
## Description

<!-- Describe your changes -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to; 
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):
before:
<img width="581" alt="Screenshot 2022-12-29 at 10 40 55 AM" src="https://user-images.githubusercontent.com/94828675/209926128-a38fb973-aaca-40d1-91fe-d8093cb77c19.png">
after:
<img width="601" alt="Screenshot 2022-12-29 at 10 40 39 AM" src="https://user-images.githubusercontent.com/94828675/209926213-139b5a1d-4cc6-450a-ad22-1f09fe9bc204.png">


## Reviewers


<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue
no related issue just Lawris said this issue on devs-all 
<!-- Please link to the issue here -->
