### PR TITLE
Implement Epoch Cron Logic For New Schema

### DIFF
--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -787,6 +787,7 @@ export type ValueTypes = {
     frequency?: number | undefined | null;
     frequency_unit?: string | undefined | null;
     start_date: ValueTypes['timestamptz'];
+    time_zone?: string | undefined | null;
     type: string;
     week?: number | undefined | null;
     weekday?: number | undefined | null;
@@ -28994,6 +28995,7 @@ export type GraphQLTypes = {
     frequency?: number | undefined;
     frequency_unit?: string | undefined;
     start_date: GraphQLTypes['timestamptz'];
+    time_zone?: string | undefined;
     type: string;
     week?: number | undefined;
     weekday?: number | undefined;

--- a/api-test/hasura/actions/_handlers/updateEpoch.test.ts
+++ b/api-test/hasura/actions/_handlers/updateEpoch.test.ts
@@ -400,6 +400,7 @@ describe('updateEpoch', () => {
             type: 'custom',
             duration: DURATION_IN_DAYS,
             duration_unit: 'days',
+            time_zone: 'UTC',
             frequency: 1,
             frequency_unit: 'weeks',
           },
@@ -428,6 +429,7 @@ describe('updateEpoch', () => {
                   end_date: now.plus({ weeks: DURATION_IN_WEEKS }).toISO(),
                   duration: DURATION_IN_WEEKS,
                   duration_unit: 'weeks',
+                  time_zone: 'America/New_York',
                   frequency: 1,
                   frequency_unit: 'weeks',
                 },
@@ -456,6 +458,7 @@ describe('updateEpoch', () => {
             type: 'custom',
             duration: DURATION_IN_WEEKS,
             duration_unit: 'weeks',
+            time_zone: 'America/New_York',
             frequency: 1,
             frequency_unit: 'weeks',
           },
@@ -486,6 +489,7 @@ describe('updateEpoch', () => {
                   end_date: now.plus({ weeks: DURATION_IN_WEEKS }).toISO(),
                   duration: DURATION_IN_WEEKS,
                   duration_unit: 'weeks',
+                  time_zone: 'bad_input',
                   frequency: 1,
                   frequency_unit: 'months',
                 },
@@ -514,6 +518,7 @@ describe('updateEpoch', () => {
             type: 'custom',
             duration: DURATION_IN_WEEKS,
             duration_unit: 'weeks',
+            time_zone: 'UTC',
             frequency: 1,
             frequency_unit: 'months',
           },
@@ -525,6 +530,223 @@ describe('updateEpoch', () => {
           .diff(DateTime.fromISO(start_date))
           .as('weeks')
       ).toBe(DURATION_IN_WEEKS);
+    });
+
+    test("doesn't adjust epoch end_date for a supported timezone leaving DST", async () => {
+      const DURATION_IN_MONTHS = 1;
+      let result;
+      const now = DateTime.now()
+        .setZone('America/New_York')
+        .plus({ years: 1 })
+        .set({ month: 11, day: 1 });
+      const first = async () =>
+        client.mutate({
+          updateEpoch: [
+            {
+              payload: {
+                id: futureEpochId,
+                circle_id: circle.id,
+                params: {
+                  type: 'custom',
+                  start_date: now.toISO(),
+                  end_date: now.plus({ months: DURATION_IN_MONTHS }).toISO(),
+                  duration: DURATION_IN_MONTHS,
+                  duration_unit: 'months',
+                  time_zone: 'America/New_York',
+                  frequency: 2,
+                  frequency_unit: 'months',
+                },
+              },
+            },
+            {
+              __typename: true,
+              epoch: {
+                start_date: true,
+                end_date: true,
+                repeat_data: [{}, true],
+              },
+            },
+          ],
+        });
+      try {
+        result = await first();
+      } catch (e: any) {
+        console.error(e.response.errors);
+      }
+      const epoch = result?.updateEpoch?.epoch;
+      assert(epoch);
+      expect(epoch).toEqual(
+        expect.objectContaining({
+          repeat_data: {
+            type: 'custom',
+            duration: DURATION_IN_MONTHS,
+            duration_unit: 'months',
+            time_zone: 'America/New_York',
+            frequency: 2,
+            frequency_unit: 'months',
+          },
+        })
+      );
+      const { start_date, end_date } = epoch;
+      expect(
+        Interval.fromISO(start_date + '/' + end_date).length('months')
+      ).toBeGreaterThan(DURATION_IN_MONTHS);
+    });
+    test("doesn't adjust epoch end_date for a supported timezone entering DST", async () => {
+      const DURATION_IN_MONTHS = 1;
+      let result;
+      const now = DateTime.now()
+        .setZone('America/New_York')
+        .plus({ years: 1 })
+        .set({ month: 3, day: 1 });
+      const first = async () =>
+        client.mutate({
+          updateEpoch: [
+            {
+              payload: {
+                id: futureEpochId,
+                circle_id: circle.id,
+                params: {
+                  type: 'custom',
+                  start_date: now.toISO(),
+                  end_date: now.plus({ months: DURATION_IN_MONTHS }).toISO(),
+                  duration: DURATION_IN_MONTHS,
+                  duration_unit: 'months',
+                  time_zone: 'America/New_York',
+                  frequency: 2,
+                  frequency_unit: 'months',
+                },
+              },
+            },
+            {
+              __typename: true,
+              epoch: {
+                start_date: true,
+                end_date: true,
+                repeat_data: [{}, true],
+              },
+            },
+          ],
+        });
+      try {
+        result = await first();
+      } catch (e: any) {
+        console.error(e.response.errors);
+      }
+      const epoch = result?.updateEpoch?.epoch;
+      assert(epoch);
+      expect(epoch).toEqual(
+        expect.objectContaining({
+          repeat_data: {
+            type: 'custom',
+            duration: DURATION_IN_MONTHS,
+            duration_unit: 'months',
+            time_zone: 'America/New_York',
+            frequency: 2,
+            frequency_unit: 'months',
+          },
+        })
+      );
+      const { start_date, end_date } = epoch;
+      expect(
+        Interval.fromISO(start_date + '/' + end_date).length('months')
+      ).toBeLessThan(DURATION_IN_MONTHS);
+    });
+
+    test('can adjust epoch end_date for an unsupported timezone', async () => {
+      const DURATION_IN_MONTHS = 1;
+      let result;
+      const now = DateTime.now().plus({ years: 1 }).set({ month: 3, day: 1 });
+      const first = async () =>
+        client.mutate({
+          updateEpoch: [
+            {
+              payload: {
+                id: futureEpochId,
+                circle_id: circle.id,
+                params: {
+                  type: 'custom',
+                  start_date: now.toISO(),
+                  end_date: now
+                    .plus({ months: DURATION_IN_MONTHS, hours: 1 })
+                    .toISO(),
+                  duration: DURATION_IN_MONTHS,
+                  duration_unit: 'months',
+                  time_zone: 'bad_zone',
+                  frequency: 2,
+                  frequency_unit: 'months',
+                },
+              },
+            },
+            {
+              __typename: true,
+              epoch: {
+                start_date: true,
+                end_date: true,
+                repeat_data: [{}, true],
+              },
+            },
+          ],
+        });
+      try {
+        result = await first();
+      } catch (e: any) {
+        console.error(e.response.errors);
+      }
+      const epoch = result?.updateEpoch?.epoch;
+      assert(epoch);
+      expect(epoch).toEqual(
+        expect.objectContaining({
+          repeat_data: {
+            type: 'custom',
+            duration: DURATION_IN_MONTHS,
+            duration_unit: 'months',
+            time_zone: 'UTC',
+            frequency: 2,
+            frequency_unit: 'months',
+          },
+        })
+      );
+      const { start_date, end_date } = epoch;
+      expect(
+        Interval.fromISO(start_date + '/' + end_date).length('months')
+      ).toBe(DURATION_IN_MONTHS);
+    });
+
+    test('cannot update an epoch where the durations mismatch', async () => {
+      expect.assertions(1);
+      const now = DateTime.now();
+      const thunk = async () =>
+        client.mutate({
+          updateEpoch: [
+            {
+              payload: {
+                id: epochId,
+                circle_id: circle.id,
+                params: {
+                  type: 'custom',
+                  start_date: now.toISO(),
+                  end_date: now.plus({ months: 1, days: 1 }).toISO(),
+                  duration: 1,
+                  duration_unit: 'months',
+                  frequency: 2,
+                  frequency_unit: 'months',
+                },
+              },
+            },
+            {
+              __typename: true,
+              epoch: {
+                start_date: true,
+                end_date: true,
+                repeat_data: [{}, true],
+              },
+            },
+          ],
+        });
+      await expect(thunk).rejects.toThrow(
+        'does not match the specified duration 1 months'
+      );
     });
 
     test('can update repeating monthly epochs without gaps', async () => {
@@ -542,6 +764,7 @@ describe('updateEpoch', () => {
                   type: 'custom',
                   start_date: now.toISO(),
                   end_date: now.plus({ months: DURATION_IN_MONTHS }).toISO(),
+                  time_zone: 'America/Chicago',
                   duration: DURATION_IN_MONTHS,
                   duration_unit: 'months',
                   frequency: 1,
@@ -572,6 +795,7 @@ describe('updateEpoch', () => {
             type: 'custom',
             duration: DURATION_IN_MONTHS,
             duration_unit: 'months',
+            time_zone: 'America/Chicago',
             frequency: 1,
             frequency_unit: 'months',
           },
@@ -753,6 +977,7 @@ describe('updateEpoch', () => {
         expect.objectContaining({
           repeat_data: {
             type: 'monthly',
+            time_zone: 'UTC',
             week: params.week,
           },
           start_date: expect.stringContaining(
@@ -810,6 +1035,7 @@ describe('updateEpoch', () => {
         expect.objectContaining({
           repeat_data: {
             type: 'monthly',
+            time_zone: 'UTC',
             week: 6,
           },
           start_date: expect.stringContaining(

--- a/api-test/hasura/cron/epochs.test.ts
+++ b/api-test/hasura/cron/epochs.test.ts
@@ -1,0 +1,130 @@
+import { DateTime } from 'luxon';
+
+import { adminClient } from '../../../api-lib/gql/adminClient';
+import { getEpoch } from '../../../api-lib/gql/queries';
+import * as HttpError from '../../../api-lib/HttpError';
+import { createNextEpoch, RepeatData } from '../../../api/hasura/cron/epochs';
+import { findMonthlyEndDate } from '../../../src/common-lib/epochs';
+import { createCircle } from '../../helpers';
+
+let circle;
+const mockErrorLog = jest.spyOn(HttpError, 'errorLog');
+beforeEach(async () => {
+  circle = await createCircle(adminClient);
+});
+const createEpoch = async (object: {
+  circle_id: number;
+  start_date: string;
+  end_date: string;
+  repeat_data?: RepeatData;
+}) => {
+  try {
+    const { insert_epochs_one } = await adminClient.mutate(
+      {
+        insert_epochs_one: [
+          { object: { ...object, ended: true, number: 1 } },
+          {
+            id: true,
+            circle_id: true,
+            start_date: true,
+            end_date: true,
+            repeat_data: [{}, true],
+            ended: true,
+          },
+        ],
+      },
+      { operationName: 'createEpochToEnd' }
+    );
+
+    return insert_epochs_one;
+  } catch (e) {
+    console.error(e);
+  }
+};
+
+describe('Epoch Cron Integration', () => {
+  describe('createNextEpoch', () => {
+    test('can create adjacent following monthly epoch', async () => {
+      const start = DateTime.now()
+        .setZone('America/Chicago')
+        .minus({ months: 1 })
+        .set({ day: 1 });
+      const mut = createEpoch({
+        circle_id: circle.id,
+        start_date: start.toISO(),
+        end_date: findMonthlyEndDate(start).toISO(),
+        repeat_data: {
+          type: 'monthly',
+          week: 0,
+        },
+      });
+
+      let result;
+      try {
+        result = await mut;
+        await createNextEpoch(result);
+        const newEpoch = await getEpoch(circle.id, result.id + 1);
+        expect(result.end_date).toBe(newEpoch.start_date);
+      } catch (e) {
+        console.error(e);
+      }
+    });
+    test('can create adjacent following custom epoch', async () => {
+      const start = DateTime.now()
+        .setZone('America/Chicago')
+        .minus({ weeks: 1 });
+      const mut = createEpoch({
+        circle_id: circle.id,
+        start_date: start.toISO(),
+        end_date: start.plus({ weeks: 1 }).toISO(),
+        repeat_data: {
+          type: 'custom',
+          duration: 1,
+          duration_unit: 'weeks',
+          frequency: 1,
+          frequency_unit: 'weeks',
+        },
+      });
+
+      let result;
+      try {
+        result = await mut;
+        await createNextEpoch(result);
+        const newEpoch = await getEpoch(circle.id, result.id + 1);
+        expect(result.end_date).toBe(newEpoch.start_date);
+      } catch (e) {
+        console.error(e);
+      }
+    });
+    test("doesn't create epoch when overlap exists", async () => {
+      const start = DateTime.now()
+        .setZone('America/Chicago')
+        .minus({ weeks: 1 });
+      const mut1 = createEpoch({
+        circle_id: circle.id,
+        start_date: start.toISO(),
+        end_date: start.plus({ weeks: 1 }).toISO(),
+        repeat_data: {
+          type: 'custom',
+          duration: 1,
+          duration_unit: 'weeks',
+          frequency: 1,
+          frequency_unit: 'weeks',
+        },
+      });
+      const mut2 = createEpoch({
+        circle_id: circle.id,
+        start_date: start.plus({ weeks: 1 }).toISO(),
+        end_date: start.plus({ weeks: 2 }).toISO(),
+      });
+
+      const result1 = await mut1;
+      const result2 = await mut2;
+      await createNextEpoch(result1);
+      expect(mockErrorLog).toBeCalledWith(
+        expect.stringContaining(`existing epoch id: ${result2.id}`),
+        false
+      );
+    });
+  });
+});

--- a/api/hasura/actions/_handlers/createEpoch.ts
+++ b/api/hasura/actions/_handlers/createEpoch.ts
@@ -22,17 +22,19 @@ Settings.defaultZone = 'UTC';
 
 type ErrorReturn = Error | undefined;
 
-const zTimeZone = z
+export const zTimeZone = z
   .string()
   .default('UTC')
   .transform(tz => {
+    // returns the defaultZone if the provided string value is an invalid
+    // or unsupported IANA time zone
     const dtWithZone = DateTime.now().setZone(tz);
     return dtWithZone.zone.name;
   });
 
-const zFrequencyUnits = z.enum(['days', 'weeks', 'months']);
+export const zFrequencyUnits = z.enum(['days', 'weeks', 'months']);
 
-const zCustomInputSchema = z
+export const zCustomRepeatData = z
   .object({
     type: z.literal('custom'),
     time_zone: zTimeZone,
@@ -40,16 +42,26 @@ const zCustomInputSchema = z
     frequency_unit: zFrequencyUnits,
     duration: z.coerce.number().min(1),
     duration_unit: zFrequencyUnits,
+  })
+  .strict();
+
+export const zMonthlyRepeatData = z
+  .object({
+    type: z.literal('monthly'),
+    time_zone: zTimeZone,
+    week: z.number().min(0),
+  })
+  .strict();
+
+const zCustomInputSchema = zCustomRepeatData
+  .extend({
     start_date: zStringISODateUTC,
     end_date: zStringISODateUTC,
   })
   .strict();
 
-const zMonthlyInputSchema = z
-  .object({
-    type: z.literal('monthly'),
-    time_zone: zTimeZone,
-    week: z.number().min(0),
+const zMonthlyInputSchema = zMonthlyRepeatData
+  .extend({
     start_date: zStringISODateUTC,
     end_date: zStringISODateUTC,
   })

--- a/api/hasura/actions/_handlers/updateEpoch.ts
+++ b/api/hasura/actions/_handlers/updateEpoch.ts
@@ -11,6 +11,7 @@ import { composeHasuraActionRequestBody } from '../../../../src/lib/zod';
 import {
   zEpochInputParams,
   checkOverlappingEpoch,
+  eliminateUtcDrift,
   verifyFutureEndDate,
   verifyStartBeforeEnd,
   checkMultipleRepeatingEpochs,
@@ -66,6 +67,7 @@ async function handler(request: VercelRequest, response: VercelResponse) {
   switch (params.type) {
     case 'custom':
       error = validateCustomInput(params);
+      input.params.end_date = eliminateUtcDrift(params);
       break;
     case 'monthly': {
       error = validateMonthlyInput(params);

--- a/api/hasura/cron/_epochs.test.ts
+++ b/api/hasura/cron/_epochs.test.ts
@@ -1,5 +1,5 @@
 import faker from 'faker';
-import { DateTime } from 'luxon';
+import { DateTime, Interval } from 'luxon';
 
 import { adminClient } from '../../../api-lib/gql/adminClient';
 import { sendSocialMessage } from '../../../api-lib/sendSocialMessage';
@@ -10,6 +10,7 @@ import {
   EpochsToNotify,
   endEpoch,
   makeNextStartDate,
+  calculateNextEpoch,
 } from './epochs';
 
 jest.mock('../../../api-lib/gql/adminClient', () => ({
@@ -148,10 +149,138 @@ function getCircle<T extends keyof EpochsToNotify>(
   return { ...mockCircle[epochPhase], ...circleInputs };
 }
 
-test('next start date generation', () => {
-  const d1 = DateTime.fromISO('2022-12-02');
-  const n1 = makeNextStartDate(d1, 2, 7);
-  expect(n1.toISODate()).toEqual('2023-01-07');
+describe('next start date generation', () => {
+  test('makeNextStartDate', () => {
+    const d1 = DateTime.fromISO('2022-12-02');
+    const n1 = makeNextStartDate(d1, 2, 7);
+    expect(n1.toISODate()).toEqual('2023-01-07');
+  });
+  describe('calculateNextEpoch', () => {
+    test('calculates epoch correctly', () => {
+      const start = DateTime.utc(2023, 2);
+      let end = start.plus({ weeks: 1 });
+      let result = calculateNextEpoch(
+        {
+          start_date: start.toISO(),
+          end_date: end.toISO(),
+        },
+        {
+          type: 'custom',
+          frequency: 1,
+          frequency_unit: 'weeks',
+          duration: 1,
+          duration_unit: 'weeks',
+          time_zone: 'UTC',
+        }
+      );
+      expect(result.nextStartDate).toEqual(end);
+      expect(result.nextStartDate).toEqual(start.plus({ weeks: 1 }));
+      expect(result.nextEndDate).toEqual(
+        result.nextStartDate.plus({ weeks: 1 })
+      );
+
+      end = start.plus({ weeks: 1 });
+      result = calculateNextEpoch(
+        {
+          start_date: start.toISO(),
+          end_date: end.toISO(),
+        },
+        {
+          type: 'custom',
+          frequency: 2,
+          frequency_unit: 'weeks',
+          duration: 1,
+          duration_unit: 'weeks',
+          time_zone: 'UTC',
+        }
+      );
+      expect(result.nextStartDate).toEqual(start.plus({ weeks: 2 }));
+      expect(result.nextEndDate).toEqual(
+        result.nextStartDate.plus({ weeks: 1 })
+      );
+
+      end = start.plus({ days: 5 });
+      result = calculateNextEpoch(
+        {
+          start_date: start.toISO(),
+          end_date: end.toISO(),
+        },
+        {
+          type: 'custom',
+          frequency: 3,
+          frequency_unit: 'weeks',
+          duration: 5,
+          duration_unit: 'days',
+          time_zone: 'UTC',
+        }
+      );
+      expect(result.nextStartDate).toEqual(start.plus({ weeks: 3 }));
+      expect(result.nextEndDate).toEqual(
+        result.nextStartDate.plus({ days: 5 })
+      );
+    });
+    test('calculates epoch containing a DST shift correctly', () => {
+      const zone = 'America/Chicago';
+      const start = DateTime.local(2023, 2, { zone });
+      const end = start.plus({ weeks: 2 });
+      const result = calculateNextEpoch(
+        {
+          start_date: start.toISO(),
+          end_date: end.toISO(),
+        },
+        {
+          type: 'custom',
+          frequency: 1,
+          frequency_unit: 'months',
+          duration: 2,
+          duration_unit: 'weeks',
+          time_zone: zone,
+        }
+      );
+      expect(result.nextStartDate).toEqual(start.plus({ months: 1 }));
+      expect(result.nextEndDate).toEqual(
+        result.nextStartDate.plus({ weeks: 2 })
+      );
+
+      expect(
+        Interval.fromDateTimes(start, end).toDuration().as('hours') -
+          Interval.fromDateTimes(result.nextStartDate, result.nextEndDate)
+            .toDuration()
+            .as('hours')
+      ).toBe(1);
+    });
+    test('calculates epoch after DST correctly', () => {
+      const zone = 'America/Chicago';
+      const start = DateTime.local(2023, 3, { zone });
+      const end = start.plus({ weeks: 2 });
+      const result = calculateNextEpoch(
+        {
+          start_date: start.toISO(),
+          end_date: end.toISO(),
+        },
+        {
+          type: 'custom',
+          frequency: 2,
+          frequency_unit: 'weeks',
+          duration: 2,
+          duration_unit: 'weeks',
+          time_zone: zone,
+        }
+      );
+      expect(result.nextStartDate).toEqual(end);
+      expect(result.nextStartDate).toEqual(start.plus({ weeks: 2 }));
+      expect(result.nextEndDate).toEqual(
+        result.nextStartDate.plus({ weeks: 2 })
+      );
+
+      expect(
+        Interval.fromDateTimes(result.nextStartDate, result.nextEndDate)
+          .toDuration()
+          .as('hours') -
+          Interval.fromDateTimes(start, end).toDuration().as('hours')
+      ).toBe(1);
+    });
+  });
 });
 
 describe('epoch Cron Logic', () => {
@@ -537,7 +666,7 @@ describe('epoch Cron Logic', () => {
           ],
         },
         {
-          operationName: 'createNextEpoch',
+          operationName: 'createNextEpochOld',
         }
       );
       expect(mockMutation).toBeCalledWith(

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -420,6 +420,7 @@ input EpochInputParams {
   type: String!
   start_date: timestamptz!
   end_date: timestamptz!
+  time_zone: String
   frequency: Int
   frequency_unit: String
   duration: Int

--- a/hasura/schema/admin/schema.graphql
+++ b/hasura/schema/admin/schema.graphql
@@ -250,6 +250,7 @@ input EpochInputParams {
   frequency: Int
   frequency_unit: String
   start_date: timestamptz!
+  time_zone: String
   type: String!
   week: Int
   weekday: Int

--- a/hasura/schema/user/schema.graphql
+++ b/hasura/schema/user/schema.graphql
@@ -216,6 +216,7 @@ input EpochInputParams {
   frequency: Int
   frequency_unit: String
   start_date: timestamptz!
+  time_zone: String
   type: String!
   week: Int
   weekday: Int

--- a/src/common-lib/epochs.ts
+++ b/src/common-lib/epochs.ts
@@ -42,12 +42,6 @@ export function findSameDayNextMonth(
   return nextEndDate;
 }
 
-/**
- * @dev This function is not safe for generating subsequent epoch start dates
- * in an existing cycle of repeating monthly epoichs
- * and is only meant to provide a porcelain interface for users creating a new
- * set of repeating epochs, either in the UI or via the API.
- */
 export function findMonthlyEndDate(start: DateTime): DateTime {
   const week = Math.floor((start.day - 1) / 7);
   return findSameDayNextMonth(start, { week });

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -759,6 +759,7 @@ export type ValueTypes = {
     frequency?: number | undefined | null;
     frequency_unit?: string | undefined | null;
     start_date: ValueTypes['timestamptz'];
+    time_zone?: string | undefined | null;
     type: string;
     week?: number | undefined | null;
     weekday?: number | undefined | null;
@@ -13546,6 +13547,7 @@ export type GraphQLTypes = {
     frequency?: number | undefined;
     frequency_unit?: string | undefined;
     start_date: GraphQLTypes['timestamptz'];
+    time_zone?: string | undefined;
     type: string;
     week?: number | undefined;
     weekday?: number | undefined;


### PR DESCRIPTION
This PR contains the epoch cron that will create repeating epochs using
the new `repeat_data` schema. A timzone has been added to the schema to
minimize the complexity of the calculations on the backend. However, the
input of this timzone is pretty unopinionated. If an unsupported zone is
entered, or just a nonsense string is, the timezone is configured to be
UTC, which eliminates any shifts due to DST. Otherwise, DSTs will be
observed when the timezone is applied to a datetime.

Merge Plan

This implementation is meant to be merged before the migration and
cutover, since the code supporting the old epoch logic is still present
and the encasing cron logic will function exactly the same until
the `repeat_data` column is populated. At that point, the new repeating
logic will kick in.