### PR TITLE
Implement Epoch Monthly backend

### DIFF
--- a/api-test/hasura/actions/_handlers/createEpoch.test.ts
+++ b/api-test/hasura/actions/_handlers/createEpoch.test.ts
@@ -609,59 +609,6 @@ describe('createEpoch', () => {
   });
 
   describe('monthly input', () => {
-    describe('findSameDayNextMonth', () => {
-      it('handles month beginnings correctly', () => {
-        let date = DateTime.fromISO('2023-01-01T20:28:00.000Z');
-        let result = findSameDayNextMonth(date, {
-          week: 0,
-        });
-        expect(result.toISO()).toBe('2023-02-05T20:28:00.000Z');
-
-        date = DateTime.fromISO('2023-02-06T20:28:00.000Z');
-        result = findSameDayNextMonth(date, {
-          week: 0,
-        });
-        expect(result.toISO()).toBe('2023-03-06T20:28:00.000Z');
-
-        date = DateTime.fromISO('2023-03-06T20:28:00.000Z');
-        result = findSameDayNextMonth(date, {
-          week: 0,
-        });
-        expect(result.toISO()).toBe('2023-04-03T20:28:00.000Z');
-      });
-
-      it('handles month endings correctly', () => {
-        const date = DateTime.fromISO('2023-01-31T20:28:00.000Z');
-
-        const result = findSameDayNextMonth(date, {
-          week: 4,
-        });
-        // truncated from 5th week to last week
-        expect(result.toISO()).toBe('2023-02-28T20:28:00.000Z');
-      });
-      test('handles weekly boundaries correctly', () => {
-        // week 0
-        // 1st Friday each month
-        let start = DateTime.fromISO('2023-04-07T00:00:00.000Z');
-        let result = findSameDayNextMonth(start, { week: 0 });
-        expect(result.toISO()).toBe('2023-05-05T00:00:00.000Z');
-        // week 5
-        // 6th Friday each month truncated to last Friday
-        result = findSameDayNextMonth(start, { week: 5 });
-        expect(result.toISO()).toBe('2023-04-28T00:00:00.000Z');
-
-        // week 1
-        // 2nd Saturday each month
-        start = DateTime.fromISO('2023-04-08T00:00:00.000Z');
-        result = findSameDayNextMonth(start, { week: 1 });
-        expect(result.toISO()).toBe('2023-05-13T00:00:00.000Z');
-        // week 6
-        // 6th Saturday each month truncated to the last Saturday
-        result = findSameDayNextMonth(start, { week: 6 });
-        expect(result.toISO()).toBe('2023-04-29T00:00:00.000Z');
-      });
-    });
-
     test('errors on malformed input', async () => {
       const now = DateTime.now();
       const params = {

--- a/api-test/hasura/actions/_handlers/createEpoch.test.ts
+++ b/api-test/hasura/actions/_handlers/createEpoch.test.ts
@@ -631,18 +631,34 @@ describe('createEpoch', () => {
       });
 
       it('handles month endings correctly', () => {
-        let date = DateTime.fromISO('2023-01-31T20:28:00.000Z');
+        const date = DateTime.fromISO('2023-01-31T20:28:00.000Z');
 
-        let result = findSameDayNextMonth(date, {
+        const result = findSameDayNextMonth(date, {
           week: 4,
         });
-        expect(result.toISO()).toBe('2023-03-07T20:28:00.000Z');
+        // truncated from 5th week to last week
+        expect(result.toISO()).toBe('2023-02-28T20:28:00.000Z');
+      });
+      test('handles weekly boundaries correctly', () => {
+        // week 0
+        // 1st Friday each month
+        let start = DateTime.fromISO('2023-04-07T00:00:00.000Z');
+        let result = findSameDayNextMonth(start, { week: 0 });
+        expect(result.toISO()).toBe('2023-05-05T00:00:00.000Z');
+        // week 5
+        // 6th Friday each month truncated to last Friday
+        result = findSameDayNextMonth(start, { week: 5 });
+        expect(result.toISO()).toBe('2023-04-28T00:00:00.000Z');
 
-        date = DateTime.fromISO('2023-02-07T20:28:00.000Z');
-        result = findSameDayNextMonth(date, {
-          week: 5,
-        });
-        expect(result.toISO()).toBe('2023-03-14T20:28:00.000Z');
+        // week 1
+        // 2nd Saturday each month
+        start = DateTime.fromISO('2023-04-08T00:00:00.000Z');
+        result = findSameDayNextMonth(start, { week: 1 });
+        expect(result.toISO()).toBe('2023-05-13T00:00:00.000Z');
+        // week 6
+        // 6th Saturday each month truncated to the last Saturday
+        result = findSameDayNextMonth(start, { week: 6 });
+        expect(result.toISO()).toBe('2023-04-29T00:00:00.000Z');
       });
     });
 
@@ -784,28 +800,6 @@ describe('createEpoch', () => {
           end_date: expect.stringContaining(params.end_date.substring(0, 16)),
         })
       );
-    });
-
-    test('handles weekly boundaries correctly', () => {
-      // week 0
-      // 1st Friday each month
-      let start = DateTime.fromISO('2023-04-07T00:00:00.000Z');
-      let result = findSameDayNextMonth(start, { week: 0 });
-      expect(result.toISO()).toBe('2023-05-05T00:00:00.000Z');
-      // week 5
-      // 6th Friday each month
-      result = findSameDayNextMonth(start, { week: 5 });
-      expect(result.toISO()).toBe('2023-05-12T00:00:00.000Z');
-
-      // week 1
-      // 2nd Saturday each month
-      start = DateTime.fromISO('2023-04-08T00:00:00.000Z');
-      result = findSameDayNextMonth(start, { week: 1 });
-      expect(result.toISO()).toBe('2023-05-13T00:00:00.000Z');
-      // week 6
-      // 6th Saturday each month
-      result = findSameDayNextMonth(start, { week: 6 });
-      expect(result.toISO()).toBe('2023-05-13T00:00:00.000Z');
     });
   });
 });

