### PR TITLE
Edit Epoch Description Inline

### DIFF
--- a/hasura/metadata/databases/default/tables/public_epoches.yaml
+++ b/hasura/metadata/databases/default/tables/public_epoches.yaml
@@ -112,3 +112,23 @@ select_permissions:
                         _eq: X-Hasura-User-Id
                   - deleted_at:
                       _is_null: true
+update_permissions:
+  - role: user
+    permission:
+      columns:
+        - description
+      filter:
+        _and:
+          - circle:
+              users:
+                _and:
+                  - profile:
+                      id:
+                        _eq: X-Hasura-User-Id
+                  - deleted_at:
+                      _is_null: true
+                  - role:
+                      _eq: 1
+          - ended:
+              _eq: false
+      check: {}

--- a/hasura/migrations/default/1675295266838_alter_table_public_epoches_add_check_constraint_description_length_constraint/down.sql
+++ b/hasura/migrations/default/1675295266838_alter_table_public_epoches_add_check_constraint_description_length_constraint/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."epoches" drop constraint "description_length_constraint";

--- a/hasura/migrations/default/1675295266838_alter_table_public_epoches_add_check_constraint_description_length_constraint/up.sql
+++ b/hasura/migrations/default/1675295266838_alter_table_public_epoches_add_check_constraint_description_length_constraint/up.sql
@@ -1,1 +1,1 @@
-alter table "public"."epoches" add constraint "description_length_constraint" check (length(description) >= 10 AND length(description) <= 100);
+alter table "public"."epoches" add constraint "description_length_constraint" check (length(description) >= 1 AND length(description) <= 100);

--- a/hasura/migrations/default/1675295266838_alter_table_public_epoches_add_check_constraint_description_length_constraint/up.sql
+++ b/hasura/migrations/default/1675295266838_alter_table_public_epoches_add_check_constraint_description_length_constraint/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."epoches" add constraint "description_length_constraint" check (length(description) >= 10 AND length(description) <= 100);

