### PR TITLE
feat: Add discord bot entrance to the enum

### DIFF
--- a/src/common-lib/constants.ts
+++ b/src/common-lib/constants.ts
@@ -6,7 +6,7 @@ export enum ENTRANCE {
   MANUAL = 'manual-address-entry',
   CSV = 'CSV',
   NOMINATION = 'vouched-in',
-
+  DISCORD_BOT = 'discord-bot',
   GUILD = 'guild',
 }
 


### PR DESCRIPTION
We'd like the discord bot to have its own entrance