### PR TITLE
validate add members list ens names

### DIFF
--- a/api-lib/validateENS.ts
+++ b/api-lib/validateENS.ts
@@ -1,0 +1,12 @@
+import { getProvider } from './provider';
+
+export const isValidENS = async (name: string, address?: string) => {
+  const resolvedAddress = await getProvider(1).resolveName(name);
+  if (
+    !resolvedAddress ||
+    resolvedAddress.toLowerCase() !== address?.toLowerCase()
+  ) {
+    return false;
+  }
+  return true;
+};

--- a/api/hasura/actions/_handlers/createUsers.ts
+++ b/api/hasura/actions/_handlers/createUsers.ts
@@ -12,7 +12,7 @@ import {
   errorResponseWithStatusCode,
   InternalServerError,
 } from '../../../../api-lib/HttpError';
-import { getProvider } from '../../../../api-lib/provider';
+import { isValidENS } from '../../../../api-lib/validateENS';
 import { ENTRANCE } from '../../../../src/common-lib/constants';
 import {
   composeHasuraActionRequestBodyWithApiPermissions,
@@ -52,12 +52,8 @@ async function handler(req: VercelRequest, res: VercelResponse) {
   const unresolvedUsers = await Promise.all(
     users.map(async user => {
       if (user.name.endsWith('.eth')) {
-        const resolvedAddress = await getProvider(1).resolveName(user.name);
-        if (
-          !resolvedAddress ||
-          resolvedAddress.toLowerCase() !== user.address.toLocaleLowerCase()
-        )
-          return user;
+        const validENS = await isValidENS(user.name, user.address);
+        if (!validENS) return user;
       }
     })
   );

--- a/api/hasura/actions/_handlers/updateProfile.ts
+++ b/api/hasura/actions/_handlers/updateProfile.ts
@@ -6,8 +6,8 @@ import { z } from 'zod';
 import { getProfilesWithName } from '../../../../api-lib/findProfile';
 import { adminClient } from '../../../../api-lib/gql/adminClient';
 import { errorResponseWithStatusCode } from '../../../../api-lib/HttpError';
-import { getProvider } from '../../../../api-lib/provider';
 import { verifyHasuraRequestMiddleware } from '../../../../api-lib/validate';
+import { isValidENS } from '../../../../api-lib/validateENS';
 import {
   composeHasuraActionRequestBodyWithSession,
   HasuraUserSessionVariables,
@@ -39,12 +39,8 @@ async function handler(req: VercelRequest, res: VercelResponse) {
   const { name } = payload;
 
   if (name.endsWith('.eth')) {
-    const resolvedAddress = await getProvider(1).resolveName(name);
-    if (
-      !resolvedAddress ||
-      resolvedAddress.toLowerCase() !==
-        session_variables.hasuraAddress.toLocaleLowerCase()
-    )
+    const validENS = await isValidENS(name, session_variables.hasuraAddress);
+    if (!validENS)
       return errorResponseWithStatusCode(
         res,
         {

--- a/api/hasura/cron/ensNames.ts
+++ b/api/hasura/cron/ensNames.ts
@@ -1,19 +1,16 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
 import { adminClient } from '../../../api-lib/gql/adminClient';
-import { getProvider } from '../../../api-lib/provider';
 import { verifyHasuraRequestMiddleware } from '../../../api-lib/validate';
+import { isValidENS } from '../../../api-lib/validateENS';
 
 async function handler(req: VercelRequest, res: VercelResponse) {
   const ensProfiles = await getEnsProfiles();
 
   await Promise.all(
     ensProfiles.profiles.map(async profile => {
-      const resolvedAddress = await getProvider(1).resolveName(profile.name);
-      if (
-        !resolvedAddress ||
-        resolvedAddress.toLowerCase() !== profile.address.toLowerCase()
-      ) {
+      const validENS = await isValidENS(profile.name, profile.address);
+      if (!validENS) {
         await updateEnsName({ id: profile.id, name: profile.name });
       }
     })

--- a/src/components/EditProfileModal.tsx
+++ b/src/components/EditProfileModal.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { updateMyProfile } from 'lib/gql/mutations';
-import { provider, zUsername } from 'lib/zod/formHelpers';
+import { zUsername, isValidENS } from 'lib/zod/formHelpers';
 import { SubmitHandler, useController, useForm } from 'react-hook-form';
 import { useMutation } from 'react-query';
 import * as z from 'zod';
@@ -133,11 +133,8 @@ export const EditProfileModal = ({
 
   const onSubmit: SubmitHandler<EditProfileFormSchema> = async params => {
     if (params.name.endsWith('.eth')) {
-      const resolvedAddress = await provider().resolveName(params.name);
-      if (
-        !resolvedAddress ||
-        resolvedAddress.toLowerCase() !== myProfile.address.toLowerCase()
-      ) {
+      const validENS = await isValidENS(params.name, myProfile.address);
+      if (!validENS) {
         setError(
           'name',
           {

--- a/src/components/MainLayout/CreateUserNameForm.tsx
+++ b/src/components/MainLayout/CreateUserNameForm.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { provider, zUsername } from 'lib/zod/formHelpers';
+import { isValidENS, zUsername } from 'lib/zod/formHelpers';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { useMutation, useQueryClient } from 'react-query';
 import { z } from 'zod';
@@ -63,11 +63,8 @@ export const CreateUserNameForm = ({ address }: { address?: string }) => {
   });
   const onSubmit: SubmitHandler<UserNameFormSchema> = async data => {
     if (data.name.endsWith('.eth')) {
-      const resolvedAddress = await provider().resolveName(data.name);
-      if (
-        !resolvedAddress ||
-        resolvedAddress.toLowerCase() !== address?.toLowerCase()
-      ) {
+      const validENS = await isValidENS(data.name, address);
+      if (!validENS) {
         setError(
           'name',
           {

--- a/src/lib/zod/formHelpers.ts
+++ b/src/lib/zod/formHelpers.ts
@@ -14,6 +14,17 @@ export const provider = () => {
   return _provider;
 };
 
+export const isValidENS = async (name: string, address?: string) => {
+  const resolvedAddress = await provider().resolveName(name);
+  if (
+    !resolvedAddress ||
+    resolvedAddress.toLowerCase() !== address?.toLowerCase()
+  ) {
+    return false;
+  }
+  return true;
+};
+
 export const zStringISODateUTC = z
   .string()
   .transform(s => DateTime.fromISO(s, { zone: 'utc' }))

--- a/src/pages/AddMembersPage/NewMemberList.tsx
+++ b/src/pages/AddMembersPage/NewMemberList.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { ENTRANCE } from 'common-lib/constants';
 import { client } from 'lib/gql/client';
-import { provider } from 'lib/zod/formHelpers';
+import { isValidENS } from 'lib/zod/formHelpers';
 import { SubmitHandler, useFieldArray, useForm } from 'react-hook-form';
 import { useQueryClient } from 'react-query';
 import { z } from 'zod';
@@ -137,11 +137,8 @@ const NewMemberList = ({
       const resolveResult = await Promise.all(
         newMembers.map(async (m, index) => {
           if (m.name.endsWith('.eth')) {
-            const resolvedAddress = await provider().resolveName(m.name);
-            if (
-              !resolvedAddress ||
-              resolvedAddress.toLowerCase() !== m.address.toLocaleLowerCase()
-            ) {
+            const validENS = await isValidENS(m.name, m.address);
+            if (!validENS) {
               setError(
                 `newMembers.${index}.name`,
                 {

--- a/src/pages/AddMembersPage/NewMemberList.tsx
+++ b/src/pages/AddMembersPage/NewMemberList.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { ENTRANCE } from 'common-lib/constants';
 import { client } from 'lib/gql/client';
+import { provider } from 'lib/zod/formHelpers';
 import { SubmitHandler, useFieldArray, useForm } from 'react-hook-form';
 import { useQueryClient } from 'react-query';
 import { z } from 'zod';
@@ -98,6 +99,7 @@ const NewMemberList = ({
     handleSubmit,
     reset,
     formState: { errors, isValid },
+    setError,
     watch,
     trigger,
   } = useForm<FormSchema>({
@@ -131,6 +133,30 @@ const NewMemberList = ({
           entrance:
             m.entrance === ENTRANCE.CSV ? ENTRANCE.CSV : ENTRANCE.MANUAL,
         }));
+
+      const resolveResult = await Promise.all(
+        newMembers.map(async (m, index) => {
+          if (m.name.endsWith('.eth')) {
+            const resolvedAddress = await provider().resolveName(m.name);
+            if (
+              !resolvedAddress ||
+              resolvedAddress.toLowerCase() !== m.address.toLocaleLowerCase()
+            ) {
+              setError(
+                `newMembers.${index}.name`,
+                {
+                  message: `The ENS ${m.name} doesn't resolve to the address: ${m.address}.`,
+                },
+                { shouldFocus: true }
+              );
+              return true;
+            }
+          }
+        })
+      );
+      if (resolveResult.find(r => r === true)) {
+        return;
+      }
       const res = await client.mutate(
         {
           createUsers: [


### PR DESCRIPTION
## Motivation and Context

issue raised by @crabsinger :
if you use the Add Members page, and use a ENS .eth in the Name field, we won't verify it, and then it will be set on the user. 

## Description

1- verify the list of names on FE and BE

## Test and Deployment Plan
go to member page and try to add a mix of addresses with correct and wrong ens names

## Screenshots (if appropriate):
front-end
![Screenshot from 2023-02-16 17-53-04](https://user-images.githubusercontent.com/34943689/219427621-0ce456b1-c19c-4ae8-9bb5-9598bd72b238.png)

back-end if front-end is bypassed
![Screenshot from 2023-02-16 18-23-17](https://user-images.githubusercontent.com/34943689/219427714-a5317e57-f1b0-4053-8c8d-630197d3af4b.png)
