### PR TITLE
remove some uses of useMyProfile

### DIFF
--- a/src/components/MainLayout/MainHeader.tsx
+++ b/src/components/MainLayout/MainHeader.tsx
@@ -152,7 +152,10 @@ const NormalHeader = ({ inCircle, walletStatus, query }: Props) => {
                 Claim Tokens
               </Button>
             )}
-            <MyAvatarMenu walletStatus={walletStatus} />
+            <MyAvatarMenu
+              walletStatus={walletStatus}
+              avatar={query.data?.profiles[0]?.avatar}
+            />
           </Suspense>
         </Box>
       </Box>

--- a/src/components/MainLayout/getMainHeaderData.ts
+++ b/src/components/MainLayout/getMainHeaderData.ts
@@ -42,7 +42,7 @@ export const getMainHeaderData = (address: string, chainId: number) =>
       ],
       profiles: [
         { limit: 1, where: { address: { _eq: address.toLowerCase() } } },
-        { name: true, id: true },
+        { name: true, id: true, avatar: true },
       ],
     },
     { operationName: 'getMainHeaderData' }

--- a/src/components/MyAvatarMenu/MyAvatarMenu.tsx
+++ b/src/components/MyAvatarMenu/MyAvatarMenu.tsx
@@ -9,7 +9,6 @@ import { ThemeSwitcher } from '../../features/theming/ThemeSwitcher';
 import { Network } from 'components';
 import { menuGroupStyle } from 'components/MainLayout/MainHeader';
 import isFeatureEnabled from 'config/features';
-import { useMyProfile } from 'recoilState/app';
 import { paths } from 'routes/paths';
 import {
   Avatar,
@@ -27,10 +26,10 @@ import { RecentTransactionsModal } from './RecentTransactionsModal';
 
 type Props = {
   walletStatus: ReturnType<typeof useWalletStatus>;
+  avatar: string | undefined;
 };
 
-export const MyAvatarMenu = ({ walletStatus }: Props) => {
-  const myProfile = useMyProfile();
+export const MyAvatarMenu = ({ walletStatus, avatar }: Props) => {
   const { icon, address, chainId, logout } = walletStatus;
   const [showTxModal, setShowTxModal] = useState(false);
 
@@ -75,7 +74,7 @@ export const MyAvatarMenu = ({ walletStatus }: Props) => {
             }}
           >
             <Link href="#">
-              <Avatar path={myProfile.avatar} name="me" />
+              <Avatar path={avatar} name="me" />
             </Link>
           </PopoverTrigger>
           <PopoverContent
@@ -117,7 +116,7 @@ export const MyAvatarMenu = ({ walletStatus }: Props) => {
             >
               <PopoverClose asChild>
                 <Box css={{ display: 'flex', alignItems: 'end', pb: '$md' }}>
-                  <Avatar path={myProfile.avatar} />
+                  <Avatar path={avatar} />
                 </Box>
               </PopoverClose>
               <Box

--- a/src/pages/JoinCirclePage/AddressIsNotMember.tsx
+++ b/src/pages/JoinCirclePage/AddressIsNotMember.tsx
@@ -1,18 +1,25 @@
-import React from 'react';
-
 import { TokenJoinInfo } from '../../../api/circle/landing/[token]';
 import CircleWithLogo from '../../components/CircleWithLogo';
-import { useMyProfile } from '../../recoilState';
 import { paths } from '../../routes/paths';
 import { AppLink, Box, Button, CenteredBox, Flex, Panel, Text } from '../../ui';
 
+import { getProfilesWithAddress } from './queries';
+
+import { Awaited } from 'types/shim';
+
+type Users = NonNullable<
+  Awaited<ReturnType<typeof getProfilesWithAddress>>
+>['users'];
+
 export const AddressIsNotMember = ({
   tokenJoinInfo,
+  address,
+  users,
 }: {
   tokenJoinInfo: TokenJoinInfo;
+  address: string;
+  users: Users;
 }) => {
-  const { address, myUsers } = useMyProfile();
-
   const bigText = {
     fontWeight: '$semibold',
     mb: '$sm',
@@ -42,12 +49,12 @@ export const AddressIsNotMember = ({
           </Text>
         </Box>
 
-        {myUsers.length > 0 && (
+        {users.length > 0 ? (
           <>
             <Box css={{ ...bigText, textAlign: 'left', mb: '$lg' }}>
               You are a member of these other circles
             </Box>
-            {myUsers.map(u => (
+            {users.map(u => (
               <AppLink key={u.id} to={paths.history(u.circle_id)}>
                 <Panel
                   nested
@@ -70,9 +77,7 @@ export const AddressIsNotMember = ({
               </AppLink>
             ))}
           </>
-        )}
-
-        {myUsers.length == 0 && (
+        ) : (
           <Box css={{ ...bigText, textAlign: 'center', mb: '$lg' }}>
             You aren&apos;t a member of any circles
           </Box>

--- a/src/pages/JoinCirclePage/JoinWithMagicLink.tsx
+++ b/src/pages/JoinCirclePage/JoinWithMagicLink.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
@@ -11,10 +11,10 @@ import CircleWithLogo from '../../components/CircleWithLogo';
 import { useToast, useApiBase } from '../../hooks';
 import { client } from '../../lib/gql/client';
 import { zUsername } from '../../lib/zod/formHelpers';
-import { useMyProfile } from '../../recoilState';
 import { paths } from '../../routes/paths';
 import { Box, Button, CenteredBox, TextField, Text, Panel } from '../../ui';
 import { normalizeError } from '../../utils/reporting';
+import useConnectedAddress from 'hooks/useConnectedAddress';
 
 export const JoinWithMagicLink = ({
   tokenJoinInfo,
@@ -27,7 +27,7 @@ export const JoinWithMagicLink = ({
   const { showError } = useToast();
   const navigate = useNavigate();
   const [loading, setLoading] = useState<boolean>(false);
-  const { address } = useMyProfile();
+  const address = useConnectedAddress();
 
   const joinSchema = z.object({ name: zUsername });
 

--- a/src/pages/JoinCirclePage/queries.ts
+++ b/src/pages/JoinCirclePage/queries.ts
@@ -3,7 +3,31 @@ import { client } from 'lib/gql/client';
 export const getProfilesWithAddress = async (address: string) => {
   const { profiles } = await client.query(
     {
-      profiles: [{ where: { address: { _ilike: address } } }, { name: true }],
+      profiles: [
+        { where: { address: { _ilike: address } } },
+        {
+          name: true,
+          users: [
+            {
+              where: {
+                deleted_at: { _is_null: true },
+                circle: {
+                  deleted_at: { _is_null: true },
+                },
+              },
+            },
+            {
+              id: true,
+              circle_id: true,
+              circle: {
+                logo: true,
+                name: true,
+                organization: { logo: true, name: true },
+              },
+            },
+          ],
+        },
+      ],
     },
     { operationName: `joinCircle_getProfilesWithAddress` }
   );


### PR DESCRIPTION
some preparatory work for #1828 -- avoiding useMyProfile is preferable because it doesn't go through Recoil & so can avoid the use of Suspense

in these cases, replacing useMyProfile is pretty easy because not many fields are used, and so we can get them from `getMainHeaderData` instead. note that this latter API request is shaping up to be the one-stop shop for getting data when you load the page, at least once you're logged in