### PR TITLE
Bugfix: Always show vaults link in side nav

### DIFF
--- a/src/features/nav/NavCurrentOrg.tsx
+++ b/src/features/nav/NavCurrentOrg.tsx
@@ -4,20 +4,15 @@ import { Box } from '../../ui';
 
 import { NavOrg } from './getNavData';
 import { NavItem } from './NavItem';
-import { isOrgAdmin } from './permissions';
 
 export const NavCurrentOrg = ({ org }: { org: NavOrg }) => {
-  const isAdmin = isOrgAdmin(org);
-
   return (
     <Box css={{ mb: '$md' }}>
-      {isAdmin && (
-        <NavItem
-          label={'Vaults'}
-          to={paths.vaultsForOrg(org.id)}
-          icon={<DollarSign />}
-        />
-      )}
+      <NavItem
+        label={'Vaults'}
+        to={paths.vaultsForOrg(org.id)}
+        icon={<DollarSign />}
+      />
     </Box>
   );
 };

--- a/src/ui/Button/Button.tsx
+++ b/src/ui/Button/Button.tsx
@@ -162,7 +162,7 @@ export const Button = styled('button', {
         borderRadius: '$4',
       },
       medium: {
-        minHeight: '$1xl',
+        minHeight: '$xl',
         padding: '$sm calc($sm + $xs)',
         fontSize: '$medium',
         fontWeight: '$medium',

--- a/src/ui/Text/Text.tsx
+++ b/src/ui/Text/Text.tsx
@@ -11,25 +11,6 @@ export const Text = styled('span', {
   textAlign: 'left',
 
   variants: {
-    color: {
-      default: { color: '$text' },
-      heading: { color: '$headingText' },
-      neutral: { color: '$neutral' },
-      alert: { color: '$alert' },
-      warning: { color: '$warning' },
-      primary: { color: '$primary' },
-      cta: { color: '$cta' },
-      secondary: { color: '$secondaryText' },
-      active: { color: '$tagActiveText' },
-      complete: { color: '$complete' },
-      inherit: { color: 'inherit' },
-    },
-    bold: { true: { fontWeight: '$bold !important' } },
-    normal: { true: { fontWeight: '$normal !important' } },
-    medium: { true: { fontWeight: '$medium !important' } },
-    semibold: { true: { fontWeight: '$semibold !important' } },
-    inline: { true: { display: 'inline !important' } },
-
     h1: {
       true: {
         fontSize: '$h1',
@@ -109,6 +90,24 @@ export const Text = styled('span', {
         whiteSpace: 'nowrap',
       },
     },
+    color: {
+      default: { color: '$text' },
+      heading: { color: '$headingText' },
+      neutral: { color: '$neutral' },
+      alert: { color: '$alert' },
+      warning: { color: '$warning' },
+      primary: { color: '$primary' },
+      cta: { color: '$cta' },
+      secondary: { color: '$secondaryText' },
+      active: { color: '$tagActiveText' },
+      complete: { color: '$complete' },
+      inherit: { color: 'inherit' },
+    },
+    bold: { true: { fontWeight: '$bold !important' } },
+    normal: { true: { fontWeight: '$normal !important' } },
+    medium: { true: { fontWeight: '$medium !important' } },
+    semibold: { true: { fontWeight: '$semibold !important' } },
+    inline: { true: { display: 'inline !important' } },
   },
   compoundVariants: [
     {


### PR DESCRIPTION
Vaults page should be viewable by anyone, but you don't see the create vault button if non-admin.  The views look like this:

### No Vault, admin
<img width="1226" alt="admin no-vault" src="https://user-images.githubusercontent.com/100873710/220461331-cd15dd5b-b424-447c-b29f-b1cc1a342c92.png">

### No Vault, non-admin
<img width="1225" alt="non-admin no-vault" src="https://user-images.githubusercontent.com/100873710/220461288-3af122fe-208a-4f31-9e60-5f5778ef1b06.png">

---------------------------------------

### Vault Created, admin
<img width="1225" alt="non-vault-creator-admin has-vault" src="https://user-images.githubusercontent.com/100873710/220461447-82bf3835-3046-4725-986f-db24a792b76b.png">

### Vault Created, non-admin
<img width="1226" alt="non-admin has-vault" src="https://user-images.githubusercontent.com/100873710/220461519-bf274893-373a-4fb9-9eda-5a0c4b520c85.png">

Ignore the color difference in the **current balance** text, I fixed that after the screengrabs
