### PR TITLE
Fix typo in permissions

### DIFF
--- a/hasura/metadata/databases/default/tables/public_contributions.yaml
+++ b/hasura/metadata/databases/default/tables/public_contributions.yaml
@@ -23,7 +23,7 @@ insert_permissions:
               - create_contributions:
                   _eq: true
       set:
-        circle_id: x-hasura--Circle-Id
+        circle_id: X-Hasura-Circle-Id
         created_with_api_key_hash: x-hasura-Api-Key-Hash
       columns:
         - datetime_created


### PR DESCRIPTION
Fix typo to allow API to work if header is set.
