### PR TITLE
Make receive Info drawer scrollable on smaller screens

### DIFF
--- a/src/components/ReceiveInfo.tsx
+++ b/src/components/ReceiveInfo.tsx
@@ -120,7 +120,7 @@ export const ReceiveInfo = () => {
         sideOffset={-38}
         alignOffset={-1}
         css={{
-          maxHeight: '$smallScreen',
+          maxHeight: '90vh',
           overflowY: 'scroll',
           zIndex: 4,
         }}


### PR DESCRIPTION
## Motivation and Context

Fixes #1710 

## Description
1- changed popover content maxHeight to 90vh


## Screenshots (if appropriate):
they are scrollable in all sizes
![image](https://user-images.githubusercontent.com/34943689/210064352-0372063d-748a-418d-a1bc-e64005a1243c.png)
![image](https://user-images.githubusercontent.com/34943689/210064396-9f18d6fe-3712-4097-bbcc-50b07faaa46c.png)
