### PR TITLE
Fix epoch timing preview rendering

### DIFF
--- a/src/pages/HistoryPage/EpochForm.tsx
+++ b/src/pages/HistoryPage/EpochForm.tsx
@@ -294,7 +294,7 @@ const EpochForm = ({
     },
   });
 
-  const watchFields = useRef<
+  const [watchFields, setWatchFields] = useState<
     Omit<epochFormSchema, 'repeat'> & { repeat: string | number }
   >({
     days: source?.epoch?.days ?? source?.epoch?.calculatedDays ?? 4,
@@ -326,10 +326,11 @@ const EpochForm = ({
         extraErrors.current = false;
         clearErrors('customError');
       }
-
-      if (data.days) watchFields.current.days = data.days;
-      if (data.repeat) watchFields.current.repeat = data.repeat;
-      if (data.start_date) watchFields.current.start_date = data.start_date;
+      const newValues = { ...watchFields };
+      if (data.days) newValues.days = data.days;
+      if (data.repeat) newValues.repeat = data.repeat;
+      if (data.start_date) newValues.start_date = data.start_date;
+      setWatchFields({ ...newValues });
     });
   }, [watch]);
 
@@ -525,9 +526,9 @@ const EpochForm = ({
               />
             </Flex>
             <Flex column>
-              {epochsPreview(watchFields.current)}
+              {epochsPreview(watchFields)}
               <Text p css={{ mt: '$lg' }}>
-                {summarizeEpoch(watchFields.current)}
+                {summarizeEpoch(watchFields)}
               </Text>
             </Flex>
           </TwoColumnLayout>


### PR DESCRIPTION
## Motivation and Context

fixes #1797

## Description

use useState to rerender the epoch preview after updating the timing of the epoch

## Test and Deployment Plan
1- create or edit a new epoch using epoch form and watch the preview of the epoch timing every time you change the dates

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/34943689/210240097-423506ba-0ede-457f-9f6e-accf8df9ec07.png)

