### PR TITLE
Locked token distribution gifts on the claim page should be filtered by ID

### DIFF
--- a/src/pages/ClaimsPage/LockedTokenGiftsTable.tsx
+++ b/src/pages/ClaimsPage/LockedTokenGiftsTable.tsx
@@ -2,12 +2,14 @@ import { useEffect, useState } from 'react';
 
 import { ethers } from 'ethers';
 
+import { useMyProfile } from '../../recoilState';
 import { Button, Link, Panel, Table, Text } from 'ui';
 import { makeExplorerUrl } from 'utils/provider';
 
 import { getLockedTokenGifts } from './queries';
 
 export default function LockedTokenGiftsTable() {
+  const profile = useMyProfile();
   const [lockedTokenGifts, setLockedTokenGifts] = useState([] as any[]);
   const hedgeyPortfolioUrl = (chainId: string) =>
     chainId === '1'
@@ -15,8 +17,8 @@ export default function LockedTokenGiftsTable() {
       : 'https://hedgey-app-v2-git-coordinape-test-hedgey-finance.vercel.app/my-rewards';
 
   useEffect(() => {
-    getLockedTokenGifts().then(setLockedTokenGifts);
-  }, []);
+    getLockedTokenGifts(profile.id).then(setLockedTokenGifts);
+  }, [profile]);
 
   if (lockedTokenGifts.length === 0) return null;
 

--- a/src/pages/ClaimsPage/queries.ts
+++ b/src/pages/ClaimsPage/queries.ts
@@ -4,12 +4,13 @@ import { Contracts } from 'lib/vaults';
 
 import type { Awaited } from 'types/shim';
 
-export const getLockedTokenGifts = async () => {
+export const getLockedTokenGifts = async (profileId: number) => {
   const { locked_token_distribution_gifts } = await client.query(
     {
       locked_token_distribution_gifts: [
         {
           where: {
+            profile_id: { _eq: profileId },
             locked_token_distribution: { tx_hash: { _is_null: false } },
           },
         },


### PR DESCRIPTION
## Motivation and Context

I noticed this issue during testing, the locked token distribution table on the claims page was not filtered by the profile ID. I had this check in but it must have gotten lost during the rebase from staging.

## Description

The locked token distribution table on the claims page was not filtered by the profile ID, so it shows all locked token distributions for each user.

## Test and Deployment Plan

Have some locked token distributions completed and visit the claims page, notice previously all locked token distributions were shown, now only the ones related to the current profile are.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/4677277/214843658-a929bb57-8535-4972-9b0e-46e48654cc74.png)


## Reviewers

@CryptoGraffe @levity 

## Related Issue

https://github.com/coordinape/coordinape/pull/1837
