### PR TITLE
fix displayed circles number in org members table

### DIFF
--- a/src/features/orgs/OrgMembersTable.tsx
+++ b/src/features/orgs/OrgMembersTable.tsx
@@ -66,7 +66,7 @@ const isCircleAdmin = (member: QueryMember): boolean => {
 };
 
 const DisplayedCircles = ({ member }: { member: QueryMember }) => {
-  if (member.profile.users.length < 2) {
+  if (member.profile.users.length <= 2) {
     return (
       <Text css={{ display: 'inline' }}>
         {member.profile.users

--- a/src/features/orgs/getOrgMembersData.ts
+++ b/src/features/orgs/getOrgMembersData.ts
@@ -17,7 +17,7 @@ export const getOrgMembersPageData = async (orgId: number) => {
                 name: true,
                 address: true,
                 users: [
-                  {},
+                  { where: { circle: { organization_id: { _eq: orgId } } } },
                   {
                     role: true,
                     circle: { name: true, id: true },


### PR DESCRIPTION
## Motivation and Context

Displayed circles on Org Members table included all circles
"see more" also appeared if there is only two circles

before:
![image](https://user-images.githubusercontent.com/34943689/226689337-adacb1bf-428a-4864-9159-7c576f0fc5a0.png)

after:
![image](https://user-images.githubusercontent.com/34943689/226689192-2c5f8aa6-516f-44df-99df-903f74528dab.png)
