### PR TITLE
chain_id was being compared as a string

### DIFF
--- a/src/pages/ClaimsPage/LockedTokenGiftsTable.tsx
+++ b/src/pages/ClaimsPage/LockedTokenGiftsTable.tsx
@@ -11,10 +11,10 @@ import { getLockedTokenGifts } from './queries';
 export default function LockedTokenGiftsTable() {
   const profile = useMyProfile();
   const [lockedTokenGifts, setLockedTokenGifts] = useState([] as any[]);
-  const hedgeyPortfolioUrl = (chainId: string) =>
-    chainId === '1'
-      ? 'https://app.hedgey.finance/my-rewards'
-      : 'https://hedgey-app-v2-git-coordinape-test-hedgey-finance.vercel.app/my-rewards';
+  const hedgeyPortfolioUrl = (chainId: number) =>
+    chainId === 5
+      ? 'https://hedgey-app-v2-git-coordinape-test-hedgey-finance.vercel.app/my-rewards'
+      : 'https://app.hedgey.finance/my-rewards';
 
   useEffect(() => {
     getLockedTokenGifts(profile.id).then(setLockedTokenGifts);


### PR DESCRIPTION
## Motivation and Context

We have a test app for testnets, the production app should link to the hedgey.finance production portfolio.

## Description

Updated the comparison to use numbers rather than strings as they are saved in the database as numbers.

## Test and Deployment Plan

Visit the claims page and ensure locked token gifts on mainnet, the view hedgeys link points to https://app.hedgey.finance/my-rewards

## Reviewers
@levity @crabsinger