### PR TITLE
Login fix

### DIFF
--- a/src/features/auth/RequireAuth.test.tsx
+++ b/src/features/auth/RequireAuth.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen, act, waitFor } from '@testing-library/react';
+import { saveAllData, EConnectorNames } from 'features/auth/useSavedAuth';
+import { useQueryClient } from 'react-query';
+
+import {
+  generateTokenString,
+  hashTokenString,
+} from '../../../api-lib/authHelpers';
+import { adminClient } from '../../../api-lib/gql/adminClient';
+import { createProfile } from '../../../api-test/helpers';
+import { useWeb3React } from 'hooks/useWeb3React';
+import { provider as getProvider, TestWrapper } from 'utils/testing';
+
+import { RequireAuth } from './RequireAuth';
+import { QUERY_KEY_LOGIN_DATA } from './useLoginData';
+
+import { Awaited } from 'types/shim';
+
+let profile: Awaited<ReturnType<typeof createProfile>>, token: string;
+
+beforeAll(async () => {
+  const tokenString = generateTokenString();
+  profile = await createProfile(adminClient);
+  const { insert_personal_access_tokens_one } = await adminClient.mutate(
+    {
+      delete_personal_access_tokens: [
+        { where: { profile: { id: { _eq: profile.id } } } },
+        { affected_rows: true },
+      ],
+      insert_personal_access_tokens_one: [
+        {
+          object: {
+            name: 'circle-access-token',
+            abilities: '["read"]',
+            tokenable_type: 'App\\Models\\Profile',
+            tokenable_id: profile.id,
+            token: hashTokenString(tokenString),
+          },
+        },
+        { id: true },
+      ],
+    },
+    { operationName: 'test' }
+  );
+  token = `${insert_personal_access_tokens_one?.id}|${tokenString}`;
+});
+
+test('show connection modal', () => {
+  render(
+    <TestWrapper>
+      <RequireAuth>
+        <div>Hello world</div>
+      </RequireAuth>
+    </TestWrapper>
+  );
+  screen.findByText('Connect Your Wallet');
+});
+
+test('reconnect with saved auth', async () => {
+  const provider = getProvider();
+  const address = await provider.getSigner().getAddress();
+
+  saveAllData({
+    recent: address.toLocaleLowerCase(),
+    data: {
+      [address.toLowerCase()]: {
+        connectorName: EConnectorNames.Injected,
+        token,
+        id: profile.id,
+      },
+    },
+  });
+
+  const WaitForAddress = (props: { children: any }) =>
+    useWeb3React().active ? props.children : <>nope</>;
+
+  let data: any;
+
+  const CheckData = () => {
+    const queryClient = useQueryClient();
+    data = queryClient.getQueryData(QUERY_KEY_LOGIN_DATA);
+    return null;
+  };
+
+  await act(async () => {
+    await render(
+      <TestWrapper withWeb3>
+        <WaitForAddress>
+          <RequireAuth>
+            <CheckData />
+          </RequireAuth>
+        </WaitForAddress>
+      </TestWrapper>
+    );
+  });
+
+  await waitFor(() => {
+    expect(data.id).toBe(profile.id);
+    expect(data.name).toBe(profile.name);
+  });
+});

--- a/src/features/auth/RequireAuth.tsx
+++ b/src/features/auth/RequireAuth.tsx
@@ -16,7 +16,7 @@ import { WalletAuthModal } from './WalletAuthModal';
 // call this hook with showErrors = false if you want to re-establish an
 // existing login session where possible, and fail silently
 export const useAuthStateMachine = (showErrors: boolean) => {
-  const [savedAuth] = useSavedAuth();
+  const { savedAuth } = useSavedAuth();
   const web3Context = useWeb3React();
   const finishAuth = useFinishAuth();
   const authStep = useAuthStore(state => state.step);
@@ -87,7 +87,7 @@ export const useAuthStateMachine = (showErrors: boolean) => {
         }
       })();
     }
