### PR TITLE
Create User Circle Event Handlers

### DIFF
--- a/api-lib/event_triggers/userAddedDiscordBot.ts
+++ b/api-lib/event_triggers/userAddedDiscordBot.ts
@@ -1,0 +1,4 @@
+import handleUserAddedMsg from '../handleUserAddedMsg';
+import makeDiscordBotEventHandler from '../make-discord-bot-event';
+
+export default makeDiscordBotEventHandler(handleUserAddedMsg);

--- a/api-lib/event_triggers/userRemovedDiscordBot.ts
+++ b/api-lib/event_triggers/userRemovedDiscordBot.ts
@@ -1,0 +1,4 @@
+import handleUserRemovedMsg from '../handleUserRemovedMsg';
+import makeDiscordBotEventHandler from '../make-discord-bot-event';
+
+export default makeDiscordBotEventHandler(handleUserRemovedMsg);

--- a/api-lib/handleOptOutMsg.ts
+++ b/api-lib/handleOptOutMsg.ts
@@ -62,7 +62,10 @@ export default async function handleOptOutMsg(
     event: { data },
   } = payload;
 
-  if (data.old.non_receiver === false && data.new.non_receiver === true) {
+  if (
+    (data.old.non_receiver === false && data.new.non_receiver === true) ||
+    (!data.old.deleted_at && data.new.deleted_at)
+  ) {
     const currentEpoch = await queries.getCurrentEpoch(data.new.circle_id);
 
     if (currentEpoch) {
@@ -107,7 +110,10 @@ export default async function handleOptOutMsg(
     }
   }
 
-  if (data.old.non_giver === false && data.new.non_giver === true) {
+  if (
+    (data.old.non_giver === false && data.new.non_giver === true) ||
+    (!data.old.deleted_at && data.new.deleted_at)
+  ) {
     const currentEpoch = await queries.getCurrentEpoch(data.new.circle_id);
 
     if (currentEpoch) {

--- a/api-lib/handleUserAddedMsg.ts
+++ b/api-lib/handleUserAddedMsg.ts
@@ -1,0 +1,80 @@
+import { isFeatureEnabled } from '../src/config/features';
+
+import * as queries from './gql/queries';
+import {
+  Channels,
+  DiscordUserAddedOrRemoved,
+  sendSocialMessage,
+} from './sendSocialMessage';
+import { Awaited } from './ts4.5shim';
+import { EventTriggerPayload } from './types';
+
+type GetChannelsProps = {
+  data: EventTriggerPayload<'users', 'INSERT' | 'UPDATE'>['event']['data'];
+  circle: Awaited<ReturnType<typeof queries.getCircle>>['circles_by_pk'];
+  profiles: Awaited<
+    ReturnType<typeof queries.getProfileAndMembership>
+  >['profiles'];
+  channels: Channels<DiscordUserAddedOrRemoved>;
+};
+
+function getChannels(
+  props: GetChannelsProps
+): Channels<DiscordUserAddedOrRemoved> {
+  const { channels, circle, data, profiles } = props || {};
+
+  const { discord_channel_id: channelId, discord_role_id: roleId } =
+    circle?.discord_circle || {};
+
+  if (
+    channels?.isDiscordBot &&
+    isFeatureEnabled('discord') &&
+    channelId &&
+    roleId
+  ) {
+    const user = profiles[0].user;
+
+    return {
+      isDiscordBot: true,
+      discordBot: {
+        type: 'user-added',
+        channelId,
+        roleId,
+        discordId: user?.user_snowflake,
+        address: data.new.address,
+        circleName: circle?.name ?? 'Unknown',
+      },
+    };
+  }
+
+  return channels;
+}
+
+export default async function handleUserAddedMsg(
+  payload: EventTriggerPayload<'users', 'INSERT' | 'UPDATE'>,
+  channels: { isDiscordBot?: boolean; discord?: boolean; telegram?: boolean }
+) {
+  const {
+    event: { data },
+  } = payload;
+
+  if (!data.old || (data.old.deleted_at && !data.new.deleted_at)) {
+    const { circles_by_pk: circle } = await queries.getCircle(
+      data.new.circle_id
+    );
+    const { profiles } = await queries.getProfileAndMembership(
+      data.new.address
+    );
+    await sendSocialMessage({
+      message: `${data.new.name} has been added to the circle.`,
+      circleId: data.new.circle_id,
+      channels: getChannels({
+        data,
+        circle,
+        channels,
+        profiles,
+      }),
+    });
+  }
+  return true;
+}

--- a/api-lib/handleUserRemovedMsg.ts
+++ b/api-lib/handleUserRemovedMsg.ts
@@ -1,0 +1,80 @@
+import { isFeatureEnabled } from '../src/config/features';
+
+import * as queries from './gql/queries';
+import {
+  Channels,
+  DiscordUserAddedOrRemoved,
+  sendSocialMessage,
+} from './sendSocialMessage';
+import { Awaited } from './ts4.5shim';
+import { EventTriggerPayload } from './types';
+
+type GetChannelsProps = {
+  data: EventTriggerPayload<'users', 'UPDATE'>['event']['data'];
+  circle: Awaited<ReturnType<typeof queries.getCircle>>['circles_by_pk'];
+  profiles: Awaited<
+    ReturnType<typeof queries.getProfileAndMembership>
+  >['profiles'];
+  channels: Channels<DiscordUserAddedOrRemoved>;
+};
+
+function getChannels(
+  props: GetChannelsProps
+): Channels<DiscordUserAddedOrRemoved> {
+  const { channels, circle, data, profiles } = props || {};
+
+  const { discord_channel_id: channelId, discord_role_id: roleId } =
+    circle?.discord_circle || {};
+
+  if (
+    channels?.isDiscordBot &&
+    isFeatureEnabled('discord') &&
+    channelId &&
+    roleId
+  ) {
+    const user = profiles[0].user;
+
+    return {
+      isDiscordBot: true,
+      discordBot: {
+        type: 'user-removed',
+        channelId,
+        roleId,
+        discordId: user?.user_snowflake,
+        address: data.new.address,
+        circleName: circle?.name ?? 'Unknown',
+      },
+    };
+  }
+
+  return channels;
+}
+
+export default async function handleUserRemovedMsg(
+  payload: EventTriggerPayload<'users', 'UPDATE'>,
+  channels: { isDiscordBot?: boolean; discord?: boolean; telegram?: boolean }
+) {
+  const {
+    event: { data },
+  } = payload;
+
+  if (!data.old.deleted_at && data.new.deleted_at) {
+    const { circles_by_pk: circle } = await queries.getCircle(
+      data.new.circle_id
+    );
+    const { profiles } = await queries.getProfileAndMembership(
+      data.new.address
+    );
+    await sendSocialMessage({
+      message: `${data.new.name} has left the circle.`,
+      circleId: data.new.circle_id,
+      channels: getChannels({
+        data,
+        circle,
+        channels,
+        profiles,
+      }),
+    });
+  }
+  return true;
+}

--- a/api-lib/sendSocialMessage.ts
+++ b/api-lib/sendSocialMessage.ts
@@ -27,6 +27,13 @@ export type DiscordNomination = DiscordEpochEvent & {
   numberOfVouches: number;
 };
 
+export type DiscordUserAddedOrRemoved = DiscordEpochEvent & {
+  type: 'user-added' | 'user-removed';
+  discordId?: string;
+  address?: string;
+  circleName: string;
+};
+
 export type DiscordOptsOut = DiscordEpochEvent & {
   type: 'user-opts-out';
   discordId?: string;
@@ -84,6 +91,7 @@ export type DiscordEnd = DiscordEpochEvent & {
 
 type SocialMessageChannels =
   | DiscordNomination
+  | DiscordUserAddedOrRemoved
   | DiscordOptsOut
   | DiscordVouch
   | DiscordVouchSuccessful

--- a/api-test/hasura/cron/epochs_stubbed.test.ts
+++ b/api-test/hasura/cron/epochs_stubbed.test.ts
@@ -118,7 +118,6 @@ const mockEpoch = {
   },
 };
 
-console.log('derp');
 function getTestInput(mockInput: {
   notifyStartEpochs?: EpochsToNotify['notifyStartEpochs'];
   notifyEndEpochs?: EpochsToNotify['notifyEndEpochs'];

--- a/api/hasura/event_triggers/eventManager.ts
+++ b/api/hasura/event_triggers/eventManager.ts
@@ -18,6 +18,8 @@ import refundGiveTelegram from '../../../api-lib/event_triggers/refundGiveTelegr
 import refundPendingGift from '../../../api-lib/event_triggers/refundPendingGift';
 import removeTeammate from '../../../api-lib/event_triggers/removeTeammate';
 import sendInteractionEventToMixpanel from '../../../api-lib/event_triggers/sendInteractionEventToMixpanel';
+import userAddedDiscordBot from '../../../api-lib/event_triggers/userAddedDiscordBot';
+import userRemovedDiscordBot from '../../../api-lib/event_triggers/userRemovedDiscordBot';
 import vouchDiscord from '../../../api-lib/event_triggers/vouchDiscord';
 import vouchDiscordBot from '../../../api-lib/event_triggers/vouchDiscordBot';
 import vouchTelegram from '../../../api-lib/event_triggers/vouchTelegram';
@@ -34,6 +36,8 @@ const HANDLERS: HandlerDict = {
   createCircleCRM,
   createContributionInteractionEvent,
   createNomineeDiscord,
+  userAddedDiscordBot,
+  userRemovedDiscordBot,
   createNomineeDiscordBot,
   createNomineeTelegram,
   createVouchedUser,

--- a/hasura/metadata/databases/default/tables/public_users.yaml
+++ b/hasura/metadata/databases/default/tables/public_users.yaml
@@ -215,3 +215,47 @@ event_triggers:
     headers:
       - name: verification_key
         value_from_env: HASURA_EVENT_SECRET
+  - name: userAddedDiscordBot
+    definition:
+      enable_manual: false
+      insert:
+        columns: '*'
+      update:
+        columns:
+          - deleted_at
+    retry_conf:
+      interval_sec: 3600
+      num_retries: 5
+      timeout_sec: 60
+    webhook: '{{HASURA_API_BASE_URL}}/event_triggers/eventManager?=userAddedDiscordBot'
+    headers:
+      - name: verification_key
+        value_from_env: HASURA_EVENT_SECRET
+    cleanup_config:
+      batch_size: 10000
+      clean_invocation_logs: false
+      clear_older_than: 168
+      paused: true
+      schedule: 0 0 * * *
+      timeout: 60
+  - name: userRemovedDiscordBot
+    definition:
+      enable_manual: false
+      update:
+        columns:
+          - deleted_at
+    retry_conf:
+      interval_sec: 3600
+      num_retries: 5
+      timeout_sec: 60
+    webhook: '{{HASURA_API_BASE_URL}}/event_triggers/eventManager?=userRemovedDiscordBot'
+    headers:
+      - name: verification_key
+        value_from_env: HASURA_EVENT_SECRET
+    cleanup_config:
+      batch_size: 10000
+      clean_invocation_logs: false
+      clear_older_than: 168
+      paused: true
+      schedule: 0 0 * * *
+      timeout: 60

--- a/hasura/metadata/databases/default/tables/public_users.yaml
+++ b/hasura/metadata/databases/default/tables/public_users.yaml
@@ -168,8 +168,9 @@ event_triggers:
       enable_manual: false
       update:
         columns:
-          - non_receiver
           - non_giver
+          - deleted_at
+          - non_receiver
     retry_conf:
       interval_sec: 10
       num_retries: 5


### PR DESCRIPTION
These handlers will be used to dispatch notification info to the discord
bot. Handlers have not been implemented for discord webhooks or
telegram, but it can be done with minimal lift if desired.

## Test Plan

This code is still not accessible from within prod and requires integration
with the bot, so that's how it will be tested for now.
