### PR TITLE
fix: Update epoch start notification after sending social message

### DIFF
--- a/api-test/hasura/cron/epochs_stubbed.test.ts
+++ b/api-test/hasura/cron/epochs_stubbed.test.ts
@@ -896,7 +896,7 @@ describe('epoch Cron Logic', () => {
         },
         { operationName: 'updateEpochStartNotification' }
       );
-      expect(mockMutation).toBeCalledTimes(3);
+      expect(mockMutation).toBeCalledTimes(4);
       expect(mockSendSocial).toBeCalledTimes(3);
       expect(mockSendSocial).toBeCalledWith({
         channels: {

--- a/api/hasura/cron/epochs.ts
+++ b/api/hasura/cron/epochs.ts
@@ -277,6 +277,7 @@ export async function notifyEpochStart({
         },
         sanitize: false,
       });
+      await updateEpochStartNotification(epoch.id);
     }
 
     if (circle.discord_webhook) {


### PR DESCRIPTION
## Motivation and Context

<!-- Why is this change required? What problem does it solve? This can be omitted if a linked issue is provided
-->

Update the epoch start notification so cron knows the notification has already been sent

## Description

<!-- Describe your changes -->

Update the epoch start notification after the social message has been sent

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

@CryptoGraffe 

## Related Issue

<!-- Please link to the issue here -->

Closes https://github.com/coordinape/discord-bot/issues/98
