### PR TITLE
Bugfix: set timezone before calculating date in tests

### DIFF
--- a/api-test/hasura/actions/_handlers/updateEpoch.test.ts
+++ b/api-test/hasura/actions/_handlers/updateEpoch.test.ts
@@ -751,8 +751,9 @@ describe('updateEpoch', () => {
 
     test('can update repeating monthly epochs without gaps', async () => {
       const DURATION_IN_MONTHS = 1;
+      const ZONE = 'America/Chicago';
       let result;
-      const now = DateTime.now();
+      const now = DateTime.now().setZone(ZONE);
       const first = async () =>
         client.mutate({
           updateEpoch: [
@@ -764,7 +765,7 @@ describe('updateEpoch', () => {
                   type: 'custom',
                   start_date: now.toISO(),
                   end_date: now.plus({ months: DURATION_IN_MONTHS }).toISO(),
-                  time_zone: 'America/Chicago',
+                  time_zone: ZONE,
                   duration: DURATION_IN_MONTHS,
                   duration_unit: 'months',
                   frequency: 1,
@@ -795,15 +796,21 @@ describe('updateEpoch', () => {
             type: 'custom',
             duration: DURATION_IN_MONTHS,
             duration_unit: 'months',
-            time_zone: 'America/Chicago',
+            time_zone: ZONE,
             frequency: 1,
             frequency_unit: 'months',
           },
         })
       );
-      const { start_date, end_date } = epoch;
+      const {
+        start_date,
+        end_date,
+        repeat_data: { time_zone },
+      } = epoch;
       expect(
-        Interval.fromISO(start_date + '/' + end_date).length('months')
+        Interval.fromISO(start_date + '/' + end_date, {
+          zone: time_zone,
+        }).length('months')
       ).toBe(DURATION_IN_MONTHS);
     });
 

--- a/api/hasura/cron/epochs.ts
+++ b/api/hasura/cron/epochs.ts
@@ -476,7 +476,11 @@ export async function createNextEpoch(epoch: {
   const parseResult = zEpochRepeatData.safeParse(repeat_data);
 
   if (!parseResult.success) {
-    errorLog(`epoch id ${id}: invalid repeat data: ${repeat_data}`);
+    errorLog(
+      `epoch id ${id}: invalid repeat data: ${JSON.stringify(
+        repeat_data
+      )}: ${JSON.stringify(parseResult)}`
+    );
     return;
   }
 

--- a/hasura/migrations/default/1676338256449_correct_repeating_epochs_not_ended/down.sql
+++ b/hasura/migrations/default/1676338256449_correct_repeating_epochs_not_ended/down.sql
@@ -1,0 +1,39 @@
+BEGIN;
+-- Convert epoch repeat data from one format to another.
+
+-- For all "weekly" repeating epoches, these are represented as "repeat: 1" in the old schema. In the new schema, these are represented as "
+-- {
+--  "frequency": 1,
+--  "frequency_unit": "weeks"
+--  "duration": <days column>
+--  "duration_unit": "days"
+--  "time_zone": "UTC"
+-- }
+
+UPDATE "public"."epoches" SET repeat_data = jsonb_build_object(
+  'frequency',      1,
+  'frequency_unit', 'weeks',
+  'duration',       days,
+  'duration_unit',  'days',
+  'time_zone',      'UTC'
+)
+WHERE repeat = 1;
+
+-- For all "monthly" repeating epoches, these are represented as "repeat: 2" in the old schema. In the new schema, these are represented as "
+-- {
+--  "frequency": 1,
+--  "frequency_unit": "months"
+--  "duration": <days column>
+--  "duration_unit": "days"
+--  "time_zone": "UTC"
+-- }
+UPDATE "public"."epoches" SET repeat_data = jsonb_build_object(
+  'frequency',      1,
+  'frequency_unit', 'months',
+  'duration',       days,
+  'duration_unit',  'days',
+  'time_zone',      'UTC'
+)
+WHERE repeat = 2;
+
+COMMIT;

--- a/hasura/migrations/default/1676338256449_correct_repeating_epochs_not_ended/up.sql
+++ b/hasura/migrations/default/1676338256449_correct_repeating_epochs_not_ended/up.sql
@@ -1,0 +1,44 @@
+
+BEGIN;
+-- Convert epoch repeat data from one format to another.
+
+-- For all "weekly" repeating epoches, these are represented as "repeat: 1" in the old schema. In the new schema, these are represented as "
+-- {
+--  "type": "custom",
+--  "frequency": 1,
+--  "frequency_unit": "weeks"
+--  "duration": <days column>
+--  "duration_unit": "days"
+--  "time_zone": "UTC"
+-- }
+
+UPDATE "public"."epoches" SET repeat_data = jsonb_build_object(
+  'type',           'custom',
+  'frequency',      1,
+  'frequency_unit', 'weeks',
+  'duration',       days,
+  'duration_unit',  'days',
+  'time_zone',      'UTC'
+)
+WHERE repeat = 1 and ended = false;
+
+-- For all "monthly" repeating epoches, these are represented as "repeat: 2" in the old schema. In the new schema, these are represented as "
+-- {
+--  "type": "custom",
+--  "frequency": 1,
+--  "frequency_unit": "months"
+--  "duration": <days column>
+--  "duration_unit": "days"
+--  "time_zone": "UTC"
+-- }
+UPDATE "public"."epoches" SET repeat_data = jsonb_build_object(
+  'type',           'custom',
+  'frequency',      1,
+  'frequency_unit', 'months',
+  'duration',       days,
+  'duration_unit',  'days',
+  'time_zone',      'UTC'
+)
+WHERE repeat = 2 and ended = false;
+
+COMMIT;


### PR DESCRIPTION
This is a bug in the test itself where a date calculation doesn't
account for the timezone as it should.
