### PR TITLE
Bugfix: Epoch repeat migration

### DIFF
--- a/api/hasura/cron/epochs.ts
+++ b/api/hasura/cron/epochs.ts
@@ -476,7 +476,11 @@ export async function createNextEpoch(epoch: {
   const parseResult = zEpochRepeatData.safeParse(repeat_data);
 
   if (!parseResult.success) {
-    errorLog(`epoch id ${id}: invalid repeat data: ${repeat_data}`);
+    errorLog(
+      `epoch id ${id}: invalid repeat data: ${JSON.stringify(
+        repeat_data
+      )}: ${JSON.stringify(parseResult)}`
+    );
     return;
   }
 

--- a/hasura/migrations/default/1676338256449_correct_repeating_epochs_not_ended/down.sql
+++ b/hasura/migrations/default/1676338256449_correct_repeating_epochs_not_ended/down.sql
@@ -1,0 +1,39 @@
+BEGIN;
+-- Convert epoch repeat data from one format to another.
+
+-- For all "weekly" repeating epoches, these are represented as "repeat: 1" in the old schema. In the new schema, these are represented as "
+-- {
+--  "frequency": 1,
+--  "frequency_unit": "weeks"
+--  "duration": <days column>
+--  "duration_unit": "days"
+--  "time_zone": "UTC"
+-- }
+
+UPDATE "public"."epoches" SET repeat_data = jsonb_build_object(
+  'frequency',      1,
+  'frequency_unit', 'weeks',
+  'duration',       days,
+  'duration_unit',  'days',
+  'time_zone',      'UTC'
+)
+WHERE repeat = 1;
+
+-- For all "monthly" repeating epoches, these are represented as "repeat: 2" in the old schema. In the new schema, these are represented as "
+-- {
+--  "frequency": 1,
+--  "frequency_unit": "months"
+--  "duration": <days column>
+--  "duration_unit": "days"
+--  "time_zone": "UTC"
+-- }
+UPDATE "public"."epoches" SET repeat_data = jsonb_build_object(
+  'frequency',      1,
+  'frequency_unit', 'months',
+  'duration',       days,
+  'duration_unit',  'days',
+  'time_zone',      'UTC'
+)
+WHERE repeat = 2;
+
+COMMIT;

--- a/hasura/migrations/default/1676338256449_correct_repeating_epochs_not_ended/up.sql
+++ b/hasura/migrations/default/1676338256449_correct_repeating_epochs_not_ended/up.sql
@@ -1,0 +1,44 @@
+
+BEGIN;
+-- Convert epoch repeat data from one format to another.
+
+-- For all "weekly" repeating epoches, these are represented as "repeat: 1" in the old schema. In the new schema, these are represented as "
+-- {
+--  "type": "custom",
+--  "frequency": 1,
+--  "frequency_unit": "weeks"
+--  "duration": <days column>
+--  "duration_unit": "days"
+--  "time_zone": "UTC"
+-- }
+
+UPDATE "public"."epoches" SET repeat_data = jsonb_build_object(
+  'type',           'custom',
+  'frequency',      1,
+  'frequency_unit', 'weeks',
+  'duration',       days,
+  'duration_unit',  'days',
+  'time_zone',      'UTC'
+)
+WHERE repeat = 1 and ended = false;
+
+-- For all "monthly" repeating epoches, these are represented as "repeat: 2" in the old schema. In the new schema, these are represented as "
+-- {
+--  "type": "custom",
+--  "frequency": 1,
+--  "frequency_unit": "months"
+--  "duration": <days column>
+--  "duration_unit": "days"
+--  "time_zone": "UTC"
+-- }
+UPDATE "public"."epoches" SET repeat_data = jsonb_build_object(
+  'type',           'custom',
+  'frequency',      1,
+  'frequency_unit', 'months',
+  'duration',       days,
+  'duration_unit',  'days',
+  'time_zone',      'UTC'
+)
+WHERE repeat = 2 and ended = false;
+
+COMMIT;


### PR DESCRIPTION
The repeat data was missing the `type` member

I also improved the error message so we an know exactly what went wrong
without investigating the database.

