### PR TITLE
Add db triggers to update `updated_at` on tables

### DIFF
--- a/hasura/migrations/default/1674672458652_add_updated_at_trigger_missing_tables/down.sql
+++ b/hasura/migrations/default/1674672458652_add_updated_at_trigger_missing_tables/down.sql
@@ -1,0 +1,1 @@
+DROP TRIGGER IF EXISTS set_public_profiles_updated_at on "public"."profiles";

--- a/hasura/migrations/default/1674672458652_add_updated_at_trigger_missing_tables/down.sql
+++ b/hasura/migrations/default/1674672458652_add_updated_at_trigger_missing_tables/down.sql
@@ -1,1 +1,2 @@
 DROP TRIGGER IF EXISTS set_public_profiles_updated_at on "public"."profiles";
+DROP TRIGGER IF EXISTS set_public_distributions_updated_at on "public"."distributions";

--- a/hasura/migrations/default/1674672458652_add_updated_at_trigger_missing_tables/up.sql
+++ b/hasura/migrations/default/1674672458652_add_updated_at_trigger_missing_tables/up.sql
@@ -1,6 +1,27 @@
-CREATE TRIGGER "set_public_profiles_updated_at"
-BEFORE UPDATE ON "public"."profiles"
-FOR EACH ROW
-EXECUTE PROCEDURE "public"."set_current_timestamp_updated_at"();
-COMMENT ON TRIGGER "set_public_profiles_updated_at" ON "public"."profiles"
-IS 'trigger to set value of column "updated_at" to current timestamp on row update';
+-- profiles
+DO $$
+BEGIN
+  CREATE TRIGGER "set_public_profiles_updated_at"
+    BEFORE UPDATE ON "public"."profiles"
+  FOR EACH ROW
+    EXECUTE PROCEDURE "public"."set_current_timestamp_updated_at"();
+    COMMENT ON TRIGGER "set_public_profiles_updated_at" ON "public"."profiles"
+  IS 'trigger to set value of column "updated_at" to current timestamp on row update';
+EXCEPTION
+    WHEN duplicate_object
+      THEN RAISE NOTICE 'updated_at trigger already exists. Ignoring...';
+END$$;
+
+-- distributions
+DO $$
+BEGIN
+  CREATE TRIGGER "set_public_distributions_updated_at"
+    BEFORE UPDATE ON "public"."distributions"
+  FOR EACH ROW
+    EXECUTE PROCEDURE "public"."set_current_timestamp_updated_at"();
+    COMMENT ON TRIGGER "set_public_distributions_updated_at" ON "public"."distributions"
+  IS 'trigger to set value of column "updated_at" to current timestamp on row update';
+EXCEPTION
+    WHEN duplicate_object
+      THEN RAISE NOTICE 'updated_at trigger already exists. Ignoring...';
+END$$;

--- a/hasura/migrations/default/1674672458652_add_updated_at_trigger_missing_tables/up.sql
+++ b/hasura/migrations/default/1674672458652_add_updated_at_trigger_missing_tables/up.sql
@@ -1,0 +1,6 @@
+CREATE TRIGGER "set_public_profiles_updated_at"
+BEFORE UPDATE ON "public"."profiles"
+FOR EACH ROW
+EXECUTE PROCEDURE "public"."set_current_timestamp_updated_at"();
+COMMENT ON TRIGGER "set_public_profiles_updated_at" ON "public"."profiles"
+IS 'trigger to set value of column "updated_at" to current timestamp on row update';


### PR DESCRIPTION
These two tables (profiles, distributions) didn't have the `updated_at` trigger to update on row changes. Adding.

- Add updated_at trigger on `profiles` table
- Add distributions table `updated_at` trigger
