### PR TITLE
Allow viewing join link page without login

### DIFF
--- a/api-test/helpers/circles.ts
+++ b/api-test/helpers/circles.ts
@@ -1,3 +1,5 @@
+import assert from 'assert';
+
 import faker from 'faker';
 import { z } from 'zod';
 
@@ -24,7 +26,7 @@ export function getCircleName() {
 export async function createCircle(
   client: GQLClientType,
   object?: Partial<CircleInput>
-): Promise<{ id: number }> {
+) {
   let organizationId = object?.organization_id;
 
   if (!organizationId) {
@@ -38,7 +40,7 @@ export async function createCircle(
     organizationId = organization?.id;
   }
 
-  const { insert_circles_one } = await client.mutate({
+  const { insert_circles_one: circle } = await client.mutate({
     insert_circles_one: [
       {
         object: {
@@ -47,15 +49,10 @@ export async function createCircle(
           organization_id: organizationId,
         },
       },
-      {
-        id: true,
-      },
+      { id: true, name: true },
     ],
   });
 
-  if (!insert_circles_one) {
-    throw new Error('Circle not created');
-  }
-
-  return insert_circles_one;
+  assert(circle, 'Circle not created');
+  return circle;
 }

--- a/api-test/helpers/circles.ts
+++ b/api-test/helpers/circles.ts
@@ -40,18 +40,21 @@ export async function createCircle(
     organizationId = organization?.id;
   }
 
-  const { insert_circles_one: circle } = await client.mutate({
-    insert_circles_one: [
-      {
-        object: {
-          ...object,
-          name: object?.name ?? getCircleName(),
-          organization_id: organizationId,
+  const { insert_circles_one: circle } = await client.mutate(
+    {
+      insert_circles_one: [
+        {
+          object: {
+            ...object,
+            name: object?.name ?? getCircleName(),
+            organization_id: organizationId,
+          },
         },
-      },
-      { id: true, name: true },
-    ],
-  });
+        { id: true, name: true },
+      ],
+    },
+    { operationName: 'createCircle' }
+  );
 
   assert(circle, 'Circle not created');
   return circle;

--- a/api-test/helpers/contributions.ts
+++ b/api-test/helpers/contributions.ts
@@ -2,22 +2,18 @@ import faker from 'faker';
 import { z } from 'zod';
 
 import { GraphQLTypes } from '../../api-lib/gql/__generated__/zeus';
-import {
-  deleteContributionInput,
-} from '../../src/lib/zod';
+import { deleteContributionInput } from '../../src/lib/zod';
 
 import type { GQLClientType } from './common';
 
-type InsertContributionInput = Partial<
-  typeof contributionSchema['_type']
->;
+type InsertContributionInput = Partial<typeof contributionSchema['_type']>;
 
 const contributionSchema = z
   .object({
     circle_id: z.number(),
     description: z.string().min(3).max(1000),
     user_id: z.number().int().positive(),
-    datetime_created: z.string()
+    datetime_created: z.string(),
   })
   .strict();
 
@@ -32,17 +28,20 @@ export async function createContribution(
   client: GQLClientType,
   object: InsertContributionInput
 ): Promise<ContributionResult | undefined> {
-  const { insert_contributions_one } = await client.mutate({
-    insert_contributions_one: [
-      {
-        object: {
-          ...object,
-          description: object.description ?? faker.lorem.sentences(3),
+  const { insert_contributions_one } = await client.mutate(
+    {
+      insert_contributions_one: [
+        {
+          object: {
+            ...object,
+            description: object.description ?? faker.lorem.sentences(3),
+          },
         },
-      },
-      { id: true, description: true, user_id: true },
-    ],
-  });
+        { id: true, description: true, user_id: true },
+      ],
+    },
+    { operationName: 'createContribution' }
+  );
 
   if (!insert_contributions_one) {
     throw new Error('Contribution not created');
@@ -55,9 +54,12 @@ export async function deleteContribution(
   client: GQLClientType,
   payload: DeleteContributionInput
 ): Promise<{ success: boolean } | undefined> {
-  const { deleteContribution } = await client.mutate({
-    deleteContribution: [{ payload }, { success: true }],
-  });
+  const { deleteContribution } = await client.mutate(
+    {
+      deleteContribution: [{ payload }, { success: true }],
+    },
+    { operationName: 'deleteContribution' }
+  );
 
   if (!deleteContribution) {
     throw new Error('Contribution not deleted');
@@ -67,9 +69,12 @@ export async function deleteContribution(
 }
 
 export async function findContributionById(client: GQLClientType, id: number) {
-  const { contributions_by_pk } = await client.query({
-    contributions_by_pk: [{ id }, { deleted_at: true }],
-  });
+  const { contributions_by_pk } = await client.query(
+    {
+      contributions_by_pk: [{ id }, { deleted_at: true }],
+    },
+    { operationName: 'findContribution' }
+  );
 
   return contributions_by_pk;
 }

--- a/api-test/helpers/epochs.ts
+++ b/api-test/helpers/epochs.ts
@@ -14,27 +14,30 @@ export async function createEpoch(
   const days = object?.days || 3;
   const start_date = object?.start_date || dateNow;
   const end_date = start_date.plus({ days });
-  const { insert_epochs_one } = await client.mutate({
-    insert_epochs_one: [
-      {
-        object: {
-          repeat: 0,
-          ...object,
-          ended: end_date < DateTime.now(),
-          days,
-          start_date: start_date.toISO(),
-          end_date: end_date.toISO(),
+  const { insert_epochs_one } = await client.mutate(
+    {
+      insert_epochs_one: [
+        {
+          object: {
+            repeat: 0,
+            ...object,
+            ended: end_date < DateTime.now(),
+            days,
+            start_date: start_date.toISO(),
+            end_date: end_date.toISO(),
+          },
         },
-      },
-      {
-        id: true,
-        start_date: true,
-        end_date: true,
-        days: true,
-        ended: true,
-      },
-    ],
-  });
+        {
+          id: true,
+          start_date: true,
+          end_date: true,
+          days: true,
+          ended: true,
+        },
+      ],
+    },
+    { operationName: 'createEpoch' }
+  );
   if (!insert_epochs_one) {
     throw new Error('Epoch not created');
   }

--- a/api-test/helpers/organizations.ts
+++ b/api-test/helpers/organizations.ts
@@ -10,16 +10,19 @@ export async function createOrganization(
   client: GQLClientType,
   object?: OrganizationInput
 ) {
-  const { insert_organizations_one } = await client.mutate({
-    insert_organizations_one: [
-      {
-        object: object || {
-          name: faker.company.companyName(),
+  const { insert_organizations_one } = await client.mutate(
+    {
+      insert_organizations_one: [
+        {
+          object: object || {
+            name: faker.company.companyName(),
+          },
         },
-      },
-      { id: true, name: true },
-    ],
-  });
+        { id: true, name: true },
+      ],
+    },
+    { operationName: 'createOrganization' }
+  );
 
   if (!insert_organizations_one) {
     throw new Error('Organization not created');

--- a/api-test/helpers/profiles.ts
+++ b/api-test/helpers/profiles.ts
@@ -16,9 +16,15 @@ export async function createProfile(
       name: `${faker.name.firstName()} ${faker.datatype.number(10000)}`,
     };
   }
-  const { insert_profiles_one: profile } = await client.mutate({
-    insert_profiles_one: [{ object }, { id: true, name: true, address: true }],
-  });
+  const { insert_profiles_one: profile } = await client.mutate(
+    {
+      insert_profiles_one: [
+        { object },
+        { id: true, name: true, address: true },
+      ],
+    },
+    { operationName: 'createProfile' }
+  );
   assert(profile, 'Profile not created');
   return profile;
 }

--- a/api-test/helpers/profiles.ts
+++ b/api-test/helpers/profiles.ts
@@ -1,3 +1,5 @@
+import assert from 'assert';
+
 import faker from 'faker';
 
 import type { GQLClientType } from './common';
@@ -7,20 +9,16 @@ type ProfileInput = { address: string; name?: string };
 export async function createProfile(
   client: GQLClientType,
   object?: ProfileInput
-): Promise<{ id: number }> {
+) {
   if (!object) {
     object = {
       address: faker.finance.ethereumAddress(),
       name: `${faker.name.firstName()} ${faker.datatype.number(10000)}`,
     };
   }
-  const { insert_profiles_one } = await client.mutate({
-    insert_profiles_one: [{ object }, { id: true, name: true }],
+  const { insert_profiles_one: profile } = await client.mutate({
+    insert_profiles_one: [{ object }, { id: true, name: true, address: true }],
   });
-
-  if (!insert_profiles_one) {
-    throw new Error('Profile not created');
-  }
-
-  return insert_profiles_one;
+  assert(profile, 'Profile not created');
+  return profile;
 }

--- a/api-test/helpers/users.ts
+++ b/api-test/helpers/users.ts
@@ -8,20 +8,23 @@ export async function createUser(
   client: GQLClientType,
   object: Partial<GraphQLTypes['users_insert_input']>
 ): Promise<{ id: number }> {
-  const { insert_users_one } = await client.mutate({
-    insert_users_one: [
-      {
-        object: {
-          ...object,
-          name: object.name ?? faker.unique(faker.name.firstName),
-          role: object.role ?? 1,
-          starting_tokens: object.starting_tokens ?? 100,
-          entrance: object.entrance ?? '?',
+  const { insert_users_one } = await client.mutate(
+    {
+      insert_users_one: [
+        {
+          object: {
+            ...object,
+            name: object.name ?? faker.unique(faker.name.firstName),
+            role: object.role ?? 1,
+            starting_tokens: object.starting_tokens ?? 100,
+            entrance: object.entrance ?? '?',
+          },
         },
-      },
-      { id: true },
-    ],
-  });
+        { id: true },
+      ],
+    },
+    { operationName: 'createUser' }
+  );
   if (!insert_users_one) {
     throw new Error('User not created');
   }

--- a/src/components/MyAvatarMenu/MyAvatarMenu.tsx
+++ b/src/components/MyAvatarMenu/MyAvatarMenu.tsx
@@ -41,6 +41,8 @@ export const MyAvatarMenu = ({ walletStatus, avatar }: Props) => {
   };
   let timeoutId: ReturnType<typeof setTimeout>;
 
+  if (!address) return null;
+
   return (
     <>
       {showTxModal && (

--- a/src/pages/JoinCirclePage/JoinCirclePage.test.tsx
+++ b/src/pages/JoinCirclePage/JoinCirclePage.test.tsx
@@ -1,0 +1,80 @@
+import assert from 'assert';
+
+import { render, screen } from '@testing-library/react';
+import { CircleTokenType } from 'common-lib/circleShareTokens';
+import { useAuthStore } from 'features/auth';
+import { setMockHeaders } from 'lib/gql/client';
+import { Routes, Route } from 'react-router-dom';
+
+import { adminClient } from '../../../api-lib/gql/adminClient';
+import { createProfile } from '../../../api-test/helpers';
+import { createCircle } from '../../../api-test/helpers/circles';
+import { TestWrapper } from 'utils/testing';
+
+import { JoinCirclePage } from './JoinCirclePage';
+
+import { Awaited } from 'types/shim';
+
+let circle: Awaited<ReturnType<typeof createCircle>>,
+  profile: Awaited<ReturnType<typeof createProfile>>,
+  joinToken: string;
+
+beforeAll(async () => {
+  profile = await createProfile(adminClient);
+  circle = await createCircle(adminClient);
+
+  const resp = await adminClient.mutate({
+    __alias: {
+      createJoinToken: {
+        insert_circle_share_tokens_one: [
+          {
+            object: { circle_id: circle.id, type: CircleTokenType.Magic },
+          },
+          { uuid: true },
+        ],
+      },
+    },
+  });
+  joinToken = resp.createJoinToken?.uuid;
+});
+
+describe('join page', () => {
+  test('invalid token', async () => {
+    render(<TestWrapper withRoutes routeHistory={[`/join/foo`]} />);
+    await screen.findByText(/Invalid invite link/);
+  });
+
+  test('valid token, logged out', async () => {
+    render(<TestWrapper withRoutes routeHistory={[`/join/${joinToken}`]} />);
+
+    assert(circle);
+    await screen.findByText(circle.name);
+    screen.getByText('Connect Wallet');
+  });
+
+  test('valid token, logged in', async () => {
+    useAuthStore.setState({ step: 'done', address: profile.address });
+    setMockHeaders({
+      'x-hasura-role': 'user',
+      'x-hasura-address': profile.address,
+      'x-hasura-user-id': profile.id.toString(),
+    });
+
+    render(
+      <TestWrapper routeHistory={[`/join/${joinToken}`]}>
+        <Routes>
+          <Route path="/join/:token" element={<JoinCirclePage />} />
+        </Routes>
+      </TestWrapper>
+    );
+    await screen.findByText('Wallet Address');
+    screen.getByText(
+      (_, el) => el instanceof HTMLInputElement && el.value === profile.address
+    );
+  });
+});
+
+describe('welcome page', () => {
+  test.todo('wrong address');
+  test.todo('already a member');
+});

--- a/src/pages/JoinCirclePage/JoinCirclePage.test.tsx
+++ b/src/pages/JoinCirclePage/JoinCirclePage.test.tsx
@@ -23,18 +23,21 @@ beforeAll(async () => {
   profile = await createProfile(adminClient);
   circle = await createCircle(adminClient);
 
-  const resp = await adminClient.mutate({
-    __alias: {
-      createJoinToken: {
-        insert_circle_share_tokens_one: [
-          {
-            object: { circle_id: circle.id, type: CircleTokenType.Magic },
-          },
-          { uuid: true },
-        ],
+  const resp = await adminClient.mutate(
+    {
+      __alias: {
+        createJoinToken: {
+          insert_circle_share_tokens_one: [
+            {
+              object: { circle_id: circle.id, type: CircleTokenType.Magic },
+            },
+            { uuid: true },
+          ],
+        },
       },
     },
-  });
+    { operationName: 'test' }
+  );
   joinToken = resp.createJoinToken?.uuid;
 });
 

--- a/src/pages/JoinCirclePage/JoinCirclePage.tsx
+++ b/src/pages/JoinCirclePage/JoinCirclePage.tsx
@@ -1,6 +1,7 @@
 import assert from 'assert';
 import { useEffect, useState } from 'react';
 
+import { useAuthStateMachine } from 'features/auth/RequireAuth';
 import { useQuery } from 'react-query';
 import { useNavigate } from 'react-router';
 import { useParams } from 'react-router-dom';
@@ -20,6 +21,7 @@ import {
 } from './queries';
 
 export const JoinCirclePage = () => {
+  useAuthStateMachine(false);
   const { token } = useParams();
 
   const navigate = useNavigate();
@@ -57,7 +59,7 @@ export const JoinCirclePage = () => {
         const res = await fetch('/api/circle/landing/' + token);
         if (!res.ok) {
           setTokenError(
-            'Invalid invite link; check with the Circle Admin, there may be a new link.'
+            'Invalid invite link; check with your Circle Admin for an updated link.'
           );
           return;
         }
@@ -75,7 +77,7 @@ export const JoinCirclePage = () => {
           return;
         }
       } catch (e) {
-        setTokenError('Network error validating invite link');
+        setTokenError('Network error; please reload the page to try again.');
       }
     };
     fn()
@@ -84,17 +86,17 @@ export const JoinCirclePage = () => {
         if (e instanceof Error) {
           setTokenError(e.message ?? 'unknown error');
         } else {
-          setTokenError('invalid token');
+          setTokenError('Invalid token');
         }
       });
   }, []);
 
   // Waiting to validate the token
-  if ((!tokenError && !tokenJoinInfo) || !profile) {
+  if (!tokenError && !tokenJoinInfo) {
     return <LoadingModal visible={true} note="token-lookup" />;
   }
 
-  if (address && tokenJoinInfo && wrongAddress) {
+  if (address && profile && tokenJoinInfo && wrongAddress) {
     return (
       <AddressIsNotMember
         address={address}
@@ -118,10 +120,7 @@ export const JoinCirclePage = () => {
         </CenteredBox>
       )}
       {tokenJoinInfo && (
-        <JoinWithMagicLink
-          tokenJoinInfo={tokenJoinInfo}
-          userName={profile.name}
-        />
+        <JoinWithMagicLink tokenJoinInfo={tokenJoinInfo} profile={profile} />
       )}
     </>
   );

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -109,8 +109,6 @@ const LoggedInRoutes = () => {
         element={<VaultTransactions />}
       />
 
-      <Route path={paths.join(':token')} element={<JoinCirclePage />} />
-
       <Route path={paths.invite(':token')} element={<JoinCirclePage />} />
       <Route path="*" element={<Redirect to={paths.home} note="catchall" />} />
     </Routes>
@@ -128,6 +126,7 @@ export const AppRoutes = () => {
           </RequireAuth>
         }
       />
+      <Route path={paths.join(':token')} element={<JoinCirclePage />} />
       <Route
         path="*"
         element={


### PR DESCRIPTION
Fixes #1807 

### Testing

- Generate a valid join link
  - Load it while logged out; verify the page appears with correct data and a "Connect Wallet" button
  - Click "Connect Wallet" and log in; verify the page re-appears after login, now with a form instead of "Connect Wallet"
  - Submit the form; verify that it adds you to the circle as before
- Load an invalid join link; verify it shows an error page, whether you're logged in or not
- Verify that welcome links still behave correctly (no change)

### TODO

- [x] extract general test environment changes into their own PR