### PR TITLE
Create discord.user_api_tokens table

### DIFF
--- a/hasura/metadata/databases/default/tables/discord_user_api_tokens.yaml
+++ b/hasura/metadata/databases/default/tables/discord_user_api_tokens.yaml
@@ -1,0 +1,3 @@
+table:
+  name: user_api_tokens
+  schema: discord

--- a/hasura/metadata/databases/default/tables/tables.yaml
+++ b/hasura/metadata/databases/default/tables/tables.yaml
@@ -1,5 +1,6 @@
 - "!include discord_circle_api_tokens.yaml"
 - "!include discord_roles_circles.yaml"
+- "!include discord_user_api_tokens.yaml"
 - "!include discord_users.yaml"
 - "!include public_activities.yaml"
 - "!include public_burns.yaml"

--- a/hasura/migrations/default/1678981500944_create_table_discord_user_api_tokens/down.sql
+++ b/hasura/migrations/default/1678981500944_create_table_discord_user_api_tokens/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE "discord"."user_api_tokens";

--- a/hasura/migrations/default/1678981500944_create_table_discord_user_api_tokens/up.sql
+++ b/hasura/migrations/default/1678981500944_create_table_discord_user_api_tokens/up.sql
@@ -1,0 +1,33 @@
+CREATE TABLE "discord"."user_api_tokens" (
+  "id" bigserial NOT NULL,
+  "profile_id" bigint NOT NULL,
+  "circle_id" bigint NOT NULL,
+  "discord_user" bigint,
+  "token" text NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY ("id"),
+  FOREIGN KEY ("circle_id") REFERENCES "public"."circles"("id") ON UPDATE cascade ON DELETE cascade,
+  FOREIGN KEY ("profile_id") REFERENCES "public"."profiles"("id") ON UPDATE cascade ON DELETE cascade,
+  FOREIGN KEY ("discord_user") REFERENCES "discord"."users"("id") ON UPDATE cascade ON DELETE cascade,
+  UNIQUE ("profile_id", "circle_id"),
+  UNIQUE ("id")
+);
+COMMENT ON TABLE "discord"."user_api_tokens" IS E'User api tokens, one per circle';
+
+CREATE OR REPLACE FUNCTION "discord"."set_current_timestamp_updated_at"()
+RETURNS TRIGGER AS $$
+DECLARE
+  _new record;
+BEGIN
+  _new := NEW;
+  _new."updated_at" = NOW();
+  RETURN _new;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER "set_discord_user_api_tokens_updated_at"
+BEFORE UPDATE ON "discord"."user_api_tokens"
+FOR EACH ROW
+EXECUTE PROCEDURE "discord"."set_current_timestamp_updated_at"();
+COMMENT ON TRIGGER "set_discord_user_api_tokens_updated_at" ON "discord"."user_api_tokens" 
+IS 'trigger to set value of column "updated_at" to current timestamp on row update';


### PR DESCRIPTION
To support the next phase of the Discord bot,, we want to support users creating contributions via the bot. This requires circle specific user api tokens. Since a user can belong to multiple circles, we need a new table for this.

This PR creates a new table in the discord schema to store these api_tokens for users.