-  }, [savedAuth.address, web3Context]);
+  }, [savedAuth.connectorName, web3Context]);
 };
 
 export const RequireAuth = (props: { children: ReactNode }) => {

--- a/src/features/auth/connectors.ts
+++ b/src/features/auth/connectors.ts
@@ -2,6 +2,7 @@ import assert from 'assert';
 
 import { AbstractConnector } from '@web3-react/abstract-connector';
 import { InjectedConnector } from '@web3-react/injected-connector';
+import { NetworkConnector } from '@web3-react/network-connector';
 import { WalletConnectConnector } from '@web3-react/walletconnect-connector';
 import { WalletLinkConnector } from '@web3-react/walletlink-connector';
 import { loginSupportedChainIds } from 'common-lib/constants';
@@ -41,6 +42,9 @@ export const connectors: { [key in EConnectorNames]: AbstractConnector } = {
 export const findConnectorName = (
   connector: AbstractConnector
 ): EConnectorNames => {
+  // workaround for ganache
+  if (connector instanceof NetworkConnector) return EConnectorNames.Injected;
+
   const match = Object.entries(connectors).find(
     ([, c]) => connector?.constructor === c.constructor
   );

--- a/src/features/auth/useFinishAuth.ts
+++ b/src/features/auth/useFinishAuth.ts
@@ -20,7 +20,7 @@ export const useFinishAuth = () => {
   const { showError } = useToast();
   const { fetchManifest } = useApiBase();
   const logout = useLogout();
-  const [savedAuth, setSavedAuth] = useSavedAuth();
+  const { setSavedAuth, getAndUpdate } = useSavedAuth();
   const web3Context = useWeb3React();
   const queryClient = useQueryClient();
 
@@ -34,6 +34,7 @@ export const useFinishAuth = () => {
         : providerType;
       assert(connectorName);
 
+      const savedAuth = getAndUpdate(address);
       logger.log('found saved auth data:', savedAuth);
       let profileId = savedAuth.id;
       if (!savedAuth.token) {
@@ -42,7 +43,7 @@ export const useFinishAuth = () => {
         if (!token) return false;
 
         logger.log('got new auth data:', loginData);
-        setSavedAuth({ address, connectorName, ...loginData });
+        setSavedAuth(address, { connectorName, ...loginData });
         profileId = loginData.id;
       }
 

--- a/src/features/auth/useFinishAuth.ts
+++ b/src/features/auth/useFinishAuth.ts
@@ -58,24 +58,23 @@ export const useFinishAuth = () => {
       // this setTimeout is needed so that the Recoil effects of updateSavedAuth
       // are finished before fetchManifest is called. in particular,
       // setAuthToken needs to be called
-      return setTimeout(
-        () =>
-          new Promise(res =>
-            fetchManifest(profileId)
-              .then(manifest => {
-                queryClient.setQueryData(
-                  QUERY_KEY_LOGIN_DATA,
-                  manifest.profiles_by_pk
-                );
-                res(true);
-              })
-              .catch(() => {
-                // we had a cached token & it's invalid, so log out
-                // FIXME don't logout if request timed out
-                logout();
-                res(false);
-              })
-          )
+      return new Promise(res =>
+        setTimeout(() =>
+          fetchManifest(profileId)
+            .then(manifest => {
+              queryClient.setQueryData(
+                QUERY_KEY_LOGIN_DATA,
+                manifest.profiles_by_pk
+              );
+              res(true);
+            })
+            .catch(() => {
+              // we had a cached token & it's invalid, so log out
+              // FIXME don't logout if request timed out
+              logout();
+              res(false);
+            })
+        )
       );
     } catch (e: any) {
       if (

--- a/src/features/auth/useLoginData.ts
+++ b/src/features/auth/useLoginData.ts
@@ -2,18 +2,15 @@ import { useQuery } from 'react-query';
 
 import { useApiBase } from 'hooks/useApiBase';
 
-import { useSavedAuth } from './useSavedAuth';
-
 export const QUERY_KEY_LOGIN_DATA = 'loginData';
 
 export const useLoginData = () => {
-  const [savedAuth] = useSavedAuth();
   const { fetchManifest } = useApiBase();
 
   const { data } = useQuery(
     QUERY_KEY_LOGIN_DATA,
     async () => {
-      const { profiles_by_pk } = await fetchManifest(savedAuth.id);
+      const { profiles_by_pk } = await fetchManifest();
       return profiles_by_pk;
     },
     { staleTime: Infinity }

--- a/src/features/auth/useLogout.ts
+++ b/src/features/auth/useLogout.ts
@@ -4,13 +4,14 @@ import { useRecoilLoadCatch } from 'hooks';
 import { rSelectedCircleIdSource } from 'recoilState/app';
 import { rApiManifest, rApiFullCircle } from 'recoilState/db';
 
-import { rSavedAuth } from './useSavedAuth';
+import { useSavedAuth } from './useSavedAuth';
 
-export const useLogout = (remote = false) =>
-  useRecoilLoadCatch(
+export const useLogout = (remote = false) => {
+  const { clearSavedAuth } = useSavedAuth();
+  return useRecoilLoadCatch(
     ({ set }) =>
       async () => {
-        set(rSavedAuth, {});
+        clearSavedAuth();
         set(rApiFullCircle, new Map());
         set(rApiManifest, undefined);
         set(rSelectedCircleIdSource, undefined);
@@ -23,3 +24,4 @@ export const useLogout = (remote = false) =>
       },
     []
   );
+};

--- a/src/features/auth/useSavedAuth.ts
+++ b/src/features/auth/useSavedAuth.ts
@@ -33,7 +33,8 @@ const getAllData = (): IAuth => {
   }
 };
 
-const saveAllData = (allData: IAuth) => {
+// only exporting for testing purposes
+export const saveAllData = (allData: IAuth) => {
   localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(allData));
 };
 

--- a/src/features/auth/useSavedAuth.ts
+++ b/src/features/auth/useSavedAuth.ts
@@ -1,13 +1,7 @@
-import assert from 'assert';
-
-import { atom, selector, useRecoilState } from 'recoil';
-
-import { DebugLogger } from '../../common-lib/log';
+import { useMemo } from 'react';
 
 import type { ProviderType } from './store';
 import { setAuthToken } from './token';
-
-const logger = new DebugLogger('auth');
 
 export enum EConnectorNames {
   Injected = 'injected',
@@ -15,49 +9,74 @@ export enum EConnectorNames {
   WalletLink = 'walletlink',
 }
 
-export interface IAuth {
-  address?: string;
+type IAuthValue = {
   connectorName?: EConnectorNames | ProviderType;
   id?: number;
   token?: string;
+};
+export interface IAuth {
+  recent?: string;
+  data: { [address: string]: IAuthValue };
 }
 
-const updateToken = ({ token }: IAuth) => {
-  logger.log('updateToken:', token);
-  setAuthToken(token);
-};
+const AUTH_STORAGE_KEY = 'capeAuth3';
 
-const AUTH_STORAGE_KEY = 'capeAuth2';
+const emptyData = () => ({ data: {} });
 
-const getSavedAuth = (): IAuth => {
+const getAllData = (): IAuth => {
   try {
-    const auth = localStorage.getItem(AUTH_STORAGE_KEY);
-    assert(auth);
-    return JSON.parse(auth);
+    const stored = localStorage.getItem(AUTH_STORAGE_KEY);
+    if (!stored) return emptyData();
+    return JSON.parse(stored);
   } catch {
-    return {};
+    return emptyData();
   }
 };
 
-export const rSavedAuth = atom({
-  key: 'rSavedAuth',
-  default: selector({
-    key: 'rSavedAuth/default',
-    get: () => {
-      const auth = getSavedAuth();
-      updateToken(auth);
-      return auth;
-    },
-  }),
-  effects_UNSTABLE: [
-    ({ onSet }) => {
-      onSet(auth => {
-        if (!auth) auth = {};
-        updateToken(auth);
-        localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(auth));
-      });
-    },
-  ],
-});
+const saveAllData = (allData: IAuth) => {
+  localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(allData));
+};
 
-export const useSavedAuth = () => useRecoilState(rSavedAuth);
+type UseSavedAuthReturn = {
+  savedAuth: IAuthValue;
+  setSavedAuth: (address: string, data: IAuthValue) => void;
+  getAndUpdate: (address: string) => IAuthValue;
+  clearSavedAuth: () => void;
+};
+export const useSavedAuth = (): UseSavedAuthReturn => {
+  const { recent, data } = getAllData();
+
+  const savedAuth = useMemo(() => {
+    const auth = recent ? data[recent] ?? {} : {};
+    setAuthToken(auth.token);
+    return auth;
+  }, [recent]);
+
+  const setSavedAuth = (address: string, data: IAuthValue) => {
+    address = address.toLowerCase();
+
+    // data.token will be null when this is called to log out
+    setAuthToken(data.token);
+
+    const previous = getAllData();
+    const updated = {
+      recent: address,
+      data: { ...previous.data, [address]: data },
+    };
+    saveAllData(updated);
+  };
+
+  // this is needed during login when the most-recent account is not the one
+  // we're currently connected to, e.g. the user switched accounts in MetaMask
+  // in between Coordinape sessions. all other cases should use savedAuth
+  // instead
+  const getAndUpdate = (address: string) => {
+    address = address.toLowerCase();
+    if (address !== recent) saveAllData({ recent: address, data });
+    return data[address.toLowerCase()] ?? {};
+  };
+
+  const clearSavedAuth = () => saveAllData(emptyData());
+
+  return { savedAuth, setSavedAuth, getAndUpdate, clearSavedAuth };
+};

--- a/src/hooks/useApiBase.ts
+++ b/src/hooks/useApiBase.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 
-import { rSavedAuth } from 'features/auth/useSavedAuth';
+import { useSavedAuth } from 'features/auth/useSavedAuth';
 import { client } from 'lib/gql/client';
 
 import {
@@ -526,10 +526,12 @@ const formatLegacyManifest = async (
 };
 
 export const useApiBase = () => {
+  const { savedAuth } = useSavedAuth();
+
   const fetchManifest = useRecoilLoadCatch(
-    ({ snapshot, set }) =>
+    ({ set }) =>
       async (profileId?: number) => {
-        if (!profileId) profileId = (await snapshot.getPromise(rSavedAuth)).id;
+        if (!profileId) profileId = savedAuth.id;
         assert(profileId, 'no profile ID for fetchManifest');
         const data = await queryManifest(profileId);
 

--- a/src/hooks/useConnectedAddress.ts
+++ b/src/hooks/useConnectedAddress.ts
@@ -1,16 +1,6 @@
-import { useEffect, useState } from 'react';
-
 import { useWeb3React } from 'hooks/useWeb3React';
 
 export default function useConnectedAddress() {
-  const { account, library } = useWeb3React();
-
-  // fallback for certain providers that don't set account directly
-  const [signerAddress, setSignerAddress] = useState();
-  useEffect(() => {
-    if (account) return;
-    library?.getSigner().getAddress().then(setSignerAddress);
-  }, [library]);
-
-  return account || signerAddress || undefined;
+  const { account } = useWeb3React();
+  return account || undefined;
 }

--- a/src/hooks/useWeb3React.tsx
+++ b/src/hooks/useWeb3React.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, createContext, useContext, useState, useRef } from 'react';
 
 import type { JsonRpcProvider } from '@ethersproject/providers';
 import { Web3Provider } from '@ethersproject/providers';
@@ -28,6 +28,12 @@ export type UseWeb3ReactReturnType<T> = Web3ReactContextInterface<T> & {
   providerType: ProviderType | undefined;
 };
 
+// this provides a workaround for providers like Ganache that don't have an
+// address set in useWeb3React by default
+const FallbackAddressContext = createContext<
+  [string | undefined, (address: string) => void]
+>([undefined, () => {}]);
+
 export function useWeb3React<T = any>(
   key?: string | undefined
 ): UseWeb3ReactReturnType<T> {
@@ -40,17 +46,41 @@ export function useWeb3React<T = any>(
 
   const setProvider = useAuthStore(state => state.setProvider);
   const providerType = useAuthStore(state => state.providerType);
-  const { provider, address, chainId } = useAuthStore(
-    pick(['provider', 'address', 'chainId'])
-  );
+  const {
+    provider,
+    address: storeAddress,
+    chainId,
+  } = useAuthStore(pick(['provider', 'address', 'chainId']));
   const library = context.library || provider;
+
+  const mounted = useRef(false);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  const [signerAddress, setSignerAddress] = useContext(FallbackAddressContext);
+  useEffect(() => {
+    if (context.account || storeAddress) return;
+    context.library
+      ?.getSigner()
+      .getAddress()
+      .then((address: string) => {
+        if (!mounted.current) return;
+        setSignerAddress(address);
+      });
+  }, [library]);
+
+  const address = context.account || storeAddress || signerAddress;
 
   return {
     ...context,
     library,
-    active: context.active || !!address,
+    active: !!address,
     chainId: context.chainId || chainId,
-    account: context.account || address,
+    account: address,
     setProvider,
     providerType,
     deactivate: context.active ? context.deactivate : () => setProvider(),
@@ -62,11 +92,14 @@ export function Web3ReactProvider({
 }: {
   children: any;
 }): JSX.Element {
+  const signerAddressState = useState<string | undefined>();
   return (
     <OriginalWeb3ReactProvider getLibrary={getLibrary}>
-      {children}
+      <FallbackAddressContext.Provider value={signerAddressState}>
+        {children}
+        <Web3EventHooks />
+      </FallbackAddressContext.Provider>
       <MagicModalFixer />
-      <Web3EventHooks />
     </OriginalWeb3ReactProvider>
   );
 }

--- a/src/pages/ClaimsPage/useClaimAllocation.test.tsx
+++ b/src/pages/ClaimsPage/useClaimAllocation.test.tsx
@@ -24,34 +24,19 @@ let snapshotId: string;
 jest.mock('lib/gql/mutations/vaults', () => {
   return {
     addVaultTx: jest.fn().mockReturnValue(Promise.resolve({})),
-    addVault: jest
-      .fn()
-      .mockImplementationOnce(x =>
-        Promise.resolve({
-          createVault: {
-            vault: {
-              ...x,
-              token_address: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
-              decimals: 18,
-              symbol: 'DAI',
-              org_id: 101,
-            },
+    addVault: jest.fn().mockImplementationOnce(x =>
+      Promise.resolve({
+        createVault: {
+          vault: {
+            ...x,
+            token_address: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+            decimals: 18,
+            symbol: 'DAI',
+            org_id: 101,
           },
-        })
-      )
-      .mockImplementationOnce(x =>
-        Promise.resolve({
-          createVault: {
-            vault: {
-              ...x,
-              token_address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-              decimals: 6,
-              symbol: 'USDC',
-              org_id: 101,
-            },
-          },
-        })
-      ),
+        },
+      })
+    ),
     savePendingVaultTx: jest.fn(),
   };
 });
@@ -63,11 +48,6 @@ beforeAll(async () => {
   const mainAccount = (await provider().listAccounts())[0];
   await mint({
     token: Asset.DAI,
-    address: mainAccount,
-    amount: '1000',
-  });
-  await mint({
-    token: Asset.USDC,
     address: mainAccount,
     amount: '1000',
   });
@@ -94,7 +74,7 @@ test('claim single successfully', async () => {
     const { deposit } = useVaultRouter(contracts);
 
     useEffect(() => {
-      if (!contracts) return;
+      if (!contracts || work) return;
       work = (async () => {
         const vault = await createVault({
           simpleTokenAddress: '0x0',

--- a/src/pages/DistributionsPage/useSubmitDistribution.test.tsx
+++ b/src/pages/DistributionsPage/useSubmitDistribution.test.tsx
@@ -105,7 +105,7 @@ test('submit distribution', async () => {
     const { deposit } = useVaultRouter(contracts);
 
     useEffect(() => {
-      if (!contracts) return;
+      if (!contracts || work) return;
 
       work = (async () => {
         const vault = await createVault({
@@ -191,7 +191,7 @@ test('previous distribution', async () => {
     const { deposit } = useVaultRouter(contracts);
 
     useEffect(() => {
-      if (!contracts) return;
+      if (!contracts || work) return;
 
       work = (async () => {
         const vault = await createVault({


### PR DESCRIPTION
This fixes a regression I introduced in my commits last week: after those changes, we were not checking that the stored auth token matched the currently connected account, and not clearing tokens correctly on logout.

to fix this, i restored the multi-account storage in useSavedAuth, then added a check in useFinishAuth to mark the correct address as the one whose token we should use.

I also ended up removing the Recoil dependency of useSavedAuth because it's more straightforward to use localStorage directly.
