### PR TITLE
store profile data globally

### DIFF
--- a/src/features/auth/useFinishAuth.ts
+++ b/src/features/auth/useFinishAuth.ts
@@ -1,6 +1,7 @@
 import assert from 'assert';
 
 import * as Sentry from '@sentry/react';
+import { useQueryClient } from 'react-query';
 
 import { DebugLogger } from '../../common-lib/log';
 import { useApiBase } from 'hooks';
@@ -9,6 +10,7 @@ import { useWeb3React } from 'hooks/useWeb3React';
 
 import { findConnectorName } from './connectors';
 import { login } from './login';
+import { QUERY_KEY_LOGIN_DATA } from './useLoginData';
 import { useLogout } from './useLogout';
 import { useSavedAuth } from './useSavedAuth';
 
@@ -20,6 +22,7 @@ export const useFinishAuth = () => {
   const logout = useLogout();
   const [savedAuth, setSavedAuth] = useSavedAuth();
   const web3Context = useWeb3React();
+  const queryClient = useQueryClient();
 
   return async () => {
     const { connector, account: address, library, providerType } = web3Context;
@@ -59,9 +62,10 @@ export const useFinishAuth = () => {
           new Promise(res =>
             fetchManifest(profileId)
               .then(manifest => {
-                // TODO extract some data from manifest
-                // and put it in auth store
-                console.log(manifest); // eslint-disable-line
+                queryClient.setQueryData(
+                  QUERY_KEY_LOGIN_DATA,
+                  manifest.profiles_by_pk
+                );
                 res(true);
               })
               .catch(() => {

--- a/src/features/auth/useLoginData.ts
+++ b/src/features/auth/useLoginData.ts
@@ -1,0 +1,22 @@
+import { useQuery } from 'react-query';
+
+import { useApiBase } from 'hooks/useApiBase';
+
+import { useSavedAuth } from './useSavedAuth';
+
+export const QUERY_KEY_LOGIN_DATA = 'loginData';
+
+export const useLoginData = () => {
+  const [savedAuth] = useSavedAuth();
+  const { fetchManifest } = useApiBase();
+
+  const { data } = useQuery(
+    QUERY_KEY_LOGIN_DATA,
+    async () => {
+      const { profiles_by_pk } = await fetchManifest(savedAuth.id);
+      return profiles_by_pk;
+    },
+    { staleTime: Infinity }
+  );
+  return data;
+};

--- a/src/lib/gql/mutations.ts
+++ b/src/lib/gql/mutations.ts
@@ -206,27 +206,6 @@ export async function updateCircle(params: ValueTypes['UpdateCircleInput']) {
   return updateCircle;
 }
 
-export async function deleteCircle(circle_id: number) {
-  const { deleteCircle } = await client.mutate(
-    {
-      deleteCircle: [
-        {
-          payload: {
-            circle_id: circle_id,
-          },
-        },
-        {
-          success: true,
-        },
-      ],
-    },
-    {
-      operationName: 'deleteCircle',
-    }
-  );
-  return deleteCircle;
-}
-
 export async function restoreCoordinapeUser(circleId: number) {
   await client.mutate(
     {

--- a/src/pages/CreateCirclePage/CreateCircleForm.tsx
+++ b/src/pages/CreateCirclePage/CreateCircleForm.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 
 import { zodResolver } from '@hookform/resolvers/zod';
+import { QUERY_KEY_LOGIN_DATA } from 'features/auth/useLoginData';
 import { QUERY_KEY_NAV } from 'features/nav/getNavData';
 import { fileToBase64 } from 'lib/base64';
 import uniqBy from 'lodash/uniqBy';
@@ -90,6 +91,7 @@ export const CreateCircleForm = ({
     queryClient.invalidateQueries(QUERY_KEY_MY_ORGS);
     queryClient.invalidateQueries(QUERY_KEY_MAIN_HEADER);
     queryClient.invalidateQueries(QUERY_KEY_NAV);
+    queryClient.invalidateQueries(QUERY_KEY_LOGIN_DATA);
     navigate({
       pathname: paths.members(circleId),
       search: NEW_CIRCLE_CREATED_PARAMS,


### PR DESCRIPTION
this stores profile data locally. i've added it to ~the existing zustand auth store for now~ react-query, and to avoid bikeshedding about the structure of local data storage, i am just storing the entire `profiles_by_pk` subtree of the fetchManifest query.

in the short term, this will be used to determine whether the user is a member of a given org, without incurring additional requests. in the longer term it will also help us continue to move away from Recoil.
