### PR TITLE
feat: Send profile name when user added, removed or opts out

### DIFF
--- a/api-lib/handleOptOutMsg.ts
+++ b/api-lib/handleOptOutMsg.ts
@@ -38,7 +38,8 @@ function getChannels(props: GetChannelsProps): Channels<DiscordOptsOut> {
     roleId &&
     alerts?.['user-opts-out']
   ) {
-    const user = profiles[0].user;
+    const discordId = profiles[0].user?.user_snowflake;
+    const profileName = profiles[0].name;
 
     return {
       isDiscordBot: true,
@@ -46,8 +47,9 @@ function getChannels(props: GetChannelsProps): Channels<DiscordOptsOut> {
         type: 'user-opts-out' as const,
         channelId,
         roleId,
-        discordId: user?.user_snowflake,
+        discordId,
         address: data.new.address,
+        profileName,
         tokenName: circle?.token_name || 'GIVE',
         circleName: circle?.name ?? 'Unknown',
         refunds: refunds ?? [],

--- a/api-lib/handleUserAddedMsg.ts
+++ b/api-lib/handleUserAddedMsg.ts
@@ -36,7 +36,8 @@ function getChannels(
     roleId &&
     alerts?.['user-added']
   ) {
-    const user = profiles[0].user;
+    const discordId = profiles[0].user?.user_snowflake;
+    const profileName = profiles[0].name;
 
     return {
       isDiscordBot: true,
@@ -44,8 +45,9 @@ function getChannels(
         type: 'user-added',
         channelId,
         roleId,
-        discordId: user?.user_snowflake,
+        discordId,
         address: data.new.address,
+        profileName,
         circleName: circle?.name ?? 'Unknown',
       },
     };

--- a/api-lib/handleUserRemovedMsg.ts
+++ b/api-lib/handleUserRemovedMsg.ts
@@ -36,7 +36,8 @@ function getChannels(
     roleId &&
     alerts?.['user-removed']
   ) {
-    const user = profiles[0].user;
+    const discordId = profiles[0].user?.user_snowflake;
+    const profileName = profiles[0].name;
 
     return {
       isDiscordBot: true,
@@ -44,8 +45,9 @@ function getChannels(
         type: 'user-removed',
         channelId,
         roleId,
-        discordId: user?.user_snowflake,
+        discordId,
         address: data.new.address,
+        profileName,
         circleName: circle?.name ?? 'Unknown',
       },
     };

--- a/api-lib/sendSocialMessage.ts
+++ b/api-lib/sendSocialMessage.ts
@@ -31,6 +31,7 @@ export type DiscordUserAddedOrRemoved = DiscordEpochEvent & {
   type: 'user-added' | 'user-removed';
   discordId?: string;
   address?: string;
+  profileName?: string;
   circleName: string;
 };
 
@@ -38,6 +39,7 @@ export type DiscordOptsOut = DiscordEpochEvent & {
   type: 'user-opts-out';
   discordId?: string;
   address?: string;
+  profileName?: string;
   tokenName: string;
   circleName: string;
   refunds: {


### PR DESCRIPTION
## Motivation and Context

Have the profile name in the discord message

## Description

Send the profile name for the following events:

* user added;
* user removed; and
* user opts out.

Complements https://github.com/coordinape/discord-bot/pull/95

## Reviewers

@topocount 

## Related Issue

Closes https://github.com/coordinape/discord-bot/issues/86
