### PR TITLE
Small-ish screen nav breakpoint updates

### DIFF
--- a/src/features/nav/NavCircleItem.tsx
+++ b/src/features/nav/NavCircleItem.tsx
@@ -1,8 +1,7 @@
 import { NavLink } from 'react-router-dom';
 
-import { ChevronDown, ChevronRight } from '../../icons/__generated';
 import { paths } from '../../routes/paths';
-import { Avatar, Box, Flex, IconButton, Text } from '../../ui';
+import { Avatar, Box, Flex, Text } from '../../ui';
 
 import { NavCurrentCircle } from './NavCurrentCircle';
 
@@ -48,13 +47,6 @@ export const NavCircleItem = ({
           >
             {circle.name}
           </Text>
-          <IconButton>
-            {isCurrentCircle || org.myCircles.length == 1 ? (
-              <ChevronDown />
-            ) : (
-              <ChevronRight />
-            )}
-          </IconButton>
         </Flex>
       }
       {(isCurrentCircle || org.myCircles.length == 1) && (

--- a/src/features/nav/NavCurrentOrg.tsx
+++ b/src/features/nav/NavCurrentOrg.tsx
@@ -9,7 +9,14 @@ import { NavItem } from './NavItem';
 export const NavCurrentOrg = ({ org }: { org: NavOrg }) => {
   const isInOrg = org.members.length > 0;
   return (
-    <Box css={{ mb: '$md' }}>
+    <Box
+      css={{
+        mb: '$md',
+        '@lg': {
+          mb: '$sm',
+        },
+      }}
+    >
       {isFeatureEnabled('activity') && (
         <NavItem
           label={'Activity'}

--- a/src/features/nav/NavItem.tsx
+++ b/src/features/nav/NavItem.tsx
@@ -2,14 +2,17 @@ import * as React from 'react';
 
 import { NavLink, useLocation } from 'react-router-dom';
 
+import { CSS } from '../../stitches.config';
 import { Box, Button, Flex, Text } from '../../ui';
 
 export const NavItem = ({
+  css,
   label,
   to,
   icon,
   onClick,
 }: {
+  css?: CSS;
   label: React.ReactNode;
   to: string;
   icon?: React.ReactNode;
@@ -18,14 +21,20 @@ export const NavItem = ({
   const location = useLocation();
 
   return (
-    <Box css={{ ml: '$xs', mb: '$xs' }} onClick={onClick}>
+    <Box css={{ ...css, ml: '$xs', mb: '$xs' }} onClick={onClick}>
       <Button
         className={location.pathname == to ? 'currentPage' : undefined}
         as={NavLink}
         color="navigation"
         to={to}
         fullWidth
-        css={{ py: '$sm', pl: '$sm' }}
+        css={{
+          py: '$sm',
+          pl: '$sm',
+          '@lg': {
+            py: '$xs',
+          },
+        }}
       >
         <Flex
           css={{

--- a/src/features/nav/NavLabel.tsx
+++ b/src/features/nav/NavLabel.tsx
@@ -14,6 +14,10 @@ export const NavLabel = ({
       css={{
         marginTop: '$xl',
         marginBottom: '$md',
+        '@lg': {
+          marginTop: '$sm',
+          marginBottom: '$sm',
+        },
         justifyContent: 'space-between',
       }}
     >

--- a/src/features/nav/NavLogo.tsx
+++ b/src/features/nav/NavLogo.tsx
@@ -24,10 +24,7 @@ export const NavLogo = ({
               width: '200px',
               minWidth: '140px',
               '@lg': {
-                width: '180px',
-              },
-              '@md': {
-                width: '160px',
+                width: '150px',
               },
               '@sm': {
                 width: '140px',

--- a/src/features/nav/NavOrgs.tsx
+++ b/src/features/nav/NavOrgs.tsx
@@ -52,6 +52,9 @@ export const NavOrgs = ({
                 alignItems: 'center',
                 borderRadius: '$3',
                 mb: '$md',
+                '@lg': {
+                  mb: '$sm',
+                },
                 textDecoration: 'none',
               }}
             >

--- a/src/features/nav/NavProfile.tsx
+++ b/src/features/nav/NavProfile.tsx
@@ -8,6 +8,7 @@ import { useWalletStatus } from '../auth';
 import { ThemeSwitcher } from '../theming/ThemeSwitcher';
 import { RecentTransactionsModal } from 'components/RecentTransactionsModal';
 import isFeatureEnabled from 'config/features';
+import { Loader } from 'icons/__generated';
 import { shortenAddressWithFrontLength } from 'utils';
 
 import { NavItem } from './NavItem';
@@ -110,6 +111,9 @@ export const NavProfile = ({
             to={paths.profile('me')}
             onClick={() => setOpen(false)}
           />
+          {isFeatureEnabled('cosoul') && (
+            <NavItem label="CoSoul" to="cosoul" icon={<Loader />} />
+          )}
           {isFeatureEnabled('vaults') && (
             <>
               <NavItem

--- a/src/features/nav/SideNav.tsx
+++ b/src/features/nav/SideNav.tsx
@@ -3,8 +3,7 @@ import { Suspense, useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { getCircleFromPath, getOrgFromPath, paths } from '../../routes/paths';
-import isFeatureEnabled from 'config/features';
-import { CoOrg, Menu, X, Loader } from 'icons/__generated';
+import { CoOrg, Menu, X } from 'icons/__generated';
 import { Flex, IconButton } from 'ui';
 
 import { NavCircle, NavOrg, useNavQuery } from './getNavData';
@@ -77,7 +76,7 @@ export const SideNav = () => {
         flexDirection: 'column',
         width: '350px',
         transition: '.2s ease-in-out',
-        '@lg': { width: '300px' },
+        '@lg': { width: '300px', p: '$lg' },
         '@md': { width: '250px' },
         '@sm': {
           position: 'absolute',
@@ -111,6 +110,9 @@ export const SideNav = () => {
             zIndex: '2',
             display: mobileMenuOpen ? 'block' : 'none',
           },
+          '@lg': {
+            mb: '$sm',
+          },
           '@sm': {
             background: mobileMenuOpen ? '$surfaceNested' : '$navBackground',
             position: 'fixed',
@@ -134,6 +136,9 @@ export const SideNav = () => {
           flex: 1,
           overflowY: 'auto',
           pt: '$sm',
+          '@sm': {
+            pt: '$lg',
+          },
           // So focus outlines don't get cropped
           mx: '-3px',
           px: '3px',
@@ -145,10 +150,19 @@ export const SideNav = () => {
           scrollbarWidth: 'none',
         }}
       >
-        <NavItem label="Home" to={paths.circles} icon={<CoOrg nostroke />} />
-        {isFeatureEnabled('cosoul') && (
-          <NavItem label="CoSoul" to="cosoul" icon={<Loader />} />
-        )}
+        <NavItem
+          label="Home"
+          to={paths.circles}
+          icon={<CoOrg nostroke />}
+          css={{
+            '@lg': {
+              display: 'none',
+            },
+            '@sm': {
+              display: 'block',
+            },
+          }}
+        />
         {data && (
           <>
             <NavOrgs

--- a/src/pages/CirclesPage/CirclesPage.tsx
+++ b/src/pages/CirclesPage/CirclesPage.tsx
@@ -216,6 +216,7 @@ export const CircleRow = ({ circle, onButtonClick, state }: CircleRowProps) => {
         display: 'flex',
         flexDirection: 'row',
         gap: '$md',
+        minHeight: '5.7rem',
         border: '1px solid transparent',
         '.hover-buttons': { display: 'none', '@sm': { display: 'flex' } },
         '&:hover, &:focus-within': {


### PR DESCRIPTION
* tighten up nav padding for breakpoints below `lg`
* remove chevron indicator from circles in nav list
* hide `Home` button below `lg`,  show again for `mobile`

<img width="1433" alt="Screenshot 2023-03-28 at 1 14 51 PM" src="https://user-images.githubusercontent.com/100873710/228356649-ad9043de-1bc1-4b35-bcd0-3b2c2c890c8e.png">
