### PR TITLE
Fix CSV export user name field

### DIFF
--- a/api-test/hasura/cron/pGiveHistoricalGen.test.ts
+++ b/api-test/hasura/cron/pGiveHistoricalGen.test.ts
@@ -20,8 +20,7 @@ beforeEach(async () => {
 
   circle = await createCircle(adminClient);
   const createDate = DateTime.local().minus({ months: 3 }).toISO();
-  const profile = await createProfile(adminClient, { address: address1 });
-  console.log(profile);
+  await createProfile(adminClient, { address: address1 });
   user1 = await createUser(adminClient, {
     address: address1,
     circle_id: circle.id,

--- a/api/hasura/actions/_handlers/allocationCsv.test.ts
+++ b/api/hasura/actions/_handlers/allocationCsv.test.ts
@@ -135,7 +135,6 @@ function getMockCircleDistribution(
     users: [
       {
         id: 1,
-        name: 'User 1',
         address: '0x1',
         fixed_payment_amount: 100,
         profile: { id: 1, name: 'User 1' },
@@ -144,7 +143,6 @@ function getMockCircleDistribution(
       },
       {
         id: 2,
-        name: 'User 2',
         address: '0x2',
         fixed_payment_amount: 101,
         profile: { id: 2, name: 'User 2' },

--- a/api/hasura/actions/_handlers/allocationCsv.ts
+++ b/api/hasura/actions/_handlers/allocationCsv.ts
@@ -147,7 +147,7 @@ export function generateCsvValues(
 
       const rowValues: (string | number)[] = [
         idx + 1,
-        (u.deleted_at ? '(Deleted) ' : '') + (u.profile.name ?? u.name),
+        (u.deleted_at ? '(Deleted) ' : '') + u.profile.name,
         u.address,
         received,
         u.sent_gifts.length
@@ -232,7 +232,6 @@ export async function getCircleDetails(
             {
               id: true,
               address: true,
-              name: true,
               deleted_at: true,
               fixed_payment_amount: true,
               profile: { id: true, name: true },


### PR DESCRIPTION
## Motivation and Context

Fix CSV exporting user name error

## Description

Upon trying to export allocations CSV users get the following error:
`GQL Error (validation-failed): field 'name' not found in type: 'users' at $.selectionSet.circles_by_pk.selectionSet.users.selectionSet.name`
The error is caused by fetching users.name field which is removed

## Test and Deployment Plan
Go to distribution page of an ended epoch and try export CSV

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/34943689/224522659-b13399ee-13dd-481e-adce-3bc46a5c095d.png)

