### PR TITLE
Fix triggering addReaction twice

### DIFF
--- a/src/features/activities/reactions/ReactionCounts.tsx
+++ b/src/features/activities/reactions/ReactionCounts.tsx
@@ -25,7 +25,6 @@ export const ReactionCounts = ({
             color="reaction"
             data-myreaction={!!rg.myReaction}
             key={rg.reaction}
-            myReaction={rg.myReaction}
             onClick={() => {
               rg.myReaction
                 ? deleteReaction(rg.myReaction)

--- a/src/features/activities/reactions/ReactionOptions.tsx
+++ b/src/features/activities/reactions/ReactionOptions.tsx
@@ -112,6 +112,9 @@ export const ReactionOptions = ({
                 className="reaction-label"
                 htmlFor={'react-' + r}
                 aria-label="like"
+                onClick={e => {
+                  e.stopPropagation();
+                }}
               >
                 {[...Array(16)].map((e, i) => (
                   <Text


### PR DESCRIPTION
## Motivation and Context

Upon adding a reaction to an activity the following error is received:

"instrument.ts:124 Error: Uniqueness violation. duplicate key value violates unique constraint "reactions_profile_id_activity_id_reaction_key"
    at index.ts:54:17'

## Description
Cause:
1- Create Reaction was triggered twice 
Fix:
Moved onClick to the checkbox input 

## Test and Deployment Plan

Go to activity stream, add a reaction,

Expect: 1 createMutation request fired

