### PR TITLE
handling saving circle w/o guild fields

### DIFF
--- a/src/lib/zod/index.ts
+++ b/src/lib/zod/index.ts
@@ -309,8 +309,8 @@ export const updateCircleInput = z
       .transform(s => (s === 'Disabled' ? null : s))
       .optional(),
     fixed_payment_vault_id: z.number().positive().nullable().optional(),
-    guild_id: z.number().nullable(),
-    guild_role_id: z.number().nullable(),
+    guild_id: z.number().nullable().optional(),
+    guild_role_id: z.number().nullable().optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Motivation and Context

There are pages other than the circle admin page that call updateCircle and they don't include all the fields
