### PR TITLE
renaming magic link -> invite link

### DIFF
--- a/api/hasura/actions/_handlers/createUserWithToken.ts
+++ b/api/hasura/actions/_handlers/createUserWithToken.ts
@@ -7,9 +7,9 @@ import { verifyHasuraRequestMiddleware } from '../../../../api-lib/validate';
 import { CircleTokenType } from '../../../../src/common-lib/circleShareTokens';
 import { ENTRANCE } from '../../../../src/common-lib/constants';
 import {
+  composeHasuraActionRequestBodyWithSession,
   createUserFromTokenInput,
   HasuraUserSessionVariables,
-  composeHasuraActionRequestBodyWithSession,
 } from '../../../../src/lib/zod';
 
 import { createUserMutation } from './createUserMutation';
@@ -27,7 +27,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
   const { hasuraProfileId } = sessionVariables;
   const address = await getAddress(hasuraProfileId);
 
-  // get the circleId from the token and make sure its magic
+  // get the circleId from the token and make sure its an invite token
   const { circle_share_tokens } = await adminClient.query(
     {
       circle_share_tokens: [
@@ -42,7 +42,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
               },
             },
             type: {
-              _eq: CircleTokenType.Magic,
+              _eq: CircleTokenType.Invite,
             },
           },
         },

--- a/src/common-lib/circleShareTokens.ts
+++ b/src/common-lib/circleShareTokens.ts
@@ -1,4 +1,4 @@
 export enum CircleTokenType {
   Welcome = 0,
-  Magic,
+  Invite,
 }

