### PR TITLE
Implement Variable Dust Allowance

### DIFF
--- a/src/lib/merkle-distributor/index.test.ts
+++ b/src/lib/merkle-distributor/index.test.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from '@ethersproject/bignumber';
 import padStart from 'lodash/padStart';
 
-import { createDistribution } from '.';
+import { createDistribution, getMaxAllowableDust } from '.';
 
 const addr = (num: number) => '0xabc' + padStart(num.toString(), 37, '0');
 
@@ -14,7 +14,8 @@ test('amounts', () => {
     },
     {},
     BigNumber.from('500000000'),
-    BigNumber.from('500000000')
+    BigNumber.from('500000000'),
+    6
   );
 
   expect(claims[addr(1)].amount).toEqual('83333333');
@@ -37,7 +38,8 @@ test('dust limit', () => {
       },
       {},
       totalAmount,
-      totalAmount
+      totalAmount,
+      6
     );
   }
 });
@@ -61,6 +63,7 @@ test('combined root', () => {
     {},
     BigNumber.from('600000000'),
     BigNumber.from('600000000'),
+    6,
     previousDist
   );
 
@@ -70,4 +73,11 @@ test('combined root', () => {
   expect(dist.claims[addr(4)].amount).toEqual('200000000');
   expect(dist.tokenTotal).toEqual('1100000000');
   expect(dist.previousTotal).toEqual('500000000');
+});
+
+test('getMaxAllowableDust', () => {
+  expect(getMaxAllowableDust(6).toString()).toBe('20');
+  expect(getMaxAllowableDust(5).toString()).toBe('2');
+  expect(getMaxAllowableDust(1).toString()).toBe('2');
+  expect(getMaxAllowableDust(18).toString()).toBe('20000000000000');
 });

--- a/src/pages/ClaimsPage/useClaimAllocation.test.tsx
+++ b/src/pages/ClaimsPage/useClaimAllocation.test.tsx
@@ -113,7 +113,8 @@ test('claim single successfully', async () => {
           gifts,
           {},
           total,
-          total
+          total,
+          6
         );
 
         expectedBalance = BigNumber.from(claims[address1].amount);

--- a/src/pages/DistributionsPage/useSubmitDistribution.test.tsx
+++ b/src/pages/DistributionsPage/useSubmitDistribution.test.tsx
@@ -208,7 +208,8 @@ test('previous distribution', async () => {
           previousGifts,
           fixedGifts,
           previousTotal,
-          previousTotal
+          previousTotal,
+          vault.decimals
         );
 
         const distro = await submitDistribution({

--- a/src/pages/DistributionsPage/useSubmitDistribution.ts
+++ b/src/pages/DistributionsPage/useSubmitDistribution.ts
@@ -97,6 +97,7 @@ export function useSubmitDistribution() {
         fixedGifts,
         newTotalAmount,
         newGiftAmount,
+        vault.decimals,
         prev
       );
 


### PR DESCRIPTION
Because the evm deals in fixed-point arithmetic, the order of magnitude
of the dust allowance should increase with the quantity of decimals a
token has.

For example, it does not make sense for DAI (18 decimals) to have the
same dust allowance as USDC (6 decimals) since that would mean we are
allowing 12 orders of magnitude less dust for DAI, making it much harder
to submit a distribution.

Test Plan

Unit Tests are included and existing tests are updated.
