### PR TITLE
disable New button when new contribution is still saving

### DIFF
--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -387,6 +387,10 @@ const ContributionsPage = () => {
     reset();
   };
 
+  const readyForNewContribution: boolean =
+    !saveState[NEW_CONTRIBUTION_ID] ||
+    saveState[NEW_CONTRIBUTION_ID] === 'stable';
+
   const addNewContribution = () => {
     setCurrentContribution({
       contribution: getNewContribution(
@@ -727,6 +731,7 @@ const ContributionsPage = () => {
                     onClick={addNewContribution}
                     // adding onMouseDown because the onBlur event on the markdown-ready textarea was preventing onClick
                     onMouseDown={addNewContribution}
+                    disabled={!readyForNewContribution}
                   >
                     <Edit />
                     New

--- a/src/pages/ContributionsPage/index.test.tsx
+++ b/src/pages/ContributionsPage/index.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+
+import { adminClient } from '../../../api-lib/gql/adminClient';
+import { createCircle, createUser } from '../../../api-test/helpers';
+import useConnectedAddress from 'hooks/useConnectedAddress';
+import { useSelectedCircle } from 'recoilState/app';
+import { TestWrapper } from 'utils/testing';
+import { setupMockClientForProfile } from 'utils/testing/client';
+
+import ContributionsPage from './ContributionsPage';
+
+jest.mock('recoilState/app', () => ({
+  useSelectedCircle: jest.fn(),
+}));
+
+jest.mock('hooks/useConnectedAddress', () => jest.fn());
+
+beforeEach(async () => {
+  const circle = await createCircle(adminClient);
+  (useSelectedCircle as jest.Mock).mockImplementation(() => ({
+    circle: { id: circle.id },
+    myUser: { role: 0 },
+  }));
+  const user = await createUser(adminClient, {
+    circle_id: circle.id,
+  });
+
+  (useConnectedAddress as jest.Mock).mockImplementation(() => user.address);
+
+  setupMockClientForProfile(user.profile);
+});
+
+test('basic rendering with no contributions', async () => {
+  render(
+    <TestWrapper>
+      <ContributionsPage />
+    </TestWrapper>
+  );
+  await screen.findByText('Contributions');
+});

--- a/src/pages/JoinCirclePage/JoinCirclePage.test.tsx
+++ b/src/pages/JoinCirclePage/JoinCirclePage.test.tsx
@@ -3,13 +3,13 @@ import assert from 'assert';
 import { render, screen } from '@testing-library/react';
 import { CircleTokenType } from 'common-lib/circleShareTokens';
 import { useAuthStore } from 'features/auth';
-import { setMockHeaders } from 'lib/gql/client';
 import { Route, Routes } from 'react-router-dom';
 
 import { adminClient } from '../../../api-lib/gql/adminClient';
 import { createProfile } from '../../../api-test/helpers';
 import { createCircle } from '../../../api-test/helpers/circles';
 import { TestWrapper } from 'utils/testing';
+import { setupMockClientForProfile } from 'utils/testing/client';
 
 import { JoinCirclePage } from './JoinCirclePage';
 
@@ -57,11 +57,7 @@ describe('join page', () => {
 
   test('valid token, logged in', async () => {
     useAuthStore.setState({ step: 'done', address: profile.address });
-    setMockHeaders({
-      'x-hasura-role': 'user',
-      'x-hasura-address': profile.address,
-      'x-hasura-user-id': profile.id.toString(),
-    });
+    setupMockClientForProfile(profile);
 
     render(
       <TestWrapper routeHistory={[`/join/${joinToken}`]}>

--- a/src/utils/testing/client.ts
+++ b/src/utils/testing/client.ts
@@ -1,0 +1,12 @@
+import { setMockHeaders } from '../../lib/gql/client';
+
+export const setupMockClientForProfile = (profile: {
+  id: number;
+  address: string;
+}) => {
+  setMockHeaders({
+    'x-hasura-role': 'user',
+    'x-hasura-user-id': profile.id.toString(),
+    'x-hasura-address': profile.address,
+  });
+};


### PR DESCRIPTION
## Motivation and Context

Does not fully deal with #1890 (with a workaround that prevents the race condition from occurring, rather than a more involved rewrite to allow concurrent saving of new contributions)

This is currently stacked on #1923 but could also be merged directly to main.