--- a/hasura/schema/user/schema.graphql
+++ b/hasura/schema/user/schema.graphql
@@ -5000,6 +5000,21 @@ input epochs_min_order_by {
 }
 
 """
+response of any mutation on the table "epoches"
+"""
+type epochs_mutation_response {
+  """
+  number of rows affected by the mutation
+  """
+  affected_rows: Int!
+
+  """
+  data from the rows affected by the mutation
+  """
+  returning: [epochs!]!
+}
+
+"""
 Ordering options when selecting data from "epoches".
 """
 input epochs_order_by {
@@ -5025,6 +5040,13 @@ input epochs_order_by {
   start_date: order_by
   token_gifts_aggregate: token_gifts_aggregate_order_by
   updated_at: order_by
+}
+
+"""
+primary key columns input for table: epoches
+"""
+input epochs_pk_columns_input {
+  id: bigint!
 }
 
 """
@@ -5118,6 +5140,13 @@ enum epochs_select_column {
 }
 
 """
+input type for updating data in table "epoches"
+"""
+input epochs_set_input {
+  description: String
+}
+
+"""
 order by stddev() on columns of table "epoches"
 """
 input epochs_stddev_order_by {
@@ -5205,6 +5234,14 @@ input epochs_sum_order_by {
   number: order_by
   repeat: order_by
   repeat_day_of_month: order_by
+}
+
+input epochs_updates {
+  """
+  sets the columns of the filtered rows to the given values
+  """
+  _set: epochs_set_input
+  where: epochs_bool_exp!
 }
 
 """
@@ -6557,6 +6594,42 @@ type mutation_root {
     """
     updates: [distributions_updates!]!
   ): [distributions_mutation_response]
+
+  """
+  update data of the table: "epoches"
+  """
+  update_epochs(
+    """
+    sets the columns of the filtered rows to the given values
+    """
+    _set: epochs_set_input
+
+    """
+    filter the rows which have to be updated
+    """
+    where: epochs_bool_exp!
+  ): epochs_mutation_response
+
+  """
+  update single row of the table: "epoches"
+  """
+  update_epochs_by_pk(
+    """
+    sets the columns of the filtered rows to the given values
+    """
+    _set: epochs_set_input
+    pk_columns: epochs_pk_columns_input!
+  ): epochs
+
+  """
+  update multiples rows of table: "epoches"
+  """
+  update_epochs_many(
+    """
+    updates to execute, in order
+    """
+    updates: [epochs_updates!]!
+  ): [epochs_mutation_response]
 
   """
   update data of the table: "locked_token_distributions"

--- a/src/lib/gql/__generated__/zeus/const.ts
+++ b/src/lib/gql/__generated__/zeus/const.ts
@@ -1598,7 +1598,11 @@ export const AllTypesProps: Record<string, any> = {
     token_gifts_aggregate: 'token_gifts_aggregate_order_by',
     updated_at: 'order_by',
   },
+  epochs_pk_columns_input: {
+    id: 'bigint',
+  },
   epochs_select_column: true,
+  epochs_set_input: {},
   epochs_stddev_order_by: {
     circle_id: 'order_by',
     days: 'order_by',
@@ -1650,6 +1654,10 @@ export const AllTypesProps: Record<string, any> = {
     number: 'order_by',
     repeat: 'order_by',
     repeat_day_of_month: 'order_by',
+  },
+  epochs_updates: {
+    _set: 'epochs_set_input',
+    where: 'epochs_bool_exp',
   },
   epochs_var_pop_order_by: {
     circle_id: 'order_by',
@@ -2170,6 +2178,17 @@ export const AllTypesProps: Record<string, any> = {
     },
     update_distributions_many: {
       updates: 'distributions_updates',
+    },
+    update_epochs: {
+      _set: 'epochs_set_input',
+      where: 'epochs_bool_exp',
+    },
+    update_epochs_by_pk: {
+      _set: 'epochs_set_input',
+      pk_columns: 'epochs_pk_columns_input',
+    },
+    update_epochs_many: {
+      updates: 'epochs_updates',
     },
     update_locked_token_distributions: {
       _set: 'locked_token_distributions_set_input',
@@ -5060,6 +5079,10 @@ export const ReturnTypes: Record<string, any> = {
     token_gifts_aggregate: 'token_gifts_aggregate',
     updated_at: 'timestamp',
   },
+  epochs_mutation_response: {
+    affected_rows: 'Int',
+    returning: 'epochs',
+  },
   gift_private: {
     gift_id: 'bigint',
     note: 'String',
@@ -5178,6 +5201,9 @@ export const ReturnTypes: Record<string, any> = {
     update_distributions: 'distributions_mutation_response',
     update_distributions_by_pk: 'distributions',
     update_distributions_many: 'distributions_mutation_response',
+    update_epochs: 'epochs_mutation_response',
+    update_epochs_by_pk: 'epochs',
+    update_epochs_many: 'epochs_mutation_response',
     update_locked_token_distributions:
       'locked_token_distributions_mutation_response',
     update_locked_token_distributions_by_pk: 'locked_token_distributions',

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -4038,6 +4038,14 @@ export type ValueTypes = {
     start_date?: ValueTypes['order_by'] | undefined | null;
     updated_at?: ValueTypes['order_by'] | undefined | null;
   };
+  /** response of any mutation on the table "epoches" */
+  ['epochs_mutation_response']: AliasType<{
+    /** number of rows affected by the mutation */
+    affected_rows?: boolean | `@${string}`;
+    /** data from the rows affected by the mutation */
+    returning?: ValueTypes['epochs'];
+    __typename?: boolean | `@${string}`;
+  }>;
   /** Ordering options when selecting data from "epoches". */
   ['epochs_order_by']: {
     burns_aggregate?: ValueTypes['burns_aggregate_order_by'] | undefined | null;
@@ -4072,8 +4080,16 @@ export type ValueTypes = {
       | null;
     updated_at?: ValueTypes['order_by'] | undefined | null;
   };
+  /** primary key columns input for table: epoches */
+  ['epochs_pk_columns_input']: {
+    id: ValueTypes['bigint'];
+  };
   /** select columns of table "epoches" */
   ['epochs_select_column']: epochs_select_column;
+  /** input type for updating data in table "epoches" */
+  ['epochs_set_input']: {
+    description?: string | undefined | null;
+  };
   /** order by stddev() on columns of table "epoches" */
   ['epochs_stddev_order_by']: {
     circle_id?: ValueTypes['order_by'] | undefined | null;
@@ -4140,6 +4156,11 @@ export type ValueTypes = {
     number?: ValueTypes['order_by'] | undefined | null;
     repeat?: ValueTypes['order_by'] | undefined | null;
     repeat_day_of_month?: ValueTypes['order_by'] | undefined | null;
+  };
+  ['epochs_updates']: {
+    /** sets the columns of the filtered rows to the given values */
+    _set?: ValueTypes['epochs_set_input'] | undefined | null;
+    where: ValueTypes['epochs_bool_exp'];
   };
   /** order by var_pop() on columns of table "epoches" */
   ['epochs_var_pop_order_by']: {
@@ -5175,6 +5196,32 @@ export type ValueTypes = {
         updates: Array<ValueTypes['distributions_updates']>;
       },
       ValueTypes['distributions_mutation_response']
+    ];
+    update_epochs?: [
+      {
+        /** sets the columns of the filtered rows to the given values */
+        _set?:
+          | ValueTypes['epochs_set_input']
+          | undefined
+          | null /** filter the rows which have to be updated */;
+        where: ValueTypes['epochs_bool_exp'];
+      },
+      ValueTypes['epochs_mutation_response']
+    ];
+    update_epochs_by_pk?: [
+      {
+        /** sets the columns of the filtered rows to the given values */
+        _set?: ValueTypes['epochs_set_input'] | undefined | null;
+        pk_columns: ValueTypes['epochs_pk_columns_input'];
+      },
+      ValueTypes['epochs']
+    ];
+    update_epochs_many?: [
+      {
+        /** updates to execute, in order */
+        updates: Array<ValueTypes['epochs_updates']>;
+      },
+      ValueTypes['epochs_mutation_response']
     ];
     update_locked_token_distributions?: [
       {
@@ -11699,10 +11746,21 @@ export type ModelTypes = {
   ['epochs_max_order_by']: GraphQLTypes['epochs_max_order_by'];
   /** order by min() on columns of table "epoches" */
   ['epochs_min_order_by']: GraphQLTypes['epochs_min_order_by'];
+  /** response of any mutation on the table "epoches" */
+  ['epochs_mutation_response']: {
+    /** number of rows affected by the mutation */
+    affected_rows: number;
+    /** data from the rows affected by the mutation */
+    returning: Array<GraphQLTypes['epochs']>;
+  };
   /** Ordering options when selecting data from "epoches". */
   ['epochs_order_by']: GraphQLTypes['epochs_order_by'];
+  /** primary key columns input for table: epoches */
+  ['epochs_pk_columns_input']: GraphQLTypes['epochs_pk_columns_input'];
   /** select columns of table "epoches" */
   ['epochs_select_column']: GraphQLTypes['epochs_select_column'];
+  /** input type for updating data in table "epoches" */
+  ['epochs_set_input']: GraphQLTypes['epochs_set_input'];
   /** order by stddev() on columns of table "epoches" */
   ['epochs_stddev_order_by']: GraphQLTypes['epochs_stddev_order_by'];
   /** order by stddev_pop() on columns of table "epoches" */
@@ -11715,6 +11773,7 @@ export type ModelTypes = {
   ['epochs_stream_cursor_value_input']: GraphQLTypes['epochs_stream_cursor_value_input'];
   /** order by sum() on columns of table "epoches" */
   ['epochs_sum_order_by']: GraphQLTypes['epochs_sum_order_by'];
+  ['epochs_updates']: GraphQLTypes['epochs_updates'];
   /** order by var_pop() on columns of table "epoches" */
   ['epochs_var_pop_order_by']: GraphQLTypes['epochs_var_pop_order_by'];
   /** order by var_samp() on columns of table "epoches" */
@@ -12051,6 +12110,14 @@ export type ModelTypes = {
     /** update multiples rows of table: "distributions" */
     update_distributions_many?:
       | Array<GraphQLTypes['distributions_mutation_response'] | undefined>
+      | undefined;
+    /** update data of the table: "epoches" */
+    update_epochs?: GraphQLTypes['epochs_mutation_response'] | undefined;
+    /** update single row of the table: "epoches" */
+    update_epochs_by_pk?: GraphQLTypes['epochs'] | undefined;
+    /** update multiples rows of table: "epoches" */
+    update_epochs_many?:
+      | Array<GraphQLTypes['epochs_mutation_response'] | undefined>
       | undefined;
     /** update data of the table: "locked_token_distributions" */
     update_locked_token_distributions?:
@@ -16237,6 +16304,14 @@ export type GraphQLTypes = {
     start_date?: GraphQLTypes['order_by'] | undefined;
     updated_at?: GraphQLTypes['order_by'] | undefined;
   };
+  /** response of any mutation on the table "epoches" */
+  ['epochs_mutation_response']: {
+    __typename: 'epochs_mutation_response';
+    /** number of rows affected by the mutation */
+    affected_rows: number;
+    /** data from the rows affected by the mutation */
+    returning: Array<GraphQLTypes['epochs']>;
+  };
   /** Ordering options when selecting data from "epoches". */
   ['epochs_order_by']: {
     burns_aggregate?: GraphQLTypes['burns_aggregate_order_by'] | undefined;
@@ -16268,8 +16343,16 @@ export type GraphQLTypes = {
       | undefined;
     updated_at?: GraphQLTypes['order_by'] | undefined;
   };
+  /** primary key columns input for table: epoches */
+  ['epochs_pk_columns_input']: {
+    id: GraphQLTypes['bigint'];
+  };
   /** select columns of table "epoches" */
   ['epochs_select_column']: epochs_select_column;
+  /** input type for updating data in table "epoches" */
+  ['epochs_set_input']: {
+    description?: string | undefined;
+  };
   /** order by stddev() on columns of table "epoches" */
   ['epochs_stddev_order_by']: {
     circle_id?: GraphQLTypes['order_by'] | undefined;
@@ -16336,6 +16419,11 @@ export type GraphQLTypes = {
     number?: GraphQLTypes['order_by'] | undefined;
     repeat?: GraphQLTypes['order_by'] | undefined;
     repeat_day_of_month?: GraphQLTypes['order_by'] | undefined;
+  };
+  ['epochs_updates']: {
+    /** sets the columns of the filtered rows to the given values */
+    _set?: GraphQLTypes['epochs_set_input'] | undefined;
+    where: GraphQLTypes['epochs_bool_exp'];
   };
   /** order by var_pop() on columns of table "epoches" */
   ['epochs_var_pop_order_by']: {
@@ -16986,6 +17074,14 @@ export type GraphQLTypes = {
     /** update multiples rows of table: "distributions" */
     update_distributions_many?:
       | Array<GraphQLTypes['distributions_mutation_response'] | undefined>
+      | undefined;
+    /** update data of the table: "epoches" */
+    update_epochs?: GraphQLTypes['epochs_mutation_response'] | undefined;
+    /** update single row of the table: "epoches" */
+    update_epochs_by_pk?: GraphQLTypes['epochs'] | undefined;
+    /** update multiples rows of table: "epoches" */
+    update_epochs_many?:
+      | Array<GraphQLTypes['epochs_mutation_response'] | undefined>
       | undefined;
     /** update data of the table: "locked_token_distributions" */
     update_locked_token_distributions?:

--- a/src/lib/gql/mutations.ts
+++ b/src/lib/gql/mutations.ts
@@ -527,7 +527,7 @@ export async function updateEpoch(
 }
 
 export async function updateEpochDescription(id: number, description: string) {
-  await client.mutate(
+  const { update_epochs_by_pk } = await client.mutate(
     {
       update_epochs_by_pk: [
         {
@@ -543,7 +543,8 @@ export async function updateEpochDescription(id: number, description: string) {
       operationName: 'updateEpochDescription',
     }
   );
-  return true;
+  if (!update_epochs_by_pk) throw 'failed to update epoch description';
+  return update_epochs_by_pk;
 }
 
 export async function updateActiveRepeatingEpoch(

--- a/src/lib/gql/mutations.ts
+++ b/src/lib/gql/mutations.ts
@@ -526,6 +526,26 @@ export async function updateEpoch(
   return updateEpoch;
 }
 
+export async function updateEpochDescription(id: number, description: string) {
+  await client.mutate(
+    {
+      update_epochs_by_pk: [
+        {
+          pk_columns: { id: id },
+          _set: { description: description },
+        },
+        {
+          id: true,
+        },
+      ],
+    },
+    {
+      operationName: 'updateEpochDescription',
+    }
+  );
+  return true;
+}
+
 export async function updateActiveRepeatingEpoch(
   circleId: number,
   epochId: number,

--- a/src/pages/HistoryPage/CurrentEpochPanel.tsx
+++ b/src/pages/HistoryPage/CurrentEpochPanel.tsx
@@ -1,10 +1,17 @@
+import { useState } from 'react';
+
+import { zodResolver } from '@hookform/resolvers/zod';
 import { DateTime, Interval } from 'luxon';
+import { useForm, SubmitHandler } from 'react-hook-form';
 import { NavLink } from 'react-router-dom';
 import { CSS } from 'stitches.config';
+import * as z from 'zod';
 
-import { Give, PlusCircle } from 'icons/__generated';
+import { FormInputField } from 'components';
+import { useToast } from 'hooks';
+import { Edit, Give, PlusCircle } from 'icons/__generated';
 import { paths } from 'routes/paths';
-import { Box, Panel, Text, Button, Flex } from 'ui';
+import { Box, Panel, Text, Button, Flex, IconButton, HR } from 'ui';
 
 type Props = {
   epoch: {
@@ -39,6 +46,10 @@ export const CurrentEpochPanel = ({
 
   const endDateFormat = endDate.month === startDate.month ? 'd' : 'MMM d';
 
+  // TODO: why is this null sometime? just from data seeding?
+  const epochDescriptionText =
+    epoch.description ?? 'Epoch ' + (epoch.number ?? '');
+
   return (
     <Panel
       css={{
@@ -61,20 +72,14 @@ export const CurrentEpochPanel = ({
           {startDate.toFormat('MMM')} {startDate.toFormat('d')} -{' '}
           {endDate.toFormat(endDateFormat)}
         </Text>
-        <Text
-          h2
-          p
-          css={{ color: '$currentEpochDescription', fontSize: '$h2Temp' }}
-        >
-          {
-            epoch.description ??
-              'Epoch ' +
-                (epoch.number ??
-                  '') /* TODO: why is this null sometime? just from data seeding? */
-          }
-        </Text>
+
+        <EpochDescription
+          description={epochDescriptionText}
+          isAdmin={isAdmin}
+        />
         {!isEditing && isAdmin && (
           <Button
+            css={{ mt: '$md' }}
             color="secondary"
             size="small"
             onClick={() => editCurrentEpoch()}
@@ -184,5 +189,127 @@ const Minicard = ({
         </Button>
       </Box>
     </Box>
+  );
+};
+
+type EpochDescriptionProps = {
+  description: string;
+  isAdmin: boolean;
+};
+const EpochDescription = ({ description, isAdmin }: EpochDescriptionProps) => {
+  const { showError } = useToast();
+  const [editDescription, setEditDescription] = useState(false);
+
+  const zEpochDescriptionSchema = z.object({
+    description: z
+      .optional(
+        z.nullable(
+          z
+            .string()
+            .refine(val => val.trim().length >= 10, {
+              message: 'Description should be at least 10 characters long',
+            })
+            .refine(val => val.length < 100, {
+              message: 'Description length should not exceed 100 characters',
+            })
+        )
+      )
+      .transform(val => (val === '' ? null : val)),
+  });
+
+  type EpochDescriptionSchema = z.infer<typeof zEpochDescriptionSchema>;
+
+  const onSubmit: SubmitHandler<EpochDescriptionSchema> = async data => {
+    try {
+      // eslint-disable-next-line no-console
+      console.log(data);
+      // TODO: implement saving
+      // await updateCircle({
+      //   circle_id: selectedCircle.id,
+      //   cont_help_text: data.cont_help_text,
+      // });
+      // setUpdatedContHelpText(data.cont_help_text);
+    } catch (e) {
+      showError(e);
+      console.warn(e);
+    }
+    setEditDescription(false);
+  };
+
+  const { control: epochDescriptionControl, handleSubmit } =
+    useForm<EpochDescriptionSchema>({
+      resolver: zodResolver(zEpochDescriptionSchema),
+      mode: 'all',
+    });
+
+  return (
+    <Flex css={{ width: '100%' }}>
+      {!editDescription ? (
+        <Flex css={{ alignItems: 'center' }}>
+          <Text
+            medium
+            css={{
+              color: '$ctaHover',
+            }}
+          >
+            {description}
+          </Text>
+          {isAdmin && (
+            <IconButton
+              onClick={() => setEditDescription(true)}
+              css={{
+                color: '$ctaHover',
+              }}
+            >
+              <Edit />
+            </IconButton>
+          )}
+        </Flex>
+      ) : (
+        isAdmin && (
+          <Flex
+            column
+            css={{
+              width: '100%',
+              pr: '$md',
+            }}
+          >
+            <Box>
+              <FormInputField
+                css={{ width: '100%' }}
+                name="description"
+                id="epoch_description_edit"
+                control={epochDescriptionControl}
+                defaultValue={description}
+                areaProps={{ rows: 2 }}
+                label="Epoch Description"
+                showFieldErrors
+                textArea
+              />
+            </Box>
+            <Flex css={{ gap: '$sm', mt: '$md' }}>
+              <Button
+                size="small"
+                color="secondary"
+                onClick={() => {
+                  setEditDescription(false);
+                }}
+              >
+                Cancel
+              </Button>
+              <Button
+                size="small"
+                color="primary"
+                type="submit"
+                onClick={handleSubmit(onSubmit)}
+              >
+                Save
+              </Button>
+            </Flex>
+            <HR />
+          </Flex>
+        )
+      )}
+    </Flex>
   );
 };

--- a/src/pages/HistoryPage/CurrentEpochPanel.tsx
+++ b/src/pages/HistoryPage/CurrentEpochPanel.tsx
@@ -287,7 +287,6 @@ const EpochDescription = ({
                 id="epoch_description_edit"
                 control={epochDescriptionControl}
                 defaultValue={description}
-                areaProps={{ rows: 2 }}
                 label="Epoch Description"
                 showFieldErrors
                 textArea

--- a/src/pages/HistoryPage/EpochForm.tsx
+++ b/src/pages/HistoryPage/EpochForm.tsx
@@ -582,6 +582,9 @@ const EpochForm = ({
       end_date: epochConfig.end_date,
     };
 
+    // eslint-disable-next-line no-console
+    console.log({ payload });
+
     (source?.epoch
       ? selectedEpoch?.number !== -1
         ? updateEpoch(source.epoch.id, { params: payload })

--- a/src/pages/HistoryPage/EpochForm.tsx
+++ b/src/pages/HistoryPage/EpochForm.tsx
@@ -102,20 +102,6 @@ const schema = z
     repeat: EpochRepeatEnum,
     repeatStartDate: z.string(),
     repeat_view: z.string(),
-    description: z
-      .optional(
-        z.nullable(
-          z
-            .string()
-            .refine(val => val.trim().length >= 10, {
-              message: 'Description should be at least 10 characters long',
-            })
-            .refine(val => val.length < 100, {
-              message: 'Description length should not exceed 100 characters',
-            })
-        )
-      )
-      .transform(val => (val === '' ? null : val)),
     customError: z.undefined(), //unregistered to disable submitting
   })
   .strict();
@@ -401,7 +387,6 @@ const EpochForm = ({
         (source?.epoch?.start_date &&
           DateTime.fromISO(source.epoch.start_date).toISODate()) ??
         DateTime.now().setZone().plus({ days: 1 }).toISODate(),
-      description: source.epoch?.description,
       custom_duration_denomination: source.epoch?.repeat_data?.duration_unit,
       custom_duration_qty: source.epoch?.repeat_data?.duration,
       custom_interval_qty: source.epoch?.repeat_data?.frequency,
@@ -582,9 +567,6 @@ const EpochForm = ({
       end_date: epochConfig.end_date,
     };
 
-    // eslint-disable-next-line no-console
-    console.log({ payload });
-
     (source?.epoch
       ? selectedEpoch?.number !== -1
         ? updateEpoch(source.epoch.id, { params: payload })
@@ -677,14 +659,6 @@ const EpochForm = ({
           </TwoColumnLayout>
           <TwoColumnLayout>
             <Flex column css={{ gap: '$sm' }}>
-              <FormInputField
-                id="description"
-                name="description"
-                defaultValue={source.epoch?.description}
-                control={control}
-                label="DESCRIPTION"
-                infoTooltip="A brief description of this epoch"
-              />
               <Flex column css={{ gap: '$sm' }}>
                 <Text h3>Epoch Frequency</Text>
                 <Flex column css={{ mt: '$sm ', mb: '$md' }}>


### PR DESCRIPTION
Resolves https://github.com/coordinape/coordinape/issues/1904

Move epoch description editing from the main form, into a inline experience.

* Change the epoch description field to be limited between 1 and 100 chars
* Enable graphql API updates for circle admins to modify the epoch description field
  - constraints on updates of epoch description:
    - must be circle admin, must be undeleted
    - epoch must be NOT ended
* Remove description from Epoch form
* Add edit icon and inline editing expereience for epoch descriptions for "current epochs"


Testing:
- API endpoint is secured for non-admin users
- Inline expereience works as expected
- Errors are handled and shown via toast bar
