### PR TITLE
Removes outline property from hedgey buttons

### DIFF
--- a/src/pages/CircleAdminPage/HedgeyIntegrationSettings.tsx
+++ b/src/pages/CircleAdminPage/HedgeyIntegrationSettings.tsx
@@ -100,7 +100,7 @@ export default function HedgeyIntegrationSettings(props: {
     return (
       <Flex css={{ flexDirection: 'column', alignItems: 'start' }}>
         <HedgeyIntro />
-        <Button color="primary" outlined onClick={() => setHedgeyEnabled(true)}>
+        <Button color="secondary" onClick={() => setHedgeyEnabled(true)}>
           Enable Hedgey Integration
         </Button>
       </Flex>
@@ -122,7 +122,6 @@ export default function HedgeyIntegrationSettings(props: {
         </div>
         <Button
           color="destructive"
-          outlined
           onClick={e => {
             e.preventDefault();
             setShowDisableModal(true);
@@ -154,7 +153,7 @@ export default function HedgeyIntegrationSettings(props: {
           onValueChange={value => setHedgeyTransferable(value)}
         />
       </Flex>
-      <Button color="primary" outlined onClick={onSaveHedgeyIntegration}>
+      <Button color="secondary" onClick={onSaveHedgeyIntegration}>
         Save Hedgey settings
       </Button>
       <Modal

--- a/src/pages/ClaimsPage/LockedTokenGiftsTable.tsx
+++ b/src/pages/ClaimsPage/LockedTokenGiftsTable.tsx
@@ -64,7 +64,7 @@ export default function LockedTokenGiftsTable() {
                       )}
                       target="_blank"
                     >
-                      <Button color="primary" size="small" outlined>
+                      <Button color="primary" size="small">
                         View Hedgeys
                       </Button>
                     </Link>

--- a/src/pages/DistributionsPage/DistributionForm.tsx
+++ b/src/pages/DistributionsPage/DistributionForm.tsx
@@ -878,7 +878,6 @@ export function DistributionForm({
           ) : isUsingHedgey && customToken?.symbol ? (
             <Button
               color="primary"
-              outlined
               disabled={giftSubmitting || !sufficientGiftTokens}
               fullWidth
             >


### PR DESCRIPTION
## Motivation and Context

We added a property "outline" to the hedgey buttons, with recent updates this has caused the buttons not to display. This PR removes the outline property.

## Description

Removes the outline property

## Test and Deployment Plan

Deploy and a quick visual test should work, previously the buttons did not show until you hover over them.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/4677277/214022346-cdc40bd3-1512-4a2a-871a-87d7027624b0.png)
![image](https://user-images.githubusercontent.com/4677277/214022449-7d7681f0-bcb7-49bd-b375-d7f04a9a2b51.png)
![image](https://user-images.githubusercontent.com/4677277/214022540-cb2a3dea-942a-443d-aef0-137c7f17051e.png)
![image](https://user-images.githubusercontent.com/4677277/214022597-55e9c285-91f8-4fff-8790-50991d98f0ec.png)


## Reviewers

@levity @crabsinger

## Related Issue

https://github.com/coordinape/coordinape/pull/1837
