### PR TITLE
org members page

### DIFF
--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -9,7 +9,8 @@ export type FeatureName =
   | 'guild'
   | 'disable_distribute_evenly'
   | 'epoch_timing_banner'
-  | 'activity';
+  | 'activity'
+  | 'org_view';
 
 // this is a very simple implementation of build-time feature flags that you can
 // hardcode or set with environment variables
@@ -22,6 +23,7 @@ const staticFeatureFlags: Partial<Record<FeatureName, boolean>> = {
   discord: true,
   guild: true,
   epoch_timing_banner: !!process.env.REACT_APP_FEATURE_FLAG_EPOCH_TIMING_BANNER,
+  org_view: false,
 };
 
 // this code is safe to use in a non-browser environment because of the typeof

--- a/src/features/nav/NavCurrentOrg.tsx
+++ b/src/features/nav/NavCurrentOrg.tsx
@@ -7,6 +7,7 @@ import { NavOrg } from './getNavData';
 import { NavItem } from './NavItem';
 
 export const NavCurrentOrg = ({ org }: { org: NavOrg }) => {
+  const isInOrg = org.members.length > 0;
   return (
     <Box css={{ mb: '$md' }}>
       <NavItem
@@ -14,7 +15,7 @@ export const NavCurrentOrg = ({ org }: { org: NavOrg }) => {
         to={paths.vaultsForOrg(org.id)}
         icon={<DollarSign />}
       />
-      {isFeatureEnabled('org_view') && (
+      {isFeatureEnabled('org_view') && isInOrg && (
         <NavItem
           label={'Members'}
           to={paths.orgMembers(org.id)}

--- a/src/features/nav/NavCurrentOrg.tsx
+++ b/src/features/nav/NavCurrentOrg.tsx
@@ -1,6 +1,7 @@
-import { DollarSign } from '../../icons/__generated';
+import { DollarSign, Member } from '../../icons/__generated';
 import { paths } from '../../routes/paths';
 import { Box } from '../../ui';
+import isFeatureEnabled from 'config/features';
 
 import { NavOrg } from './getNavData';
 import { NavItem } from './NavItem';
@@ -13,6 +14,13 @@ export const NavCurrentOrg = ({ org }: { org: NavOrg }) => {
         to={paths.vaultsForOrg(org.id)}
         icon={<DollarSign />}
       />
+      {isFeatureEnabled('org_view') && (
+        <NavItem
+          label={'Members'}
+          to={paths.orgMembers(org.id)}
+          icon={<Member nostroke />}
+        />
+      )}
     </Box>
   );
 };

--- a/src/features/nav/SideNav.test.tsx
+++ b/src/features/nav/SideNav.test.tsx
@@ -1,11 +1,9 @@
 import { useEffect } from 'react';
 
 import { act, render, screen } from '@testing-library/react';
-import { setAuthToken } from 'features/auth';
 import { useNavigate } from 'react-router-dom';
 
-import { rSelectedCircleIdSource } from 'recoilState';
-import { fixtures, TestWrapper, useMockRecoilState } from 'utils/testing';
+import { fixtures, TestWrapper } from 'utils/testing';
 
 import { useNavQuery } from './getNavData';
 import { SideNav } from './SideNav';
@@ -14,13 +12,11 @@ jest.mock('./getNavData', () => ({
   useNavQuery: jest.fn(),
 }));
 
-const snapshotState: any = {};
+jest.mock('../../pages/HistoryPage/useReceiveInfo', () => ({
+  useReceiveInfo: jest.fn(() => ({})),
+}));
 
-beforeEach(() => {
-  setAuthToken('mock');
-});
-
-afterEach(() => snapshotState.release?.());
+beforeEach(() => {});
 
 test('show circle links for distributions route', async () => {
   (useNavQuery as any).mockReturnValue({
@@ -38,6 +34,7 @@ test('show circle links for distributions route', async () => {
               users: [{ ...fixtures.user, role: 1 }],
             },
           ],
+          members: [],
         },
       ],
       profile: { name: 'tonka' },
@@ -46,10 +43,6 @@ test('show circle links for distributions route', async () => {
   });
   const Harness = () => {
     const navigate = useNavigate();
-
-    useMockRecoilState(snapshotState, set => {
-      set(rSelectedCircleIdSource, () => fixtures.circle.id);
-    });
 
     useEffect(() => {
       navigate(`/circles/${fixtures.circle.id}/distributions/10`);

--- a/src/features/nav/getNavData.ts
+++ b/src/features/nav/getNavData.ts
@@ -1,11 +1,10 @@
-import { useIsLoggedIn } from 'features/auth';
+import { useAuthStore, useIsLoggedIn } from 'features/auth';
 import { client } from 'lib/gql/client';
 import { useQuery } from 'react-query';
 
-import useConnectedAddress from 'hooks/useConnectedAddress';
 import { useWeb3React } from 'hooks/useWeb3React';
 
-export const getNavData = (address: string, chainId: number) =>
+export const getNavData = (profileId: number, chainId: number) =>
   client.query(
     {
       organizations: [
@@ -21,17 +20,21 @@ export const getNavData = (address: string, chainId: number) =>
               name: true,
               logo: true,
               users: [
-                { where: { address: { _eq: address.toLowerCase() } } },
+                { where: { profile: { id: { _eq: profileId } } } },
                 { role: true, id: true },
               ],
             },
+          ],
+          members: [
+            { where: { profile_id: { _eq: profileId } } },
+            { role: true },
           ],
         },
       ],
       claims_aggregate: [
         {
           where: {
-            profile: { address: { _eq: address.toLowerCase() } },
+            profile_id: { _eq: profileId },
             txHash: { _is_null: true },
             distribution: {
               tx_hash: { _is_null: false },
@@ -42,7 +45,7 @@ export const getNavData = (address: string, chainId: number) =>
         { aggregate: { count: [{}, true] } },
       ],
       profiles: [
-        { limit: 1, where: { address: { _eq: address.toLowerCase() } } },
+        { limit: 1, where: { id: { _eq: profileId } } },
         { name: true, id: true, avatar: true },
       ],
     },
@@ -51,25 +54,23 @@ export const getNavData = (address: string, chainId: number) =>
 
 export const QUERY_KEY_NAV = 'Nav';
 
+// FIXME this is redundant with fetchManifest
 export const useNavQuery = () => {
-  const address = useConnectedAddress();
   const { chainId } = useWeb3React();
   const isLoggedIn = useIsLoggedIn();
+  const profileId = useAuthStore(state => state.profileId);
   return useQuery(
-    [QUERY_KEY_NAV, address],
+    [QUERY_KEY_NAV, profileId],
     async () => {
-      const data = await getNavData(address as string, chainId as number);
+      const data = await getNavData(profileId as number, chainId as number);
       const profile = data.profiles?.[0];
       if (!profile) {
         throw new Error('no profile for current user');
       }
-      return {
-        ...data,
-        profile,
-      };
+      return { ...data, profile };
     },
     {
-      enabled: !!address && !!chainId && isLoggedIn,
+      enabled: !!profileId && !!chainId && isLoggedIn,
       staleTime: Infinity,
     }
   );

--- a/src/features/nav/permissions.ts
+++ b/src/features/nav/permissions.ts
@@ -2,10 +2,7 @@ import { isUserAdmin } from 'lib/users';
 
 import { NavCircle, NavOrg } from './getNavData';
 
-export const isCircleAdmin = (circle: NavCircle) => {
-  return circle.users.some(isUserAdmin);
-};
+export const isCircleAdmin = (circle: NavCircle) =>
+  circle.users.some(isUserAdmin);
 
-export const isOrgAdmin = (org: NavOrg) => {
-  return org.circles.some(c => c.users.some(u => u.role == 1));
-};
+export const isOrgAdmin = (org: NavOrg) => org.circles.some(isCircleAdmin);

--- a/src/features/orgs/OrgMembersPage.tsx
+++ b/src/features/orgs/OrgMembersPage.tsx
@@ -1,5 +1,0 @@
-import { SingleColumnLayout } from 'ui/layouts';
-
-export const OrgMembersPage = () => {
-  return <SingleColumnLayout>hello world</SingleColumnLayout>;
-};

--- a/src/features/orgs/OrgMembersTable.tsx
+++ b/src/features/orgs/OrgMembersTable.tsx
@@ -1,0 +1,189 @@
+import { useEffect, useState } from 'react';
+
+import { isUserAdmin, Role } from 'lib/users';
+import { styled } from 'stitches.config';
+
+import { makeTable } from 'components';
+import { useNavigation } from 'hooks';
+import useMobileDetect from 'hooks/useMobileDetect';
+import { Check, X } from 'icons/__generated';
+import { Avatar, Box, Link, Text, Tooltip } from 'ui';
+import { shortenAddress } from 'utils';
+
+import { QueryMember } from './getOrgMembersData';
+
+const TD = styled('td', {});
+const TR = styled('tr', {});
+
+const headerStyles = {
+  color: '$secondaryText',
+  textTransform: 'uppercase',
+  fontSize: '$small',
+  fontWeight: '$semibold',
+  lineHeight: '$shorter',
+};
+
+const MemberName = ({ member }: { member: QueryMember }) => {
+  const { getToProfile } = useNavigation();
+
+  return (
+    <Box
+      css={{
+        height: '$2xl',
+        alignItems: 'center',
+
+        overflow: 'hidden',
+        display: 'grid',
+        gridTemplateColumns: 'auto 1fr auto',
+        width: '100%',
+      }}
+    >
+      <Avatar
+        path={member.profile.avatar}
+        name={member.profile.name}
+        size="small"
+        onClick={getToProfile(member.profile.address)}
+        css={{ mr: '$sm' }}
+      />
+      <Text
+        css={{
+          display: 'block',
+          textOverflow: 'ellipsis',
+          overflow: 'hidden',
+          whiteSpace: 'nowrap',
+          minWidth: 0,
+        }}
+      >
+        {member.profile.name}{' '}
+      </Text>
+    </Box>
+  );
+};
+
+const isCircleAdmin = (member: QueryMember): boolean => {
+  if (member.profile.users.find(u => isUserAdmin(u)) !== undefined) return true;
+  return false;
+};
+
+const DisplayedCircles = ({ member }: { member: QueryMember }) => {
+  if (member.profile.users.length < 2) {
+    return (
+      <Text css={{ display: 'inline' }}>
+        {member.profile.users
+          .map(u => `${u.circle.name}${u.role === Role.ADMIN ? ' (A)' : ''}`)
+          .join(', ')}
+      </Text>
+    );
+  } else {
+    const circles = () => (
+      <Text>
+        {member.profile.users
+          .map(u => `${u.circle.name}${u.role === Role.ADMIN ? ' (A)' : ''}`)
+          .join(', ')}
+        .
+      </Text>
+    );
+    return (
+      <Text css={{ display: 'inline' }}>
+        {member.profile.users
+          .slice(0, 2)
+          .map(u => `${u.circle.name}${u.role === Role.ADMIN ? ' (A)' : ''}`)
+          .join(', ')}
+        <Tooltip content={circles()}>
+          <Link inlineLink target="_blank" rel="noreferrer">
+            , see more
+          </Link>{' '}
+        </Tooltip>
+      </Text>
+    );
+  }
+};
+export const MemberRow = ({ member }: { member: QueryMember }) => {
+  return (
+    <TR key={member.id}>
+      <TD css={{ width: '20%' }} align="left">
+        <MemberName member={member} />
+      </TD>
+      <TD>{shortenAddress(member.profile.address)}</TD>
+      <TD
+        css={{
+          textAlign: 'right !important',
+          minWidth: '$3xl',
+        }}
+      >
+        {isCircleAdmin(member) ? (
+          <Check size="lg" color="complete" />
+        ) : (
+          <X size="lg" color="neutral" />
+        )}
+      </TD>
+      <TD
+        css={{
+          textAlign: 'right !important',
+          minWidth: '$3xl',
+        }}
+      >
+        <DisplayedCircles member={member} />
+      </TD>
+    </TR>
+  );
+};
+
+export const OrgMembersTable = ({
+  members,
+  filter,
+  perPage,
+}: {
+  members: QueryMember[];
+  filter: (u: QueryMember) => boolean;
+  perPage: number;
+}) => {
+  const { isMobile } = useMobileDetect();
+  const [view, setView] = useState<QueryMember[]>([]);
+
+  useEffect(() => {
+    const filtered = filter ? members.filter(filter) : members;
+    setView(filtered);
+  }, [members, perPage, filter]);
+
+  const OrgMembersTable = makeTable<QueryMember>('OrgMembersTable');
+
+  const headers = [
+    { title: 'Name', css: headerStyles },
+    {
+      title: 'ETH WALLET',
+      css: headerStyles,
+      isHidden: isMobile,
+    },
+    {
+      title: 'Admin',
+      css: {
+        ...headerStyles,
+        textAlign: 'right !important',
+      },
+    },
+    {
+      title: 'Circles',
+      css: { ...headerStyles, textAlign: 'right' },
+    },
+  ];
+
+  return (
+    <OrgMembersTable
+      headers={headers}
+      data={view}
+      startingSortIndex={0}
+      perPage={perPage}
+      sortByColumn={(index: number) => {
+        if (index === 0)
+          return (m: QueryMember) => m.profile.name.toLowerCase();
+        if (index === 1)
+          return (m: QueryMember) => m.profile.address.toLowerCase();
+        if (index === 2) return (m: QueryMember) => isCircleAdmin(m);
+        return (m: QueryMember) => m.profile.name.toLowerCase();
+      }}
+    >
+      {member => <MemberRow key={member.id} member={member} />}
+    </OrgMembersTable>
+  );
+};

--- a/src/features/orgs/getOrgMembersData.ts
+++ b/src/features/orgs/getOrgMembersData.ts
@@ -1,0 +1,41 @@
+import { client } from 'lib/gql/client';
+
+import { Awaited } from 'types/shim';
+
+export const getOrgMembersPageData = async (orgId: number) => {
+  return client.query(
+    {
+      organizations_by_pk: [
+        { id: orgId },
+        {
+          members: [
+            {},
+            {
+              id: true,
+              profile: {
+                avatar: true,
+                name: true,
+                address: true,
+                users: [
+                  {},
+                  {
+                    role: true,
+                    circle: { name: true, id: true },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    },
+    { operationName: 'getOrgMembersPageData' }
+  );
+};
+
+export type OrgMembersPageQuery = NonNullable<
+  Awaited<ReturnType<typeof getOrgMembersPageData>>['organizations_by_pk']
+>;
+export type QueryMember = OrgMembersPageQuery['members'][number];
+
+export const QUERY_KEY_GET_ORG_MEMBERS_DATA = 'getOrgMembersPageData';

--- a/src/features/orgs/index.tsx
+++ b/src/features/orgs/index.tsx
@@ -1,3 +1,2 @@
 export { OrgPage } from './OrgPage';
-export { OrgMembersPage } from './OrgMembersPage';
 export { OrgSettingsPage } from './OrgSettingsPage';

--- a/src/pages/OrgMembersPage/index.tsx
+++ b/src/pages/OrgMembersPage/index.tsx
@@ -1,0 +1,109 @@
+import assert from 'assert';
+import React, { useState, useMemo, useEffect } from 'react';
+
+import {
+  getOrgMembersPageData,
+  QueryMember,
+  QUERY_KEY_GET_ORG_MEMBERS_DATA,
+} from 'features/orgs/getOrgMembersData';
+import { OrgMembersTable } from 'features/orgs/OrgMembersTable';
+import { useQuery } from 'react-query';
+import { useParams } from 'react-router-dom';
+
+import { LoadingModal } from 'components';
+import { useToast } from 'hooks';
+import useMobileDetect from 'hooks/useMobileDetect';
+import { Search } from 'icons/__generated';
+import { ContentHeader, Flex, Panel, Text, TextField } from 'ui';
+import { SingleColumnLayout } from 'ui/layouts';
+
+const OrgMembersPage = () => {
+  const { isMobile } = useMobileDetect();
+  const { showError } = useToast();
+
+  const [keyword, setKeyword] = useState<string>('');
+
+  const params = useParams();
+
+  assert(params.orgId, 'missing circleId param');
+  const orgId = Number.parseInt(params.orgId);
+
+  const { error, data } = useQuery(
+    [QUERY_KEY_GET_ORG_MEMBERS_DATA, orgId],
+    () => getOrgMembersPageData(orgId as number),
+    {
+      enabled: !!orgId,
+      refetchOnWindowFocus: false,
+      staleTime: Infinity,
+    }
+  );
+
+  useEffect(() => {
+    if (error instanceof Error) showError(error.message);
+  }, [error]);
+
+  // User Columns
+  const filterMember = useMemo(
+    () => (m: QueryMember) => {
+      const r = new RegExp(keyword, 'i');
+      return r.test(m.profile?.name) || r.test(m.profile.address);
+    },
+    [keyword]
+  );
+
+  const organization = data?.organizations_by_pk;
+  if (!organization) return <LoadingModal visible />;
+  const { members } = organization;
+
+  return (
+    <SingleColumnLayout>
+      <ContentHeader>
+        <Flex column css={{ gap: '$sm', flexGrow: 1 }}>
+          <Text h1>Organization Members</Text>
+          <Text p as="p">
+            View and Manage members.
+          </Text>
+        </Flex>
+        {!isMobile && (
+          <Flex
+            css={{
+              flexGrow: 1,
+              flexWrap: 'wrap',
+              justifyContent: 'flex-end',
+              gap: '$md',
+            }}
+          >
+            <Text size={'small'} css={{ color: '$headingText' }}>
+              <Text>
+                {members.length} Member{members.length > 1 ? 's' : ''}
+              </Text>
+            </Text>
+          </Flex>
+        )}
+      </ContentHeader>
+
+      <Panel css={{ p: '$lg' }}>
+        <Flex css={{ justifyContent: 'space-between', mb: '$md' }}>
+          <Text large css={{ fontWeight: '$semibold', color: '$headingText' }}>
+            Members
+          </Text>
+          <Flex alignItems="center" css={{ gap: '$sm' }}>
+            <Search color="neutral" />
+            <TextField
+              inPanel
+              size="sm"
+              onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                setKeyword(event.target.value)
+              }
+              placeholder="Search"
+              value={keyword}
+            />
+          </Flex>
+        </Flex>
+        <OrgMembersTable members={members} filter={filterMember} perPage={15} />
+      </Panel>
+    </SingleColumnLayout>
+  );
+};
+
+export default OrgMembersPage;

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -75,6 +75,7 @@ export const paths = {
   organization: (orgId: string) => `/organizations/${orgId}`,
   organizationSettings: orgPath(`settings`),
   vaultsForOrg: orgPath(`vaults`),
+  orgMembers: orgPath(`members`),
 
   // for circle links
   invite: (token: string) => `/welcome/${token}`,

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -3,7 +3,7 @@ import { lazy, Suspense } from 'react';
 import { RequireAuth, useLoginData } from 'features/auth';
 import { MintPage, SplashPage } from 'features/cosoul';
 import CoSoulLayout from 'features/cosoul/CoSoulLayout';
-import { OrgPage, OrgSettingsPage, OrgMembersPage } from 'features/orgs';
+import { OrgPage, OrgSettingsPage } from 'features/orgs';
 import { isUserAdmin, isUserMember } from 'lib/users';
 import {
   Navigate,
@@ -41,6 +41,7 @@ import HistoryPage from 'pages/HistoryPage';
 import IntegrationCallbackPage from 'pages/IntegrationCallbackPage';
 import MembersPage from 'pages/MembersPage';
 import { NewNominationPage } from 'pages/NewNominationPage/NewNominationPage';
+import OrgMembersPage from 'pages/OrgMembersPage';
 import ProfilePage from 'pages/ProfilePage';
 import VaultsPage from 'pages/VaultsPage';
 import { VaultTransactions } from 'pages/VaultsPage/VaultTransactions';
@@ -57,6 +58,10 @@ const LazyAssetMapPage = lazy(() => import('pages/AssetMapPage'));
 const LoggedInRoutes = () => {
   return (
     <Routes>
+      <Route path={paths.organization(':orgId')} element={<OrgRouteHandler />}>
+        <Route path="members" element={<OrgMembersPage />} />
+      </Route>
+
       {/* circle routes that all org members can view */}
       <Route path="circles/:circleId" element={<OrgRouteHandler />}>
         <Route path="activity" element={<CircleActivityPage />} />
@@ -84,7 +89,6 @@ const LoggedInRoutes = () => {
             element={<IntegrationCallbackPage />}
           />
         </Route>
-
         <Route path="distributions/:epochId" element={<DistributionsPage />} />
       </Route>
 
@@ -101,7 +105,6 @@ const LoggedInRoutes = () => {
         <Route path="" element={<OrgPage />} />
         <Route path="settings" element={<OrgSettingsPage />} />
         <Route path="vaults" element={<VaultsPage />} />
-        <Route path="members" element={<OrgMembersPage />} />
       </Route>
 
       <Route


### PR DESCRIPTION
## Motivation and Context

resolves #2003 

## Description

1- Add Members Nav item to organization nav
2- Add OrgMembersPage to display list of org_members

## Test and Deployment Plan
1- you need to enable "org_view" feature use `localStorage.setItem('feature:org_view','true')` in browser console
2- open a terminal in coordinape folder and run `yarn repl` 
3-  use `createMembersFromCircles(OrgId:number)` inside the repl to populate org_members table for that org

## Screenshots (if appropriate):

![Screenshot from 2023-03-13 23-09-21](https://user-images.githubusercontent.com/34943689/224836282-9d3c17a4-a0d0-421a-87e4-75fd926c1f59.png)