--- a/api-test/hasura/actions/_handlers/createEpoch.test.ts
+++ b/api-test/hasura/actions/_handlers/createEpoch.test.ts
@@ -4,6 +4,7 @@ import { DateTime, Interval } from 'luxon';
 
 import { adminClient } from '../../../../api-lib/gql/adminClient';
 import { zEpochInputParams } from '../../../../api/hasura/actions/_handlers/createEpoch';
+import { findSameDayNextMonth } from '../../../../src/common-lib/epochs';
 import {
   createCircle,
   createProfile,
@@ -108,7 +109,7 @@ describe('createEpoch', () => {
       );
     });
 
-    test('errors when epoch ends before or as soon as it starts ', async () => {
+    test('errors when epoch ends before or as soon as it starts', async () => {
       expect.assertions(1);
       const now = DateTime.now().plus({ weeks: 2 });
       const thunk = async () =>
@@ -608,13 +609,203 @@ describe('createEpoch', () => {
   });
 
   describe('monthly input', () => {
-    test.todo('errors on malformed input');
-    test.todo(
-      'creates a new epoch on the correct day of the correct week of the month'
-    );
-    test.todo('handles cases at the end of the month correctly');
-    test.todo(
-      'always extends the epoch to end on the start date of the following month'
-    );
+    describe('findSameDayNextMonth', () => {
+      it('handles month beginnings correctly', () => {
+        let date = DateTime.fromISO('2023-01-01T20:28:00.000Z');
+        let result = findSameDayNextMonth(date, {
+          week: 0,
+        });
+        expect(result.toISO()).toBe('2023-02-05T20:28:00.000Z');
+
+        date = DateTime.fromISO('2023-02-06T20:28:00.000Z');
+        result = findSameDayNextMonth(date, {
+          week: 0,
+        });
+        expect(result.toISO()).toBe('2023-03-06T20:28:00.000Z');
+
+        date = DateTime.fromISO('2023-03-06T20:28:00.000Z');
+        result = findSameDayNextMonth(date, {
+          week: 0,
+        });
+        expect(result.toISO()).toBe('2023-04-03T20:28:00.000Z');
+      });
+
+      it('handles month endings correctly', () => {
+        let date = DateTime.fromISO('2023-01-31T20:28:00.000Z');
+
+        let result = findSameDayNextMonth(date, {
+          week: 4,
+        });
+        expect(result.toISO()).toBe('2023-03-07T20:28:00.000Z');
+
+        date = DateTime.fromISO('2023-02-07T20:28:00.000Z');
+        result = findSameDayNextMonth(date, {
+          week: 5,
+        });
+        expect(result.toISO()).toBe('2023-03-14T20:28:00.000Z');
+      });
+    });
+
+    test('errors on malformed input', async () => {
+      const now = DateTime.now();
+      const params = {
+        type: 'monthly',
+        start_date: now.toISO(),
+        end_date: findSameDayNextMonth(now, {
+          week: Math.floor(now.day / 7),
+        })
+          .plus({ days: 1 })
+          .toISO(),
+        week: Math.floor(now.day / 7),
+      };
+      const first = async () =>
+        client.mutate({
+          createEpoch: [
+            {
+              payload: {
+                circle_id: circle.id,
+                params,
+              },
+            },
+            {
+              epoch: {
+                start_date: true,
+                end_date: true,
+                repeat_data: [{}, true],
+              },
+            },
+          ],
+        });
+
+      await expect(first).rejects.toThrow(/do not match the end date/);
+    });
+
+    test('creates a new epoch on the correct day of the correct week of the month', async () => {
+      let result;
+      const now = DateTime.now();
+      const params = {
+        type: 'monthly',
+        start_date: now.toISO(),
+        end_date: findSameDayNextMonth(now, {
+          week: Math.floor(now.day / 7),
+        }).toISO(),
+        week: Math.floor(now.day / 7),
+      };
+      const first = async () =>
+        client.mutate({
+          createEpoch: [
+            {
+              payload: {
+                circle_id: circle.id,
+                params,
+              },
+            },
+            {
+              epoch: {
+                start_date: true,
+                end_date: true,
+                repeat_data: [{}, true],
+              },
+            },
+          ],
+        });
+      try {
+        result = await first();
+      } catch (e: any) {
+        console.error(e.response.errors);
+      }
+      const epoch = result?.createEpoch?.epoch;
+      assert(epoch);
+      const { start_date, end_date } = epoch;
+      expect(DateTime.fromISO(start_date).zoneName).toBe('UTC');
+      expect(DateTime.fromISO(end_date).zoneName).toBe('UTC');
+      expect(epoch).toEqual(
+        expect.objectContaining({
+          repeat_data: {
+            type: 'monthly',
+            week: params.week,
+          },
+          start_date: expect.stringContaining(
+            params.start_date.substring(0, 16)
+          ),
+          end_date: expect.stringContaining(params.end_date.substring(0, 16)),
+        })
+      );
+    });
+
+    test('handles cases at the end of the month correctly', async () => {
+      let result;
+      const start = DateTime.now().startOf('month').plus({ weeks: 6 });
+      const params = {
+        type: 'monthly',
+        start_date: start.toISO(),
+        end_date: findSameDayNextMonth(start, {
+          week: 6,
+        }).toISO(),
+        week: 6,
+      };
+      const first = async () =>
+        client.mutate({
+          createEpoch: [
+            {
+              payload: {
+                circle_id: circle.id,
+                params,
+              },
+            },
+            {
+              epoch: {
+                start_date: true,
+                end_date: true,
+                repeat_data: [{}, true],
+              },
+            },
+          ],
+        });
+      try {
+        result = await first();
+      } catch (e: any) {
+        console.error(e.response.errors);
+      }
+      const epoch = result?.createEpoch?.epoch;
+      assert(epoch);
+      const { start_date, end_date } = epoch;
+      expect(DateTime.fromISO(start_date).zoneName).toBe('UTC');
+      expect(DateTime.fromISO(end_date).zoneName).toBe('UTC');
+      expect(epoch).toEqual(
+        expect.objectContaining({
+          repeat_data: {
+            type: 'monthly',
+            week: 6,
+          },
+          start_date: expect.stringContaining(
+            params.start_date.substring(0, 16)
+          ),
+          end_date: expect.stringContaining(params.end_date.substring(0, 16)),
+        })
+      );
+    });
+
+    test('handles weekly boundaries correctly', () => {
+      // week 0
+      // 1st Friday each month
+      let start = DateTime.fromISO('2023-04-07T00:00:00.000Z');
+      let result = findSameDayNextMonth(start, { week: 0 });
+      expect(result.toISO()).toBe('2023-05-05T00:00:00.000Z');
+      // week 5
+      // 6th Friday each month
+      result = findSameDayNextMonth(start, { week: 5 });
+      expect(result.toISO()).toBe('2023-05-12T00:00:00.000Z');
+
+      // week 1
+      // 2nd Saturday each month
+      start = DateTime.fromISO('2023-04-08T00:00:00.000Z');
+      result = findSameDayNextMonth(start, { week: 1 });
+      expect(result.toISO()).toBe('2023-05-13T00:00:00.000Z');
+      // week 6
+      // 6th Saturday each month
+      result = findSameDayNextMonth(start, { week: 6 });
+      expect(result.toISO()).toBe('2023-05-13T00:00:00.000Z');
+    });
   });
 });

--- a/api/hasura/actions/_handlers/createEpoch.ts
+++ b/api/hasura/actions/_handlers/createEpoch.ts
@@ -11,6 +11,7 @@ import {
   getRepeatingEpoch,
 } from '../../../../api-lib/gql/queries';
 import { errorResponseWithStatusCode } from '../../../../api-lib/HttpError';
+import { findSameDayNextMonth } from '../../../../src/common-lib/epochs';
 import {
   composeHasuraActionRequestBodyWithSession,
   HasuraUserSessionVariables,
@@ -38,8 +39,7 @@ const zCustomInputSchema = z
 const zMonthlyInputSchema = z
   .object({
     type: z.literal('monthly'),
-    weekday: z.number().min(1).max(7),
-    week: z.number().min(1).max(6),
+    week: z.number().min(0),
     start_date: zStringISODateUTC,
     end_date: zStringISODateUTC,
   })
@@ -94,9 +94,10 @@ async function handler(request: VercelRequest, response: VercelResponse) {
     case 'custom':
       error = validateCustomInput(params);
       break;
-    case 'monthly':
-      error = new Error('not implemented');
+    case 'monthly': {
+      error = validateMonthlyInput(params);
       break;
+    }
   }
   if (error) {
     errorResponseWithStatusCode(response, error, 422);
@@ -104,6 +105,23 @@ async function handler(request: VercelRequest, response: VercelResponse) {
   }
 
   insertNewEpoch(response, input);
+}
+
+function validateMonthlyInput(
+  input: z.infer<typeof zMonthlyInputSchema>
+): ErrorReturn {
+  const { start_date, end_date } = input;
+
+  const endDateIsValid = findSameDayNextMonth(start_date, input).equals(
+    end_date
+  );
+  if (!endDateIsValid)
+    return new Error(
+      dedent`
+        start day and week "${start_date.toISO()}" do not match the end date
+        "${end_date.toISO()}"
+      `
+    );
 }
 
 function validateCustomInput(

--- a/src/common-lib/epochs.test.ts
+++ b/src/common-lib/epochs.test.ts
@@ -1,0 +1,62 @@
+import { DateTime, Settings } from 'luxon';
+
+import { findSameDayNextMonth } from './epochs';
+
+beforeAll(() => {
+  Settings.defaultZone = 'utc';
+});
+
+it('handles month beginnings correctly', () => {
+  let date = DateTime.fromISO('2023-01-01T20:28:00.000Z');
+  expect(date.zoneName).toBe('UTC');
+
+  let result = findSameDayNextMonth(date, {
+    week: 0,
+  });
+  expect(result.zoneName).toBe('UTC');
+  expect(result.toISO()).toBe('2023-02-05T20:28:00.000Z');
+
+  date = DateTime.fromISO('2023-02-06T20:28:00.000Z');
+  result = findSameDayNextMonth(date, {
+    week: 0,
+  });
+  expect(result.toISO()).toBe('2023-03-06T20:28:00.000Z');
+
+  date = DateTime.fromISO('2023-03-06T20:28:00.000Z');
+  result = findSameDayNextMonth(date, {
+    week: 0,
+  });
+  expect(result.toISO()).toBe('2023-04-03T20:28:00.000Z');
+});
+
+it('handles month endings correctly', () => {
+  const date = DateTime.fromISO('2023-01-31T20:28:00.000Z');
+
+  const result = findSameDayNextMonth(date, {
+    week: 4,
+  });
+  // truncated from 5th week to last week
+  expect(result.toISO()).toBe('2023-02-28T20:28:00.000Z');
+});
+
+test('handles weekly boundaries correctly', () => {
+  // week 0
+  // 1st Friday each month
+  let start = DateTime.fromISO('2023-04-07T00:00:00.000Z');
+  let result = findSameDayNextMonth(start, { week: 0 });
+  expect(result.toISO()).toBe('2023-05-05T00:00:00.000Z');
+  // week 5
+  // 6th Friday each month truncated to last Friday
+  result = findSameDayNextMonth(start, { week: 5 });
+  expect(result.toISO()).toBe('2023-04-28T00:00:00.000Z');
+
+  // week 1
+  // 2nd Saturday each month
+  start = DateTime.fromISO('2023-04-08T00:00:00.000Z');
+  result = findSameDayNextMonth(start, { week: 1 });
+  expect(result.toISO()).toBe('2023-05-13T00:00:00.000Z');
+  // week 6
+  // 6th Saturday each month truncated to the last Saturday
+  result = findSameDayNextMonth(start, { week: 6 });
+  expect(result.toISO()).toBe('2023-04-29T00:00:00.000Z');
+});

--- a/src/common-lib/epochs.ts
+++ b/src/common-lib/epochs.ts
@@ -35,6 +35,10 @@ export function findSameDayNextMonth(
     nextEndDate = nextEndDate.plus({ weeks: week + 1 });
   }
 
+  while (week > 3 && nextMonthStart.plus({ months: 1 }) < nextEndDate) {
+    nextEndDate = nextEndDate.minus({ weeks: 1 });
+  }
+
   return nextEndDate;
 }
 

--- a/src/common-lib/epochs.ts
+++ b/src/common-lib/epochs.ts
@@ -1,0 +1,50 @@
+import { DateTime } from 'luxon';
+
+export function findSameDayNextMonth(
+  start: DateTime,
+  { week }: { week: number }
+): DateTime {
+  const weekday = start.weekday;
+
+  const day = start.day;
+  const startWeek = Math.floor((day - 1) / 7);
+
+  start = start.set({
+    hour: start.hour,
+    minute: start.minute,
+  });
+
+  let nextEndDate = start;
+
+  if (startWeek === week) {
+    nextEndDate = nextEndDate.plus({ months: 1 });
+  }
+
+  const nextMonthStart = nextEndDate.startOf('month').set({
+    hour: start.hour,
+    minute: start.minute,
+  });
+
+  nextEndDate = nextMonthStart.set({
+    weekday,
+  });
+
+  if (nextEndDate >= nextMonthStart)
+    nextEndDate = nextEndDate.plus({ weeks: week });
+  else {
+    nextEndDate = nextEndDate.plus({ weeks: week + 1 });
+  }
+
+  return nextEndDate;
+}
+
+/**
+ * @dev This function is not safe for generating subsequent epoch start dates
+ * in an existing cycle of repeating monthly epoichs
+ * and is only meant to provide a porcelain interface for users creating a new
+ * set of repeating epochs, either in the UI or via the API.
+ */
+export function findMonthlyEndDate(start: DateTime): DateTime {
+  const week = Math.floor((start.day - 1) / 7);
+  return findSameDayNextMonth(start, { week });
+}


### PR DESCRIPTION
## Motivation and Context

This implements the backend for creating a repeating epoch that starts
on the same day of the same week each month.

## Description

This logic accepts a start date, end date, and week number. The start
date and end date must be the same weekday. They also must fall on the
week number of the month. The first week of the month is week 0.

The week number is a necessary extra parameter because it can't
necessarily be inferred from the date. If a following date overflows
into the following month, the inferred week number would cause all
following epochs to start at the beginning of the following month than
the end of the current month, as was originally intended

## Test Plan

unit tests are provided

## Merge Plan

This can merge after #1773 is merged

## Related Issue

#1816
<!-- Please link to the issue here -->
