### PR TITLE
Allow activities and contributions to circle org members

### DIFF
--- a/hasura/metadata/databases/default/tables/public_activities.yaml
+++ b/hasura/metadata/databases/default/tables/public_activities.yaml
@@ -48,11 +48,21 @@ select_permissions:
         - created_at
         - updated_at
       filter:
-        _and:
+        _or:
           - organization:
               circles:
                 users:
-                  profile:
-                    id:
+                  _and:
+                    - profile:
+                        id:
+                          _eq: X-Hasura-User-Id
+                    - deleted_at:
+                        _is_null: true
+          - organization:
+              members:
+                _and:
+                  - id:
                       _eq: X-Hasura-User-Id
+                  - deleted_at:
+                      _is_null: true
       allow_aggregations: true

--- a/hasura/metadata/databases/default/tables/public_contributions.yaml
+++ b/hasura/metadata/databases/default/tables/public_contributions.yaml
@@ -80,14 +80,23 @@ select_permissions:
         - updated_at
         - user_id
       filter:
-        _and:
+        _or:
           - circle:
-              users:
-                profile:
-                  id:
-                    _eq: X-Hasura-User-Id
-          - deleted_at:
-              _is_null: true
+              organization:
+                members:
+                  _and:
+                    - profile_id:
+                        _eq: X-Hasura-User-Id
+                    - deleted_at:
+                        _is_null: true
+          - _and:
+              - circle:
+                  users:
+                    profile:
+                      id:
+                        _eq: X-Hasura-User-Id
+              - deleted_at:
+                  _is_null: true
       allow_aggregations: true
 event_triggers:
   - name: activityContributionInsert


### PR DESCRIPTION
## Motivation and Context
Allow activities and contributions  select permission to circle org members

## Description

Update Hasura perms.

## Test and Deployment Plan

With activity enabled, add a user as org member but not circle member, and you should see contributions from circles, and activities for circles.

