### PR TITLE
fix: Check if channel is discord bot

### DIFF
--- a/api-lib/sendSocialMessage.ts
+++ b/api-lib/sendSocialMessage.ts
@@ -125,7 +125,11 @@ export async function sendSocialMessage({
 
   const { circles_by_pk: circle } = await queries.getCircle(circleId);
 
-  if (isFeatureEnabled('discord') && channels?.isDiscordBot) {
+  if (
+    isFeatureEnabled('discord') &&
+    channels?.isDiscordBot &&
+    channels.discordBot
+  ) {
     const { type } = channels.discordBot || {};
     const res = await fetch(
       `https://coordinape-discord-bot.herokuapp.com/api/epoch/${type}`,


### PR DESCRIPTION
## Motivation and Context

We are POST a bunch of requests that should not go through unless the channel is the discord bo
```
2023-02-25T12:01:23.336575+00:00 heroku[router]: at=info method=POST path="/api/epoch/undefined" host=coordinape-discord-bot.herokuapp.com request_id=f7aad109-e58c-4cfb-8eff-0dfdeed534e9 fwd="20.42.13.0" dyno=web.1 connect=0ms service=1ms status=404 bytes=403 protocol=https
2023-02-25T12:01:28.307190+00:00 heroku[router]: at=info method=POST path="/api/epoch/undefined" host=coordinape-discord-bot.herokuapp.com request_id=09cc83bc-e70d-4609-a7f2-564cd54aa1be fwd="20.42.13.0" dyno=web.1 connect=0ms service=1ms status=404 bytes=403 protocol=https
2023-02-25T12:01:31.943736+00:00 heroku[router]: at=info method=POST path="/api/epoch/undefined" host=coordinape-discord-bot.herokuapp.com request_id=4c9452a8-3a9d-4903-9a03-88db5c819ba8 fwd="172.177.129.243" dyno=web.1 connect=0ms service=1ms status=404 bytes=403 protocol=https
2023-02-25T12:01:39.310867+00:00 heroku[router]: at=info method=POST path="/api/epoch/undefined" host=coordinape-discord-bot.herokuapp.com request_id=d716a845-3322-4591-b96c-eae298e92781 fwd="20.42.13.0" dyno=web.1 connect=0ms service=1ms status=404 bytes=403 protocol=https
2023-02-25T12:01:42.933022+00:00 heroku[router]: at=info method=POST path="/api/epoch/undefined" host=coordinape-discord-bot.herokuapp.com request_id=4d8d89c6-3196-42d9-9bb8-a34a4a2e10cb fwd="172.177.129.243" dyno=web.1 connect=0ms service=1ms status=404 bytes=403 protocol=https
2023-02-25T12:01:50.361898+00:00 heroku[router]: at=info method=POST path="/api/epoch/undefined" host=coordinape-discord-bot.herokuapp.com request_id=fc8ed5ad-5a70-422c-ae1e-d8a895aee628 fwd="20.42.13.0" dyno=web.1 connect=0ms service=2ms status=404 bytes=403 protocol=https
```

## Description

<!-- Describe your changes -->

Check if channel is the discord bot before POSTing.

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->
@topocount 
