### PR TITLE
feat: Give necessary permissons to generated api

### DIFF
--- a/src/pages/DiscordPage/DiscordPage.tsx
+++ b/src/pages/DiscordPage/DiscordPage.tsx
@@ -59,6 +59,16 @@ export const DiscordPage = () => {
       const result = await generateCircleApiKey({
         circle_id: Number(circleIdParam),
         name: 'discord-bot',
+        read_circle: true,
+        update_circle: true,
+        read_nominees: true,
+        create_vouches: true,
+        read_pending_token_gifts: true,
+        update_pending_token_gifts: true,
+        read_member_profiles: true,
+        read_epochs: true,
+        read_contributions: true,
+        create_contributions: true,
       });
 
       if (!result?.api_key) {

--- a/src/pages/DiscordPage/DiscordPage.tsx
+++ b/src/pages/DiscordPage/DiscordPage.tsx
@@ -69,6 +69,8 @@ export const DiscordPage = () => {
         read_epochs: true,
         read_contributions: true,
         create_contributions: true,
+        manage_users: true,
+        read_discord: true,
       });
 
       if (!result?.api_key) {


### PR DESCRIPTION
## Motivation and Context

<!-- Why is this change required? What problem does it solve? This can be omitted if a linked issue is provided
-->

Allow discord bot api users to access/update data with their api key

For example, in order to read a profile

`{"users":{"circle":{"api_keys":{"_and":[{"hash":{"_eq":"X-Hasura-Api-Key-Hash"}},{"read_member_profiles":{"_eq":true}}]}}}}`

## Description

<!-- Describe your changes -->

Add all permissions to discord bot api users

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

@topocount 
