### PR TITLE
fix/add operation names

### DIFF
--- a/api-lib/gql/makeThunder.ts
+++ b/api-lib/gql/makeThunder.ts
@@ -1,4 +1,14 @@
-import { apiFetch, Thunder } from './__generated__/zeus';
+import {
+  apiFetch,
+  FetchFunction,
+  fullChainConstruct,
+  GenericOperation,
+  GraphQLTypes,
+  InputType,
+  OperationOptions,
+  ValueTypes,
+} from './__generated__/zeus';
+import { Ops } from './__generated__/zeus/const';
 
 type ThunderOptions = {
   url: string;
@@ -6,7 +16,24 @@ type ThunderOptions = {
   timeout?: number;
 };
 
+/* A bit verbose TS, but this allows us to enforce OperationName as a required */
+export const ThunderRequireOperationName =
+  (fn: FetchFunction) =>
+  <
+    O extends keyof typeof Ops,
+    R extends keyof ValueTypes = GenericOperation<O>
+  >(
+    operation: O
+  ) =>
+  <Z extends ValueTypes[R]>(
+    o: Z | ValueTypes[R],
+    ops: Omit<OperationOptions, 'operationName'> & { operationName: string }
+  ) =>
+    fullChainConstruct(fn)(operation)(o as any, ops) as Promise<
+      InputType<GraphQLTypes[R], Z>
+    >;
+
 export const makeThunder = ({ url, headers, timeout = 0 }: ThunderOptions) =>
-  Thunder(async (...params) =>
+  ThunderRequireOperationName(async (...params) =>
     apiFetch([url, { method: 'POST', headers, timeout: timeout }])(...params)
   );

--- a/api-lib/gql/queries.ts
+++ b/api-lib/gql/queries.ts
@@ -176,72 +176,75 @@ export async function getUserByIdAndCurrentEpoch(
 ): Promise<typeof user | undefined> {
   const {
     users: [user],
-  } = await adminClient.query({
-    users: [
-      {
-        limit: 1,
-        where: {
-          id: { _eq: id },
-          circle_id: { _eq: circleId },
+  } = await adminClient.query(
+    {
+      users: [
+        {
+          limit: 1,
+          where: {
+            id: { _eq: id },
+            circle_id: { _eq: circleId },
+          },
         },
-      },
-      {
-        id: true,
-        fixed_non_receiver: true,
-        non_giver: true,
-        non_receiver: true,
-        starting_tokens: true,
-        give_token_received: true,
-        give_token_remaining: true,
-        fixed_payment_amount: true,
-        pending_sent_gifts: [
-          // the join filters down to only gifts to the user
-          {},
-          {
-            id: true,
-            epoch_id: true,
-            sender_id: true,
-            sender_address: true,
-            recipient_id: true,
-            recipient_address: true,
-            note: true,
-            tokens: true,
-          },
-        ],
-        pending_received_gifts: [
-          // the join filters down to only gifts to the user
-          {},
-          {
-            id: true,
-            epoch_id: true,
-            sender_id: true,
-            sender_address: true,
-            recipient_id: true,
-            recipient_address: true,
-            note: true,
-            tokens: true,
-          },
-        ],
-        circle: {
-          epochs: [
+        {
+          id: true,
+          fixed_non_receiver: true,
+          non_giver: true,
+          non_receiver: true,
+          starting_tokens: true,
+          give_token_received: true,
+          give_token_remaining: true,
+          fixed_payment_amount: true,
+          pending_sent_gifts: [
+            // the join filters down to only gifts to the user
+            {},
             {
-              where: {
-                _and: [
-                  { end_date: { _gt: 'now()' } },
-                  { start_date: { _lt: 'now()' } },
-                ],
-              },
-            },
-            {
-              start_date: true,
-              end_date: true,
               id: true,
+              epoch_id: true,
+              sender_id: true,
+              sender_address: true,
+              recipient_id: true,
+              recipient_address: true,
+              note: true,
+              tokens: true,
             },
           ],
+          pending_received_gifts: [
+            // the join filters down to only gifts to the user
+            {},
+            {
+              id: true,
+              epoch_id: true,
+              sender_id: true,
+              sender_address: true,
+              recipient_id: true,
+              recipient_address: true,
+              note: true,
+              tokens: true,
+            },
+          ],
+          circle: {
+            epochs: [
+              {
+                where: {
+                  _and: [
+                    { end_date: { _gt: 'now()' } },
+                    { start_date: { _lt: 'now()' } },
+                  ],
+                },
+              },
+              {
+                start_date: true,
+                end_date: true,
+                id: true,
+              },
+            ],
+          },
         },
-      },
-    ],
-  });
+      ],
+    },
+    { operationName: 'getUserByIdAndCurrentEpoch' }
+  );
   return user;
 }
 

--- a/api/hasura/actions/_handlers/createSampleCircle.ts
+++ b/api/hasura/actions/_handlers/createSampleCircle.ts
@@ -40,40 +40,48 @@ export const createSampleCircleForProfile = async (
   address: string
 ) => {
   // if the org already exists and was created by this profile, we want to use that org ID
-  const { organizations } = await adminClient.query({
-    organizations: [
-      {
-        where: {
-          sample: { _eq: true },
-          created_by: { _eq: profileID },
+  const { organizations } = await adminClient.query(
+    {
+      organizations: [
+        {
+          where: {
+            sample: { _eq: true },
+            created_by: { _eq: profileID },
+          },
         },
-      },
-      {
-        id: true,
-      },
-    ],
-  });
+        {
+          id: true,
+        },
+      ],
+    },
+    {
+      operationName: 'getExistingOrgId__sampleCircle',
+    }
+  );
 
   const organization_id: number | undefined = organizations.pop()?.id;
 
   // if the circle already exists, thats a problem!
   if (organization_id) {
     // org exists, lets check for any non-deleted circles
-    const { circles_aggregate } = await adminClient.query({
-      circles_aggregate: [
-        {
-          where: {
-            organization_id: { _eq: organization_id },
-            deleted_at: { _is_null: true },
+    const { circles_aggregate } = await adminClient.query(
+      {
+        circles_aggregate: [
+          {
+            where: {
+              organization_id: { _eq: organization_id },
+              deleted_at: { _is_null: true },
+            },
           },
-        },
-        {
-          aggregate: {
-            count: [{}, true],
+          {
+            aggregate: {
+              count: [{}, true],
+            },
           },
-        },
-      ],
-    });
+        ],
+      },
+      { operationName: 'getNonDeletedCircles__sampleCircle' }
+    );
 
     if ((circles_aggregate.aggregate?.count ?? 0) > 0) {
       // the sample org exists and it has at least 1 non-deleted circle

--- a/api/hasura/actions/_handlers/createSampleCircle.ts
+++ b/api/hasura/actions/_handlers/createSampleCircle.ts
@@ -189,21 +189,24 @@ const addSampleMember = async (
   const address =
     '0x' +
     generateAddress(Buffer.from(sample.name), Buffer.from('')).toString('hex');
-  const { insert_users_one } = await adminClient.mutate({
-    insert_users_one: [
-      {
-        object: {
-          address,
-          bio: sample.epochStatement,
-          circle_id,
-          name: sample.name,
+  const { insert_users_one } = await adminClient.mutate(
+    {
+      insert_users_one: [
+        {
+          object: {
+            address,
+            bio: sample.epochStatement,
+            circle_id,
+            name: sample.name,
+          },
         },
-      },
-      {
-        id: true,
-      },
-    ],
-  });
+        {
+          id: true,
+        },
+      ],
+    },
+    { operationName: 'addSampleMember' }
+  );
   if (!insert_users_one) {
     throw new Error('insert sample user failed');
   }
@@ -216,20 +219,23 @@ const addSampleContribution = async (
   user_id: number,
   contribution: string
 ) => {
-  const { insert_contributions_one } = await adminClient.mutate({
-    insert_contributions_one: [
-      {
-        object: {
-          circle_id,
-          user_id,
-          description: contribution,
+  const { insert_contributions_one } = await adminClient.mutate(
+    {
+      insert_contributions_one: [
+        {
+          object: {
+            circle_id,
+            user_id,
+            description: contribution,
+          },
         },
-      },
-      {
-        id: true,
-      },
-    ],
-  });
+        {
+          id: true,
+        },
+      ],
+    },
+    { operationName: 'addSampleContribution' }
+  );
   if (!insert_contributions_one) {
     throw new Error('insert sample contribution failed');
   }
@@ -246,23 +252,26 @@ const addSampleAllocation = async (
   gift: number,
   note?: string
 ) => {
-  const { insert_pending_token_gifts_one } = await adminClient.mutate({
-    insert_pending_token_gifts_one: [
-      {
-        object: {
-          recipient_id: recipient_id,
-          note: note,
-          circle_id,
-          epoch_id: epoch_id,
-          sender_id: user_id,
-          sender_address: sender_address,
-          recipient_address: recipient_address,
-          tokens: gift,
+  const { insert_pending_token_gifts_one } = await adminClient.mutate(
+    {
+      insert_pending_token_gifts_one: [
+        {
+          object: {
+            recipient_id: recipient_id,
+            note: note,
+            circle_id,
+            epoch_id: epoch_id,
+            sender_id: user_id,
+            sender_address: sender_address,
+            recipient_address: recipient_address,
+            tokens: gift,
+          },
         },
-      },
-      { __typename: true },
-    ],
-  });
+        { __typename: true },
+      ],
+    },
+    { operationName: 'addSampleAllocation' }
+  );
   if (!insert_pending_token_gifts_one) {
     throw new Error('insert sample allocation failed');
   }

--- a/api/hasura/actions/_handlers/createUserWithToken.ts
+++ b/api/hasura/actions/_handlers/createUserWithToken.ts
@@ -51,7 +51,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
         },
       ],
     },
-    { operationName: 'createShareTokens' }
+    { operationName: 'getShareTokens__createUserWithToken' }
   );
 
   const circleId = circle_share_tokens.pop()?.circle_id;

--- a/api/hasura/actions/_handlers/createUserWithToken.ts
+++ b/api/hasura/actions/_handlers/createUserWithToken.ts
@@ -28,28 +28,31 @@ async function handler(req: VercelRequest, res: VercelResponse) {
   const address = await getAddress(hasuraProfileId);
 
   // get the circleId from the token and make sure its magic
-  const { circle_share_tokens } = await adminClient.query({
-    circle_share_tokens: [
-      {
-        where: {
-          uuid: {
-            _eq: input.token,
-          },
-          circle: {
-            deleted_at: {
-              _is_null: true,
+  const { circle_share_tokens } = await adminClient.query(
+    {
+      circle_share_tokens: [
+        {
+          where: {
+            uuid: {
+              _eq: input.token,
+            },
+            circle: {
+              deleted_at: {
+                _is_null: true,
+              },
+            },
+            type: {
+              _eq: CircleTokenType.Magic,
             },
           },
-          type: {
-            _eq: CircleTokenType.Magic,
-          },
         },
-      },
-      {
-        circle_id: true,
-      },
-    ],
-  });
+        {
+          circle_id: true,
+        },
+      ],
+    },
+    { operationName: 'createShareTokens' }
+  );
 
   const circleId = circle_share_tokens.pop()?.circle_id;
   if (!circleId) {

--- a/api/hasura/actions/_handlers/createVaultTx.ts
+++ b/api/hasura/actions/_handlers/createVaultTx.ts
@@ -155,22 +155,25 @@ const VaultLogUnionSchema = z.discriminatedUnion('tx_type', [
 ]);
 
 async function getVaultForAddress(address: string, vaultId: number) {
-  const result = await adminClient.query({
-    vaults_by_pk: [
-      {
-        id: vaultId,
-      },
-      {
-        organization: {
-          id: true,
-          circles: [
-            { where: { users: { address: { _eq: address } } } },
-            { id: true },
-          ],
+  const result = await adminClient.query(
+    {
+      vaults_by_pk: [
+        {
+          id: vaultId,
         },
-      },
-    ],
-  });
+        {
+          organization: {
+            id: true,
+            circles: [
+              { where: { users: { address: { _eq: address } } } },
+              { id: true },
+            ],
+          },
+        },
+      ],
+    },
+    { operationName: 'getVaultForAddress' }
+  );
   return result.vaults_by_pk;
 }
 
@@ -183,17 +186,20 @@ async function getDistributionForVault({
   tx_hash: string;
   distribution_id: number;
 }) {
-  const result = await adminClient.query({
-    distributions: [
-      {
-        where: {
-          id: { _eq: distribution_id },
-          tx_hash: { _eq: tx_hash },
-          vault_id: { _eq: vault_id },
+  const result = await adminClient.query(
+    {
+      distributions: [
+        {
+          where: {
+            id: { _eq: distribution_id },
+            tx_hash: { _eq: tx_hash },
+            vault_id: { _eq: vault_id },
+          },
         },
-      },
-      { __typename: true },
-    ],
-  });
+        { __typename: true },
+      ],
+    },
+    { operationName: 'getDistributionForVault' }
+  );
   return result.distributions;
 }

--- a/api/hasura/actions/_handlers/linkDiscordCircle.ts
+++ b/api/hasura/actions/_handlers/linkDiscordCircle.ts
@@ -28,16 +28,21 @@ async function handler(req: VercelRequest, res: VercelResponse) {
 
   const { circle_id, token } = payload;
 
-  const { discord_circle_api_tokens } = await adminClient.query({
-    discord_circle_api_tokens: [
-      {
-        where: { circle_id: { _eq: Number(circle_id) } },
-      },
-      {
-        token: true,
-      },
-    ],
-  });
+  const { discord_circle_api_tokens } = await adminClient.query(
+    {
+      discord_circle_api_tokens: [
+        {
+          where: { circle_id: { _eq: Number(circle_id) } },
+        },
+        {
+          token: true,
+        },
+      ],
+    },
+    {
+      operationName: 'getDiscordApiTokens',
+    }
+  );
 
   if (
     discord_circle_api_tokens.length === 0 ||
@@ -58,19 +63,22 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     );
   }
 
-  const { update_discord_circle_api_tokens } = await adminClient.mutate({
-    update_discord_circle_api_tokens: [
-      {
-        _set: { token },
-        where: { circle_id: { _eq: Number(circle_id) } },
-      },
-      {
-        returning: {
-          id: true,
+  const { update_discord_circle_api_tokens } = await adminClient.mutate(
+    {
+      update_discord_circle_api_tokens: [
+        {
+          _set: { token },
+          where: { circle_id: { _eq: Number(circle_id) } },
         },
-      },
-    ],
-  });
+        {
+          returning: {
+            id: true,
+          },
+        },
+      ],
+    },
+    { operationName: 'updateDiscordCircleApiTokens' }
+  );
   assert(update_discord_circle_api_tokens, 'panic: Unexpected GQL response');
 
   const returnResult = update_discord_circle_api_tokens.returning.pop();

--- a/api/hasura/actions/_handlers/linkDiscordUser.ts
+++ b/api/hasura/actions/_handlers/linkDiscordUser.ts
@@ -28,18 +28,21 @@ async function handler(req: VercelRequest, res: VercelResponse) {
 
   // no validation here; It's the caller's responsibility to pass in
   // a valid snowflake
-  const result = await adminClient.mutate({
-    insert_discord_users_one: [
-      {
-        object: { user_snowflake: discord_id, profile_id },
-        on_conflict: {
-          constraint: discord_users_constraint.users_profile_id_key,
-          update_columns: [discord_users_update_column.user_snowflake],
+  const result = await adminClient.mutate(
+    {
+      insert_discord_users_one: [
+        {
+          object: { user_snowflake: discord_id, profile_id },
+          on_conflict: {
+            constraint: discord_users_constraint.users_profile_id_key,
+            update_columns: [discord_users_update_column.user_snowflake],
+          },
         },
-      },
-      { id: true },
-    ],
-  });
+        { id: true },
+      ],
+    },
+    { operationName: 'createDiscordUser' }
+  );
   assert(result.insert_discord_users_one, 'panic: Unexpected GQL response');
   const returnResult = result.insert_discord_users_one;
 

--- a/api/hasura/actions/_handlers/updateUser.ts
+++ b/api/hasura/actions/_handlers/updateUser.ts
@@ -26,24 +26,27 @@ async function handler(req: VercelRequest, res: VercelResponse) {
 
   const {
     users: [user],
-  } = await adminClient.query({
-    users: [
-      {
-        limit: 1,
-        where: {
-          address: { _ilike: address },
-          circle_id: { _eq: circle_id },
-          // ignore soft_deleted users
-          deleted_at: { _is_null: true },
+  } = await adminClient.query(
+    {
+      users: [
+        {
+          limit: 1,
+          where: {
+            address: { _ilike: address },
+            circle_id: { _eq: circle_id },
+            // ignore soft_deleted users
+            deleted_at: { _is_null: true },
+          },
         },
-      },
-      {
-        id: true,
-        fixed_non_receiver: true,
-        give_token_received: true,
-      },
-    ],
-  });
+        {
+          id: true,
+          fixed_non_receiver: true,
+          give_token_received: true,
+        },
+      ],
+    },
+    { operationName: 'getUsers' }
+  );
 
   if (!user) {
     return errorResponse(res, {

--- a/api/hasura/actions/_handlers/updateUser.ts
+++ b/api/hasura/actions/_handlers/updateUser.ts
@@ -45,7 +45,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
         },
       ],
     },
-    { operationName: 'getUsers' }
+    { operationName: 'getUsers__updateUser' }
   );
 
   if (!user) {

--- a/scripts/db_seed_test.ts
+++ b/scripts/db_seed_test.ts
@@ -37,16 +37,19 @@ main()
   .catch(console.error);
 
 async function getOrganizationIdForCircle(circleId: number) {
-  const { circles_by_pk } = await adminClient.query({
-    circles_by_pk: [
-      {
-        id: circleId,
-      },
-      {
-        organization_id: true,
-      },
-    ],
-  });
+  const { circles_by_pk } = await adminClient.query(
+    {
+      circles_by_pk: [
+        {
+          id: circleId,
+        },
+        {
+          organization_id: true,
+        },
+      ],
+    },
+    { operationName: 'getOrganizationIdForCircle' }
+  );
   return circles_by_pk?.organization_id;
 }
 async function createCircleWithGiftsNotYetEnded() {
@@ -200,7 +203,8 @@ async function createCircleInOrgButNoDevMember(organizationId: number) {
         },
       },
     ],
-  });
+  },
+    { operationName: 'createCircleInOrgButNoDevMember'});
 }
 
 async function createFreshOpenEpochDevAdminWithFixedPaymentToken() {

--- a/src/lib/gql/client.test.ts
+++ b/src/lib/gql/client.test.ts
@@ -15,9 +15,12 @@ import { client, setMockHeaders } from './client';
 
 test('set Bearer authorization with token', async () => {
   setAuthToken('mock-token');
-  const args = (await client.query({
-    profiles: [{}, { name: true }],
-  })) as unknown as [string, Record<string, any>];
+  const args = (await client.query(
+    {
+      profiles: [{}, { name: true }],
+    },
+    { operationName: 'test__getProfile' }
+  )) as unknown as [string, Record<string, any>];
   expect(args[1].headers.Authorization).toEqual('Bearer mock-token');
 });
 
@@ -28,9 +31,12 @@ test('set mock headers', async () => {
     'x-hasura-address': '0xface0101face',
   };
   setMockHeaders(mockHeaders);
-  const args = (await client.query({
-    profiles: [{}, { name: true }],
-  })) as unknown as [string, Record<string, any>];
+  const args = (await client.query(
+    {
+      profiles: [{}, { name: true }],
+    },
+    { operationName: 'test__getProfile' }
+  )) as unknown as [string, Record<string, any>];
   expect(args[1].headers).toMatchObject({
     ...mockHeaders,
     Authorization: TEST_SKIP_AUTH,

--- a/src/lib/gql/client.ts
+++ b/src/lib/gql/client.ts
@@ -22,7 +22,8 @@ export const setMockHeaders = (h: Record<string, string>) => {
   mockHeaders = h;
 };
 
-export const ThunderButCool =
+/* A bit verbose TS, but this allows us to enforce OperationName as a required */
+export const ThunderRequireOperationName =
   (fn: FetchFunction) =>
   <
     O extends keyof typeof Ops,
@@ -39,7 +40,7 @@ export const ThunderButCool =
     >;
 
 const makeThunder = (headers = {}) =>
-  ThunderButCool(async (...params) =>
+  ThunderRequireOperationName(async (...params) =>
     apiFetch([
       REACT_APP_HASURA_URL,
       {
@@ -57,9 +58,6 @@ const makeThunder = (headers = {}) =>
   );
 
 const thunder = makeThunder();
-
-// const t = ReturnType<thunder('query')>
-// type thunderParams = Parameters<typeof Return thunder('query')>;
 
 export const client = {
   query: thunder('query'),

--- a/src/lib/gql/client.ts
+++ b/src/lib/gql/client.ts
@@ -4,7 +4,17 @@ import isEmpty from 'lodash/isEmpty';
 import { REACT_APP_HASURA_URL } from '../../config/env';
 import { TEST_SKIP_AUTH } from 'utils/testing/api';
 
-import { apiFetch, Thunder } from './__generated__/zeus';
+import {
+  apiFetch,
+  FetchFunction,
+  fullChainConstruct,
+  GenericOperation,
+  GraphQLTypes,
+  InputType,
+  OperationOptions,
+  ValueTypes,
+} from './__generated__/zeus';
+import { Ops } from './__generated__/zeus/const';
 
 let mockHeaders: Record<string, string> = {};
 
@@ -12,8 +22,24 @@ export const setMockHeaders = (h: Record<string, string>) => {
   mockHeaders = h;
 };
 
+export const ThunderButCool =
+  (fn: FetchFunction) =>
+  <
+    O extends keyof typeof Ops,
+    R extends keyof ValueTypes = GenericOperation<O>
+  >(
+    operation: O
+  ) =>
+  <Z extends ValueTypes[R]>(
+    o: Z | ValueTypes[R],
+    ops: Omit<OperationOptions, 'operationName'> & { operationName: string }
+  ) =>
+    fullChainConstruct(fn)(operation)(o as any, ops) as Promise<
+      InputType<GraphQLTypes[R], Z>
+    >;
+
 const makeThunder = (headers = {}) =>
-  Thunder(async (...params) =>
+  ThunderButCool(async (...params) =>
     apiFetch([
       REACT_APP_HASURA_URL,
       {
@@ -31,6 +57,9 @@ const makeThunder = (headers = {}) =>
   );
 
 const thunder = makeThunder();
+
+// const t = ReturnType<thunder('query')>
+// type thunderParams = Parameters<typeof Return thunder('query')>;
 
 export const client = {
   query: thunder('query'),

--- a/src/lib/gql/mutations/vaults.ts
+++ b/src/lib/gql/mutations/vaults.ts
@@ -58,17 +58,23 @@ export const addVault = (payload: ValueTypes['CreateVaultInput']) =>
   );
 
 export const addVaultTx = (payload: ValueTypes['LogVaultTxInput']) =>
-  client.mutate({
-    createVaultTx: [{ payload }, { __typename: true }],
-  });
+  client.mutate(
+    {
+      createVaultTx: [{ payload }, { __typename: true }],
+    },
+    { operationName: 'createVaultTx' }
+  );
 
 export async function savePendingVaultTx(
   input: ValueTypes['pending_vault_transactions_insert_input']
 ) {
-  client.mutate({
-    insert_pending_vault_transactions_one: [
-      { object: { ...input } },
-      { __typename: true },
-    ],
-  });
+  client.mutate(
+    {
+      insert_pending_vault_transactions_one: [
+        { object: { ...input } },
+        { __typename: true },
+      ],
+    },
+    { operationName: 'savePendingVaultTx' }
+  );
 }

--- a/src/pages/AddMembersPage/NewMemberList.tsx
+++ b/src/pages/AddMembersPage/NewMemberList.tsx
@@ -131,24 +131,29 @@ const NewMemberList = ({
           entrance:
             m.entrance === ENTRANCE.CSV ? ENTRANCE.CSV : ENTRANCE.MANUAL,
         }));
-      const res = await client.mutate({
-        createUsers: [
-          {
-            payload: {
-              circle_id: circleId,
-              users: filteredMembers,
-            },
-          },
-          {
-            UserResponse: {
-              address: true,
-              profile: {
-                name: true,
+      const res = await client.mutate(
+        {
+          createUsers: [
+            {
+              payload: {
+                circle_id: circleId,
+                users: filteredMembers,
               },
             },
-          },
-        ],
-      });
+            {
+              UserResponse: {
+                address: true,
+                profile: {
+                  name: true,
+                },
+              },
+            },
+          ],
+        },
+        {
+          operationName: 'createUsers_newMemberList',
+        }
+      );
 
       const replacedNames = res?.createUsers
         ?.filter(res =>

--- a/src/pages/AddMembersPage/useCircleTokens.ts
+++ b/src/pages/AddMembersPage/useCircleTokens.ts
@@ -25,47 +25,55 @@ const useCircleTokens = (circleId: number, type: CircleTokenType) => {
   return useQuery(
     ['circle-token-', circleId, type],
     async (): Promise<string> => {
-      const { circle_share_tokens } = await client.query({
-        circle_share_tokens: [
-          {
-            where: {
-              circle: {
-                deleted_at: {
-                  _is_null: true,
+      const { circle_share_tokens } = await client.query(
+        {
+          circle_share_tokens: [
+            {
+              where: {
+                circle: {
+                  deleted_at: {
+                    _is_null: true,
+                  },
+                },
+                circle_id: {
+                  _eq: circleId,
+                },
+                type: {
+                  _eq: type,
                 },
               },
-              circle_id: {
-                _eq: circleId,
-              },
-              type: {
-                _eq: type,
-              },
             },
-          },
-          {
-            uuid: true,
-          },
-        ],
-      });
+            {
+              uuid: true,
+            },
+          ],
+        },
+        {
+          operationName: 'getCircleTokens',
+        }
+      );
       const token = circle_share_tokens?.pop();
       if (token) {
         return token.uuid;
       }
 
       // none exists, need to make one
-      const { insert_circle_share_tokens_one } = await client.mutate({
-        insert_circle_share_tokens_one: [
-          {
-            object: {
-              circle_id: circleId,
-              type: type,
+      const { insert_circle_share_tokens_one } = await client.mutate(
+        {
+          insert_circle_share_tokens_one: [
+            {
+              object: {
+                circle_id: circleId,
+                type: type,
+              },
             },
-          },
-          {
-            uuid: true,
-          },
-        ],
-      });
+            {
+              uuid: true,
+            },
+          ],
+        },
+        { operationName: 'createCircleShareTokens' }
+      );
       assert(insert_circle_share_tokens_one);
       return insert_circle_share_tokens_one.uuid;
     }
@@ -73,15 +81,20 @@ const useCircleTokens = (circleId: number, type: CircleTokenType) => {
 };
 
 const deleteToken = async (circleId: number, type: CircleTokenType) => {
-  await client.mutate({
-    delete_circle_share_tokens_by_pk: [
-      {
-        circle_id: circleId,
-        type: type,
-      },
-      {
-        __typename: true,
-      },
-    ],
-  });
+  await client.mutate(
+    {
+      delete_circle_share_tokens_by_pk: [
+        {
+          circle_id: circleId,
+          type: type,
+        },
+        {
+          __typename: true,
+        },
+      ],
+    },
+    {
+      operationName: 'deleteCircleShareTokens',
+    }
+  );
 };

--- a/src/pages/ClaimsPage/queries.ts
+++ b/src/pages/ClaimsPage/queries.ts
@@ -5,26 +5,31 @@ import { Contracts } from 'lib/vaults';
 import type { Awaited } from 'types/shim';
 
 export const getLockedTokenGifts = async () => {
-  const { locked_token_distribution_gifts } = await client.query({
-    locked_token_distribution_gifts: [
-      {
-        where: {
-          locked_token_distribution: { tx_hash: { _is_null: false } },
+  const { locked_token_distribution_gifts } = await client.query(
+    {
+      locked_token_distribution_gifts: [
+        {
+          where: {
+            locked_token_distribution: { tx_hash: { _is_null: false } },
+          },
         },
-      },
-      {
-        earnings: true,
-        id: true,
-        locked_token_distribution: {
-          token_contract_address: true,
-          tx_hash: true,
-          chain_id: true,
-          token_symbol: true,
-          token_decimals: true,
+        {
+          earnings: true,
+          id: true,
+          locked_token_distribution: {
+            token_contract_address: true,
+            tx_hash: true,
+            chain_id: true,
+            token_symbol: true,
+            token_decimals: true,
+          },
         },
-      },
-    ],
-  });
+      ],
+    },
+    {
+      operationName: 'getLockedTokenGifts',
+    }
+  );
   return locked_token_distribution_gifts;
 };
 

--- a/src/pages/ContributionsPage/mutations.ts
+++ b/src/pages/ContributionsPage/mutations.ts
@@ -4,29 +4,42 @@ import { client } from 'lib/gql/client';
 export const updateContributionMutation = async (
   payload: ValueTypes['UpdateContributionInput']
 ) =>
-  client.mutate({
-    updateContribution: [
-      { payload },
-      { updateContribution_Contribution: { description: true, id: true } },
-    ],
-  });
+  client.mutate(
+    {
+      updateContribution: [
+        { payload },
+        { updateContribution_Contribution: { description: true, id: true } },
+      ],
+    },
+    {
+      operationName: 'updateContribution',
+    }
+  );
 
 export const deleteContributionMutation = async (
   payload: ValueTypes['DeleteContributionInput']
 ) => {
-  await client.mutate({
-    deleteContribution: [{ payload }, { __typename: true }],
-  });
+  await client.mutate(
+    {
+      deleteContribution: [{ payload }, { __typename: true }],
+    },
+    { operationName: 'deleteContribution' }
+  );
   return { contribution_id: payload.contribution_id };
 };
 
 export const createContributionMutation = async (
   object: ValueTypes['contributions_insert_input']
 ) => {
-  return client.mutate({
-    insert_contributions_one: [
-      { object },
-      { id: true, description: true, datetime_created: true, user_id: true },
-    ],
-  });
+  return client.mutate(
+    {
+      insert_contributions_one: [
+        { object },
+        { id: true, description: true, datetime_created: true, user_id: true },
+      ],
+    },
+    {
+      operationName: 'createContribution',
+    }
+  );
 };

--- a/src/pages/ContributionsPage/queries.ts
+++ b/src/pages/ContributionsPage/queries.ts
@@ -23,55 +23,60 @@ export const getContributionsAndEpochs = async ({
   epochId?: number;
   userAddress?: string;
 }) =>
-  client.query({
-    users: [
-      {
-        where: {
-          circle_id: { _eq: circleId },
-          address: { _eq: userAddress?.toLowerCase() },
+  client.query(
+    {
+      users: [
+        {
+          where: {
+            circle_id: { _eq: circleId },
+            address: { _eq: userAddress?.toLowerCase() },
+          },
         },
-      },
-      { id: true },
-    ],
-    contributions: [
-      {
-        where: {
-          circle_id: { _eq: circleId },
-          user: userAddress
-            ? { address: { _eq: userAddress.toLowerCase() } }
-            : undefined,
+        { id: true },
+      ],
+      contributions: [
+        {
+          where: {
+            circle_id: { _eq: circleId },
+            user: userAddress
+              ? { address: { _eq: userAddress.toLowerCase() } }
+              : undefined,
+          },
+          order_by: [{ datetime_created: order_by.desc }],
         },
-        order_by: [{ datetime_created: order_by.desc }],
-      },
-      { id: true, description: true, datetime_created: true, user_id: true },
-    ],
-    epochs: [
-      {
-        where: {
-          circle_id: { _eq: circleId },
-          id: epochId ? { _eq: epochId } : undefined,
-          end_date: endDateInProd,
+        { id: true, description: true, datetime_created: true, user_id: true },
+      ],
+      epochs: [
+        {
+          where: {
+            circle_id: { _eq: circleId },
+            id: epochId ? { _eq: epochId } : undefined,
+            end_date: endDateInProd,
+          },
+          order_by: [{ end_date: order_by.desc }],
         },
-        order_by: [{ end_date: order_by.desc }],
-      },
-      {
-        id: true,
-        number: true,
-        start_date: true,
-        end_date: true,
-        ended: true,
-        description: true,
-      },
-    ],
-    circles_by_pk: [
-      {
-        id: circleId,
-      },
-      {
-        cont_help_text: true,
-      },
-    ],
-  });
+        {
+          id: true,
+          number: true,
+          start_date: true,
+          end_date: true,
+          ended: true,
+          description: true,
+        },
+      ],
+      circles_by_pk: [
+        {
+          id: circleId,
+        },
+        {
+          cont_help_text: true,
+        },
+      ],
+    },
+    {
+      operationName: 'getContributionsAndEpochs',
+    }
+  );
 
 export type ContributionsAndEpochs = Awaited<
   ReturnType<typeof getContributionsAndEpochs>

--- a/src/pages/CreateCirclePage/CreateSampleCircle.tsx
+++ b/src/pages/CreateCirclePage/CreateSampleCircle.tsx
@@ -17,9 +17,14 @@ export const CreateSampleCircle = ({
   const createSampleCircle = async () => {
     try {
       setLoading(true);
-      const { createSampleCircle: created } = await client.mutate({
-        createSampleCircle: { id: true },
-      });
+      const { createSampleCircle: created } = await client.mutate(
+        {
+          createSampleCircle: { id: true },
+        },
+        {
+          operationName: 'createSampleCircle',
+        }
+      );
       if (!created) {
         throw new Error('create sample circle failed');
       }

--- a/src/pages/DiscordPage/queries.ts
+++ b/src/pages/DiscordPage/queries.ts
@@ -7,16 +7,21 @@ export const getDiscordUserByProfileId = async ({
 }: {
   profileId: number;
 }) => {
-  const { discord_users } = await client.query({
-    discord_users: [
-      {
-        where: {
-          profile_id: { _eq: profileId },
+  const { discord_users } = await client.query(
+    {
+      discord_users: [
+        {
+          where: {
+            profile_id: { _eq: profileId },
+          },
         },
-      },
-      { id: true, user_snowflake: true, profile_id: true },
-    ],
-  });
+        { id: true, user_snowflake: true, profile_id: true },
+      ],
+    },
+    {
+      operationName: 'getDiscordUserByProfileId',
+    }
+  );
   return discord_users;
 };
 

--- a/src/pages/DistributionsPage/mutations.ts
+++ b/src/pages/DistributionsPage/mutations.ts
@@ -88,38 +88,48 @@ export function useMarkDistributionDone() {
 
 export function useSaveLockedTokenDistribution() {
   return useMutation(async (distribution: any) => {
-    const { insert_locked_token_distributions_one } = await client.mutate({
-      insert_locked_token_distributions_one: [
-        {
-          object: {
-            token_symbol: distribution.token_symbol,
-            token_decimals: distribution.token_decimals,
-            token_contract_address: distribution.token_contract_address,
-            gift_amount: distribution.gift_amount,
-            locked_token_distribution_gifts: {
-              data: distribution.locked_token_distribution_gifts,
+    const { insert_locked_token_distributions_one } = await client.mutate(
+      {
+        insert_locked_token_distributions_one: [
+          {
+            object: {
+              token_symbol: distribution.token_symbol,
+              token_decimals: distribution.token_decimals,
+              token_contract_address: distribution.token_contract_address,
+              gift_amount: distribution.gift_amount,
+              locked_token_distribution_gifts: {
+                data: distribution.locked_token_distribution_gifts,
+              },
+              epoch_id: distribution.epoch_id,
+              chain_id: distribution.chain_id,
             },
-            epoch_id: distribution.epoch_id,
-            chain_id: distribution.chain_id,
           },
-        },
-        { id: true },
-      ],
-    });
+          { id: true },
+        ],
+      },
+      {
+        operationName: 'createLockedTokenDistribution',
+      }
+    );
     return insert_locked_token_distributions_one;
   });
 }
 
 export function useMarkLockedDistributionDone() {
   return useMutation(({ id, tx_hash }: { id: number; tx_hash: string }) => {
-    return client.mutate({
-      update_locked_token_distributions_by_pk: [
-        {
-          _set: { tx_hash },
-          pk_columns: { id },
-        },
-        { id: true },
-      ],
-    });
+    return client.mutate(
+      {
+        update_locked_token_distributions_by_pk: [
+          {
+            _set: { tx_hash },
+            pk_columns: { id },
+          },
+          { id: true },
+        ],
+      },
+      {
+        operationName: 'updateLockedTokenDistribution',
+      }
+    );
   });
 }

--- a/src/pages/DistributionsPage/queries.ts
+++ b/src/pages/DistributionsPage/queries.ts
@@ -8,15 +8,20 @@ import type { Contracts } from 'lib/vaults';
 import type { Awaited } from 'types/shim';
 
 export const getProfileIds = async (addresses: string[]) => {
-  const { profiles } = await client.query({
-    profiles: [
-      { where: { address: { _in: addresses } } },
-      {
-        id: true,
-        address: true,
-      },
-    ],
-  });
+  const { profiles } = await client.query(
+    {
+      profiles: [
+        { where: { address: { _in: addresses } } },
+        {
+          id: true,
+          address: true,
+        },
+      ],
+    },
+    {
+      operationName: 'getProfileIds__DistributionPage',
+    }
+  );
   return profiles;
 };
 

--- a/src/pages/GivePage/index.tsx
+++ b/src/pages/GivePage/index.tsx
@@ -178,19 +178,24 @@ const GivePage = () => {
 
     try {
       // Save this and update the members collection
-      await client.mutate({
-        updateTeammates: [
-          {
-            payload: {
-              circle_id: selectedCircle.id,
-              teammates: newTeammates,
+      await client.mutate(
+        {
+          updateTeammates: [
+            {
+              payload: {
+                circle_id: selectedCircle.id,
+                teammates: newTeammates,
+              },
             },
-          },
-          {
-            __typename: true,
-          },
-        ],
-      });
+            {
+              __typename: true,
+            },
+          ],
+        },
+        {
+          operationName: 'updateTeammate',
+        }
+      );
       await queryClient.invalidateQueries(['teammates', selectedCircle.id]);
     } catch (e) {
       showError(e);
@@ -202,24 +207,29 @@ const GivePage = () => {
     // update all the pending gifts
     setSaveState('saving');
     try {
-      await client.mutate({
-        updateAllocations: [
-          {
-            payload: {
-              circle_id: selectedCircle.id,
-              allocations: Object.values(giftsRef.current).map(g => ({
-                ...g,
-                tokens: g.tokens ?? 0,
-                // note is required in the db schema
-                note: g.note ?? '',
-              })),
+      await client.mutate(
+        {
+          updateAllocations: [
+            {
+              payload: {
+                circle_id: selectedCircle.id,
+                allocations: Object.values(giftsRef.current).map(g => ({
+                  ...g,
+                  tokens: g.tokens ?? 0,
+                  // note is required in the db schema
+                  note: g.note ?? '',
+                })),
+              },
             },
-          },
-          {
-            __typename: true,
-          },
-        ],
-      });
+            {
+              __typename: true,
+            },
+          ],
+        },
+        {
+          operationName: 'saveGifts',
+        }
+      );
       setSaveState(prevState => {
         // this is to check if someone scheduled dirty changes while we were saving
         if (prevState == 'scheduled') {

--- a/src/pages/GivePage/queries.ts
+++ b/src/pages/GivePage/queries.ts
@@ -15,22 +15,27 @@ export const getContributionsForEpoch = async ({
   start_date: Date;
   end_date: Date;
 }) => {
-  const { contributions } = await client.query({
-    contributions: [
-      {
-        where: {
-          _and: [
-            { datetime_created: { _gt: start_date.toISOString() } },
-            { datetime_created: { _lt: end_date.toISOString() } },
-            { circle_id: { _eq: circleId } },
-            { user_id: { _eq: userId } },
-          ],
+  const { contributions } = await client.query(
+    {
+      contributions: [
+        {
+          where: {
+            _and: [
+              { datetime_created: { _gt: start_date.toISOString() } },
+              { datetime_created: { _lt: end_date.toISOString() } },
+              { circle_id: { _eq: circleId } },
+              { user_id: { _eq: userId } },
+            ],
+          },
+          order_by: [{ datetime_created: order_by.desc }],
         },
-        order_by: [{ datetime_created: order_by.desc }],
-      },
-      { id: true, description: true, datetime_created: true, user_id: true },
-    ],
-  });
+        { id: true, description: true, datetime_created: true, user_id: true },
+      ],
+    },
+    {
+      operationName: 'getContributionsForEpoch',
+    }
+  );
   return contributions;
 };
 
@@ -100,20 +105,25 @@ export const getMembersWithContributions = async (
   };
 };
 export const getCircleAllocationText = async (circleId: number) => {
-  const { circle } = await client.query({
-    __alias: {
-      circle: {
-        circles_by_pk: [
-          {
-            id: circleId,
-          },
-          {
-            alloc_text: true,
-          },
-        ],
+  const { circle } = await client.query(
+    {
+      __alias: {
+        circle: {
+          circles_by_pk: [
+            {
+              id: circleId,
+            },
+            {
+              alloc_text: true,
+            },
+          ],
+        },
       },
     },
-  });
+    {
+      operationName: 'getCircleAllocationText',
+    }
+  );
   return circle;
 };
 

--- a/src/pages/JoinCirclePage/JoinWithMagicLink.tsx
+++ b/src/pages/JoinCirclePage/JoinWithMagicLink.tsx
@@ -53,19 +53,22 @@ export const JoinWithMagicLink = ({
   const submitMagicToken = async ({ name }: { name: string }) => {
     try {
       setLoading(true);
-      const { createUserWithToken } = await client.mutate({
-        createUserWithToken: [
-          {
-            payload: {
-              token: tokenJoinInfo.token,
-              name: name,
+      const { createUserWithToken } = await client.mutate(
+        {
+          createUserWithToken: [
+            {
+              payload: {
+                token: tokenJoinInfo.token,
+                name: name,
+              },
             },
-          },
-          {
-            id: true,
-          },
-        ],
-      });
+            {
+              id: true,
+            },
+          ],
+        },
+        { operationName: 'createUserWithToken' }
+      );
       await fetchManifest();
       if (createUserWithToken?.id) {
         navigate(paths.history(tokenJoinInfo.circle.id));

--- a/src/pages/MembersPage/MembersTable.tsx
+++ b/src/pages/MembersPage/MembersTable.tsx
@@ -314,16 +314,19 @@ const MemberRow = ({
   useEffect(() => {
     (async () => {
       if (!contracts || !fixedPayment?.vaultId || !open) return;
-      const { vaults_by_pk: vault } = await client.query({
-        vaults_by_pk: [
-          { id: fixedPayment.vaultId },
-          {
-            simple_token_address: true,
-            vault_address: true,
-            decimals: true,
-          },
-        ],
-      });
+      const { vaults_by_pk: vault } = await client.query(
+        {
+          vaults_by_pk: [
+            { id: fixedPayment.vaultId },
+            {
+              simple_token_address: true,
+              vault_address: true,
+              decimals: true,
+            },
+          ],
+        },
+        { operationName: 'getVaultsMembersPage' }
+      );
       if (!vault) return;
       const balance = await contracts.getVaultBalance(vault);
       const available = formatUnits(balance, vault.decimals);

--- a/src/pages/OrganizationSettingsPage/mutations.ts
+++ b/src/pages/OrganizationSettingsPage/mutations.ts
@@ -6,13 +6,18 @@ type orgData = {
 };
 
 export const updateOrg = (orgId: number, data: orgData) => {
-  return client.mutate({
-    update_organizations_by_pk: [
-      {
-        _set: { ...data },
-        pk_columns: { id: orgId },
-      },
-      { id: true },
-    ],
-  });
+  return client.mutate(
+    {
+      update_organizations_by_pk: [
+        {
+          _set: { ...data },
+          pk_columns: { id: orgId },
+        },
+        { id: true },
+      ],
+    },
+    {
+      operationName: 'updateOrg',
+    }
+  );
 };


### PR DESCRIPTION
## Add operation_name to all Graphql requests

Having an `operation_name` is very useful for debugging and performance
monitoring of our requests. We add a TS requirement that makes operation_name
required in the makeThunder client for FE and admin requests, and then add names to all requests that
didn't have them.

