### PR TITLE
Refactor updateEpoch to utilize repeat_data

### DIFF
--- a/api-lib/gql/__generated__/zeus/const.ts
+++ b/api-lib/gql/__generated__/zeus/const.ts
@@ -56,7 +56,7 @@ export const AllTypesProps: Record<string, any> = {
     datetime_created: 'timestamptz',
   },
   UpdateEpochInput: {
-    start_date: 'timestamptz',
+    params: 'EpochInputParams',
   },
   UpdateProfileInput: {},
   UpdateTeammatesInput: {},

--- a/api-lib/gql/__generated__/zeus/const.ts
+++ b/api-lib/gql/__generated__/zeus/const.ts
@@ -58,6 +58,9 @@ export const AllTypesProps: Record<string, any> = {
   UpdateEpochInput: {
     params: 'EpochInputParams',
   },
+  UpdateEpochOldInput: {
+    start_date: 'timestamptz',
+  },
   UpdateProfileInput: {},
   UpdateTeammatesInput: {},
   UpdateUserInput: {},
@@ -3594,6 +3597,9 @@ export const AllTypesProps: Record<string, any> = {
     },
     updateEpoch: {
       payload: 'UpdateEpochInput',
+    },
+    updateEpochOld: {
+      payload: 'UpdateEpochOldInput',
     },
     updateProfile: {
       payload: 'UpdateProfileInput',
@@ -9923,6 +9929,7 @@ export const ReturnTypes: Record<string, any> = {
     updateCircle: 'UpdateCircleOutput',
     updateContribution: 'UpdateContributionResponse',
     updateEpoch: 'EpochResponse',
+    updateEpochOld: 'EpochResponse',
     updateProfile: 'UpdateProfileResponse',
     updateTeammates: 'UpdateTeammatesResponse',
     updateUser: 'UserResponse',

--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -710,6 +710,7 @@ export type ValueTypes = {
   }>;
   ['CreateEpochInput']: {
     circle_id: number;
+    grant?: number | undefined | null;
     params: ValueTypes['EpochInputParams'];
   };
   ['CreateEpochOldInput']: {
@@ -786,7 +787,6 @@ export type ValueTypes = {
     end_date: ValueTypes['timestamptz'];
     frequency?: number | undefined | null;
     frequency_unit?: string | undefined | null;
-    grant?: number | undefined | null;
     start_date: ValueTypes['timestamptz'];
     type: string;
     week?: number | undefined | null;
@@ -948,12 +948,10 @@ export type ValueTypes = {
   }>;
   ['UpdateEpochInput']: {
     circle_id: number;
-    days: number;
     description?: string | undefined | null;
     grant?: number | undefined | null;
     id: number;
-    repeat: number;
-    start_date: ValueTypes['timestamptz'];
+    params?: ValueTypes['EpochInputParams'] | undefined | null;
   };
   ['UpdateOrgResponse']: AliasType<{
     id?: boolean | `@${string}`;
@@ -28766,6 +28764,7 @@ export type GraphQLTypes = {
   };
   ['CreateEpochInput']: {
     circle_id: number;
+    grant?: number | undefined;
     params: GraphQLTypes['EpochInputParams'];
   };
   ['CreateEpochOldInput']: {
@@ -28842,7 +28841,6 @@ export type GraphQLTypes = {
     end_date: GraphQLTypes['timestamptz'];
     frequency?: number | undefined;
     frequency_unit?: string | undefined;
-    grant?: number | undefined;
     start_date: GraphQLTypes['timestamptz'];
     type: string;
     week?: number | undefined;
@@ -29004,12 +29002,10 @@ export type GraphQLTypes = {
   };
   ['UpdateEpochInput']: {
     circle_id: number;
-    days: number;
     description?: string | undefined;
     grant?: number | undefined;
     id: number;
-    repeat: number;
-    start_date: GraphQLTypes['timestamptz'];
+    params?: GraphQLTypes['EpochInputParams'] | undefined;
   };
   ['UpdateOrgResponse']: {
     __typename: 'UpdateOrgResponse';

--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -953,6 +953,15 @@ export type ValueTypes = {
     id: number;
     params?: ValueTypes['EpochInputParams'] | undefined | null;
   };
+  ['UpdateEpochOldInput']: {
+    circle_id: number;
+    days: number;
+    description?: string | undefined | null;
+    grant?: number | undefined | null;
+    id: number;
+    repeat: number;
+    start_date: ValueTypes['timestamptz'];
+  };
   ['UpdateOrgResponse']: AliasType<{
     id?: boolean | `@${string}`;
     org?: ValueTypes['organizations'];
@@ -9955,6 +9964,10 @@ export type ValueTypes = {
     ];
     updateEpoch?: [
       { payload: ValueTypes['UpdateEpochInput'] },
+      ValueTypes['EpochResponse']
+    ];
+    updateEpochOld?: [
+      { payload: ValueTypes['UpdateEpochOldInput'] },
       ValueTypes['EpochResponse']
     ];
     updateProfile?: [
@@ -21307,6 +21320,7 @@ export type ModelTypes = {
     updateContribution_Contribution?: GraphQLTypes['contributions'] | undefined;
   };
   ['UpdateEpochInput']: GraphQLTypes['UpdateEpochInput'];
+  ['UpdateEpochOldInput']: GraphQLTypes['UpdateEpochOldInput'];
   ['UpdateOrgResponse']: {
     id: number;
     org?: GraphQLTypes['organizations'] | undefined;
@@ -25292,6 +25306,7 @@ export type ModelTypes = {
     /** users can modify contributions and update their dates. */
     updateContribution?: GraphQLTypes['UpdateContributionResponse'] | undefined;
     updateEpoch?: GraphQLTypes['EpochResponse'] | undefined;
+    updateEpochOld?: GraphQLTypes['EpochResponse'] | undefined;
     updateProfile?: GraphQLTypes['UpdateProfileResponse'] | undefined;
     updateTeammates?: GraphQLTypes['UpdateTeammatesResponse'] | undefined;
     /** Update own user */
@@ -29006,6 +29021,15 @@ export type GraphQLTypes = {
     grant?: number | undefined;
     id: number;
     params?: GraphQLTypes['EpochInputParams'] | undefined;
+  };
+  ['UpdateEpochOldInput']: {
+    circle_id: number;
+    days: number;
+    description?: string | undefined;
+    grant?: number | undefined;
+    id: number;
+    repeat: number;
+    start_date: GraphQLTypes['timestamptz'];
   };
   ['UpdateOrgResponse']: {
     __typename: 'UpdateOrgResponse';
@@ -36203,6 +36227,7 @@ export type GraphQLTypes = {
     /** users can modify contributions and update their dates. */
     updateContribution?: GraphQLTypes['UpdateContributionResponse'] | undefined;
     updateEpoch?: GraphQLTypes['EpochResponse'] | undefined;
+    updateEpochOld?: GraphQLTypes['EpochResponse'] | undefined;
     updateProfile?: GraphQLTypes['UpdateProfileResponse'] | undefined;
     updateTeammates?: GraphQLTypes['UpdateTeammatesResponse'] | undefined;
     /** Update own user */

--- a/api-test/hasura/actions/_handlers/updateEpoch.test.ts
+++ b/api-test/hasura/actions/_handlers/updateEpoch.test.ts
@@ -643,17 +643,13 @@ describe('updateEpoch', () => {
           duration: { _errors: ['Number must be greater than or equal to 1'] },
           duration_unit: {
             _errors: [
-              'Invalid literal value, expected "days"',
-              'Invalid literal value, expected "weeks"',
-              'Invalid literal value, expected "months"',
+              "Invalid enum value. Expected 'days' | 'weeks' | 'months', received 'decades'",
             ],
           },
           frequency: { _errors: ['Expected number, received nan'] },
           frequency_unit: {
             _errors: [
-              'Invalid literal value, expected "days"',
-              'Invalid literal value, expected "weeks"',
-              'Invalid literal value, expected "months"',
+              "Invalid enum value. Expected 'days' | 'weeks' | 'months', received 'years'",
             ],
           },
         });
@@ -668,19 +664,11 @@ describe('updateEpoch', () => {
           end_date: { _errors: ['Required'] },
           duration: { _errors: ['Expected number, received nan'] },
           duration_unit: {
-            _errors: [
-              'Invalid literal value, expected "days"',
-              'Invalid literal value, expected "weeks"',
-              'Invalid literal value, expected "months"',
-            ],
+            _errors: ['Required'],
           },
           frequency: { _errors: ['Expected number, received nan'] },
           frequency_unit: {
-            _errors: [
-              'Invalid literal value, expected "days"',
-              'Invalid literal value, expected "weeks"',
-              'Invalid literal value, expected "months"',
-            ],
+            _errors: ['Required'],
           },
         });
     });

--- a/api-test/hasura/actions/_handlers/updateEpoch.test.ts
+++ b/api-test/hasura/actions/_handlers/updateEpoch.test.ts
@@ -1,0 +1,766 @@
+import { assert } from 'console';
+
+import { DateTime, Interval } from 'luxon';
+
+import { adminClient } from '../../../../api-lib/gql/adminClient';
+import { zEpochInputParams } from '../../../../api/hasura/actions/_handlers/createEpoch';
+import { findSameDayNextMonth } from '../../../../src/common-lib/epochs';
+import {
+  createCircle,
+  createProfile,
+  mockUserClient,
+  createUser,
+} from '../../../helpers';
+import { getUniqueAddress } from '../../../helpers/getUniqueAddress';
+
+let address, profile, circle, client, epochId;
+
+const now = DateTime.now();
+const DURATION_IN_DAYS = 3;
+beforeEach(async () => {
+  address = await getUniqueAddress();
+  circle = await createCircle(adminClient);
+  profile = await createProfile(adminClient, { address });
+  await createUser(adminClient, { address, circle_id: circle.id });
+  client = mockUserClient({ profileId: profile.id, address });
+  const result = await client.mutate({
+    createEpoch: [
+      {
+        payload: {
+          circle_id: circle.id,
+          params: {
+            type: 'one-off',
+            start_date: now.toISO(),
+            end_date: now.plus({ days: DURATION_IN_DAYS }).toISO(),
+          },
+        },
+      },
+      {
+        id: true,
+        epoch: {
+          start_date: true,
+          end_date: true,
+          repeat_data: [{}, true],
+        },
+      },
+    ],
+  });
+  epochId = result.createEpoch.id as number;
+});
+
+describe('updateEpoch', () => {
+  describe('invalid input', () => {
+    test('errors when another repeating epoch exists', async () => {
+      expect.assertions(1);
+      const now = DateTime.now();
+      const then = now.plus({ weeks: 2 });
+      const first = async () =>
+        client.mutate({
+          createEpoch: [
+            {
+              payload: {
+                circle_id: circle.id,
+                params: {
+                  type: 'custom',
+                  start_date: then.plus({ days: 4 }).toISO(),
+                  end_date: then.plus({ days: 6 }).toISO(),
+                  frequency: 1,
+                  frequency_unit: 'weeks',
+                },
+              },
+            },
+            { __typename: true },
+          ],
+        });
+
+      const second = async () =>
+        client.mutate({
+          updateEpoch: [
+            {
+              payload: {
+                id: epochId,
+                circle_id: circle.id,
+                params: {
+                  type: 'custom',
+                  start_date: now.toISO(),
+                  end_date: now.plus({ days: 3 }).toISO(),
+                  frequency: 1,
+                  frequency_unit: 'weeks',
+                },
+              },
+            },
+            { __typename: true },
+          ],
+        });
+
+      try {
+        await first();
+      } catch (e) {
+        console.error(e);
+        return;
+      }
+      return second().catch((e: any) => {
+        expect(e.response.errors[0].message).toContain(
+          'You cannot have more than one repeating active epoch.'
+        );
+      });
+    });
+    test('errors when epoch ends in the past', async () => {
+      expect.assertions(1);
+      const prior = DateTime.now().minus({ weeks: 2 });
+      const thunk = async () =>
+        client.mutate({
+          updateEpoch: [
+            {
+              payload: {
+                id: epochId,
+                circle_id: circle.id,
+                params: {
+                  type: 'custom',
+                  start_date: prior.toISO(),
+                  end_date: prior.plus({ days: 3 }).toISO(),
+                  frequency: 1,
+                  frequency_unit: 'days',
+                },
+              },
+            },
+            {
+              __typename: true,
+              epoch: {
+                start_date: true,
+                end_date: true,
+                repeat_data: [{}, true],
+              },
+            },
+          ],
+        });
+      return thunk().catch((e: any) => {
+        expect(e.response.errors[0].message).toMatch(
+          'You cannot create an epoch that ends before now'
+        );
+      });
+    });
+    test('errors when epoch ends before or as soon as it starts ', async () => {
+      expect.assertions(1);
+      const now = DateTime.now().plus({ weeks: 2 });
+      const thunk = async () =>
+        client.mutate({
+          updateEpoch: [
+            {
+              payload: {
+                id: epochId,
+                circle_id: circle.id,
+                params: {
+                  type: 'custom',
+                  start_date: now.toISO(),
+                  end_date: now.toISO(),
+                  frequency: 1,
+                  frequency_unit: 'days',
+                },
+              },
+            },
+            {
+              epoch: {
+                start_date: true,
+                end_date: true,
+                repeat_data: [{}, true],
+              },
+            },
+          ],
+        });
+      return thunk().catch((e: any) => {
+        expect(e.response.errors[0].message).toMatch(
+          'Start date must precede end date'
+        );
+      });
+    });
+    test('errors when an overlapping epoch exists', async () => {
+      expect.assertions(1);
+      const next = DateTime.now().plus({ months: 1 });
+      const first = async () =>
+        client.mutate({
+          createEpoch: [
+            {
+              payload: {
+                circle_id: circle.id,
+                params: {
+                  type: 'one-off',
+                  start_date: next.toISO(),
+                  end_date: next.plus({ days: 1 }).toISO(),
+                },
+              },
+            },
+            { __typename: true },
+          ],
+        });
+
+      const second = async () =>
+        client.mutate({
+          updateEpoch: [
+            {
+              payload: {
+                id: epochId,
+                circle_id: circle.id,
+                params: {
+                  type: 'one-off',
+                  start_date: next.toISO(),
+                  end_date: next.plus({ days: 2 }).toISO(),
+                },
+              },
+            },
+            { __typename: true },
+          ],
+        });
+
+      try {
+        await first();
+      } catch (e) {
+        console.error(JSON.stringify(e));
+        return;
+      }
+      return second().catch((e: any) => {
+        expect(e.response.errors[0].message).toContain('This epoch overlaps');
+      });
+    });
+    test("errors when epoch doesn't exist", async () => {
+      const thunk = async () =>
+        client.mutate({
+          updateEpoch: [
+            {
+              payload: {
+                id: -5,
+                circle_id: circle.id,
+                params: {
+                  type: 'one-off',
+                  start_date: DateTime.now().toISO(),
+                  end_date: DateTime.now().plus({ days: 2 }).toISO(),
+                },
+              },
+            },
+            { __typename: true },
+          ],
+        });
+
+      return thunk().catch((e: any) => {
+        expect(e.response.errors[0].message).toContain('Epoch not found');
+      });
+    });
+  });
+  describe('one-off input', () => {
+    it('can update a one-off epoch', async () => {
+      expect.assertions(2);
+      const DURATION_IN_DAYS = 3;
+      let result;
+      const now = DateTime.now();
+      const first = async () =>
+        client.mutate({
+          updateEpoch: [
+            {
+              payload: {
+                id: epochId,
+                circle_id: circle.id,
+                params: {
+                  type: 'one-off',
+                  start_date: now.toISO(),
+                  end_date: now.plus({ days: DURATION_IN_DAYS }).toISO(),
+                },
+              },
+            },
+            {
+              __typename: true,
+              epoch: {
+                start_date: true,
+                end_date: true,
+                repeat_data: [{}, true],
+              },
+            },
+          ],
+        });
+      try {
+        result = await first();
+      } catch (e: any) {
+        console.error(JSON.stringify(e.response.errors));
+        return;
+      }
+      const epoch = result?.updateEpoch?.epoch;
+      assert(epoch);
+      expect(epoch).toEqual(
+        expect.objectContaining({
+          repeat_data: null,
+        })
+      );
+      const { start_date, end_date } = epoch;
+      expect(
+        DateTime.fromISO(end_date).diff(DateTime.fromISO(start_date)).as('days')
+      ).toBe(DURATION_IN_DAYS);
+    });
+    test('errors on malformed input', () => {
+      let result = zEpochInputParams.safeParse({
+        type: 'one-off',
+        start_date: 'a',
+        end_date: 'b',
+      });
+      if (result.success === false)
+        expect(result.error.format()).toMatchObject({
+          start_date: {
+            _errors: [
+              'invalid datetime: the input "a" can\'t be parsed as ISO 8601',
+            ],
+          },
+          end_date: {
+            _errors: [
+              'invalid datetime: the input "b" can\'t be parsed as ISO 8601',
+            ],
+          },
+        });
+      result = zEpochInputParams.safeParse({
+        type: 'one-off',
+        bad: 'property',
+      });
+      if (result.success === false)
+        expect(result.error.format()).toEqual({
+          _errors: ["Unrecognized key(s) in object: 'bad'"],
+          start_date: { _errors: ['Required'] },
+          end_date: { _errors: ['Required'] },
+        });
+    });
+  });
+  describe('custom input', () => {
+    test('can update repeating weekly epochs with gaps', async () => {
+      const DURATION_IN_DAYS = 3;
+      let result;
+      const now = DateTime.now();
+      const first = async () =>
+        client.mutate({
+          updateEpoch: [
+            {
+              payload: {
+                id: epochId,
+                circle_id: circle.id,
+                params: {
+                  type: 'custom',
+                  start_date: now.toISO(),
+                  end_date: now.plus({ days: DURATION_IN_DAYS }).toISO(),
+                  frequency: 1,
+                  frequency_unit: 'weeks',
+                },
+              },
+            },
+            {
+              __typename: true,
+              epoch: {
+                start_date: true,
+                end_date: true,
+                repeat_data: [{}, true],
+              },
+            },
+          ],
+        });
+      try {
+        result = await first();
+      } catch (e: any) {
+        console.error(e.response.errors);
+      }
+      const epoch = result?.updateEpoch?.epoch;
+      assert(epoch);
+      expect(epoch).toEqual(
+        expect.objectContaining({
+          repeat_data: {
+            type: 'custom',
+            frequency: 1,
+            frequency_unit: 'weeks',
+          },
+        })
+      );
+      const { start_date, end_date } = epoch;
+      expect(
+        DateTime.fromISO(end_date).diff(DateTime.fromISO(start_date)).as('days')
+      ).toBe(DURATION_IN_DAYS);
+    });
+    test('can update repeating weekly epochs without gaps', async () => {
+      const DURATION_IN_WEEKS = 1;
+      let result;
+      const now = DateTime.now();
+      const first = async () =>
+        client.mutate({
+          updateEpoch: [
+            {
+              payload: {
+                id: epochId,
+                circle_id: circle.id,
+                params: {
+                  type: 'custom',
+                  start_date: now.toISO(),
+                  end_date: now.plus({ weeks: DURATION_IN_WEEKS }).toISO(),
+                  frequency: 1,
+                  frequency_unit: 'weeks',
+                },
+              },
+            },
+            {
+              __typename: true,
+              epoch: {
+                start_date: true,
+                end_date: true,
+                repeat_data: [{}, true],
+              },
+            },
+          ],
+        });
+      try {
+        result = await first();
+      } catch (e: any) {
+        console.error(e.response.errors);
+      }
+      const epoch = result?.updateEpoch?.epoch;
+      assert(epoch);
+      expect(epoch).toEqual(
+        expect.objectContaining({
+          repeat_data: {
+            type: 'custom',
+            frequency: 1,
+            frequency_unit: 'weeks',
+          },
+        })
+      );
+      const { start_date, end_date } = epoch;
+      expect(
+        DateTime.fromISO(end_date)
+          .diff(DateTime.fromISO(start_date))
+          .as('weeks')
+      ).toBe(DURATION_IN_WEEKS);
+    });
+    test('can update repeating monthly epochs with gaps', async () => {
+      const DURATION_IN_WEEKS = 2;
+      let result;
+      const now = DateTime.now();
+      const first = async () =>
+        client.mutate({
+          updateEpoch: [
+            {
+              payload: {
+                id: epochId,
+                circle_id: circle.id,
+                params: {
+                  type: 'custom',
+                  start_date: now.toISO(),
+                  end_date: now.plus({ weeks: DURATION_IN_WEEKS }).toISO(),
+                  frequency: 1,
+                  frequency_unit: 'months',
+                },
+              },
+            },
+            {
+              __typename: true,
+              epoch: {
+                start_date: true,
+                end_date: true,
+                repeat_data: [{}, true],
+              },
+            },
+          ],
+        });
+      try {
+        result = await first();
+      } catch (e: any) {
+        console.error(e.response.errors);
+      }
+      const epoch = result?.updateEpoch?.epoch;
+      assert(epoch);
+      expect(epoch).toEqual(
+        expect.objectContaining({
+          repeat_data: {
+            type: 'custom',
+            frequency: 1,
+            frequency_unit: 'months',
+          },
+        })
+      );
+      const { start_date, end_date } = epoch;
+      expect(
+        DateTime.fromISO(end_date)
+          .diff(DateTime.fromISO(start_date))
+          .as('weeks')
+      ).toBe(DURATION_IN_WEEKS);
+    });
+    test('can update repeating monthly epochs without gaps', async () => {
+      const DURATION_IN_MONTHS = 1;
+      let result;
+      const now = DateTime.now();
+      const first = async () =>
+        client.mutate({
+          updateEpoch: [
+            {
+              payload: {
+                id: epochId,
+                circle_id: circle.id,
+                params: {
+                  type: 'custom',
+                  start_date: now.toISO(),
+                  end_date: now.plus({ months: DURATION_IN_MONTHS }).toISO(),
+                  frequency: 1,
+                  frequency_unit: 'months',
+                },
+              },
+            },
+            {
+              __typename: true,
+              epoch: {
+                start_date: true,
+                end_date: true,
+                repeat_data: [{}, true],
+              },
+            },
+          ],
+        });
+      try {
+        result = await first();
+      } catch (e: any) {
+        console.error(e.response.errors);
+      }
+      const epoch = result?.updateEpoch?.epoch;
+      assert(epoch);
+      expect(epoch).toEqual(
+        expect.objectContaining({
+          repeat_data: {
+            type: 'custom',
+            frequency: 1,
+            frequency_unit: 'months',
+          },
+        })
+      );
+      const { start_date, end_date } = epoch;
+      expect(
+        Interval.fromISO(start_date + '/' + end_date).length('months')
+      ).toBe(DURATION_IN_MONTHS);
+    });
+    test('cannot repeat with a frequency that is shorter than the duration', async () => {
+      expect.assertions(1);
+      const now = DateTime.now();
+      const thunk = async () =>
+        client.mutate({
+          updateEpoch: [
+            {
+              payload: {
+                id: epochId,
+                circle_id: circle.id,
+                params: {
+                  type: 'custom',
+                  start_date: now.toISO(),
+                  end_date: now.plus({ days: 3 }).toISO(),
+                  frequency: 1,
+                  frequency_unit: 'days',
+                },
+              },
+            },
+            {
+              __typename: true,
+              epoch: {
+                start_date: true,
+                end_date: true,
+                repeat_data: [{}, true],
+              },
+            },
+          ],
+        });
+      return thunk().catch((e: any) => {
+        expect(e.response.errors[0].message).toMatch('is longer than chosen');
+      });
+    });
+    test('errors on malformed input', () => {
+      let result = zEpochInputParams.safeParse({
+        type: 'custom',
+        start_date: 'a',
+        end_date: 'b',
+        frequency: 'bad',
+        frequency_unit: 'years',
+      });
+      if (result.success === false)
+        expect(result.error.format()).toMatchObject({
+          start_date: {
+            _errors: [
+              'invalid datetime: the input "a" can\'t be parsed as ISO 8601',
+            ],
+          },
+          end_date: {
+            _errors: [
+              'invalid datetime: the input "b" can\'t be parsed as ISO 8601',
+            ],
+          },
+          frequency: { _errors: ['Expected number, received nan'] },
+          frequency_unit: {
+            _errors: [
+              'Invalid literal value, expected "days"',
+              'Invalid literal value, expected "weeks"',
+              'Invalid literal value, expected "months"',
+            ],
+          },
+        });
+      result = zEpochInputParams.safeParse({
+        type: 'custom',
+        bad: 'input',
+      });
+      if (result.success === false)
+        expect(result.error.format()).toEqual({
+          _errors: ["Unrecognized key(s) in object: 'bad'"],
+          start_date: { _errors: ['Required'] },
+          end_date: { _errors: ['Required'] },
+          frequency: { _errors: ['Expected number, received nan'] },
+          frequency_unit: {
+            _errors: [
+              'Invalid literal value, expected "days"',
+              'Invalid literal value, expected "weeks"',
+              'Invalid literal value, expected "months"',
+            ],
+          },
+        });
+    });
+  });
+  describe('monthly input', () => {
+    test('errors on malformed input', async () => {
+      const now = DateTime.now();
+      const params = {
+        type: 'monthly',
+        start_date: now.toISO(),
+        end_date: findSameDayNextMonth(now, {
+          week: Math.floor(now.day / 7),
+        })
+          .plus({ days: 1 })
+          .toISO(),
+        week: Math.floor(now.day / 7),
+      };
+      const first = async () =>
+        client.mutate({
+          updateEpoch: [
+            {
+              payload: {
+                id: epochId,
+                circle_id: circle.id,
+                params,
+              },
+            },
+            {
+              epoch: {
+                start_date: true,
+                end_date: true,
+                repeat_data: [{}, true],
+              },
+            },
+          ],
+        });
+
+      return first().catch((e: any) => {
+        expect(e.response.errors[0].message).toContain(
+          'do not match the end date'
+        );
+      });
+    });
+
+    test('updates a new epoch on the correct day of the correct week of the month', async () => {
+      let result;
+      const now = DateTime.now();
+      const params = {
+        type: 'monthly',
+        start_date: now.toISO(),
+        end_date: findSameDayNextMonth(now, {
+          week: Math.floor(now.day / 7),
+        }).toISO(),
+        week: Math.floor(now.day / 7),
+      };
+      const first = async () =>
+        client.mutate({
+          updateEpoch: [
+            {
+              payload: {
+                id: epochId,
+                circle_id: circle.id,
+                params,
+              },
+            },
+            {
+              epoch: {
+                start_date: true,
+                end_date: true,
+                repeat_data: [{}, true],
+              },
+            },
+          ],
+        });
+      try {
+        result = await first();
+      } catch (e: any) {
+        console.error(e.response.errors);
+      }
+      const epoch = result?.updateEpoch?.epoch;
+      assert(epoch);
+      const { start_date, end_date } = epoch;
+      expect(DateTime.fromISO(start_date).zoneName).toBe('UTC');
+      expect(DateTime.fromISO(end_date).zoneName).toBe('UTC');
+      expect(epoch).toEqual(
+        expect.objectContaining({
+          repeat_data: {
+            type: 'monthly',
+            week: params.week,
+          },
+          start_date: expect.stringContaining(
+            params.start_date.substring(0, 16)
+          ),
+          end_date: expect.stringContaining(params.end_date.substring(0, 16)),
+        })
+      );
+    });
+    xtest('handles cases at the end of the month correctly', async () => {
+      let result;
+      const start = DateTime.now().startOf('month').plus({ weeks: 6 });
+      const params = {
+        type: 'monthly',
+        start_date: start.toISO(),
+        end_date: findSameDayNextMonth(start, {
+          week: 6,
+        }).toISO(),
+        week: 6,
+      };
+      const first = async () =>
+        client.mutate({
+          updateEpoch: [
+            {
+              payload: {
+                id: epochId,
+                circle_id: circle.id,
+                params,
+              },
+            },
+            {
+              epoch: {
+                start_date: true,
+                end_date: true,
+                repeat_data: [{}, true],
+              },
+            },
+          ],
+        });
+      try {
+        result = await first();
+      } catch (e: any) {
+        console.error(e.response.errors);
+      }
+      const epoch = result?.updateEpoch?.epoch;
+      assert(epoch);
+      const { start_date, end_date } = epoch;
+      expect(DateTime.fromISO(start_date).zoneName).toBe('UTC');
+      expect(DateTime.fromISO(end_date).zoneName).toBe('UTC');
+      expect(epoch).toEqual(
+        expect.objectContaining({
+          repeat_data: {
+            type: 'monthly',
+            week: 6,
+          },
+          start_date: expect.stringContaining(
+            params.start_date.substring(0, 16)
+          ),
+          end_date: expect.stringContaining(params.end_date.substring(0, 16)),
+        })
+      );
+    });
+  });
+});

--- a/api-test/hasura/actions/_handlers/updateEpoch.test.ts
+++ b/api-test/hasura/actions/_handlers/updateEpoch.test.ts
@@ -89,6 +89,8 @@ describe('updateEpoch', () => {
                   type: 'custom',
                   start_date: then.plus({ days: 4 }).toISO(),
                   end_date: then.plus({ days: 6 }).toISO(),
+                  duration: 2,
+                  duration_unit: 'days',
                   frequency: 1,
                   frequency_unit: 'weeks',
                 },
@@ -109,6 +111,8 @@ describe('updateEpoch', () => {
                   type: 'custom',
                   start_date: now.toISO(),
                   end_date: now.plus({ days: 3 }).toISO(),
+                  duration: 3,
+                  duration_unit: 'days',
                   frequency: 1,
                   frequency_unit: 'weeks',
                 },
@@ -144,6 +148,8 @@ describe('updateEpoch', () => {
                   type: 'custom',
                   start_date: prior.toISO(),
                   end_date: prior.plus({ days: 3 }).toISO(),
+                  duration: 3,
+                  duration_unit: 'days',
                   frequency: 1,
                   frequency_unit: 'days',
                 },
@@ -179,6 +185,8 @@ describe('updateEpoch', () => {
                   type: 'custom',
                   start_date: now.toISO(),
                   end_date: now.toISO(),
+                  duration: 1,
+                  duration_unit: 'days',
                   frequency: 1,
                   frequency_unit: 'days',
                 },
@@ -366,6 +374,8 @@ describe('updateEpoch', () => {
                   type: 'custom',
                   start_date: now.toISO(),
                   end_date: now.plus({ days: DURATION_IN_DAYS }).toISO(),
+                  duration: DURATION_IN_DAYS,
+                  duration_unit: 'days',
                   frequency: 1,
                   frequency_unit: 'weeks',
                 },
@@ -392,6 +402,8 @@ describe('updateEpoch', () => {
         expect.objectContaining({
           repeat_data: {
             type: 'custom',
+            duration: DURATION_IN_DAYS,
+            duration_unit: 'days',
             frequency: 1,
             frequency_unit: 'weeks',
           },
@@ -417,6 +429,8 @@ describe('updateEpoch', () => {
                   type: 'custom',
                   start_date: now.toISO(),
                   end_date: now.plus({ weeks: DURATION_IN_WEEKS }).toISO(),
+                  duration: DURATION_IN_WEEKS,
+                  duration_unit: 'weeks',
                   frequency: 1,
                   frequency_unit: 'weeks',
                 },
@@ -443,6 +457,8 @@ describe('updateEpoch', () => {
         expect.objectContaining({
           repeat_data: {
             type: 'custom',
+            duration: DURATION_IN_WEEKS,
+            duration_unit: 'weeks',
             frequency: 1,
             frequency_unit: 'weeks',
           },
@@ -470,6 +486,8 @@ describe('updateEpoch', () => {
                   type: 'custom',
                   start_date: now.toISO(),
                   end_date: now.plus({ weeks: DURATION_IN_WEEKS }).toISO(),
+                  duration: DURATION_IN_WEEKS,
+                  duration_unit: 'weeks',
                   frequency: 1,
                   frequency_unit: 'months',
                 },
@@ -496,6 +514,8 @@ describe('updateEpoch', () => {
         expect.objectContaining({
           repeat_data: {
             type: 'custom',
+            duration: DURATION_IN_WEEKS,
+            duration_unit: 'weeks',
             frequency: 1,
             frequency_unit: 'months',
           },
@@ -523,6 +543,8 @@ describe('updateEpoch', () => {
                   type: 'custom',
                   start_date: now.toISO(),
                   end_date: now.plus({ months: DURATION_IN_MONTHS }).toISO(),
+                  duration: DURATION_IN_MONTHS,
+                  duration_unit: 'months',
                   frequency: 1,
                   frequency_unit: 'months',
                 },
@@ -549,6 +571,8 @@ describe('updateEpoch', () => {
         expect.objectContaining({
           repeat_data: {
             type: 'custom',
+            duration: DURATION_IN_MONTHS,
+            duration_unit: 'months',
             frequency: 1,
             frequency_unit: 'months',
           },
@@ -573,6 +597,8 @@ describe('updateEpoch', () => {
                   type: 'custom',
                   start_date: now.toISO(),
                   end_date: now.plus({ days: 3 }).toISO(),
+                  duration: 3,
+                  duration_unit: 'days',
                   frequency: 1,
                   frequency_unit: 'days',
                 },
@@ -597,6 +623,8 @@ describe('updateEpoch', () => {
         type: 'custom',
         start_date: 'a',
         end_date: 'b',
+        duration: 0,
+        duration_unit: 'decades',
         frequency: 'bad',
         frequency_unit: 'years',
       });
@@ -610,6 +638,14 @@ describe('updateEpoch', () => {
           end_date: {
             _errors: [
               'invalid datetime: the input "b" can\'t be parsed as ISO 8601',
+            ],
+          },
+          duration: { _errors: ['Number must be greater than or equal to 1'] },
+          duration_unit: {
+            _errors: [
+              'Invalid literal value, expected "days"',
+              'Invalid literal value, expected "weeks"',
+              'Invalid literal value, expected "months"',
             ],
           },
           frequency: { _errors: ['Expected number, received nan'] },
@@ -630,6 +666,14 @@ describe('updateEpoch', () => {
           _errors: ["Unrecognized key(s) in object: 'bad'"],
           start_date: { _errors: ['Required'] },
           end_date: { _errors: ['Required'] },
+          duration: { _errors: ['Expected number, received nan'] },
+          duration_unit: {
+            _errors: [
+              'Invalid literal value, expected "days"',
+              'Invalid literal value, expected "weeks"',
+              'Invalid literal value, expected "months"',
+            ],
+          },
           frequency: { _errors: ['Expected number, received nan'] },
           frequency_unit: {
             _errors: [

--- a/api/hasura/actions/_handlers/createEpoch.ts
+++ b/api/hasura/actions/_handlers/createEpoch.ts
@@ -107,7 +107,7 @@ async function handler(request: VercelRequest, response: VercelResponse) {
   insertNewEpoch(response, input);
 }
 
-function validateMonthlyInput(
+export function validateMonthlyInput(
   input: z.infer<typeof zMonthlyInputSchema>
 ): ErrorReturn {
   const { start_date, end_date } = input;
@@ -124,7 +124,7 @@ function validateMonthlyInput(
     );
 }
 
-function validateCustomInput(
+export function validateCustomInput(
   input: z.infer<typeof zCustomInputSchema>
 ): ErrorReturn {
   const {
@@ -198,12 +198,16 @@ async function insertNewEpoch(
   response.status(200).json(insert_epochs_one);
 }
 
-async function verifyFutureEndDate({ end_date }: { end_date: DateTime }) {
+export async function verifyFutureEndDate({
+  end_date,
+}: {
+  end_date: DateTime;
+}) {
   if (DateTime.now() > end_date)
     throw new Error(`You cannot create an epoch that ends before now`);
 }
 
-async function verifyStartBeforeEnd({
+export async function verifyStartBeforeEnd({
   start_date,
   end_date,
 }: {
@@ -214,7 +218,7 @@ async function verifyStartBeforeEnd({
     throw new Error(`Start date must precede end date`);
 }
 
-async function checkMultipleRepeatingEpochs(circle_id: number) {
+export async function checkMultipleRepeatingEpochs(circle_id: number) {
   const repeatingEpoch = await getRepeatingEpoch(circle_id);
   if (repeatingEpoch) {
     throw new Error(
@@ -229,14 +233,16 @@ async function checkMultipleRepeatingEpochs(circle_id: number) {
   }
 }
 
-async function checkOverlappingEpoch({
+export async function checkOverlappingEpoch({
+  id,
   circle_id,
   params: { start_date, end_date },
-}: z.infer<typeof EpochInputSchema>) {
+}: z.infer<typeof EpochInputSchema> & { id?: number }) {
   const overlappingEpoch = await getOverlappingEpoch(
     start_date,
     end_date,
-    circle_id
+    circle_id,
+    id
   );
   if (overlappingEpoch) {
     throw new Error(

--- a/api/hasura/actions/_handlers/updateEpoch.ts
+++ b/api/hasura/actions/_handlers/updateEpoch.ts
@@ -85,27 +85,11 @@ async function updateEpoch(
   existingEpoch: ExistingEpoch,
   {
     id,
-    circle_id,
-    grant,
     params: { start_date, end_date, ...repeatData },
   }: z.infer<typeof EpochUpdateSchema>
 ) {
   const { update_epochs_by_pk } = await adminClient.mutate(
     {
-      insert_epochs_one: [
-        {
-          object: {
-            circle_id,
-            grant,
-            start_date: start_date.toISO(),
-            end_date: end_date.toISO(),
-            repeat_data: repeatData.type !== 'one-off' ? repeatData : undefined,
-          },
-        },
-        {
-          id: true,
-        },
-      ],
       update_epochs_by_pk: [
         {
           _set: {

--- a/api/hasura/actions/_handlers/updateEpoch.ts
+++ b/api/hasura/actions/_handlers/updateEpoch.ts
@@ -1,39 +1,138 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { DateTime, Settings } from 'luxon';
+import { z } from 'zod';
 
 import { authCircleAdminMiddleware } from '../../../../api-lib/circleAdmin';
-import { EPOCH_REPEAT } from '../../../../api-lib/constants';
-import { formatShortDateTime } from '../../../../api-lib/dateTimeHelpers';
 import { adminClient } from '../../../../api-lib/gql/adminClient';
-import {
-  getOverlappingEpoch,
-  getRepeatingEpoch,
-} from '../../../../api-lib/gql/queries';
 import { errorResponseWithStatusCode } from '../../../../api-lib/HttpError';
+import { Awaited } from '../../../../api-lib/ts4.5shim';
+import { composeHasuraActionRequestBody } from '../../../../src/lib/zod';
+
 import {
-  updateEpochInput,
-  composeHasuraActionRequestBody,
-} from '../../../../src/lib/zod';
+  zEpochInputParams,
+  checkOverlappingEpoch,
+  verifyFutureEndDate,
+  verifyStartBeforeEnd,
+  checkMultipleRepeatingEpochs,
+  validateCustomInput,
+  validateMonthlyInput,
+} from './createEpoch';
 
 Settings.defaultZone = 'utc';
 
+const EpochUpdateSchema = z.object({
+  id: z.number(),
+  circle_id: z.number(),
+  grant: z.number().optional(),
+  description: z.string().optional(),
+  params: zEpochInputParams,
+});
+
 async function handler(request: VercelRequest, response: VercelResponse) {
-  const now = DateTime.now();
   const {
     input: { payload: input },
-  } = composeHasuraActionRequestBody(updateEpochInput).parse(request.body);
-  const { circle_id, repeat, start_date, days, id } = input;
-  const end_date = start_date.plus({ days: days });
-  if (now > end_date) {
+  } = composeHasuraActionRequestBody(EpochUpdateSchema).parse(request.body);
+  const { params, circle_id } = input;
+  const editingEpoch = await getExistingEpoch(input);
+
+  if (!editingEpoch) {
     errorResponseWithStatusCode(
       response,
       {
-        message: `You cannot set an epoch that ends before now`,
+        message: `Epoch not found`,
       },
       422
     );
     return;
   }
+
+  const results = await Promise.allSettled([
+    checkOverlappingEpoch(input),
+    verifyFutureEndDate(params),
+    verifyStartBeforeEnd(params),
+    checkStartDateNotInPast(input, editingEpoch),
+    params.type !== 'one-off' && !editingEpoch.repeat_data
+      ? checkMultipleRepeatingEpochs(circle_id)
+      : Promise.resolve(),
+  ]);
+  for (const result of results) {
+    if (result.status === 'rejected') {
+      errorResponseWithStatusCode(response, result.reason, 422);
+      return;
+    }
+  }
+
+  let error;
+  switch (params.type) {
+    case 'custom':
+      error = validateCustomInput(params);
+      break;
+    case 'monthly': {
+      error = validateMonthlyInput(params);
+      break;
+    }
+  }
+  if (error) {
+    errorResponseWithStatusCode(response, error, 422);
+    return;
+  }
+
+  return updateEpoch(response, editingEpoch, input);
+}
+
+async function updateEpoch(
+  response: VercelResponse,
+  existingEpoch: ExistingEpoch,
+  {
+    id,
+    circle_id,
+    grant,
+    params: { start_date, end_date, ...repeatData },
+  }: z.infer<typeof EpochUpdateSchema>
+) {
+  const { update_epochs_by_pk } = await adminClient.mutate(
+    {
+      insert_epochs_one: [
+        {
+          object: {
+            circle_id,
+            grant,
+            start_date: start_date.toISO(),
+            end_date: end_date.toISO(),
+            repeat_data: repeatData.type !== 'one-off' ? repeatData : undefined,
+          },
+        },
+        {
+          id: true,
+        },
+      ],
+      update_epochs_by_pk: [
+        {
+          _set: {
+            ...existingEpoch,
+            start_date: start_date.toISO(),
+            end_date: end_date.toISO(),
+            repeat_data: repeatData.type !== 'one-off' ? repeatData : undefined,
+          },
+          pk_columns: { id },
+        },
+        {
+          id: true,
+        },
+      ],
+    },
+    {
+      operationName: 'createEpoch_insert',
+    }
+  );
+
+  response.status(200).json(update_epochs_by_pk);
+}
+
+async function getExistingEpoch({
+  circle_id,
+  id,
+}: z.infer<typeof EpochUpdateSchema>) {
   const {
     epochs: [editingEpoch],
   } = await adminClient.query(
@@ -51,8 +150,7 @@ async function handler(request: VercelRequest, response: VercelResponse) {
           id: true,
           start_date: true,
           end_date: true,
-          repeat: true,
-          repeat_day_of_month: true,
+          repeat_data: [{}, true],
           description: true,
         },
       ],
@@ -62,95 +160,20 @@ async function handler(request: VercelRequest, response: VercelResponse) {
     }
   );
 
-  if (!editingEpoch) {
-    errorResponseWithStatusCode(
-      response,
-      {
-        message: `Epoch not found`,
-      },
-      422
+  return editingEpoch;
+}
+
+type ExistingEpoch = NonNullable<Awaited<ReturnType<typeof getExistingEpoch>>>;
+
+async function checkStartDateNotInPast(
+  { params: { start_date } }: z.infer<typeof EpochUpdateSchema>,
+  existingEpoch: ExistingEpoch
+) {
+  const now = DateTime.now();
+  if (now >= DateTime.fromISO(existingEpoch.start_date) && start_date >= now)
+    throw new Error(
+      `You cannot change the start date to later than now when epoch has already started`
     );
-    return;
-  }
-
-  if (now >= DateTime.fromISO(editingEpoch.start_date) && start_date >= now) {
-    errorResponseWithStatusCode(
-      response,
-      {
-        message: `You cannot change the start date to later than now when epoch has already started`,
-      },
-      422
-    );
-    return;
-  }
-  let repeat_day_of_month = editingEpoch.repeat_day_of_month;
-  if (repeat > 0 && editingEpoch.repeat === 0) {
-    const repeatingEpoch = await getRepeatingEpoch(circle_id);
-    if (repeatingEpoch) {
-      errorResponseWithStatusCode(
-        response,
-        {
-          message:
-            `You cannot have more than one repeating active epoch. ` +
-            `Repeating Epoch id #${repeatingEpoch?.id} ` +
-            `occurs between ` +
-            `${formatShortDateTime(repeatingEpoch?.start_date)} and ` +
-            `${formatShortDateTime(repeatingEpoch?.end_date)}`,
-        },
-        422
-      );
-      return;
-    }
-    if (repeat === EPOCH_REPEAT.MONTHLY) {
-      repeat_day_of_month = start_date.day;
-    }
-  }
-
-  const overlappingEpoch = await getOverlappingEpoch(
-    start_date,
-    end_date,
-    circle_id,
-    id
-  );
-  if (overlappingEpoch) {
-    errorResponseWithStatusCode(
-      response,
-      {
-        message:
-          `This epoch overlaps with an existing epoch that occurs between ` +
-          `${formatShortDateTime(overlappingEpoch?.start_date)} and ` +
-          `${formatShortDateTime(overlappingEpoch?.end_date)}. ` +
-          `Please adjust epoch settings to avoid overlapping with existing epochs`,
-      },
-      422
-    );
-    return;
-  }
-
-  const { update_epochs_by_pk } = await adminClient.mutate(
-    {
-      update_epochs_by_pk: [
-        {
-          _set: {
-            ...editingEpoch,
-            ...input,
-            start_date: input.start_date.toISO(),
-            repeat_day_of_month,
-            end_date: end_date.toISO(),
-          },
-          pk_columns: { id },
-        },
-        {
-          id: true,
-        },
-      ],
-    },
-    {
-      operationName: 'updateEpoch_update',
-    }
-  );
-
-  response.status(200).json(update_epochs_by_pk);
 }
 
 export default authCircleAdminMiddleware(handler);

--- a/api/hasura/actions/_handlers/updateEpochOld.ts
+++ b/api/hasura/actions/_handlers/updateEpochOld.ts
@@ -1,0 +1,156 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { DateTime, Settings } from 'luxon';
+
+import { authCircleAdminMiddleware } from '../../../../api-lib/circleAdmin';
+import { EPOCH_REPEAT } from '../../../../api-lib/constants';
+import { formatShortDateTime } from '../../../../api-lib/dateTimeHelpers';
+import { adminClient } from '../../../../api-lib/gql/adminClient';
+import {
+  getOverlappingEpoch,
+  getRepeatingEpoch,
+} from '../../../../api-lib/gql/queries';
+import { errorResponseWithStatusCode } from '../../../../api-lib/HttpError';
+import {
+  updateEpochInput,
+  composeHasuraActionRequestBody,
+} from '../../../../src/lib/zod';
+
+Settings.defaultZone = 'utc';
+
+async function handler(request: VercelRequest, response: VercelResponse) {
+  const now = DateTime.now();
+  const {
+    input: { payload: input },
+  } = composeHasuraActionRequestBody(updateEpochInput).parse(request.body);
+  const { circle_id, repeat, start_date, days, id } = input;
+  const end_date = start_date.plus({ days: days });
+  if (now > end_date) {
+    errorResponseWithStatusCode(
+      response,
+      {
+        message: `You cannot set an epoch that ends before now`,
+      },
+      422
+    );
+    return;
+  }
+  const {
+    epochs: [editingEpoch],
+  } = await adminClient.query(
+    {
+      epochs: [
+        {
+          limit: 1,
+          where: {
+            circle_id: { _eq: circle_id },
+            id: { _eq: id },
+            ended: { _eq: false },
+          },
+        },
+        {
+          id: true,
+          start_date: true,
+          end_date: true,
+          repeat: true,
+          repeat_day_of_month: true,
+          description: true,
+        },
+      ],
+    },
+    {
+      operationName: 'updateEpoch_getEpoch',
+    }
+  );
+
+  if (!editingEpoch) {
+    errorResponseWithStatusCode(
+      response,
+      {
+        message: `Epoch not found`,
+      },
+      422
+    );
+    return;
+  }
+
+  if (now >= DateTime.fromISO(editingEpoch.start_date) && start_date >= now) {
+    errorResponseWithStatusCode(
+      response,
+      {
+        message: `You cannot change the start date to later than now when epoch has already started`,
+      },
+      422
+    );
+    return;
+  }
+  let repeat_day_of_month = editingEpoch.repeat_day_of_month;
+  if (repeat > 0 && editingEpoch.repeat === 0) {
+    const repeatingEpoch = await getRepeatingEpoch(circle_id);
+    if (repeatingEpoch) {
+      errorResponseWithStatusCode(
+        response,
+        {
+          message:
+            `You cannot have more than one repeating active epoch. ` +
+            `Repeating Epoch id #${repeatingEpoch?.id} ` +
+            `occurs between ` +
+            `${formatShortDateTime(repeatingEpoch?.start_date)} and ` +
+            `${formatShortDateTime(repeatingEpoch?.end_date)}`,
+        },
+        422
+      );
+      return;
+    }
+    if (repeat === EPOCH_REPEAT.MONTHLY) {
+      repeat_day_of_month = start_date.day;
+    }
+  }
+
+  const overlappingEpoch = await getOverlappingEpoch(
+    start_date,
+    end_date,
+    circle_id,
+    id
+  );
+  if (overlappingEpoch) {
+    errorResponseWithStatusCode(
+      response,
+      {
+        message:
+          `This epoch overlaps with an existing epoch that occurs between ` +
+          `${formatShortDateTime(overlappingEpoch?.start_date)} and ` +
+          `${formatShortDateTime(overlappingEpoch?.end_date)}. ` +
+          `Please adjust epoch settings to avoid overlapping with existing epochs`,
+      },
+      422
+    );
+    return;
+  }
+
+  const { update_epochs_by_pk } = await adminClient.mutate(
+    {
+      update_epochs_by_pk: [
+        {
+          _set: {
+            ...editingEpoch,
+            ...input,
+            start_date: input.start_date.toISO(),
+            repeat_day_of_month,
+            end_date: end_date.toISO(),
+          },
+          pk_columns: { id },
+        },
+        {
+          id: true,
+        },
+      ],
+    },
+    {
+      operationName: 'updateEpoch_update',
+    }
+  );
+
+  response.status(200).json(update_epochs_by_pk);
+}
+
+export default authCircleAdminMiddleware(handler);

--- a/api/hasura/actions/actionManager.ts
+++ b/api/hasura/actions/actionManager.ts
@@ -29,6 +29,7 @@ import updateAllocations from './_handlers/updateAllocations';
 import updateCircle from './_handlers/updateCircle';
 import updateContribution from './_handlers/updateContribution';
 import updateEpoch from './_handlers/updateEpoch';
+import updateEpochOld from './_handlers/updateEpochOld';
 import updateProfile from './_handlers/updateProfile';
 import updateTeammates from './_handlers/updateTeammates';
 import updateUser from './_handlers/updateUser';
@@ -66,6 +67,7 @@ const HANDLERS: HandlerDict = {
   updateCircle,
   updateContribution,
   updateEpoch,
+  updateEpochOld,
   updateProfile,
   updateTeammates,
   updateUser,

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -11,11 +11,11 @@ type Mutation {
 }
 
 type Mutation {
-  createEpochOld(payload: CreateEpochOldInput!): EpochResponse
+  createEpoch(payload: CreateEpochInput!): EpochResponse
 }
 
 type Mutation {
-  createEpoch(payload: CreateEpochInput!): EpochResponse
+  createEpochOld(payload: CreateEpochOldInput!): EpochResponse
 }
 
 type Mutation {
@@ -106,6 +106,10 @@ type Mutation {
 
 type Mutation {
   updateEpoch(payload: UpdateEpochInput!): EpochResponse
+}
+
+type Mutation {
+  updateEpochOld(payload: UpdateEpochOldInput!): EpochResponse
 }
 
 type Mutation {
@@ -244,6 +248,16 @@ input UpdateCircleInput {
   fixed_payment_token_type: String
   fixed_payment_vault_id: Int
   show_pending_gives: Boolean
+}
+
+input UpdateEpochOldInput {
+  id: Int!
+  circle_id: Int!
+  start_date: timestamptz!
+  days: Int!
+  repeat: Int!
+  grant: Float
+  description: String
 }
 
 input UpdateEpochInput {

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -249,11 +249,9 @@ input UpdateCircleInput {
 input UpdateEpochInput {
   id: Int!
   circle_id: Int!
-  start_date: timestamptz!
-  days: Int!
-  repeat: Int!
   grant: Float
   description: String
+  params: EpochInputParams
 }
 
 input Allocation {
@@ -409,11 +407,11 @@ input EpochInputParams {
   duration_unit: String
   weekday: Int
   week: Int
-  grant: Float
 }
 
 input CreateEpochInput {
   circle_id: Int!
+  grant: Float
   params: EpochInputParams!
 }
 

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -28,15 +28,6 @@ actions:
           value_from_env: HASURA_EVENT_SECRET
     permissions:
       - role: user
-  - name: createEpochOld
-    definition:
-      kind: synchronous
-      handler: '{{HASURA_API_BASE_URL}}/actions/actionManager?action_name=createEpochOld'
-      headers:
-        - name: verification_key
-          value_from_env: HASURA_EVENT_SECRET
-    permissions:
-      - role: user
   - name: createEpoch
     definition:
       kind: synchronous
@@ -47,6 +38,15 @@ actions:
     permissions:
       - role: user
     comment: create epoch using new, more flexible api
+  - name: createEpochOld
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_API_BASE_URL}}/actions/actionManager?action_name=createEpochOld'
+      headers:
+        - name: verification_key
+          value_from_env: HASURA_EVENT_SECRET
+    permissions:
+      - role: user
   - name: createNominee
     definition:
       kind: synchronous
@@ -248,6 +248,15 @@ actions:
           value_from_env: HASURA_EVENT_SECRET
     permissions:
       - role: user
+  - name: updateEpochOld
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_API_BASE_URL}}/actions/actionManager?action_name=updateEpochOld'
+      headers:
+        - name: verification_key
+          value_from_env: HASURA_EVENT_SECRET
+    permissions:
+      - role: user
   - name: updateProfile
     definition:
       kind: synchronous
@@ -343,6 +352,7 @@ custom_types:
     - name: UpdateTeammatesInput
     - name: DeleteUserInput
     - name: UpdateCircleInput
+    - name: UpdateEpochOldInput
     - name: UpdateEpochInput
     - name: Allocation
     - name: Allocations

--- a/hasura/schema/admin/schema.graphql
+++ b/hasura/schema/admin/schema.graphql
@@ -161,6 +161,7 @@ type CreateCircleResponse {
 
 input CreateEpochInput {
   circle_id: Int!
+  grant: Float
   params: EpochInputParams!
 }
 
@@ -249,7 +250,6 @@ input EpochInputParams {
   end_date: timestamptz!
   frequency: Int
   frequency_unit: String
-  grant: Float
   start_date: timestamptz!
   type: String!
   week: Int
@@ -455,12 +455,10 @@ type UpdateContributionResponse {
 
 input UpdateEpochInput {
   circle_id: Int!
-  days: Int!
   description: String
   grant: Float
   id: Int!
-  repeat: Int!
-  start_date: timestamptz!
+  params: EpochInputParams
 }
 
 type UpdateOrgResponse {

--- a/hasura/schema/admin/schema.graphql
+++ b/hasura/schema/admin/schema.graphql
@@ -461,6 +461,16 @@ input UpdateEpochInput {
   params: EpochInputParams
 }
 
+input UpdateEpochOldInput {
+  circle_id: Int!
+  days: Int!
+  description: String
+  grant: Float
+  id: Int!
+  repeat: Int!
+  start_date: timestamptz!
+}
+
 type UpdateOrgResponse {
   id: Int!
   org: organizations
@@ -13927,6 +13937,7 @@ type mutation_root {
     payload: UpdateContributionInput!
   ): UpdateContributionResponse
   updateEpoch(payload: UpdateEpochInput!): EpochResponse
+  updateEpochOld(payload: UpdateEpochOldInput!): EpochResponse
   updateProfile(payload: UpdateProfileInput!): UpdateProfileResponse
   updateTeammates(payload: UpdateTeammatesInput!): UpdateTeammatesResponse
 

--- a/hasura/schema/user/schema.graphql
+++ b/hasura/schema/user/schema.graphql
@@ -131,6 +131,7 @@ type CreateCircleResponse {
 
 input CreateEpochInput {
   circle_id: Int!
+  grant: Float
   params: EpochInputParams!
 }
 
@@ -215,7 +216,6 @@ input EpochInputParams {
   end_date: timestamptz!
   frequency: Int
   frequency_unit: String
-  grant: Float
   start_date: timestamptz!
   type: String!
   week: Int
@@ -421,12 +421,10 @@ type UpdateContributionResponse {
 
 input UpdateEpochInput {
   circle_id: Int!
-  days: Int!
   description: String
   grant: Float
   id: Int!
-  repeat: Int!
-  start_date: timestamptz!
+  params: EpochInputParams
 }
 
 type UpdateOrgResponse {

--- a/hasura/schema/user/schema.graphql
+++ b/hasura/schema/user/schema.graphql
@@ -427,6 +427,16 @@ input UpdateEpochInput {
   params: EpochInputParams
 }
 
+input UpdateEpochOldInput {
+  circle_id: Int!
+  days: Int!
+  description: String
+  grant: Float
+  id: Int!
+  repeat: Int!
+  start_date: timestamptz!
+}
+
 type UpdateOrgResponse {
   id: Int!
   org: organizations
@@ -6283,6 +6293,7 @@ type mutation_root {
     payload: UpdateContributionInput!
   ): UpdateContributionResponse
   updateEpoch(payload: UpdateEpochInput!): EpochResponse
+  updateEpochOld(payload: UpdateEpochOldInput!): EpochResponse
   updateProfile(payload: UpdateProfileInput!): UpdateProfileResponse
   updateTeammates(payload: UpdateTeammatesInput!): UpdateTeammatesResponse
 

--- a/src/lib/gql/__generated__/zeus/const.ts
+++ b/src/lib/gql/__generated__/zeus/const.ts
@@ -50,7 +50,7 @@ export const AllTypesProps: Record<string, any> = {
     datetime_created: 'timestamptz',
   },
   UpdateEpochInput: {
-    start_date: 'timestamptz',
+    params: 'EpochInputParams',
   },
   UpdateProfileInput: {},
   UpdateTeammatesInput: {},

--- a/src/lib/gql/__generated__/zeus/const.ts
+++ b/src/lib/gql/__generated__/zeus/const.ts
@@ -52,6 +52,9 @@ export const AllTypesProps: Record<string, any> = {
   UpdateEpochInput: {
     params: 'EpochInputParams',
   },
+  UpdateEpochOldInput: {
+    start_date: 'timestamptz',
+  },
   UpdateProfileInput: {},
   UpdateTeammatesInput: {},
   UpdateUserInput: {},
@@ -2073,6 +2076,9 @@ export const AllTypesProps: Record<string, any> = {
     },
     updateEpoch: {
       payload: 'UpdateEpochInput',
+    },
+    updateEpochOld: {
+      payload: 'UpdateEpochOldInput',
     },
     updateProfile: {
       payload: 'UpdateProfileInput',
@@ -5103,6 +5109,7 @@ export const ReturnTypes: Record<string, any> = {
     updateCircle: 'UpdateCircleOutput',
     updateContribution: 'UpdateContributionResponse',
     updateEpoch: 'EpochResponse',
+    updateEpochOld: 'EpochResponse',
     updateProfile: 'UpdateProfileResponse',
     updateTeammates: 'UpdateTeammatesResponse',
     updateUser: 'UserResponse',

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -925,6 +925,15 @@ export type ValueTypes = {
     id: number;
     params?: ValueTypes['EpochInputParams'] | undefined | null;
   };
+  ['UpdateEpochOldInput']: {
+    circle_id: number;
+    days: number;
+    description?: string | undefined | null;
+    grant?: number | undefined | null;
+    id: number;
+    repeat: number;
+    start_date: ValueTypes['timestamptz'];
+  };
   ['UpdateOrgResponse']: AliasType<{
     id?: boolean | `@${string}`;
     org?: ValueTypes['organizations'];
@@ -4956,6 +4965,10 @@ export type ValueTypes = {
     ];
     updateEpoch?: [
       { payload: ValueTypes['UpdateEpochInput'] },
+      ValueTypes['EpochResponse']
+    ];
+    updateEpochOld?: [
+      { payload: ValueTypes['UpdateEpochOldInput'] },
       ValueTypes['EpochResponse']
     ];
     updateProfile?: [
@@ -10567,6 +10580,7 @@ export type ModelTypes = {
     updateContribution_Contribution?: GraphQLTypes['contributions'] | undefined;
   };
   ['UpdateEpochInput']: GraphQLTypes['UpdateEpochInput'];
+  ['UpdateEpochOldInput']: GraphQLTypes['UpdateEpochOldInput'];
   ['UpdateOrgResponse']: {
     id: number;
     org?: GraphQLTypes['organizations'] | undefined;
@@ -11898,6 +11912,7 @@ export type ModelTypes = {
     /** users can modify contributions and update their dates. */
     updateContribution?: GraphQLTypes['UpdateContributionResponse'] | undefined;
     updateEpoch?: GraphQLTypes['EpochResponse'] | undefined;
+    updateEpochOld?: GraphQLTypes['EpochResponse'] | undefined;
     updateProfile?: GraphQLTypes['UpdateProfileResponse'] | undefined;
     updateTeammates?: GraphQLTypes['UpdateTeammatesResponse'] | undefined;
     /** Update own user */
@@ -13615,6 +13630,15 @@ export type GraphQLTypes = {
     grant?: number | undefined;
     id: number;
     params?: GraphQLTypes['EpochInputParams'] | undefined;
+  };
+  ['UpdateEpochOldInput']: {
+    circle_id: number;
+    days: number;
+    description?: string | undefined;
+    grant?: number | undefined;
+    id: number;
+    repeat: number;
+    start_date: GraphQLTypes['timestamptz'];
   };
   ['UpdateOrgResponse']: {
     __typename: 'UpdateOrgResponse';
@@ -16767,6 +16791,7 @@ export type GraphQLTypes = {
     /** users can modify contributions and update their dates. */
     updateContribution?: GraphQLTypes['UpdateContributionResponse'] | undefined;
     updateEpoch?: GraphQLTypes['EpochResponse'] | undefined;
+    updateEpochOld?: GraphQLTypes['EpochResponse'] | undefined;
     updateProfile?: GraphQLTypes['UpdateProfileResponse'] | undefined;
     updateTeammates?: GraphQLTypes['UpdateTeammatesResponse'] | undefined;
     /** Update own user */

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -685,6 +685,7 @@ export type ValueTypes = {
   }>;
   ['CreateEpochInput']: {
     circle_id: number;
+    grant?: number | undefined | null;
     params: ValueTypes['EpochInputParams'];
   };
   ['CreateEpochOldInput']: {
@@ -758,7 +759,6 @@ export type ValueTypes = {
     end_date: ValueTypes['timestamptz'];
     frequency?: number | undefined | null;
     frequency_unit?: string | undefined | null;
-    grant?: number | undefined | null;
     start_date: ValueTypes['timestamptz'];
     type: string;
     week?: number | undefined | null;
@@ -920,12 +920,10 @@ export type ValueTypes = {
   }>;
   ['UpdateEpochInput']: {
     circle_id: number;
-    days: number;
     description?: string | undefined | null;
     grant?: number | undefined | null;
     id: number;
-    repeat: number;
-    start_date: ValueTypes['timestamptz'];
+    params?: ValueTypes['EpochInputParams'] | undefined | null;
   };
   ['UpdateOrgResponse']: AliasType<{
     id?: boolean | `@${string}`;
@@ -13378,6 +13376,7 @@ export type GraphQLTypes = {
   };
   ['CreateEpochInput']: {
     circle_id: number;
+    grant?: number | undefined;
     params: GraphQLTypes['EpochInputParams'];
   };
   ['CreateEpochOldInput']: {
@@ -13451,7 +13450,6 @@ export type GraphQLTypes = {
     end_date: GraphQLTypes['timestamptz'];
     frequency?: number | undefined;
     frequency_unit?: string | undefined;
-    grant?: number | undefined;
     start_date: GraphQLTypes['timestamptz'];
     type: string;
     week?: number | undefined;
@@ -13613,12 +13611,10 @@ export type GraphQLTypes = {
   };
   ['UpdateEpochInput']: {
     circle_id: number;
-    days: number;
     description?: string | undefined;
     grant?: number | undefined;
     id: number;
-    repeat: number;
-    start_date: GraphQLTypes['timestamptz'];
+    params?: GraphQLTypes['EpochInputParams'] | undefined;
   };
   ['UpdateOrgResponse']: {
     __typename: 'UpdateOrgResponse';

--- a/src/lib/gql/mutations.ts
+++ b/src/lib/gql/mutations.ts
@@ -502,9 +502,9 @@ export async function updateEpoch(
   epochId: number,
   params: UpdateCreateEpochParam
 ) {
-  const { updateEpoch } = await client.mutate(
+  const { updateEpochOld } = await client.mutate(
     {
-      updateEpoch: [
+      updateEpochOld: [
         {
           payload: {
             circle_id: circleId,
@@ -518,10 +518,10 @@ export async function updateEpoch(
       ],
     },
     {
-      operationName: 'updateEpoch',
+      operationName: 'updateEpochOld',
     }
   );
-  return updateEpoch;
+  return updateEpochOld;
 }
 
 export async function allocationCsv(


### PR DESCRIPTION
This refactoring utilizes the more configurable epoch structures.

## Description

modifying a repeating epoch that has already begun is quite
difficult, so we have to convert that epoch to a one-off, then quietly
create a new repeating epoch using the original config after the
one-off. This flow is already fleshed out in the frontend, but it needs
to be re-integrated.

## Test and Deployment Plan

Unit tests have been written. They are fully integrated, using the
graphql api. Test cases where repeating epochs are modified are not
supported, for the reasons described above.
