### PR TITLE
Add Shared Secret For Discord Bot Notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,11 @@ DEBUG=coordinape*
 DISCORD_BOT_CLIENT_ID=no_token
 DISCORD_BOT_CLIENT_SECRET=no_token
 DISCORD_BOT_REDIRECT_URI=http://localhost:3000/discord/link
+# used by hasura notification events to authenticate notification requests
+# with the discord bot
+COORDINAPE_BOT_SECRET=bot-secret
+# used by the discord bot to authenticate requests to hasura
+HASURA_DISCORD_SECRET=discord-secret
 
 # Enable local logging
 # DEV_LOGGING=true
@@ -96,3 +101,5 @@ MAX_NOTE_BONUS_PER_USER=30;
 
 #this should be set to the last day of the previous month to enable backfilling
 BACKFILL_TO=2022-12-31
+
+# vim: ft=sh

--- a/api-lib/config.ts
+++ b/api-lib/config.ts
@@ -87,3 +87,8 @@ export const DISCORD_BOT_REDIRECT_URI: string = getEnvValue(
   'DISCORD_BOT_REDIRECT_URI',
   'http://localhost:3000/discord/link'
 );
+
+export const COORDINAPE_BOT_SECRET: string = getEnvValue(
+  'COORDINAPE_BOT_SECRET',
+  'bot-secret'
+);

--- a/api-lib/sendSocialMessage.ts
+++ b/api-lib/sendSocialMessage.ts
@@ -2,7 +2,7 @@ import fetch from 'node-fetch';
 
 import { isFeatureEnabled } from '../src/config/features';
 
-import { TELEGRAM_BOT_BASE_URL } from './config';
+import { TELEGRAM_BOT_BASE_URL, COORDINAPE_BOT_SECRET } from './config';
 import { DISCORD_BOT_NAME, DISCORD_BOT_AVATAR_URL } from './constants';
 import * as queries from './gql/queries';
 
@@ -174,6 +174,7 @@ export async function sendSocialMessage({
       body: JSON.stringify(telegramBotPost),
       headers: {
         'Content-Type': 'application/json',
+        'x-coordinape-bot-secret': COORDINAPE_BOT_SECRET,
       },
     });
 


### PR DESCRIPTION
The notification endpoints on the discord bot need to have a way to
reject unauthorized requests. A shared secret allows the discord bot
notification endpoints to authenticate requests in a simple way.

