### PR TITLE
fix creating epoch during if DST is included

### DIFF
--- a/api/hasura/actions/_handlers/createEpoch.ts
+++ b/api/hasura/actions/_handlers/createEpoch.ts
@@ -137,9 +137,14 @@ export function validateMonthlyInput(
 ): ErrorReturn {
   const { start_date, end_date } = input;
 
-  const endDateIsValid = findSameDayNextMonth(start_date, input).equals(
-    end_date
-  );
+  const endDateIsValid =
+    findSameDayNextMonth(start_date, input).equals(end_date) ||
+    findSameDayNextMonth(start_date, input).equals(
+      end_date.plus({ hours: 1 })
+    ) ||
+    findSameDayNextMonth(start_date, input).equals(
+      end_date.minus({ hours: 1 })
+    );
   if (!endDateIsValid)
     return new Error(
       dedent`

--- a/api/hasura/actions/_handlers/createEpoch.ts
+++ b/api/hasura/actions/_handlers/createEpoch.ts
@@ -186,7 +186,10 @@ export function validateCustomInput({
   const frequencyDuration = Duration.fromObject({
     [frequency_unit]: frequency,
   });
-  if (interval.length(frequency_unit) > frequencyDuration.as(frequency_unit))
+  if (
+    interval.length(frequency_unit) >
+    frequencyDuration.plus({ hours: 1 }).as(frequency_unit)
+  )
     return new Error(
       dedent`
         epoch duration ${

--- a/src/common-lib/epochs.test.ts
+++ b/src/common-lib/epochs.test.ts
@@ -1,6 +1,6 @@
 import { DateTime, Settings } from 'luxon';
 
-import { findSameDayNextMonth } from './epochs';
+import { findSameDayNextMonth, findMonthlyEndDate } from './epochs';
 
 beforeAll(() => {
   Settings.defaultZone = 'utc';
@@ -62,4 +62,9 @@ test('handles weekly boundaries correctly', () => {
   // 5th Tuesday each month truncated to the last Tuesday
   result = findSameDayNextMonth(start, { week: 4 });
   expect(result.toISO()).toBe('2023-03-28T00:00:00.000Z');
+
+  // check southern hemisphere time zone DTS
+  start = DateTime.fromISO('2023-03-28T13:00:00.000Z');
+  result = findMonthlyEndDate(start);
+  expect(result.toISO()).toBe('2023-04-25T13:00:00.000Z');
 });


### PR DESCRIPTION

## Description

allow time diff to be off by one hour during  checking for epoch end date to account for southern hemisphere DST switching during next epoch

## Test and Deployment Plan
1-change your time zone to UTC+13 and create a monthly or weekly epoch that includes the 2nd of April 2023

