### PR TITLE
Refactor Time and Date Pickers to raw elements

### DIFF
--- a/src/components/FormDatePicker.tsx
+++ b/src/components/FormDatePicker.tsx
@@ -1,31 +1,14 @@
 import React from 'react';
 
-import { DateType } from '@date-io/type';
+import { FieldValues } from 'react-hook-form';
 
-import { DatePicker } from '@material-ui/pickers';
+import { FormInputField, TFormInputField } from 'components/index';
 
-import { DeprecatedApeTextField } from 'components/index';
-
-export const FormDatePicker = ({
-  onChange,
-  errorText,
-  error,
-  ...props
-}: Omit<React.ComponentProps<typeof DatePicker>, 'onChange'> & {
-  onChange: (newValue: string) => void;
-  errorText?: string;
-}) => {
-  const handleChange = (date: DateType | null) => {
-    onChange(date?.toISO() ?? '');
-  };
-
-  return (
-    <DatePicker
-      {...props}
-      error={error}
-      helperText={errorText}
-      onChange={handleChange}
-      TextFieldComponent={DeprecatedApeTextField}
-    />
-  );
+export const FormDatePicker = <TFieldValues extends FieldValues>(
+  props: Pick<
+    TFormInputField<TFieldValues>,
+    'defaultValue' | 'id' | 'control' | 'name' | 'disabled' | 'css'
+  >
+) => {
+  return <FormInputField {...props} inputProps={{ type: 'date' }} />;
 };

--- a/src/components/FormDateTimePicker.tsx
+++ b/src/components/FormDateTimePicker.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import { FieldValues } from 'react-hook-form';
+
+import { FormInputField, TFormInputField } from 'components/index';
+
+export const FormDateTimePicker = <TFieldValues extends FieldValues>(
+  props: Pick<
+    TFormInputField<TFieldValues>,
+    'defaultValue' | 'id' | 'control' | 'name' | 'disabled' | 'css'
+  >
+) => {
+  return <FormInputField {...props} inputProps={{ type: 'datetime-local' }} />;
+};

--- a/src/components/FormInputField.tsx
+++ b/src/components/FormInputField.tsx
@@ -68,6 +68,11 @@ export const FormInputField = <TFieldValues extends FieldValues>(
       TFieldValues,
       Path<TFieldValues>
     >;
+  } else if (inputProps?.type === 'datetime-local') {
+    fieldValue = DateTime.fromISO(fieldValue).toISO().slice(0, 16) as PathValue<
+      TFieldValues,
+      Path<TFieldValues>
+    >;
   } else if (inputProps?.type === 'time') {
     fieldValue = DateTime.fromISO(fieldValue).toFormat('T') as PathValue<
       TFieldValues,

--- a/src/components/FormTimePicker.tsx
+++ b/src/components/FormTimePicker.tsx
@@ -1,35 +1,14 @@
 import React from 'react';
 
-import { DateType } from '@date-io/type';
+import { FieldValues } from 'react-hook-form';
 
-import { TimePicker } from '@material-ui/pickers';
+import { FormInputField, TFormInputField } from 'components/index';
 
-import { DeprecatedApeTextField } from 'components/index';
-
-export const FormTimePicker = ({
-  onChange,
-  errorText,
-  error,
-  ...props
-}: Omit<React.ComponentProps<typeof TimePicker>, 'onChange'> & {
-  onChange: (newValue: string) => void;
-  errorText?: string;
-}) => {
-  const handleChange = (date: DateType | null) => {
-    onChange(date?.toISO() ?? '');
-  };
-
-  const labelFunc = (date: DateType | null, invalidLabel: string) =>
-    date?.toFormat('hh:mm a') ?? invalidLabel;
-
-  return (
-    <TimePicker
-      {...props}
-      error={error}
-      labelFunc={labelFunc}
-      helperText={errorText}
-      onChange={handleChange}
-      TextFieldComponent={DeprecatedApeTextField}
-    />
-  );
+export const FormTimePicker = <TFieldValues extends FieldValues>(
+  props: Pick<
+    TFormInputField<TFieldValues>,
+    'defaultValue' | 'id' | 'control' | 'name' | 'disabled' | 'css'
+  >
+) => {
+  return <FormInputField {...props} inputProps={{ type: 'time' }} />;
 };

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -12,6 +12,7 @@ export * from './Drawer';
 export * from './ErrorBoundary';
 export * from './FormAutocomplete';
 export * from './FormDatePicker';
+export * from './FormDateTimePicker';
 export * from './FormFileUpload';
 export * from './FormInputField';
 export * from './FormRadioGroup';

--- a/src/pages/HistoryPage/EpochForm.tsx
+++ b/src/pages/HistoryPage/EpochForm.tsx
@@ -3,7 +3,7 @@ import { useState, useMemo, useEffect, useRef } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import isEmpty from 'lodash/isEmpty';
 import { DateTime, Interval } from 'luxon';
-import { useForm, Controller, SubmitHandler } from 'react-hook-form';
+import { useForm, SubmitHandler } from 'react-hook-form';
 import { useQueryClient } from 'react-query';
 import { SafeParseReturnType, z } from 'zod';
 
@@ -430,7 +430,7 @@ const EpochForm = ({
             />
             <Flex column css={{ gap: '$lg' }}>
               <Text h3>Epoch Timing</Text>
-              <Flex css={{ gap: '$xs' }}>
+              <Flex css={{ gap: '$sm' }}>
                 <Flex
                   column
                   alignItems="start"
@@ -445,24 +445,13 @@ const EpochForm = ({
                       <Info size="sm" />
                     </Tooltip>
                   </FormLabel>
-                  <Controller
+                  <FormDatePicker
                     control={control}
+                    id="start_date"
                     name="start_date"
-                    render={({ field: { onChange, value, onBlur } }) => (
-                      <FormDatePicker
-                        onChange={onChange}
-                        value={value}
-                        onBlur={onBlur}
-                        disabled={
-                          selectedEpoch &&
-                          currentEpoch?.id === selectedEpoch?.id
-                        }
-                        format="MMM dd, yyyy"
-                        style={{
-                          marginLeft: 0,
-                        }}
-                      />
-                    )}
+                    disabled={
+                      selectedEpoch && currentEpoch?.id === selectedEpoch?.id
+                    }
                   />
                 </Flex>
                 <Flex css={{ maxWidth: '150px' }}>
@@ -486,28 +475,22 @@ const EpochForm = ({
                     </Tooltip>
                   </FormLabel>
                   <Flex row css={{ gap: '$sm' }}>
-                    <Controller
-                      control={control}
-                      name="start_date"
-                      render={({ field: { onChange, value, onBlur } }) => (
-                        <Box
-                          css={{
-                            maxWidth: '150px',
-                            '> div': { mb: '0 !important' },
-                          }}
-                        >
-                          <FormTimePicker
-                            onBlur={onBlur}
-                            onChange={onChange}
-                            value={value}
-                            disabled={
-                              selectedEpoch &&
-                              currentEpoch?.id === selectedEpoch?.id
-                            }
-                          />
-                        </Box>
-                      )}
-                    />
+                    <Box
+                      css={{
+                        maxWidth: '150px',
+                        '> div': { mb: '0 !important' },
+                      }}
+                    >
+                      <FormTimePicker
+                        control={control}
+                        name="start_date"
+                        id="start_date"
+                        disabled={
+                          selectedEpoch &&
+                          currentEpoch?.id === selectedEpoch?.id
+                        }
+                      />
+                    </Box>
                     <Text size="medium">
                       In your
                       <br /> local timezone

--- a/src/pages/HistoryPage/EpochForm.tsx
+++ b/src/pages/HistoryPage/EpochForm.tsx
@@ -7,12 +7,7 @@ import { useForm, SubmitHandler } from 'react-hook-form';
 import { useQueryClient } from 'react-query';
 import { SafeParseReturnType, z } from 'zod';
 
-import {
-  FormInputField,
-  FormRadioGroup,
-  FormDatePicker,
-  FormTimePicker,
-} from 'components';
+import { FormInputField, FormRadioGroup, FormDateTimePicker } from 'components';
 import { useApiAdminCircle } from 'hooks';
 import { Info } from 'icons/__generated';
 import { QUERY_KEY_MY_ORGS } from 'pages/CirclesPage/getOrgData';
@@ -431,29 +426,6 @@ const EpochForm = ({
             <Flex column css={{ gap: '$lg' }}>
               <Text h3>Epoch Timing</Text>
               <Flex css={{ gap: '$sm' }}>
-                <Flex
-                  column
-                  alignItems="start"
-                  css={{
-                    maxWidth: '150px',
-                    gap: '$xs',
-                  }}
-                >
-                  <FormLabel type="label" css={{ fontWeight: '$bold' }}>
-                    Start Date{' '}
-                    <Tooltip content="The first day of the epoch in your local time zone">
-                      <Info size="sm" />
-                    </Tooltip>
-                  </FormLabel>
-                  <FormDatePicker
-                    control={control}
-                    id="start_date"
-                    name="start_date"
-                    disabled={
-                      selectedEpoch && currentEpoch?.id === selectedEpoch?.id
-                    }
-                  />
-                </Flex>
                 <Flex css={{ maxWidth: '150px' }}>
                   <FormInputField
                     id="days"
@@ -477,11 +449,10 @@ const EpochForm = ({
                   <Flex row css={{ gap: '$sm' }}>
                     <Box
                       css={{
-                        maxWidth: '150px',
                         '> div': { mb: '0 !important' },
                       }}
                     >
-                      <FormTimePicker
+                      <FormDateTimePicker
                         control={control}
                         name="start_date"
                         id="start_date"
@@ -491,7 +462,7 @@ const EpochForm = ({
                         }
                       />
                     </Box>
-                    <Text size="medium">
+                    <Text size="small" color="neutral">
                       In your
                       <br /> local timezone
                     </Text>


### PR DESCRIPTION
The integration isn't quite working yet because the datetime picker element doesn't handle time zones. So while we're successfully saving start_times, I'm not sure we're submitting them with the correct timestamp.

Secondly, displaying existing epoch start times and modifying them hasn't successfully been integrated yet either 
So we're still using one field value but we need to make sure the local time zone is appended to it before it is submitted to the api

TODOs:
1. Handle submitting:     // BEFORE SUBMITTING: we need to convert the time from the UI time picker into a time with the local timezone. Or correct absolute time.
2. Handle reading existing values: When we fetch data, we're getting a time in UTC, and need to convert it to local time. Probably by calling set zone and then passing it to the element. Then just call .toISO on it and pass it to the UI datetime picker.

![image](https://user-images.githubusercontent.com/17910833/211905826-c9d14e9b-62cd-46f9-9cd7-66fc3d7a7b38.png)
