### PR TITLE
remove name field from update_user mutations

### DIFF
--- a/api/hasura/actions/_handlers/createUsers.ts
+++ b/api/hasura/actions/_handlers/createUsers.ts
@@ -109,6 +109,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     return {
       ...eu,
       ...updatedUser,
+      name: undefined,
       give_token_remaining: updatedUser?.starting_tokens,
     };
   });

--- a/src/lib/zod/index.ts
+++ b/src/lib/zod/index.ts
@@ -58,7 +58,6 @@ export const adminUpdateUserSchemaInput = z
     circle_id: z.number(),
     address: zEthAddressOnly,
     new_address: zEthAddressOnly.optional(),
-    name: zUsername.optional(),
     starting_tokens: z.number().optional(),
     non_giver: z.boolean().optional(),
     fixed_non_receiver: z.boolean().optional(),


### PR DESCRIPTION
## Motivation and Context

remove name field from update_user mutations

## Description

1- upon adding re-adding a deleted user to a circle update_user is invoked causing error because name field is still used there

## Test and Deployment Plan

1- add a new user to a circle
2- remove the user from the circle(using delete button from Members table)
3- re add the user to the circle