### PR TITLE
Handle replaced transactions

### DIFF
--- a/src/hooks/useVaultFactory.ts
+++ b/src/hooks/useVaultFactory.ts
@@ -51,6 +51,7 @@ export function useVaultFactory(orgId?: number) {
           showError,
           description: `Create ${type || customSymbol} Vault`,
           chainId: contracts.chainId,
+          contract: contracts.vaultFactory,
           savePending: async (txHash: string) => {
             if (setTxHash) setTxHash(txHash);
             return savePendingVaultTx({

--- a/src/hooks/useVaultRouter.ts
+++ b/src/hooks/useVaultRouter.ts
@@ -50,6 +50,7 @@ export function useVaultRouter(contracts?: Contracts) {
           signingMessage: 'Please sign the transaction to wrap your ETH.',
           description: `Deposit ${humanAmount} ETH`,
           chainId: contracts.chainId,
+          contract: weth,
         }
       );
 
@@ -73,6 +74,7 @@ export function useVaultRouter(contracts?: Contracts) {
             'Please sign the transaction to approve the transfer.',
           description: `Approve ${humanAmount} ${symbol}`,
           chainId: contracts.chainId,
+          contract: token,
         }
       );
       if (result.error) return result;
@@ -93,6 +95,7 @@ export function useVaultRouter(contracts?: Contracts) {
         signingMessage: 'Please sign the transaction to deposit tokens.',
         description: `Deposit ${humanAmount} ${symbol}`,
         chainId: contracts.chainId,
+        contract: isSimpleToken ? token : contracts.router,
       }
     );
     if (txResult?.tx)
@@ -129,6 +132,7 @@ export function useVaultRouter(contracts?: Contracts) {
         signingMessage: 'Please sign the transaction to withdraw tokens.',
         chainId: contracts.chainId,
         description: `Withdraw ${humanAmount} ${symbol}`,
+        contract: vaultContract,
       }
     );
     if (txResult?.tx)

--- a/src/lib/ethers/addContractWait.ts
+++ b/src/lib/ethers/addContractWait.ts
@@ -1,0 +1,54 @@
+import assert from 'assert';
+
+import type { LogDescription } from '@ethersproject/abi';
+import type { TransactionResponse } from '@ethersproject/abstract-provider';
+import { BytesLike } from '@ethersproject/bytes';
+import type {
+  Contract,
+  ContractReceipt,
+  Event,
+} from '@ethersproject/contracts';
+import { deepCopy } from '@ethersproject/properties';
+
+// source: https://github.com/ethers-io/ethers.js/blob/v5.7.2/packages/contracts/src.ts/index.ts#L334
+// it's tweaked to pass typing & formatting checks but no functionality is changed
+export function addContractWait(contract: Contract, tx: TransactionResponse) {
+  const wait = tx.wait.bind(tx);
+  tx.wait = (confirmations?: number) => {
+    return wait(confirmations).then((receipt: ContractReceipt) => {
+      (receipt as any).events = receipt.logs.map(log => {
+        const event: Event = deepCopy(log) as Event;
+        let parsed: LogDescription | null = null;
+        try {
+          parsed = contract.interface.parseLog(log);
+        } catch (e) {} // eslint-disable-line no-empty
+
+        // Successfully parsed the event log; include it
+        if (parsed) {
+          event.args = parsed.args;
+          event.decode = (data: BytesLike, topics?: Array<any>) => {
+            assert(parsed);
+            return contract.interface.decodeEventLog(
+              parsed.eventFragment,
+              data,
+              topics
+            );
+          };
+          event.event = parsed.name;
+          event.eventSignature = parsed.signature;
+        }
+
+        // Useful operations
+        event.removeListener = () => contract.provider;
+        event.getBlock = () => contract.provider.getBlock(receipt.blockHash);
+        event.getTransaction = () =>
+          contract.provider.getTransaction(receipt.transactionHash);
+        event.getTransactionReceipt = () => Promise.resolve(receipt);
+
+        return event;
+      });
+
+      return receipt;
+    });
+  };
+}

--- a/src/pages/ClaimsPage/useClaimAllocation.ts
+++ b/src/pages/ClaimsPage/useClaimAllocation.ts
@@ -78,6 +78,7 @@ export function useClaimAllocation() {
               chain_id: Number.parseInt(contracts.chainId),
               tx_type: vault_tx_types_enum.Claim,
             }),
+          contract: contracts.distributor,
         }
       );
 
@@ -111,6 +112,7 @@ export function useClaimAllocation() {
           signingMessage: 'Please sign the transaction to unwrap your WETH.',
           description: `Unwrapped ${amount} ETH`,
           chainId: contracts.chainId,
+          contract: weth,
         });
       }
 

--- a/src/pages/DistributionsPage/useSubmitDistribution.ts
+++ b/src/pages/DistributionsPage/useSubmitDistribution.ts
@@ -170,6 +170,7 @@ export function useSubmitDistribution() {
               chain_id: Number.parseInt(contracts.chainId),
               tx_type: vault_tx_types_enum.Distribution,
             }),
+          contract: contracts.distributor,
         }
       );
 


### PR DESCRIPTION
## Motivation and Context

Fixes #1836 (on the frontend, at least)

## Description

On frontend: catch the TRANSACTION_REPLACED error and update the UI as well as the `pending_vault_transactions` table with the new transaction hash

## Test and Deployment Plan

- Submit any transaction (vault creation, deposit, distribution, claim, etc.) in the UI on Goerli with a very low gas price
- Re-submit it with a normal gas price (e.g. with the "Speed Up" button in MetaMask)
- Wait for the UI to update as normal
