### PR TITLE
Explicitly set pointerEvents for Toasts

### DIFF
--- a/src/components/ToastContainer.tsx
+++ b/src/components/ToastContainer.tsx
@@ -10,6 +10,7 @@ const themeEnabled = !!isFeatureEnabled('theme_switcher');
 
 const StyledContainer = styled(ToastifyContainer, {
   '&.Toastify__toast-container': {
+    pointerEvents: 'auto',
     width: '80%',
     minWidth: '400px',
     maxWidth: '660px',


### PR DESCRIPTION
This overrides the pointerEvents none when Modals are displayed, showing toasts on Modal pages.
