### PR TITLE
Remove invalid repeat data

### DIFF
--- a/api/hasura/actions/_handlers/createSampleCircle.ts
+++ b/api/hasura/actions/_handlers/createSampleCircle.ts
@@ -122,7 +122,6 @@ async function createCircle(
             start_date: start_date.toISO(),
             end_date: end_date.toISO(),
             circle_id: circle.id,
-            repeat: 3,
           },
         },
         {


### PR DESCRIPTION
Fix invalid epoch repeat data for the sample circle.

The `repeat` column is the old epoch repeat data column, and not used in the new UI. Also, 3 is a value I'm unfamiliar its meaning of.
