### PR TITLE
allow epochs to start 100 days in the past

### DIFF
--- a/src/pages/HistoryPage/EpochForm.tsx
+++ b/src/pages/HistoryPage/EpochForm.tsx
@@ -269,7 +269,7 @@ const getZodParser = (
       },
       {
         path: ['start_date'],
-        message: 'Start date can not be earlier than 100 days',
+        message: 'Start date can not be earlier than 100 days ago',
       }
     )
     .refine(

--- a/src/pages/HistoryPage/EpochForm.tsx
+++ b/src/pages/HistoryPage/EpochForm.tsx
@@ -155,7 +155,7 @@ const getCollisionMessage = (
 ) => {
   if (
     newInterval.overlaps(e.interval) ||
-    (e.repeatEnum === 'none' && !newRepeat)
+    (e.repeatEnum === 'none' && (!newRepeat || newRepeat.type === 'one-off'))
   ) {
     return newInterval.overlaps(e.interval)
       ? `Overlap with an epoch starting ${e.startDate.toFormat(longFormat)}`
@@ -263,13 +263,13 @@ const getZodParser = (
     .refine(
       ({ start_date }) => {
         return (
-          start_date > DateTime.now().setZone() ||
+          start_date > DateTime.now().setZone().minus({ days: 100 }) ||
           (currentEpoch && source?.epoch?.id === currentEpoch.id)
         );
       },
       {
         path: ['start_date'],
-        message: 'Start date must be in the future',
+        message: 'Start date can not be earlier than 100 days',
       }
     )
     .refine(

--- a/src/pages/HistoryPage/EpochForm.tsx
+++ b/src/pages/HistoryPage/EpochForm.tsx
@@ -269,7 +269,7 @@ const getZodParser = (
       },
       {
         path: ['start_date'],
-        message: 'Start date can not be earlier than 100 days ago',
+        message: 'Start date cannot be earlier than 100 days ago',
       }
     )
     .refine(


### PR DESCRIPTION
## Motivation and Context

resolves #2060


## Test and Deployment Plan

Make sure that current unit test passes.
1- created an epoch that starts in the past
2- created a future epoch and periodic epochs that starts in the past to check collision
