### PR TITLE
fix: Refunds sender and receiver

### DIFF
--- a/api-lib/gql/queries.ts
+++ b/api-lib/gql/queries.ts
@@ -585,7 +585,7 @@ export async function getEpoch(
   return epoch;
 }
 
-export async function getPendingTokenGifts({
+export async function getPendingTokenGiftsSent({
   senderId,
   epochId,
 }: {
@@ -608,6 +608,41 @@ export async function getPendingTokenGifts({
         {
           id: true,
           recipient: {
+            name: true,
+          },
+          tokens: true,
+        },
+      ],
+    },
+    {
+      operationName: 'getPendingTokenGifts',
+    }
+  );
+}
+
+export async function getPendingTokenGiftsReceived({
+  recipientId,
+  epochId,
+}: {
+  recipientId: number;
+  epochId: number;
+}) {
+  return await adminClient.query(
+    {
+      pending_token_gifts: [
+        {
+          where: {
+            recipient_id: {
+              _eq: recipientId,
+            },
+            epoch_id: {
+              _eq: epochId,
+            },
+          },
+        },
+        {
+          id: true,
+          sender: {
             name: true,
           },
           tokens: true,

--- a/api-lib/handleOptOutMsg.ts
+++ b/api-lib/handleOptOutMsg.ts
@@ -75,8 +75,8 @@ export default async function handleOptOutMsg(
       );
 
       const { pending_token_gifts: refunds } =
-        await queries.getPendingTokenGifts({
-          senderId: data.new.id,
+        await queries.getPendingTokenGiftsReceived({
+          recipientId: data.new.id,
           epochId: currentEpoch.id,
         });
 
@@ -97,8 +97,8 @@ export default async function handleOptOutMsg(
           profiles,
           refunds: refunds
             .filter(({ tokens }) => tokens > 0)
-            .map(({ recipient, tokens }) => ({
-              username: recipient.name,
+            .map(({ sender, tokens }) => ({
+              username: sender.name,
               give: tokens,
             })),
         }),
@@ -120,7 +120,7 @@ export default async function handleOptOutMsg(
       );
 
       const { pending_token_gifts: refunds } =
-        await queries.getPendingTokenGifts({
+        await queries.getPendingTokenGiftsSent({
           senderId: data.new.id,
           epochId: currentEpoch.id,
         });


### PR DESCRIPTION
## Motivation and Context

<!-- Why is this change required? What problem does it solve? This can be omitted if a linked issue is provided
-->

Fix the way we display the refunds

## Description

<!-- Describe your changes -->

We were not displaying the refunds correctly, depending on if an opt out is a giver or a sender

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

@topocount 