--- a/src/common-lib/constants.ts
+++ b/src/common-lib/constants.ts
@@ -2,7 +2,7 @@ import { IN_DEVELOPMENT } from '../config/env';
 
 export enum ENTRANCE {
   ADMIN = 'circle-create-initial-admin',
-  LINK = 'magic-link',
+  LINK = 'invite-link',
   MANUAL = 'manual-address-entry',
   CSV = 'CSV',
   NOMINATION = 'vouched-in',

--- a/src/pages/AddMembersPage/AddMembersPage.tsx
+++ b/src/pages/AddMembersPage/AddMembersPage.tsx
@@ -9,13 +9,13 @@ import { AppLink, Box, ContentHeader, Flex, Link, Panel, Text } from 'ui';
 import { SingleColumnLayout } from 'ui/layouts';
 
 import CSVImport from './CSVImport';
-import MagicLink from './MagicLink';
+import InviteLink from './InviteLink';
 import NewMemberList, { NewMember } from './NewMemberList';
 import TabButton, { Tab } from './TabButton';
 import {
-  deleteMagicToken,
+  deleteInviteToken,
   deleteWelcomeToken,
-  useMagicToken,
+  useInviteToken,
   useWelcomeToken,
 } from './useCircleTokens';
 
@@ -24,21 +24,21 @@ const AddMembersPage = () => {
 
   const [loading, setLoading] = useState<boolean>(false);
 
-  const { data: magicLinkUuid, refetch: refetchMagicToken } =
-    useMagicToken(circleId);
+  const { data: inviteLinkUuid, refetch: fetchInviteToken } =
+    useInviteToken(circleId);
   const { data: welcomeUuid, refetch: refetchWelcomeToken } =
     useWelcomeToken(circleId);
 
   // Wait for initial load, show nothing but loading modal
-  if (!magicLinkUuid || !welcomeUuid) {
+  if (!inviteLinkUuid || !welcomeUuid) {
     return <LoadingModal visible={true} />;
   }
 
-  const revokeMagic = async () => {
+  const revokeInvite = async () => {
     try {
       setLoading(true);
-      await deleteMagicToken(circleId);
-      await refetchMagicToken();
+      await deleteInviteToken(circleId);
+      await fetchInviteToken();
     } finally {
       setLoading(false);
     }
@@ -54,7 +54,7 @@ const AddMembersPage = () => {
     }
   };
 
-  const magicLink = APP_URL + paths.join(magicLinkUuid);
+  const inviteLink = APP_URL + paths.join(inviteLinkUuid);
   const welcomeLink = APP_URL + paths.invite(welcomeUuid);
 
   return (
@@ -63,8 +63,8 @@ const AddMembersPage = () => {
       <AddMembersContents
         circle={circle}
         welcomeLink={welcomeLink}
-        magicLink={magicLink}
-        revokeMagic={revokeMagic}
+        inviteLink={inviteLink}
+        revokeInvite={revokeInvite}
         revokeWelcome={revokeWelcome}
       />
     </>
@@ -74,14 +74,14 @@ const AddMembersPage = () => {
 const AddMembersContents = ({
   circle,
   welcomeLink,
-  magicLink,
-  // revokeMagic, TODO: add revoke in a later PR when UI is better defined
+  inviteLink,
+  // revokeInvite, TODO: add revoke in a later PR when UI is better defined
   revokeWelcome,
 }: {
   circle: ICircle;
   welcomeLink: string;
-  magicLink: string;
-  revokeMagic(): void;
+  inviteLink: string;
+  revokeInvite(): void;
   revokeWelcome(): void;
 }) => {
   const [currentTab, setCurrentTab] = useState<Tab>(Tab.ETH);
@@ -128,7 +128,7 @@ const AddMembersContents = ({
           currentTab={currentTab}
           setCurrentTab={setCurrentTab}
         >
-          Magic Link
+          Invite Link
         </TabButton>
         <TabButton
           tab={Tab.CSV}
@@ -164,9 +164,9 @@ const AddMembersContents = ({
           {currentTab === Tab.LINK && (
             <Box>
               <Text css={{ pb: '$lg', pt: '$sm' }} size="medium">
-                Add new members by sharing a magic link.
+                Add new members by sharing an invite link.
               </Text>
-              <MagicLink magicLink={magicLink} />
+              <InviteLink inviteLink={inviteLink} />
             </Box>
           )}
           {currentTab === Tab.CSV && (

--- a/src/pages/AddMembersPage/InviteLink.tsx
+++ b/src/pages/AddMembersPage/InviteLink.tsx
@@ -4,13 +4,13 @@ import CopyCodeTextField from '../../components/CopyCodeTextField';
 import { AlertTriangle } from '../../icons/__generated';
 import { Box, Flex, Panel, Text } from '../../ui';
 
-const MagicLink = ({ magicLink }: { magicLink: string }) => {
+const InviteLink = ({ inviteLink }: { inviteLink: string }) => {
   return (
     <Box>
       <Flex alignItems="center" css={{ mb: '$xs' }}>
-        <Text variant="label">Magic Circle Link</Text>
+        <Text variant="label">Circle Invite Link</Text>
       </Flex>
-      <CopyCodeTextField value={magicLink} />
+      <CopyCodeTextField value={inviteLink} />
 
       <Panel alert css={{ mt: '$xl', mb: '$md' }}>
         <Flex alignItems="center">
@@ -22,8 +22,8 @@ const MagicLink = ({ magicLink }: { magicLink: string }) => {
             }}
           />
           <Text color="inherit">
-            Anyone with this link can join this circle and set their name. For
-            added security, add new members using their wallet addresses.
+            Anyone with this link can join this circle. For added security, add
+            new members using their wallet addresses.
           </Text>
         </Flex>
       </Panel>
@@ -31,4 +31,4 @@ const MagicLink = ({ magicLink }: { magicLink: string }) => {
   );
 };
 
-export default MagicLink;
+export default InviteLink;

--- a/src/pages/AddMembersPage/useCircleTokens.ts
+++ b/src/pages/AddMembersPage/useCircleTokens.ts
@@ -5,16 +5,16 @@ import { useQuery } from 'react-query';
 import { CircleTokenType } from '../../common-lib/circleShareTokens';
 import { client } from '../../lib/gql/client';
 
-export const useMagicToken = (circleId: number) => {
-  return useCircleTokens(circleId, CircleTokenType.Magic);
+export const useInviteToken = (circleId: number) => {
+  return useCircleTokens(circleId, CircleTokenType.Invite);
 };
 
 export const useWelcomeToken = (circleId: number) => {
   return useCircleTokens(circleId, CircleTokenType.Welcome);
 };
 
-export const deleteMagicToken = (circleId: number) => {
-  return deleteToken(circleId, CircleTokenType.Magic);
+export const deleteInviteToken = (circleId: number) => {
+  return deleteToken(circleId, CircleTokenType.Invite);
 };
 
 export const deleteWelcomeToken = (circleId: number) => {

--- a/src/pages/JoinCirclePage/JoinCirclePage.test.tsx
+++ b/src/pages/JoinCirclePage/JoinCirclePage.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from '@testing-library/react';
 import { CircleTokenType } from 'common-lib/circleShareTokens';
 import { useAuthStore } from 'features/auth';
 import { setMockHeaders } from 'lib/gql/client';
-import { Routes, Route } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 
 import { adminClient } from '../../../api-lib/gql/adminClient';
 import { createProfile } from '../../../api-test/helpers';
@@ -29,7 +29,7 @@ beforeAll(async () => {
         createJoinToken: {
           insert_circle_share_tokens_one: [
             {
-              object: { circle_id: circle.id, type: CircleTokenType.Magic },
+              object: { circle_id: circle.id, type: CircleTokenType.Invite },
             },
             { uuid: true },
           ],

--- a/src/pages/JoinCirclePage/JoinCirclePage.tsx
+++ b/src/pages/JoinCirclePage/JoinCirclePage.tsx
@@ -14,7 +14,7 @@ import { CenteredBox, Panel, Text } from '../../ui';
 import useConnectedAddress from 'hooks/useConnectedAddress';
 
 import { AddressIsNotMember } from './AddressIsNotMember';
-import { JoinWithMagicLink } from './JoinWithMagicLink';
+import { JoinWithInviteLink } from './JoinWithInviteLink';
 import {
   getProfilesWithAddress,
   QUERY_KEY_PROFILE_BY_ADDRESS,
@@ -120,7 +120,7 @@ export const JoinCirclePage = () => {
         </CenteredBox>
       )}
       {tokenJoinInfo && (
-        <JoinWithMagicLink tokenJoinInfo={tokenJoinInfo} profile={profile} />
+        <JoinWithInviteLink tokenJoinInfo={tokenJoinInfo} profile={profile} />
       )}
     </>
   );

--- a/src/pages/JoinCirclePage/JoinWithInviteLink.tsx
+++ b/src/pages/JoinCirclePage/JoinWithInviteLink.tsx
@@ -9,15 +9,15 @@ import { z } from 'zod';
 import type { TokenJoinInfo } from '../../../api/circle/landing/[token]';
 import { LoadingModal } from '../../components';
 import CircleWithLogo from '../../components/CircleWithLogo';
-import { useToast, useApiBase } from '../../hooks';
+import { useApiBase, useToast } from '../../hooks';
 import { client } from '../../lib/gql/client';
 import { zUsername } from '../../lib/zod/formHelpers';
 import { paths } from '../../routes/paths';
-import { Box, Button, CenteredBox, TextField, Text, Panel } from '../../ui';
+import { Box, Button, CenteredBox, Panel, Text, TextField } from '../../ui';
 import { normalizeError } from '../../utils/reporting';
 import useConnectedAddress from 'hooks/useConnectedAddress';
 
-export const JoinWithMagicLink = ({
+export const JoinWithInviteLink = ({
   tokenJoinInfo,
   profile,
 }: {
@@ -119,7 +119,7 @@ const JoinForm = ({
 
   const { token, circle } = tokenJoinInfo;
 
-  const submitMagicToken = async ({ name }: { name: string }) => {
+  const submitInviteToken = async ({ name }: { name: string }) => {
     try {
       setLoading(true);
       const { createUserWithToken } = await client.mutate(
@@ -141,7 +141,7 @@ const JoinForm = ({
   };
 
   return (
-    <form onSubmit={handleSubmit(submitMagicToken)}>
+    <form onSubmit={handleSubmit(submitInviteToken)}>
       <Box
         css={{
           mb: '$md',


### PR DESCRIPTION
## Motivation and Context

Our naming of Magic Link clashes with the third party integration with magic.link 

## Description

Renamed our magic link to simply "invite link"

## Test and Deployment Plan
Make sure it all looks good in the add members pane and joining by invite link still works
