### PR TITLE
Minor spacing fix for sidenav

### DIFF
--- a/src/features/nav/SideNav.tsx
+++ b/src/features/nav/SideNav.tsx
@@ -94,6 +94,7 @@ export const SideNav = () => {
           alignItems: 'center',
           justifyContent: 'space-between',
           gap: '$md',
+          mb: '$md',
           button: { display: 'none' },
           position: 'relative',
           zIndex: '2',
@@ -132,7 +133,7 @@ export const SideNav = () => {
         css={{
           flex: 1,
           overflowY: 'auto',
-          pt: '$xl',
+          pt: '$md',
           // So focus outlines don't get cropped
           mx: '-3px',
           px: '3px',

--- a/src/features/nav/SideNav.tsx
+++ b/src/features/nav/SideNav.tsx
@@ -94,7 +94,7 @@ export const SideNav = () => {
           alignItems: 'center',
           justifyContent: 'space-between',
           gap: '$md',
-          mb: '$md',
+          mb: '$lg',
           button: { display: 'none' },
           position: 'relative',
           zIndex: '2',
@@ -133,7 +133,7 @@ export const SideNav = () => {
         css={{
           flex: 1,
           overflowY: 'auto',
-          pt: '$md',
+          pt: '$sm',
           // So focus outlines don't get cropped
           mx: '-3px',
           px: '3px',

--- a/src/pages/GivePage/MyGiveRow.tsx
+++ b/src/pages/GivePage/MyGiveRow.tsx
@@ -134,7 +134,7 @@ export const MyGiveRow = ({
                   whiteSpace: 'nowrap',
                 }}
               >
-                {contributionCount} contribution
+                {contributionCount} Contribution
                 {contributionCount == 1 ? '' : 's'}
               </Text>
               {!statementCompelete && (


### PR DESCRIPTION

<img width="358" alt="Screenshot 2023-03-15 at 1 35 59 PM" src="https://user-images.githubusercontent.com/100873710/225435975-f1fa08c6-b459-4569-97d9-320fb5b520e5.png">


added some bottom padding to the logo so overflow isn't right at the edge of the logo.  