### PR TITLE
Orgs Backend: createOrgMembers action handler

### DIFF
--- a/api-lib/findUser.ts
+++ b/api-lib/findUser.ts
@@ -20,6 +20,32 @@ const userSelector = Selector('users')({
   fixed_payment_amount: true,
 });
 
+// TODO: implement org admins
+// For now, an org admin is an admin of the org's circles.
+export const isOrgAdmin = async (orgId: number, profileId: number) => {
+  const { profiles_by_pk } = await adminClient.query(
+    {
+      profiles_by_pk: [
+        { id: profileId },
+        {
+          users_aggregate: [
+            {
+              where: {
+                role: { _eq: 1 },
+                circle: { organization_id: { _eq: orgId } },
+              },
+            },
+            { aggregate: { count: [{}, true] } },
+          ],
+        },
+      ],
+    },
+    { operationName: 'isOrgAdmin__findUsers' }
+  );
+
+  return profiles_by_pk?.users_aggregate?.aggregate?.count || 0 > 0;
+};
+
 export const getUserFromProfileId = async (
   profileId: number,
   circleId: number

--- a/api-lib/gql/__generated__/zeus/const.ts
+++ b/api-lib/gql/__generated__/zeus/const.ts
@@ -9215,6 +9215,7 @@ export const ReturnTypes: Record<string, any> = {
   OrgMemberResponse: {
     OrgMemberResponse: 'org_members',
     id: 'ID',
+    new: 'Boolean',
   },
   UpdateCircleOutput: {
     circle: 'circles',

--- a/api-lib/gql/__generated__/zeus/const.ts
+++ b/api-lib/gql/__generated__/zeus/const.ts
@@ -26,6 +26,9 @@ export const AllTypesProps: Record<string, any> = {
     params: 'EpochInputParams',
   },
   CreateNomineeInput: {},
+  CreateOrgMembersInput: {
+    users: 'UserObj',
+  },
   CreateUserWithTokenInput: {},
   CreateUsersInput: {
     users: 'UserObj',
@@ -3881,6 +3884,9 @@ export const AllTypesProps: Record<string, any> = {
     },
     createNominee: {
       payload: 'CreateNomineeInput',
+    },
+    createOrgMembers: {
+      payload: 'CreateOrgMembersInput',
     },
     createUserWithToken: {
       payload: 'CreateUserWithTokenInput',
@@ -9206,6 +9212,10 @@ export const ReturnTypes: Record<string, any> = {
   MarkClaimedOutput: {
     ids: 'Int',
   },
+  OrgMemberResponse: {
+    OrgMemberResponse: 'org_members',
+    id: 'ID',
+  },
   UpdateCircleOutput: {
     circle: 'circles',
     id: 'Int',
@@ -11720,6 +11730,7 @@ export const ReturnTypes: Record<string, any> = {
     createCircle: 'CreateCircleResponse',
     createEpoch: 'EpochResponse',
     createNominee: 'CreateNomineeResponse',
+    createOrgMembers: 'OrgMemberResponse',
     createSampleCircle: 'CreateSampleCircleResponse',
     createUserWithToken: 'UserResponse',
     createUsers: 'UserResponse',

--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -903,6 +903,7 @@ export type ValueTypes = {
   ['OrgMemberResponse']: AliasType<{
     OrgMemberResponse?: ValueTypes['org_members'];
     id?: boolean | `@${string}`;
+    new?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
@@ -25307,6 +25308,7 @@ export type ModelTypes = {
   ['OrgMemberResponse']: {
     OrgMemberResponse?: GraphQLTypes['org_members'] | undefined;
     id: string;
+    new: boolean;
   };
   /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
   ['String_comparison_exp']: GraphQLTypes['String_comparison_exp'];
@@ -34188,6 +34190,7 @@ export type GraphQLTypes = {
     __typename: 'OrgMemberResponse';
     OrgMemberResponse?: GraphQLTypes['org_members'] | undefined;
     id: string;
+    new: boolean;
   };
   /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
   ['String_comparison_exp']: {

--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -724,6 +724,10 @@ export type ValueTypes = {
     nominee?: ValueTypes['nominees'];
     __typename?: boolean | `@${string}`;
   }>;
+  ['CreateOrgMembersInput']: {
+    org_id: number;
+    users: Array<ValueTypes['UserObj'] | undefined | null>;
+  };
   ['CreateSampleCircleResponse']: AliasType<{
     circle?: ValueTypes['circles'];
     id?: boolean | `@${string}`;
@@ -894,6 +898,11 @@ export type ValueTypes = {
   };
   ['MarkClaimedOutput']: AliasType<{
     ids?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  ['OrgMemberResponse']: AliasType<{
+    OrgMemberResponse?: ValueTypes['org_members'];
+    id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
@@ -10541,6 +10550,10 @@ export type ValueTypes = {
     createNominee?: [
       { payload: ValueTypes['CreateNomineeInput'] },
       ValueTypes['CreateNomineeResponse']
+    ];
+    createOrgMembers?: [
+      { payload: ValueTypes['CreateOrgMembersInput'] },
+      ValueTypes['OrgMemberResponse']
     ];
     createSampleCircle?: ValueTypes['CreateSampleCircleResponse'];
     createUserWithToken?: [
@@ -25215,6 +25228,7 @@ export type ModelTypes = {
     id?: number | undefined;
     nominee?: GraphQLTypes['nominees'] | undefined;
   };
+  ['CreateOrgMembersInput']: GraphQLTypes['CreateOrgMembersInput'];
   ['CreateSampleCircleResponse']: {
     circle?: GraphQLTypes['circles'] | undefined;
     id: number;
@@ -25289,6 +25303,10 @@ export type ModelTypes = {
   ['MarkClaimedInput']: GraphQLTypes['MarkClaimedInput'];
   ['MarkClaimedOutput']: {
     ids: Array<number>;
+  };
+  ['OrgMemberResponse']: {
+    OrgMemberResponse?: GraphQLTypes['org_members'] | undefined;
+    id: string;
   };
   /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
   ['String_comparison_exp']: GraphQLTypes['String_comparison_exp'];
@@ -29375,6 +29393,9 @@ export type ModelTypes = {
     /** create epoch using new, more flexible api */
     createEpoch?: GraphQLTypes['EpochResponse'] | undefined;
     createNominee?: GraphQLTypes['CreateNomineeResponse'] | undefined;
+    createOrgMembers?:
+      | Array<GraphQLTypes['OrgMemberResponse'] | undefined>
+      | undefined;
     createSampleCircle?: GraphQLTypes['CreateSampleCircleResponse'] | undefined;
     createUserWithToken?: GraphQLTypes['UserResponse'] | undefined;
     createUsers?: Array<GraphQLTypes['UserResponse'] | undefined> | undefined;
@@ -33987,6 +34008,10 @@ export type GraphQLTypes = {
     id?: number | undefined;
     nominee?: GraphQLTypes['nominees'] | undefined;
   };
+  ['CreateOrgMembersInput']: {
+    org_id: number;
+    users: Array<GraphQLTypes['UserObj'] | undefined>;
+  };
   ['CreateSampleCircleResponse']: {
     __typename: 'CreateSampleCircleResponse';
     circle?: GraphQLTypes['circles'] | undefined;
@@ -34158,6 +34183,11 @@ export type GraphQLTypes = {
   ['MarkClaimedOutput']: {
     __typename: 'MarkClaimedOutput';
     ids: Array<number>;
+  };
+  ['OrgMemberResponse']: {
+    __typename: 'OrgMemberResponse';
+    OrgMemberResponse?: GraphQLTypes['org_members'] | undefined;
+    id: string;
   };
   /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
   ['String_comparison_exp']: {
@@ -42389,6 +42419,9 @@ export type GraphQLTypes = {
     /** create epoch using new, more flexible api */
     createEpoch?: GraphQLTypes['EpochResponse'] | undefined;
     createNominee?: GraphQLTypes['CreateNomineeResponse'] | undefined;
+    createOrgMembers?:
+      | Array<GraphQLTypes['OrgMemberResponse'] | undefined>
+      | undefined;
     createSampleCircle?: GraphQLTypes['CreateSampleCircleResponse'] | undefined;
     createUserWithToken?: GraphQLTypes['UserResponse'] | undefined;
     createUsers?: Array<GraphQLTypes['UserResponse'] | undefined> | undefined;

--- a/api-lib/orgAdmin.ts
+++ b/api-lib/orgAdmin.ts
@@ -1,0 +1,47 @@
+import type {
+  VercelRequest,
+  VercelResponse,
+  VercelApiHandler,
+} from '@vercel/node';
+import { z } from 'zod';
+
+import { composeHasuraActionRequestBodyWithApiPermissions } from '../src/lib/zod';
+
+import { isOrgAdmin } from './findUser';
+import { UnauthorizedError } from './HttpError';
+import { verifyHasuraRequestMiddleware } from './validate';
+
+const requestSchema = composeHasuraActionRequestBodyWithApiPermissions(
+  z.object({ org_id: z.number() }).strip(),
+  []
+);
+
+const middleware =
+  (handler: VercelApiHandler) =>
+  async (req: VercelRequest, res: VercelResponse): Promise<void> => {
+    const {
+      input: { payload: input },
+      session_variables: sessionVariables,
+    } = await requestSchema.parseAsync(req.body);
+
+    // the admin role is validated early by zod
+    if (sessionVariables.hasuraRole === 'admin') {
+      handler(req, res);
+      return;
+    }
+
+    if (sessionVariables.hasuraRole === 'user') {
+      const { org_id } = input;
+      const profileId = sessionVariables.hasuraProfileId;
+
+      if (await isOrgAdmin(org_id, profileId)) {
+        handler(req, res);
+        return;
+      } else {
+        throw new UnauthorizedError('User is not org admin');
+      }
+    }
+  };
+
+export const authOrgAdminMiddleware = (handler: VercelApiHandler) =>
+  verifyHasuraRequestMiddleware(middleware(handler));

--- a/api-test/hasura/actions/_handlers/createOrgMembers.test.ts
+++ b/api-test/hasura/actions/_handlers/createOrgMembers.test.ts
@@ -1,0 +1,250 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import faker from 'faker';
+
+const { mockLog } = jest.requireMock('../../../../src/common-lib/log');
+import { adminClient } from '../../../../api-lib/gql/adminClient';
+import {
+  createCircle,
+  createOrganization,
+  createProfile,
+  createOrgMember,
+  createUser,
+  mockUserClient,
+} from '../../../helpers';
+import { getUniqueAddress } from '../../../helpers/getUniqueAddress';
+
+let address, profile, user, circle, org, org_member;
+
+beforeEach(async () => {
+  address = await getUniqueAddress();
+  org = await createOrganization(adminClient);
+  circle = await createCircle(adminClient, {
+    name: 'test org',
+    organization_id: org.id,
+  });
+  profile = await createProfile(adminClient, {
+    address,
+    name: `${faker.name.firstName()} ${faker.datatype.number(10000)}`,
+  });
+  user = await createUser(adminClient, {
+    address,
+    circle_id: circle.id,
+  });
+  org_member = await createOrgMember(adminClient, {
+    org_id: org.id,
+    profile_id: profile.id,
+  });
+});
+
+describe('provided invalid input', () => {
+  test('errors if user list contains duplicates', async () => {
+    const client = mockUserClient({ profileId: profile.id, address });
+    await expect(() =>
+      client.mutate(
+        {
+          createOrgMembers: [
+            {
+              payload: {
+                org_id: org.id,
+                users: [
+                  {
+                    address: '0x1d3bf13f8f7a83390d03db5e23a950778e1d1309',
+                    name: 'tester',
+                    entrance: 'manual-address-entry',
+                  },
+                  {
+                    address: '0x1d3bf13f8f7a83390d03db5e23a950778e1d1309',
+                    name: 'tester2',
+                    entrance: 'manual-address-entry',
+                  },
+                ],
+              },
+            },
+            { __typename: true },
+          ],
+        },
+        { operationName: 'test_createOrgMembers' }
+      )
+    ).rejects.toThrow();
+    expect(mockLog).toHaveBeenCalledWith(
+      JSON.stringify(
+        {
+          errors: [
+            {
+              extensions: {
+                code: '422',
+              },
+              message:
+                'Users list contains duplicate addresses: 0x1d3bf13f8f7a83390d03db5e23a950778e1d1309',
+            },
+          ],
+        },
+        null,
+        2
+      )
+    );
+  });
+
+  test('errors if user list contains invalid ENS', async () => {
+    const client = mockUserClient({ profileId: profile.id, address });
+    await expect(() =>
+      client.mutate(
+        {
+          createOrgMembers: [
+            {
+              payload: {
+                org_id: org.id,
+                users: [
+                  {
+                    address: '0x1d3bf13f8f7a83390d03db5e23a950778e1d1309',
+                    name: 'vitalik.eth',
+                    entrance: 'manual-address-entry',
+                  },
+                ],
+              },
+            },
+            { __typename: true },
+          ],
+        },
+        { operationName: 'test_createOrgMembers' }
+      )
+    ).rejects.toThrow();
+    expect(mockLog).toHaveBeenCalledWith(
+      JSON.stringify(
+        {
+          errors: [
+            {
+              extensions: {
+                code: '422',
+              },
+              message:
+                'ENS vitalik.eth does not resolve to the entered address.',
+            },
+          ],
+        },
+        null,
+        2
+      )
+    );
+  });
+
+  test('it undeletes deleted members users', async () => {
+    // create a deleted org member
+    const deleted_profile = await createProfile(adminClient);
+    await createOrgMember(adminClient, {
+      org_id: org.id,
+      profile_id: deleted_profile.id,
+      deleted_at: new Date().toISOString(),
+    });
+
+    const client = mockUserClient({ profileId: profile.id, address });
+    await expect(
+      client.mutate(
+        {
+          createOrgMembers: [
+            {
+              payload: {
+                org_id: org.id,
+                users: [
+                  {
+                    address: deleted_profile.address,
+                    name: deleted_profile.name,
+                    entrance: 'manual-address-entry',
+                  },
+                ],
+              },
+            },
+            {
+              new: true,
+              OrgMemberResponse: { profile_id: true },
+            },
+          ],
+        },
+        { operationName: 'test_createOrgMembers' }
+      )
+    ).resolves.toEqual({
+      createOrgMembers: [
+        {
+          OrgMemberResponse: { profile_id: deleted_profile.id },
+          new: true,
+        },
+      ],
+    });
+  });
+
+  test('it no-ops on existing users', async () => {
+    // create a deleted org member
+    const existing_profile = await createProfile(adminClient);
+    await createOrgMember(adminClient, {
+      org_id: org.id,
+      profile_id: existing_profile.id,
+    });
+
+    const client = mockUserClient({ profileId: profile.id, address });
+    await expect(
+      client.mutate(
+        {
+          createOrgMembers: [
+            {
+              payload: {
+                org_id: org.id,
+                users: [
+                  {
+                    address: existing_profile.address,
+                    name: existing_profile.name,
+                    entrance: 'manual-address-entry',
+                  },
+                ],
+              },
+            },
+            {
+              new: true,
+            },
+          ],
+        },
+        { operationName: 'test_createOrgMembers' }
+      )
+    ).resolves.toEqual({
+      createOrgMembers: [
+        {
+          new: false,
+        },
+      ],
+    });
+  });
+  test('it creates new users', async () => {
+    const client = mockUserClient({ profileId: profile.id, address });
+    await expect(
+      client.mutate(
+        {
+          createOrgMembers: [
+            {
+              payload: {
+                org_id: org.id,
+                users: [
+                  {
+                    address: await getUniqueAddress(),
+                    name: `${faker.name.firstName()} ${faker.datatype.number(
+                      10000
+                    )}`,
+                    entrance: 'manual-address-entry',
+                  },
+                ],
+              },
+            },
+            {
+              new: true,
+            },
+          ],
+        },
+        { operationName: 'test_createOrgMembers' }
+      )
+    ).resolves.toEqual({
+      createOrgMembers: [
+        {
+          new: true,
+        },
+      ],
+    });
+  });
+});

--- a/api-test/helpers/index.ts
+++ b/api-test/helpers/index.ts
@@ -6,3 +6,4 @@ export * from './mockUserClient';
 export * from './profiles';
 export * from './tokenGifts';
 export * from './users';
+export * from './org_members';

--- a/api-test/helpers/org_members.ts
+++ b/api-test/helpers/org_members.ts
@@ -1,0 +1,31 @@
+import { GraphQLTypes } from '../../api-lib/gql/__generated__/zeus';
+
+import type { GQLClientType } from './common';
+
+export async function createOrgMember(
+  client: GQLClientType,
+  object: Partial<GraphQLTypes['org_members_insert_input']>
+) {
+  const { insert_org_members_one } = await client.mutate(
+    {
+      insert_org_members_one: [
+        {
+          object: {
+            org_id: object.org_id,
+            profile_id: object.profile_id,
+            role: object.role || 1,
+            deleted_at: object?.deleted_at,
+          },
+        },
+        { id: true, org_id: true },
+      ],
+    },
+    { operationName: 'createOrganization' }
+  );
+
+  if (!insert_org_members_one) {
+    throw new Error('Org member not created');
+  }
+
+  return insert_org_members_one;
+}

--- a/api/hasura/actions/_handlers/createOrgMembers.ts
+++ b/api/hasura/actions/_handlers/createOrgMembers.ts
@@ -171,6 +171,7 @@ const addMemberToOrg = async ({
         { operationName: 'createOrgMember_undelete' }
       );
       assert(update_org_members_by_pk?.__typename, 'update failed');
+      return { id: existingId, new: true };
     }
 
     return { id: existingId, new: false };

--- a/api/hasura/actions/_handlers/createOrgMembers.ts
+++ b/api/hasura/actions/_handlers/createOrgMembers.ts
@@ -1,0 +1,278 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { z } from 'zod';
+
+import {
+  profiles_constraint,
+  profiles_update_column,
+  ValueTypes,
+} from '../../../../api-lib/gql/__generated__/zeus';
+import { adminClient } from '../../../../api-lib/gql/adminClient';
+import { insertInteractionEvents } from '../../../../api-lib/gql/mutations';
+import {
+  errorResponseWithStatusCode,
+  InternalServerError,
+} from '../../../../api-lib/HttpError';
+import { authOrgAdminMiddleware } from '../../../../api-lib/orgAdmin';
+import { isValidENS } from '../../../../api-lib/validateENS';
+import { ENTRANCE } from '../../../../src/common-lib/constants';
+import {
+  composeHasuraActionRequestBodyWithApiPermissions,
+  createUserSchemaInput,
+} from '../../../../src/lib/zod';
+
+const USER_ALIAS_PREFIX = 'update_org_member_';
+
+const createOrgUsersBulkSchemaInput = z
+  .object({
+    org_id: z.number(),
+    users: createUserSchemaInput.omit({ circle_id: true }).array().min(1),
+  })
+  .strict();
+
+async function handler(req: VercelRequest, res: VercelResponse) {
+  // this has to do parseAsync due to the ENS validation
+  const {
+    input: { payload: input },
+    session_variables: sessionVariables,
+  } = await composeHasuraActionRequestBodyWithApiPermissions(
+    createOrgUsersBulkSchemaInput,
+    ['manage_users']
+  ).parseAsync(req.body);
+
+  const { org_id, users } = input;
+
+  const uniqueAddresses = [...new Set(users.map(u => u.address.toLowerCase()))];
+
+  // Check if bulk contains duplicates.
+  if (uniqueAddresses.length < users.length) {
+    const dupes = uniqueAddresses.filter(
+      uq => users.filter(u => u.address.toLowerCase() == uq).length > 1
+    );
+    return errorResponseWithStatusCode(
+      res,
+      { message: `Users list contains duplicate addresses: ${dupes}` },
+      422
+    );
+  }
+
+  // Validate ENS names.
+  const unresolvedUsers = await Promise.all(
+    users.map(async user => {
+      if (user.name.endsWith('.eth')) {
+        const validENS = await isValidENS(user.name, user.address);
+        if (!validENS) return user;
+      }
+    })
+  );
+
+  const unresolvedNames: string[] = [];
+  unresolvedUsers.forEach(u => {
+    if (u !== undefined) {
+      unresolvedNames.push(u.name);
+    }
+  });
+
+  if (unresolvedNames.length > 0) {
+    return errorResponseWithStatusCode(
+      res,
+      {
+        message: `ENS ${unresolvedNames.join(', ')} ${
+          unresolvedNames.length > 1 ? 'do' : 'does'
+        } not resolve to the entered ${
+          unresolvedNames.length > 1 ? 'addresses' : 'address'
+        }.`,
+      },
+      422
+    );
+  }
+
+  // Given a set of new users we separate these into groups of new org members, and updates to existing org members.
+
+  // Check for existing org members with input addresses.
+  const { org_members: existingOrgMembers } = await adminClient.query(
+    {
+      org_members: [
+        {
+          where: {
+            org_id: { _eq: org_id },
+            profile: {
+              _or: uniqueAddresses.map(addr => {
+                return { address: { _ilike: addr } };
+              }),
+            },
+          },
+        },
+        {
+          id: true,
+          profile: {
+            id: true,
+            address: true,
+          },
+          deleted_at: true,
+        },
+      ],
+    },
+    { operationName: 'getExistingOrgUsers' }
+  );
+
+  const orgMembersToUpdate = existingOrgMembers.map(eu => {
+    const updatedUser = users.find(
+      u => u.address.toLowerCase() === eu.profile.address.toLowerCase()
+    );
+    return {
+      ...eu,
+      ...updatedUser,
+      name: undefined,
+    };
+  });
+
+  // Check if a user exists without a soft deletion conflicts with the new bulk.
+  const conflict = orgMembersToUpdate.filter(u => !u.deleted_at);
+  if (conflict.length) {
+    return errorResponseWithStatusCode(
+      res,
+      {
+        message: `Users already exist: [${conflict
+          .map(e => e.address)
+          .join(', ')}]`,
+      },
+      422
+    );
+  }
+
+  const newOrgMembers = users
+    .filter(u => {
+      return !existingOrgMembers.some(
+        eu => eu.profile.address.toLowerCase() === u.address.toLowerCase()
+      );
+    })
+    .map(u => ({ ...u, org_id }));
+
+  const updateUsersMutation = orgMembersToUpdate.reduce((opts, user) => {
+    opts[USER_ALIAS_PREFIX + user.address] = {
+      update_org_members_by_pk: [
+        {
+          pk_columns: { id: user.id },
+          _set: {
+            ...user,
+            entrance: ENTRANCE.MANUAL,
+            deleted_at: null,
+          },
+        },
+        { id: true },
+      ],
+    };
+
+    return opts;
+  }, {} as { [aliasKey: string]: ValueTypes['mutation_root'] });
+
+  //check if names are used by other coordinape users
+  const { profiles: existingNames } = await adminClient.query(
+    {
+      profiles: [
+        {
+          where: {
+            _or: newOrgMembers.map(user => {
+              return {
+                _and: [
+                  { name: { _eq: user.name } },
+                  { address: { _nilike: user.address } },
+                ],
+              };
+            }),
+          },
+        },
+        { name: true },
+      ],
+    },
+    { operationName: 'createOrgUsers_getExistingNames' }
+  );
+
+  if (existingNames.length > 0) {
+    const names = existingNames.map(u => u.name);
+    return errorResponseWithStatusCode(
+      res,
+      {
+        message: `Users list contains ${
+          names.length > 1 ? 'names already in use' : 'a name already in use'
+        }: ${names}`,
+      },
+      422
+    );
+  }
+
+  //update profiles table with new names
+  await adminClient.mutate(
+    {
+      insert_profiles: [
+        {
+          objects: newOrgMembers.map(user => {
+            return {
+              address: user.address.toLowerCase(),
+              name: user.name,
+            };
+          }),
+          on_conflict: {
+            constraint: profiles_constraint.profiles_address_key,
+            update_columns: [profiles_update_column.name],
+            where: {
+              name: { _is_null: true },
+            },
+          },
+        },
+        { returning: { id: true } },
+      ],
+    },
+    {
+      operationName: 'createOrgUsers_createProfiles',
+    }
+  );
+
+  const newOrgMemberObjects = newOrgMembers.map(user => ({
+    ...user,
+    name: undefined,
+  }));
+  // Update the state after all validations have passed
+  const mutationResult = await adminClient.mutate(
+    {
+      insert_org_members: [
+        { objects: newOrgMemberObjects },
+        {
+          returning: { id: true, address: true },
+        },
+      ],
+      __alias: { ...updateUsersMutation },
+    },
+    { operationName: 'insertOrgMembers' }
+  );
+
+  const insertedUsers = mutationResult.insert_org_members?.returning;
+
+  if (!insertedUsers)
+    throw new InternalServerError(
+      `panic: insertedUsers is null; ${JSON.stringify(mutationResult, null, 2)}`
+    );
+
+  let profileId: number;
+  if (sessionVariables.hasuraRole == 'user') {
+    profileId = sessionVariables.hasuraProfileId;
+  }
+
+  await insertInteractionEvents(
+    ...insertedUsers.map(invitedUserId => ({
+      event_type: 'add_org_member',
+      profile_id: profileId,
+      org_id: input.org_id,
+      data: { invited_user_id: invitedUserId },
+    }))
+  );
+
+  // Get the returning values from each update-user aliases.
+  const results: Array<{ id: number }> = orgMembersToUpdate
+    .map(u => mutationResult[USER_ALIAS_PREFIX + u.address] as { id: number })
+    .concat(insertedUsers);
+
+  return res.status(200).json(results);
+}
+
+export default authOrgAdminMiddleware(handler);

--- a/api/hasura/actions/actionManager.ts
+++ b/api/hasura/actions/actionManager.ts
@@ -8,6 +8,7 @@ import allocationCsv from './_handlers/allocationCsv';
 import createCircle from './_handlers/createCircle';
 import createEpoch from './_handlers/createEpoch';
 import createNominee from './_handlers/createNominee';
+import createOrgMembers from './_handlers/createOrgMembers';
 import createSampleCircle from './_handlers/createSampleCircle';
 import createUsers from './_handlers/createUsers';
 import createUserWithToken from './_handlers/createUserWithToken';
@@ -46,9 +47,10 @@ const HANDLERS: HandlerDict = {
   createCircle,
   createEpoch,
   createNominee,
+  createOrgMembers,
   createSampleCircle,
-  createUsers,
   createUserWithToken,
+  createUsers,
   createVault,
   createVaultTx,
   deleteCircle,

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -19,7 +19,7 @@ type Mutation {
 }
 
 type Mutation {
-  createOrgMembers(payload: CreateOrgMembersInput!): [UserResponse]
+  createOrgMembers(payload: CreateOrgMembersInput!): [OrgMemberResponse]
 }
 
 type Mutation {
@@ -567,6 +567,10 @@ type GuildInfoOutput {
   member_count: Int!
   admins: [GuildAdmin]
   roles: [GuildRole]
+}
+
+type OrgMemberResponse {
+  id: ID!
 }
 
 scalar timestamptz

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -19,6 +19,10 @@ type Mutation {
 }
 
 type Mutation {
+  createOrgMembers(payload: CreateOrgMembersInput!): [UserResponse]
+}
+
+type Mutation {
   createSampleCircle: CreateSampleCircleResponse
 }
 
@@ -266,6 +270,11 @@ input Allocations {
 
 input CreateUsersInput {
   circle_id: Int!
+  users: [UserObj]!
+}
+
+input CreateOrgMembersInput {
+  org_id: Int!
   users: [UserObj]!
 }
 

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -571,6 +571,7 @@ type GuildInfoOutput {
 
 type OrgMemberResponse {
   id: ID!
+  new: Boolean!
 }
 
 scalar timestamptz

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -48,6 +48,16 @@ actions:
           value_from_env: HASURA_EVENT_SECRET
     permissions:
       - role: user
+  - name: createOrgMembers
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_API_BASE_URL}}/actions/actionManager?action_name=createOrgMembers'
+      forward_client_headers: true
+      headers:
+        - name: verification_key
+          value_from_env: HASURA_EVENT_SECRET
+    permissions:
+      - role: user
   - name: createSampleCircle
     definition:
       kind: synchronous
@@ -359,6 +369,7 @@ custom_types:
     - name: Allocation
     - name: Allocations
     - name: CreateUsersInput
+    - name: CreateOrgMembersInput
     - name: UserObj
     - name: AllocationCsvInput
     - name: CreateVaultInput
@@ -437,7 +448,7 @@ custom_types:
             id: id
           name: UserResponse
           remote_table:
-            name: users
+            name: org_members
             schema: public
           source: default
           type: object

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -448,7 +448,7 @@ custom_types:
             id: id
           name: UserResponse
           remote_table:
-            name: org_members
+            name: users
             schema: public
           source: default
           type: object
@@ -604,5 +604,15 @@ custom_types:
     - name: GuildAdmin
     - name: GuildRole
     - name: GuildInfoOutput
+    - name: OrgMemberResponse
+      relationships:
+        - field_mapping:
+            id: id
+          name: OrgMemberResponse
+          remote_table:
+            name: org_members
+            schema: public
+          source: default
+          type: object
   scalars:
     - name: timestamptz

--- a/hasura/migrations/default/1680036748448_create_org_share_tokens_table/down.sql
+++ b/hasura/migrations/default/1680036748448_create_org_share_tokens_table/down.sql
@@ -1,2 +1,2 @@
-DROP TRIGGER "set_public_org_share_tokens_updated_at" ON "public"."org_share_token";
+DROP TRIGGER "set_public_org_share_tokens_updated_at" ON "public"."org_share_tokens";
 DROP TABLE "public"."org_share_tokens";

--- a/hasura/schema/admin/schema.graphql
+++ b/hasura/schema/admin/schema.graphql
@@ -177,6 +177,11 @@ type CreateNomineeResponse {
   nominee: nominees
 }
 
+input CreateOrgMembersInput {
+  org_id: Int!
+  users: [UserObj]!
+}
+
 type CreateSampleCircleResponse {
   circle: circles
   id: Int!
@@ -367,6 +372,11 @@ input MarkClaimedInput {
 
 type MarkClaimedOutput {
   ids: [Int!]!
+}
+
+type OrgMemberResponse {
+  OrgMemberResponse: org_members
+  id: ID!
 }
 
 """
@@ -14813,6 +14823,7 @@ type mutation_root {
   """
   createEpoch(payload: CreateEpochInput!): EpochResponse
   createNominee(payload: CreateNomineeInput!): CreateNomineeResponse
+  createOrgMembers(payload: CreateOrgMembersInput!): [OrgMemberResponse]
   createSampleCircle: CreateSampleCircleResponse
   createUserWithToken(payload: CreateUserWithTokenInput!): UserResponse
   createUsers(payload: CreateUsersInput!): [UserResponse]

--- a/hasura/schema/admin/schema.graphql
+++ b/hasura/schema/admin/schema.graphql
@@ -377,6 +377,7 @@ type MarkClaimedOutput {
 type OrgMemberResponse {
   OrgMemberResponse: org_members
   id: ID!
+  new: Boolean!
 }
 
 """

--- a/hasura/schema/user/schema.graphql
+++ b/hasura/schema/user/schema.graphql
@@ -343,6 +343,7 @@ type MarkClaimedOutput {
 type OrgMemberResponse {
   OrgMemberResponse: org_members
   id: ID!
+  new: Boolean!
 }
 
 """

--- a/hasura/schema/user/schema.graphql
+++ b/hasura/schema/user/schema.graphql
@@ -147,6 +147,11 @@ type CreateNomineeResponse {
   nominee: nominees
 }
 
+input CreateOrgMembersInput {
+  org_id: Int!
+  users: [UserObj]!
+}
+
 type CreateSampleCircleResponse {
   circle: circles
   id: Int!
@@ -333,6 +338,11 @@ input MarkClaimedInput {
 
 type MarkClaimedOutput {
   ids: [Int!]!
+}
+
+type OrgMemberResponse {
+  OrgMemberResponse: org_members
+  id: ID!
 }
 
 """
@@ -7167,6 +7177,7 @@ type mutation_root {
   """
   createEpoch(payload: CreateEpochInput!): EpochResponse
   createNominee(payload: CreateNomineeInput!): CreateNomineeResponse
+  createOrgMembers(payload: CreateOrgMembersInput!): [OrgMemberResponse]
   createSampleCircle: CreateSampleCircleResponse
   createUserWithToken(payload: CreateUserWithTokenInput!): UserResponse
   createUsers(payload: CreateUsersInput!): [UserResponse]

--- a/scripts/repl/org_membership.ts
+++ b/scripts/repl/org_membership.ts
@@ -25,7 +25,7 @@ export const init = async () => {
 
     const existing = org.members.map(m => m.profile.id);
     const all = org.circles.flatMap(c => c.users.map(u => u.profile.id));
-    const missing = fp.difference(all, existing);
+    const missing = fp.uniq(fp.difference(all, existing));
 
     return client.mutate(
       {

--- a/src/features/auth/useFinishAuth.ts
+++ b/src/features/auth/useFinishAuth.ts
@@ -47,7 +47,6 @@ export const useFinishAuth = () => {
         logger.log('got new auth data:', loginData);
         setSavedAuth(address, { connectorName, ...loginData });
         profileId = loginData.id;
-        setProfileId(profileId);
       }
 
       assert(profileId, 'missing profile ID after login');

--- a/src/lib/gql/__generated__/zeus/const.ts
+++ b/src/lib/gql/__generated__/zeus/const.ts
@@ -21,6 +21,9 @@ export const AllTypesProps: Record<string, any> = {
     params: 'EpochInputParams',
   },
   CreateNomineeInput: {},
+  CreateOrgMembersInput: {
+    users: 'UserObj',
+  },
   CreateUserWithTokenInput: {},
   CreateUsersInput: {
     users: 'UserObj',
@@ -2381,6 +2384,9 @@ export const AllTypesProps: Record<string, any> = {
     },
     createNominee: {
       payload: 'CreateNomineeInput',
+    },
+    createOrgMembers: {
+      payload: 'CreateOrgMembersInput',
     },
     createUserWithToken: {
       payload: 'CreateUserWithTokenInput',
@@ -5439,6 +5445,10 @@ export const ReturnTypes: Record<string, any> = {
   MarkClaimedOutput: {
     ids: 'Int',
   },
+  OrgMemberResponse: {
+    OrgMemberResponse: 'org_members',
+    id: 'ID',
+  },
   UpdateCircleOutput: {
     circle: 'circles',
     id: 'Int',
@@ -6215,6 +6225,7 @@ export const ReturnTypes: Record<string, any> = {
     createCircle: 'CreateCircleResponse',
     createEpoch: 'EpochResponse',
     createNominee: 'CreateNomineeResponse',
+    createOrgMembers: 'OrgMemberResponse',
     createSampleCircle: 'CreateSampleCircleResponse',
     createUserWithToken: 'UserResponse',
     createUsers: 'UserResponse',

--- a/src/lib/gql/__generated__/zeus/const.ts
+++ b/src/lib/gql/__generated__/zeus/const.ts
@@ -5448,6 +5448,7 @@ export const ReturnTypes: Record<string, any> = {
   OrgMemberResponse: {
     OrgMemberResponse: 'org_members',
     id: 'ID',
+    new: 'Boolean',
   },
   UpdateCircleOutput: {
     circle: 'circles',

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -875,6 +875,7 @@ export type ValueTypes = {
   ['OrgMemberResponse']: AliasType<{
     OrgMemberResponse?: ValueTypes['org_members'];
     id?: boolean | `@${string}`;
+    new?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
@@ -12773,6 +12774,7 @@ export type ModelTypes = {
   ['OrgMemberResponse']: {
     OrgMemberResponse?: GraphQLTypes['org_members'] | undefined;
     id: string;
+    new: boolean;
   };
   /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
   ['String_comparison_exp']: GraphQLTypes['String_comparison_exp'];
@@ -16430,6 +16432,7 @@ export type GraphQLTypes = {
     __typename: 'OrgMemberResponse';
     OrgMemberResponse?: GraphQLTypes['org_members'] | undefined;
     id: string;
+    new: boolean;
   };
   /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
   ['String_comparison_exp']: {

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -699,6 +699,10 @@ export type ValueTypes = {
     nominee?: ValueTypes['nominees'];
     __typename?: boolean | `@${string}`;
   }>;
+  ['CreateOrgMembersInput']: {
+    org_id: number;
+    users: Array<ValueTypes['UserObj'] | undefined | null>;
+  };
   ['CreateSampleCircleResponse']: AliasType<{
     circle?: ValueTypes['circles'];
     id?: boolean | `@${string}`;
@@ -866,6 +870,11 @@ export type ValueTypes = {
   };
   ['MarkClaimedOutput']: AliasType<{
     ids?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  ['OrgMemberResponse']: AliasType<{
+    OrgMemberResponse?: ValueTypes['org_members'];
+    id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
@@ -5570,6 +5579,10 @@ export type ValueTypes = {
     createNominee?: [
       { payload: ValueTypes['CreateNomineeInput'] },
       ValueTypes['CreateNomineeResponse']
+    ];
+    createOrgMembers?: [
+      { payload: ValueTypes['CreateOrgMembersInput'] },
+      ValueTypes['OrgMemberResponse']
     ];
     createSampleCircle?: ValueTypes['CreateSampleCircleResponse'];
     createUserWithToken?: [
@@ -12682,6 +12695,7 @@ export type ModelTypes = {
     id?: number | undefined;
     nominee?: GraphQLTypes['nominees'] | undefined;
   };
+  ['CreateOrgMembersInput']: GraphQLTypes['CreateOrgMembersInput'];
   ['CreateSampleCircleResponse']: {
     circle?: GraphQLTypes['circles'] | undefined;
     id: number;
@@ -12755,6 +12769,10 @@ export type ModelTypes = {
   ['MarkClaimedInput']: GraphQLTypes['MarkClaimedInput'];
   ['MarkClaimedOutput']: {
     ids: Array<number>;
+  };
+  ['OrgMemberResponse']: {
+    OrgMemberResponse?: GraphQLTypes['org_members'] | undefined;
+    id: string;
   };
   /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
   ['String_comparison_exp']: GraphQLTypes['String_comparison_exp'];
@@ -14272,6 +14290,9 @@ export type ModelTypes = {
     /** create epoch using new, more flexible api */
     createEpoch?: GraphQLTypes['EpochResponse'] | undefined;
     createNominee?: GraphQLTypes['CreateNomineeResponse'] | undefined;
+    createOrgMembers?:
+      | Array<GraphQLTypes['OrgMemberResponse'] | undefined>
+      | undefined;
     createSampleCircle?: GraphQLTypes['CreateSampleCircleResponse'] | undefined;
     createUserWithToken?: GraphQLTypes['UserResponse'] | undefined;
     createUsers?: Array<GraphQLTypes['UserResponse'] | undefined> | undefined;
@@ -16232,6 +16253,10 @@ export type GraphQLTypes = {
     id?: number | undefined;
     nominee?: GraphQLTypes['nominees'] | undefined;
   };
+  ['CreateOrgMembersInput']: {
+    org_id: number;
+    users: Array<GraphQLTypes['UserObj'] | undefined>;
+  };
   ['CreateSampleCircleResponse']: {
     __typename: 'CreateSampleCircleResponse';
     circle?: GraphQLTypes['circles'] | undefined;
@@ -16400,6 +16425,11 @@ export type GraphQLTypes = {
   ['MarkClaimedOutput']: {
     __typename: 'MarkClaimedOutput';
     ids: Array<number>;
+  };
+  ['OrgMemberResponse']: {
+    __typename: 'OrgMemberResponse';
+    OrgMemberResponse?: GraphQLTypes['org_members'] | undefined;
+    id: string;
   };
   /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
   ['String_comparison_exp']: {
@@ -20266,6 +20296,9 @@ export type GraphQLTypes = {
     /** create epoch using new, more flexible api */
     createEpoch?: GraphQLTypes['EpochResponse'] | undefined;
     createNominee?: GraphQLTypes['CreateNomineeResponse'] | undefined;
+    createOrgMembers?:
+      | Array<GraphQLTypes['OrgMemberResponse'] | undefined>
+      | undefined;
     createSampleCircle?: GraphQLTypes['CreateSampleCircleResponse'] | undefined;
     createUserWithToken?: GraphQLTypes['UserResponse'] | undefined;
     createUsers?: Array<GraphQLTypes['UserResponse'] | undefined> | undefined;


### PR DESCRIPTION
## Motivation and Context

Create an action handler to support adding org_members.


## Test and Deployment Plan

Test these variations:
- [x] adding an org member previously deleted from the org (no UI yet for this)
- [x] ENS valid
- [x] ENS invalid
- [x] profile already exists
- [x] profile doesn't already exist
- [x] user already is in org

