### PR TITLE
bugfix: align discord folder structure to match route

### DIFF
--- a/api/discord/oauth.ts
+++ b/api/discord/oauth.ts
@@ -7,7 +7,7 @@ import {
   DISCORD_BOT_CLIENT_ID,
   DISCORD_BOT_CLIENT_SECRET,
   DISCORD_BOT_REDIRECT_URI,
-} from '../api-lib/config';
+} from '../../api-lib/config';
 
 type AccessTokenResponse = {
   access_token: string;

--- a/scripts/serve_dev.ts
+++ b/scripts/serve_dev.ts
@@ -4,7 +4,7 @@ import { createProxyMiddleware } from 'http-proxy-middleware';
 import morgan from 'morgan';
 
 import landing from '../api/circle/landing/[token]';
-import discord from '../api/discord';
+import discord from '../api/discord/oauth';
 import actionManager from '../api/hasura/actions/actionManager';
 import auth from '../api/hasura/auth';
 import checkNominee from '../api/hasura/cron/checkNominee';


### PR DESCRIPTION
The route invoked is /api/discord/oauth. This change allows the folder
structure to match the route.
