### PR TITLE
Remove all orgs vaults routes

### DIFF
--- a/src/components/MainLayout/getMainHeaderData.ts
+++ b/src/components/MainLayout/getMainHeaderData.ts
@@ -5,8 +5,8 @@ import { useQuery } from 'react-query';
 import useConnectedAddress from 'hooks/useConnectedAddress';
 import { useWeb3React } from 'hooks/useWeb3React';
 
-export const getMainHeaderData = (address: string, chainId: number) => {
-  return client.query(
+export const getMainHeaderData = (address: string, chainId: number) =>
+  client.query(
     {
       organizations: [
         {},
@@ -47,7 +47,6 @@ export const getMainHeaderData = (address: string, chainId: number) => {
     },
     { operationName: 'getMainHeaderData' }
   );
-};
 
 export const QUERY_KEY_MAIN_HEADER = 'MainHeader';
 
@@ -69,6 +68,3 @@ export const useMainHeaderQuery = () => {
 };
 
 export type MainHeaderQuery = Partial<ReturnType<typeof useMainHeaderQuery>>;
-export type MainHeaderOrgs = NonNullable<
-  MainHeaderQuery['data']
->['organizations'];

--- a/src/components/MainLayout/getMainHeaderData.ts
+++ b/src/components/MainLayout/getMainHeaderData.ts
@@ -5,8 +5,8 @@ import { useQuery } from 'react-query';
 import useConnectedAddress from 'hooks/useConnectedAddress';
 import { useWeb3React } from 'hooks/useWeb3React';
 
-export const getMainHeaderData = (address: string, chainId: number) =>
-  client.query(
+export const getMainHeaderData = (address: string, chainId: number) => {
+  return client.query(
     {
       organizations: [
         {},
@@ -47,6 +47,7 @@ export const getMainHeaderData = (address: string, chainId: number) =>
     },
     { operationName: 'getMainHeaderData' }
   );
+};
 
 export const QUERY_KEY_MAIN_HEADER = 'MainHeader';
 
@@ -68,3 +69,6 @@ export const useMainHeaderQuery = () => {
 };
 
 export type MainHeaderQuery = Partial<ReturnType<typeof useMainHeaderQuery>>;
+export type MainHeaderOrgs = NonNullable<
+  MainHeaderQuery['data']
+>['organizations'];

--- a/src/hooks/gql/useVaults.ts
+++ b/src/hooks/gql/useVaults.ts
@@ -9,7 +9,7 @@ export function useVaults({
   orgId,
   chainId,
 }: {
-  orgId: number;
+  orgId?: number;
   chainId: number;
 }) {
   return useQuery(
@@ -60,6 +60,7 @@ export function useVaults({
                 },
               ],
               organization: {
+                id: true,
                 name: true,
               },
             },

--- a/src/lib/gql/mutations/vaults.ts
+++ b/src/lib/gql/mutations/vaults.ts
@@ -20,6 +20,7 @@ export const addVault = (payload: ValueTypes['CreateVaultInput']) =>
             chain_id: true,
             deployment_block: true,
             organization: {
+              id: true,
               name: true,
             },
             vault_transactions: [

--- a/src/pages/HistoryPage/HistoryPage.tsx
+++ b/src/pages/HistoryPage/HistoryPage.tsx
@@ -240,7 +240,7 @@ export const HistoryPage = () => {
               >
                 Start an Epoch
               </Button>
-               <AppLink to={paths.vaultsForOrg(circle.organization_id)}>
+              <AppLink to={paths.vaultsForOrg(circle.organization_id)}>
                 <Button color="secondary" inline>
                   Create a Vault
                 </Button>

--- a/src/pages/HistoryPage/HistoryPage.tsx
+++ b/src/pages/HistoryPage/HistoryPage.tsx
@@ -240,7 +240,7 @@ export const HistoryPage = () => {
               >
                 Start an Epoch
               </Button>
-              <AppLink to={paths.vaults}>
+               <AppLink to={paths.vaultsForOrg(circle.organization_id)}>
                 <Button color="secondary" inline>
                   Create a Vault
                 </Button>

--- a/src/pages/HistoryPage/getHistoryData.ts
+++ b/src/pages/HistoryPage/getHistoryData.ts
@@ -13,6 +13,7 @@ export const getHistoryData = async (circleId: number, userId: number) => {
           name: true,
           token_name: true,
           vouching: true,
+          organization_id: true,
           users: [
             { where: { id: { _eq: userId } } },
             { role: true, give_token_remaining: true, non_giver: true },

--- a/src/pages/VaultsPage/VaultRow.tsx
+++ b/src/pages/VaultsPage/VaultRow.tsx
@@ -171,7 +171,13 @@ const RecentTransactions = ({ vault }: { vault: Vault }) => {
               fontSize: '$small',
             }}
           >
-            <AppLink inlineLink to={paths.vaultTxs(vault.vault_address)}>
+            <AppLink
+              inlineLink
+              to={paths.vaultTxs(
+                vault.organization.id.toString(),
+                vault.vault_address
+              )}
+            >
               View All Transactions
             </AppLink>
           </Text>

--- a/src/pages/VaultsPage/VaultsPage.tsx
+++ b/src/pages/VaultsPage/VaultsPage.tsx
@@ -2,12 +2,16 @@ import { useEffect, useState } from 'react';
 
 import { useIsEmailWallet } from 'features/auth';
 import { isUserAdmin } from 'lib/users';
+import { Contracts } from 'lib/vaults';
 import { useParams } from 'react-router-dom';
 import { useRecoilValueLoadable } from 'recoil';
 
 import { LoadingModal } from 'components';
 import HintBanner from 'components/HintBanner';
-import { useMainHeaderQuery } from 'components/MainLayout/getMainHeaderData';
+import {
+  MainHeaderOrgs,
+  useMainHeaderQuery,
+} from 'components/MainLayout/getMainHeaderData';
 import { useContracts } from 'hooks';
 import { useVaults } from 'hooks/gql/useVaults';
 import useRequireSupportedChain from 'hooks/useRequireSupportedChain';
@@ -19,8 +23,6 @@ import { CreateForm } from './CreateForm';
 import { VaultRow } from './VaultRow';
 
 const VaultsPage = () => {
-  const [modal, setModal] = useState(false);
-
   const circleId = useRecoilValueLoadable(rSelectedCircleId).valueMaybe();
   const orgsQuery = useMainHeaderQuery();
   const contracts = useContracts();
@@ -28,34 +30,57 @@ const VaultsPage = () => {
   const { orgId: orgFromParams } = useParams();
   const specificOrg = orgFromParams ? Number(orgFromParams) : undefined;
 
+  useRequireSupportedChain();
+
+  if (orgsQuery.isLoading || orgsQuery.isIdle || orgsQuery.isFetching)
+    return <LoadingModal visible note="VaultsPage" />;
+
+  return (
+    <VaultsSelect
+      circleId={circleId}
+      orgId={specificOrg}
+      orgs={orgsQuery?.data?.organizations}
+      contracts={contracts}
+    />
+  );
+};
+
+const VaultsSelect = ({
+  circleId,
+  orgId: specificOrg,
+  orgs,
+  contracts,
+}: {
+  circleId?: number;
+  orgId?: number;
+  orgs?: MainHeaderOrgs;
+  contracts?: Contracts;
+}) => {
+  const [modal, setModal] = useState(false);
+
   const [currentOrgId, setCurrentOrgId] = useState<number | undefined>(
     specificOrg
   );
 
-  useRequireSupportedChain();
-
   useEffect(() => {
     const orgIndex = circleId
-      ? orgsQuery?.data?.organizations.findIndex(o =>
-          o.circles.some(c => c.id === circleId)
-        )
+      ? orgs?.findIndex(o => o.circles.some(c => c.id === circleId))
       : 0;
 
-    if (!currentOrgId && orgsQuery.data)
-      setCurrentOrgId(orgsQuery.data.organizations[orgIndex ?? 0].id);
-  }, [orgsQuery.data]);
+    if (!currentOrgId && orgs) setCurrentOrgId(orgs[orgIndex ?? 0].id);
+  }, [orgs]);
 
-  const orgs = orgsQuery.data?.organizations;
   const currentOrg = orgs
     ? orgs.find(o => o.id === currentOrgId) || orgs[0]
     : undefined;
-  const isAdmin = !!currentOrg?.circles.some(c => isUserAdmin(c.users[0]));
 
   const {
     refetch,
     isLoading,
     data: vaults,
   } = useVaults({ orgId: currentOrg?.id, chainId: Number(contracts?.chainId) });
+
+  const isAdmin = !!currentOrg?.circles.some(c => isUserAdmin(c.users[0]));
 
   const closeModal = () => {
     refetch();
@@ -64,9 +89,6 @@ const VaultsPage = () => {
 
   const [saving, setSaving] = useState(false);
   const isEmailWallet = useIsEmailWallet();
-
-  if (orgsQuery.isLoading || orgsQuery.isIdle)
-    return <LoadingModal visible note="VaultsPage" />;
 
   return (
     <SingleColumnLayout>

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -70,12 +70,12 @@ export const paths = {
   mint: '/cosoul/mint',
 
   profile: (address: string) => `/profile/${address}`,
-  vaults: '/vaults',
-  vaultTxs: (address: string) => `${paths.vaults}/${address}/txs`,
   organization: (orgId: string) => `/organizations/${orgId}`,
   orgActivity: orgPath('activity'),
   organizationSettings: orgPath(`settings`),
   vaultsForOrg: orgPath(`vaults`),
+  vaultTxs: (orgId: string, address: string) =>
+    `/organizations/${orgId}/vaults/${address}/txs`,
   orgMembers: orgPath(`members`),
 
   // for circle links

--- a/src/routes/routes.test.tsx
+++ b/src/routes/routes.test.tsx
@@ -1,10 +1,30 @@
 import { render, screen } from '@testing-library/react';
 import { useAuthStore } from 'features/auth';
 
+import { adminClient } from '../../api-lib/gql/adminClient';
+import { createUser } from '../../api-test/helpers';
 import { TestWrapper } from 'utils/testing';
 
+import { Awaited } from 'types/shim';
+
+let user: Awaited<ReturnType<typeof createUser>>;
+
+beforeAll(async () => {
+  user = await createUser(adminClient);
+});
+
 test('redirect after login', async () => {
-  useAuthStore.setState({ step: 'done', address: '0x0' });
-  render(<TestWrapper withRoutes routeHistory={['/login?next=/vaults']} />);
+  useAuthStore.setState({
+    step: 'done',
+    address: user.address,
+  });
+  render(
+    <TestWrapper
+      withRoutes
+      routeHistory={[
+        `/login?next=/organizations/${user.circle.organization.id}/vaults`,
+      ]}
+    />
+  );
   screen.getByTestId('loading-VaultsPage');
 });

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -102,22 +102,17 @@ const LoggedInRoutes = () => {
       <Route path={paths.organization(':orgId')}>
         <Route path="" element={<OrgPage />} />
         <Route path="settings" element={<OrgSettingsPage />} />
-        <Route path="vaults" element={<VaultsPage />} />
+        <Route path="vaults" element={<VaultsPage />}>
+          <Route
+            path={paths.vaultTxs(':orgId', ':address')}
+            element={<VaultTransactions />}
+          />
+        </Route>
       </Route>
 
       <Route
         path={paths.profile(':profileAddress')}
         element={<ProfilePage />}
-      />
-      <Route path={paths.vaults} element={<VaultsPage />} />
-      <Route
-        path={paths.vaultTxs(':address')}
-        element={<VaultTransactions />}
-      />
-
-      <Route
-        path={paths.vaultTxs(':address')}
-        element={<VaultTransactions />}
       />
 
       <Route path={paths.invite(':token')} element={<JoinCirclePage />} />


### PR DESCRIPTION
## Motivation and Context

Removed all organization vaults content

## Description
Error:
1- creating a new circle with a new org (without vaults) will have a helper banner with a link to vaults page
![image](https://user-images.githubusercontent.com/34943689/228729991-60c3c055-0c30-47b3-9f12-ae3fb469c709.png)
2- Clicking this link will crash the page with the following error
![Screenshot from 2023-03-29 16-45-58](https://user-images.githubusercontent.com/34943689/228730105-fa121363-bf4f-4190-ab40-d97b7e1e1aad.png)
3- it's caused by trying to access an org that's not fetched yet.

Fix:
1- Removed /vaults route and content
2- made all vaults routes specific to organizations

## Test and Deployment Plan
1- create a new circle with a new org
2- navigate  to Epochs/Overview page and click create a new vault

