### PR TITLE
allow org admins to remove members

### DIFF
--- a/api-lib/gql/__generated__/zeus/const.ts
+++ b/api-lib/gql/__generated__/zeus/const.ts
@@ -47,6 +47,7 @@ export const AllTypesProps: Record<string, any> = {
   },
   GenerateApiKeyInput: {},
   GuildInfoInput: {},
+  IdInput: {},
   Int_comparison_exp: {},
   LinkDiscordCircleInput: {},
   LinkDiscordUserInput: {},
@@ -3911,6 +3912,9 @@ export const AllTypesProps: Record<string, any> = {
     },
     deleteEpoch: {
       payload: 'DeleteEpochInput',
+    },
+    deleteOrgMember: {
+      payload: 'IdInput',
     },
     deleteUser: {
       payload: 'DeleteUserInput',
@@ -11741,6 +11745,7 @@ export const ReturnTypes: Record<string, any> = {
     deleteContribution: 'ConfirmationResponse',
     deleteDiscordUser: 'ConfirmationResponse',
     deleteEpoch: 'DeleteEpochResponse',
+    deleteOrgMember: 'ConfirmationResponse',
     deleteUser: 'ConfirmationResponse',
     deleteUsers: 'DeleteUsersResponse',
     delete_activities: 'activities_mutation_response',

--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -844,6 +844,9 @@ export type ValueTypes = {
     name?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
+  ['IdInput']: {
+    id: number;
+  };
   /** Boolean expression to compare columns of type "Int". All fields are combined with logical 'AND'. */
   ['Int_comparison_exp']: {
     _eq?: number | undefined | null;
@@ -10588,6 +10591,10 @@ export type ValueTypes = {
     deleteEpoch?: [
       { payload: ValueTypes['DeleteEpochInput'] },
       ValueTypes['DeleteEpochResponse']
+    ];
+    deleteOrgMember?: [
+      { payload: ValueTypes['IdInput'] },
+      ValueTypes['ConfirmationResponse']
     ];
     deleteUser?: [
       { payload: ValueTypes['DeleteUserInput'] },
@@ -25281,6 +25288,7 @@ export type ModelTypes = {
     member_count: number;
     name: string;
   };
+  ['IdInput']: GraphQLTypes['IdInput'];
   /** Boolean expression to compare columns of type "Int". All fields are combined with logical 'AND'. */
   ['Int_comparison_exp']: GraphQLTypes['Int_comparison_exp'];
   ['LinkDiscordCircleInput']: GraphQLTypes['LinkDiscordCircleInput'];
@@ -29408,6 +29416,7 @@ export type ModelTypes = {
     deleteContribution?: GraphQLTypes['ConfirmationResponse'] | undefined;
     deleteDiscordUser?: GraphQLTypes['ConfirmationResponse'] | undefined;
     deleteEpoch?: GraphQLTypes['DeleteEpochResponse'] | undefined;
+    deleteOrgMember?: GraphQLTypes['ConfirmationResponse'] | undefined;
     deleteUser?: GraphQLTypes['ConfirmationResponse'] | undefined;
     deleteUsers?: GraphQLTypes['DeleteUsersResponse'] | undefined;
     /** delete data from the table: "activities" */
@@ -34129,6 +34138,9 @@ export type GraphQLTypes = {
     image_url: string;
     member_count: number;
     name: string;
+  };
+  ['IdInput']: {
+    id: number;
   };
   /** Boolean expression to compare columns of type "Int". All fields are combined with logical 'AND'. */
   ['Int_comparison_exp']: {
@@ -42435,6 +42447,7 @@ export type GraphQLTypes = {
     deleteContribution?: GraphQLTypes['ConfirmationResponse'] | undefined;
     deleteDiscordUser?: GraphQLTypes['ConfirmationResponse'] | undefined;
     deleteEpoch?: GraphQLTypes['DeleteEpochResponse'] | undefined;
+    deleteOrgMember?: GraphQLTypes['ConfirmationResponse'] | undefined;
     deleteUser?: GraphQLTypes['ConfirmationResponse'] | undefined;
     deleteUsers?: GraphQLTypes['DeleteUsersResponse'] | undefined;
     /** delete data from the table: "activities" */

--- a/api-test/hasura/actions/_handlers/createUserWithToken.test.ts
+++ b/api-test/hasura/actions/_handlers/createUserWithToken.test.ts
@@ -1,0 +1,46 @@
+import { adminClient } from '../../../../api-lib/gql/adminClient';
+import { ShareTokenType } from '../../../../src/common-lib/shareTokens';
+import {
+  createOrganization,
+  createProfile,
+  mockUserClient,
+} from '../../../helpers';
+
+let profile, org, client, token;
+
+beforeAll(async () => {
+  profile = await createProfile(adminClient);
+  org = await createOrganization(adminClient);
+
+  client = mockUserClient({
+    profileId: profile.id,
+    address: profile.address,
+  });
+
+  const { insert_org_share_tokens_one: data } = await adminClient.mutate(
+    {
+      insert_org_share_tokens_one: [
+        { object: { org_id: org.id, type: ShareTokenType.Invite } },
+        { uuid: true },
+      ],
+    },
+    { operationName: 'test' }
+  );
+  token = data?.uuid;
+});
+
+test('add an org member', async () => {
+  await client.mutate(
+    { createUserWithToken: [{ payload: { token } }, { id: true }] },
+    { operationName: 'test' }
+  );
+
+  const data = await client.query({
+    profiles_by_pk: [
+      { id: profile.id },
+      { org_members: [{}, { org_id: true }] },
+    ],
+  });
+
+  expect(data.profiles_by_pk?.org_members[0]?.org_id).toEqual(org.id);
+});

--- a/api-test/hasura/actions/_handlers/deleteOrgMember.test.ts
+++ b/api-test/hasura/actions/_handlers/deleteOrgMember.test.ts
@@ -1,0 +1,47 @@
+import { adminClient } from '../../../../api-lib/gql/adminClient';
+import { Role } from '../../../../src/lib/users';
+import { createUser, createOrgMember, mockUserClient } from '../../../helpers';
+
+let user, member, admin, client;
+
+beforeAll(async () => {
+  user = await createUser(adminClient);
+  member = await createOrgMember(adminClient, {
+    org_id: user.circle.organization.id,
+    profile_id: user.profile.id,
+  });
+
+  admin = await createUser(adminClient, {
+    circle_id: user.circle.id,
+    role: Role.ADMIN,
+  });
+
+  client = mockUserClient({
+    profileId: admin.profile.id,
+    address: admin.profile.address,
+  });
+});
+
+test('allow deleting a member only if they are not in any circle', async () => {
+  await expect(
+    client.mutate({
+      deleteOrgMember: [{ payload: { id: member.id } }, { success: true }],
+    })
+  ).rejects.toThrow('member is still in some circle in the org');
+
+  await adminClient.mutate(
+    {
+      update_users_by_pk: [
+        { pk_columns: { id: user.id }, _set: { deleted_at: 'now' } },
+        { id: true },
+      ],
+    },
+    { operationName: 'test' }
+  );
+
+  await expect(
+    client.mutate({
+      deleteOrgMember: [{ payload: { id: member.id } }, { success: true }],
+    })
+  ).resolves.toEqual({ deleteOrgMember: { success: true } });
+});

--- a/api/hasura/actions/_handlers/createUserWithToken.ts
+++ b/api/hasura/actions/_handlers/createUserWithToken.ts
@@ -3,11 +3,11 @@ import assert from 'assert';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { AuthenticationError } from 'apollo-server-express';
 
+import { ShareTokenType } from '../../.../../../../src/common-lib/shareTokens';
 import { adminClient } from '../../../../api-lib/gql/adminClient';
 import { getAddress } from '../../../../api-lib/gql/queries';
 import { UnprocessableError } from '../../../../api-lib/HttpError';
 import { verifyHasuraRequestMiddleware } from '../../../../api-lib/validate';
-import { CircleTokenType } from '../../../../src/common-lib/circleShareTokens';
 import { ENTRANCE } from '../../../../src/common-lib/constants';
 import { isGuildMember } from '../../../../src/features/guild/guild-api';
 import {
@@ -79,7 +79,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
 
   let entrance = ENTRANCE.LINK;
   // if its an invite link, they can join, if not they better have another way to join!
-  if (token.type != CircleTokenType.Invite) {
+  if (token.type != ShareTokenType.Invite) {
     // check guild
     if (!token.circle.guild_id) {
       throw new AuthenticationError('not allowed to join');

--- a/api/hasura/actions/_handlers/deleteOrgMember.ts
+++ b/api/hasura/actions/_handlers/deleteOrgMember.ts
@@ -1,0 +1,56 @@
+/**
+ * This handler is only needed while org-admin privileges are derived from
+ * circle admin roles. Once we're using `org_members.role` instead, the Hasura
+ * update permissions can be changed to use that, and then the client can call
+ * `update_org_members_by_pk` to soft-delete members.
+ */
+
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { z } from 'zod';
+
+import { isOrgAdmin } from '../../../../api-lib/findUser';
+import { adminClient } from '../../../../api-lib/gql/adminClient';
+import {
+  UnauthorizedError,
+  UnprocessableError,
+} from '../../../../api-lib/HttpError';
+import { composeHasuraActionRequestBody } from '../../../../src/lib/zod';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const {
+    input: { payload },
+    session_variables: { hasuraProfileId: profileId },
+  } = await composeHasuraActionRequestBody(
+    z.object({ id: z.number() })
+  ).parseAsync(req.body);
+
+  const { org_members_by_pk: member } = await adminClient.query(
+    {
+      org_members_by_pk: [
+        { id: payload.id },
+        { org_id: true, deleted_at: true },
+      ],
+    },
+    { operationName: 'deleteOrgMember_fetch' }
+  );
+
+  if (!member || member.deleted_at) {
+    throw new UnprocessableError('member does not exist or is already deleted');
+  }
+
+  if (!profileId || !(await isOrgAdmin(member.org_id, profileId))) {
+    throw new UnauthorizedError('not an org admin');
+  }
+
+  await adminClient.mutate(
+    {
+      update_org_members_by_pk: [
+        { pk_columns: { id: payload.id }, _set: { deleted_at: 'now' } },
+        { __typename: true },
+      ],
+    },
+    { operationName: 'deleteOrgMember_delete' }
+  );
+
+  return res.status(200).json({ success: true });
+}

--- a/api/hasura/actions/actionManager.ts
+++ b/api/hasura/actions/actionManager.ts
@@ -17,6 +17,7 @@ import createVaultTx from './_handlers/createVaultTx';
 import deleteCircle from './_handlers/deleteCircle';
 import deleteContribution from './_handlers/deleteContribution';
 import deleteEpoch from './_handlers/deleteEpoch';
+import deleteOrgMember from './_handlers/deleteOrgMember';
 import deleteUser from './_handlers/deleteUser';
 import deleteUsers from './_handlers/deleteUsers';
 import endEpoch from './_handlers/endEpoch';
@@ -56,6 +57,7 @@ const HANDLERS: HandlerDict = {
   deleteCircle,
   deleteContribution,
   deleteEpoch,
+  deleteOrgMember,
   deleteUser,
   deleteUsers,
   endEpoch,

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -59,6 +59,10 @@ type Mutation {
 }
 
 type Mutation {
+  deleteOrgMember(payload: IdInput!): ConfirmationResponse
+}
+
+type Mutation {
   deleteUser(payload: DeleteUserInput!): ConfirmationResponse
 }
 
@@ -432,6 +436,10 @@ input EndEpochInput {
   circle_id: Int!
 }
 
+input IdInput {
+  id: Int!
+}
+
 type CreateCircleResponse {
   id: Int!
 }
@@ -572,6 +580,10 @@ type GuildInfoOutput {
 type OrgMemberResponse {
   id: ID!
   new: Boolean!
+}
+
+type SuccessResponse {
+  success: Boolean!
 }
 
 scalar timestamptz

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -137,6 +137,16 @@ actions:
           value_from_env: HASURA_EVENT_SECRET
     permissions:
       - role: user
+  - name: deleteOrgMember
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_API_BASE_URL}}/actions/actionManager?action_name=deleteOrgMember'
+      forward_client_headers: true
+      headers:
+        - name: verification_key
+          value_from_env: HASURA_EVENT_SECRET
+    permissions:
+      - role: user
   - name: deleteUser
     definition:
       kind: synchronous
@@ -393,6 +403,7 @@ custom_types:
     - name: CreateEpochInput
     - name: GuildInfoInput
     - name: EndEpochInput
+    - name: IdInput
   objects:
     - name: CreateCircleResponse
       relationships:
@@ -614,5 +625,6 @@ custom_types:
             schema: public
           source: default
           type: object
+    - name: SuccessResponse
   scalars:
     - name: timestamptz

--- a/hasura/schema/admin/schema.graphql
+++ b/hasura/schema/admin/schema.graphql
@@ -311,6 +311,10 @@ type GuildRole {
   name: String!
 }
 
+input IdInput {
+  id: Int!
+}
+
 """
 Boolean expression to compare columns of type "Int". All fields are combined with logical 'AND'.
 """
@@ -14838,6 +14842,7 @@ type mutation_root {
   deleteContribution(payload: DeleteContributionInput!): ConfirmationResponse
   deleteDiscordUser(payload: DeleteDiscordUserInput!): ConfirmationResponse
   deleteEpoch(payload: DeleteEpochInput!): DeleteEpochResponse
+  deleteOrgMember(payload: IdInput!): ConfirmationResponse
   deleteUser(payload: DeleteUserInput!): ConfirmationResponse
   deleteUsers(payload: DeleteUsersInput!): DeleteUsersResponse
 

--- a/hasura/schema/user/schema.graphql
+++ b/hasura/schema/user/schema.graphql
@@ -277,6 +277,10 @@ type GuildRole {
   name: String!
 }
 
+input IdInput {
+  id: Int!
+}
+
 """
 Boolean expression to compare columns of type "Int". All fields are combined with logical 'AND'.
 """
@@ -7191,6 +7195,7 @@ type mutation_root {
   deleteCircle(payload: DeleteCircleInput!): ConfirmationResponse
   deleteContribution(payload: DeleteContributionInput!): ConfirmationResponse
   deleteEpoch(payload: DeleteEpochInput!): DeleteEpochResponse
+  deleteOrgMember(payload: IdInput!): ConfirmationResponse
   deleteUser(payload: DeleteUserInput!): ConfirmationResponse
   deleteUsers(payload: DeleteUsersInput!): DeleteUsersResponse
 

--- a/scripts/seed_hasura.sh
+++ b/scripts/seed_hasura.sh
@@ -2,16 +2,6 @@
 set -e
 SCRIPT_DIR="$(dirname $BASH_SOURCE[0])"
 
-PG_CXN="postgres://$LOCAL_POSTGRES_USER:$LOCAL_POSTGRES_PASSWORD@localhost:$LOCAL_POSTGRES_PORT/$LOCAL_POSTGRES_DATABASE"
-
-CMD_TRUNCATE_ALL="DO \$\$ BEGIN
-  EXECUTE (SELECT 'TRUNCATE TABLE ' || string_agg(oid::regclass::text, ', ') || ' CASCADE'
-    FROM pg_class 
-    WHERE relkind = 'r' 
-    AND relnamespace = 'public'::regnamespace
-    AND oid::regclass::text != 'vault_tx_types');
-END\$\$"
-
 until curl -s -o/dev/null http://localhost:"$LOCAL_HASURA_PORT"; do
   sleep 1
   echo "waiting for hasura to start"
@@ -23,11 +13,7 @@ done
 # Re-seed database
 if [ "$1" == "--clean" ]; then
   echo "Truncating all tables..."
-  if [ "$FAST_TRUNCATE" ]; then
-    psql $PG_CXN -c "$CMD_TRUNCATE_ALL" >/dev/null
-  else
-    ts-node ./scripts/db_clean.ts
-  fi
+  ts-node ./scripts/db_clean.ts
 fi
 
 if [ "$1" == "--QA" ]; then

--- a/src/common-lib/circleShareTokens.ts
+++ b/src/common-lib/circleShareTokens.ts
@@ -1,4 +1,0 @@
-export enum CircleTokenType {
-  Welcome = 0,
-  Invite,
-}

--- a/src/common-lib/shareTokens.ts
+++ b/src/common-lib/shareTokens.ts
@@ -1,0 +1,4 @@
+export enum ShareTokenType {
+  Welcome = 0,
+  Invite,
+}

--- a/src/features/orgs/OrgMembersTable.tsx
+++ b/src/features/orgs/OrgMembersTable.tsx
@@ -1,16 +1,21 @@
 import { useEffect, useState } from 'react';
 
+import { client } from 'lib/gql/client';
 import { isUserAdmin, Role } from 'lib/users';
+import { useQueryClient } from 'react-query';
 import { styled } from 'stitches.config';
 
 import { makeTable } from 'components';
 import { useNavigation } from 'hooks';
 import useMobileDetect from 'hooks/useMobileDetect';
 import { Check, X } from 'icons/__generated';
-import { Avatar, Box, Link, Text, Tooltip } from 'ui';
+import { Avatar, Box, Button, Flex, Link, Modal, Text, Tooltip } from 'ui';
 import { shortenAddress } from 'utils';
 
-import { QueryMember } from './getOrgMembersData';
+import {
+  QueryMember,
+  QUERY_KEY_GET_ORG_MEMBERS_DATA,
+} from './getOrgMembersData';
 
 const TD = styled('td', {});
 const TR = styled('tr', {});
@@ -66,65 +71,83 @@ const isCircleAdmin = (member: QueryMember): boolean => {
 };
 
 const DisplayedCircles = ({ member }: { member: QueryMember }) => {
-  if (member.profile.users.length <= 2) {
-    return (
-      <Text css={{ display: 'inline' }}>
-        {member.profile.users
-          .map(u => `${u.circle.name}${u.role === Role.ADMIN ? ' (A)' : ''}`)
-          .join(', ')}
-      </Text>
-    );
-  } else {
-    const circles = () => (
-      <Text>
-        {member.profile.users
-          .map(u => `${u.circle.name}${u.role === Role.ADMIN ? ' (A)' : ''}`)
-          .join(', ')}
-        .
-      </Text>
-    );
-    return (
-      <Text css={{ display: 'inline' }}>
-        {member.profile.users
-          .slice(0, 2)
-          .map(u => `${u.circle.name}${u.role === Role.ADMIN ? ' (A)' : ''}`)
-          .join(', ')}
-        <Tooltip content={circles()}>
+  const circles = member.profile.users.map(
+    u => `${u.circle.name}${u.role === Role.ADMIN ? ' (A)' : ''}`
+  );
+
+  return (
+    <Text css={{ display: 'inline' }}>
+      {circles.slice(0, 2).join(', ')}
+      {circles.length > 2 && (
+        <Tooltip content={circles.join(', ')}>
           <Link inlineLink target="_blank" rel="noreferrer">
             , see more
           </Link>{' '}
         </Tooltip>
-      </Text>
-    );
-  }
+      )}
+    </Text>
+  );
 };
-export const MemberRow = ({ member }: { member: QueryMember }) => {
+
+export const MemberRow = ({
+  member,
+  isAdmin,
+}: {
+  member: QueryMember;
+  isAdmin: boolean;
+}) => {
+  const [showRemove, setShowRemove] = useState(false);
+  const queryClient = useQueryClient();
+
+  const removeUser = async () => {
+    await client.mutate(
+      { deleteOrgMember: [{ payload: { id: member.id } }, { success: true }] },
+      { operationName: 'removeOrgMember' }
+    );
+    setShowRemove(false);
+    queryClient.invalidateQueries(QUERY_KEY_GET_ORG_MEMBERS_DATA);
+  };
+
   return (
     <TR key={member.id}>
       <TD css={{ width: '20%' }} align="left">
         <MemberName member={member} />
       </TD>
       <TD>{shortenAddress(member.profile.address)}</TD>
-      <TD
-        css={{
-          textAlign: 'right !important',
-          minWidth: '$3xl',
-        }}
-      >
+      <TD css={{ textAlign: 'right !important', minWidth: '$3xl' }}>
         {isCircleAdmin(member) ? (
           <Check size="lg" color="complete" />
         ) : (
           <X size="lg" color="neutral" />
         )}
       </TD>
-      <TD
-        css={{
-          textAlign: 'right !important',
-          minWidth: '$3xl',
-        }}
-      >
-        <DisplayedCircles member={member} />
+      <TD css={{ textAlign: 'right !important', minWidth: '$3xl' }}>
+        {isAdmin && member.profile.users.length === 0 ? (
+          <Button
+            inline
+            size="xs"
+            color="secondary"
+            onClick={() => setShowRemove(true)}
+          >
+            Remove
+          </Button>
+        ) : (
+          <DisplayedCircles member={member} />
+        )}
       </TD>
+      {showRemove && (
+        <Modal
+          open
+          title={`Remove ${member.profile.name} from this organization?`}
+          onOpenChange={() => setShowRemove(false)}
+        >
+          <Flex column alignItems="start" css={{ gap: '$md' }}>
+            <Button color="destructive" onClick={removeUser}>
+              Remove
+            </Button>
+          </Flex>
+        </Modal>
+      )}
     </TR>
   );
 };
@@ -133,10 +156,12 @@ export const OrgMembersTable = ({
   members,
   filter,
   perPage,
+  isAdmin,
 }: {
   members: QueryMember[];
   filter: (u: QueryMember) => boolean;
   perPage: number;
+  isAdmin: boolean;
 }) => {
   const { isMobile } = useMobileDetect();
   const [view, setView] = useState<QueryMember[]>([]);
@@ -183,7 +208,9 @@ export const OrgMembersTable = ({
         return (m: QueryMember) => m.profile.name.toLowerCase();
       }}
     >
-      {member => <MemberRow key={member.id} member={member} />}
+      {member => (
+        <MemberRow key={member.id} member={member} isAdmin={isAdmin} />
+      )}
     </OrgMembersTable>
   );
 };

--- a/src/features/orgs/useOrgInviteToken.ts
+++ b/src/features/orgs/useOrgInviteToken.ts
@@ -2,10 +2,10 @@ import assert from 'assert';
 
 import { useQuery } from 'react-query';
 
-import { CircleTokenType } from '../../common-lib/circleShareTokens';
+import { ShareTokenType } from '../../common-lib/shareTokens';
 import { client } from '../../lib/gql/client';
 
-const type = CircleTokenType.Invite;
+const type = ShareTokenType.Invite;
 
 export const useOrgInviteToken = (orgId: number) => {
   return useQuery(

--- a/src/lib/gql/__generated__/zeus/const.ts
+++ b/src/lib/gql/__generated__/zeus/const.ts
@@ -41,6 +41,7 @@ export const AllTypesProps: Record<string, any> = {
   },
   GenerateApiKeyInput: {},
   GuildInfoInput: {},
+  IdInput: {},
   Int_comparison_exp: {},
   LinkDiscordCircleInput: {},
   LinkDiscordUserInput: {},
@@ -2408,6 +2409,9 @@ export const AllTypesProps: Record<string, any> = {
     },
     deleteEpoch: {
       payload: 'DeleteEpochInput',
+    },
+    deleteOrgMember: {
+      payload: 'IdInput',
     },
     deleteUser: {
       payload: 'DeleteUserInput',
@@ -6235,6 +6239,7 @@ export const ReturnTypes: Record<string, any> = {
     deleteCircle: 'ConfirmationResponse',
     deleteContribution: 'ConfirmationResponse',
     deleteEpoch: 'DeleteEpochResponse',
+    deleteOrgMember: 'ConfirmationResponse',
     deleteUser: 'ConfirmationResponse',
     deleteUsers: 'DeleteUsersResponse',
     delete_circle_api_keys: 'circle_api_keys_mutation_response',

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -816,6 +816,9 @@ export type ValueTypes = {
     name?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
+  ['IdInput']: {
+    id: number;
+  };
   /** Boolean expression to compare columns of type "Int". All fields are combined with logical 'AND'. */
   ['Int_comparison_exp']: {
     _eq?: number | undefined | null;
@@ -5613,6 +5616,10 @@ export type ValueTypes = {
     deleteEpoch?: [
       { payload: ValueTypes['DeleteEpochInput'] },
       ValueTypes['DeleteEpochResponse']
+    ];
+    deleteOrgMember?: [
+      { payload: ValueTypes['IdInput'] },
+      ValueTypes['ConfirmationResponse']
     ];
     deleteUser?: [
       { payload: ValueTypes['DeleteUserInput'] },
@@ -12747,6 +12754,7 @@ export type ModelTypes = {
     member_count: number;
     name: string;
   };
+  ['IdInput']: GraphQLTypes['IdInput'];
   /** Boolean expression to compare columns of type "Int". All fields are combined with logical 'AND'. */
   ['Int_comparison_exp']: GraphQLTypes['Int_comparison_exp'];
   ['LinkDiscordCircleInput']: GraphQLTypes['LinkDiscordCircleInput'];
@@ -14304,6 +14312,7 @@ export type ModelTypes = {
     deleteCircle?: GraphQLTypes['ConfirmationResponse'] | undefined;
     deleteContribution?: GraphQLTypes['ConfirmationResponse'] | undefined;
     deleteEpoch?: GraphQLTypes['DeleteEpochResponse'] | undefined;
+    deleteOrgMember?: GraphQLTypes['ConfirmationResponse'] | undefined;
     deleteUser?: GraphQLTypes['ConfirmationResponse'] | undefined;
     deleteUsers?: GraphQLTypes['DeleteUsersResponse'] | undefined;
     /** delete data from the table: "circle_api_keys" */
@@ -16371,6 +16380,9 @@ export type GraphQLTypes = {
     image_url: string;
     member_count: number;
     name: string;
+  };
+  ['IdInput']: {
+    id: number;
   };
   /** Boolean expression to compare columns of type "Int". All fields are combined with logical 'AND'. */
   ['Int_comparison_exp']: {
@@ -20311,6 +20323,7 @@ export type GraphQLTypes = {
     deleteCircle?: GraphQLTypes['ConfirmationResponse'] | undefined;
     deleteContribution?: GraphQLTypes['ConfirmationResponse'] | undefined;
     deleteEpoch?: GraphQLTypes['DeleteEpochResponse'] | undefined;
+    deleteOrgMember?: GraphQLTypes['ConfirmationResponse'] | undefined;
     deleteUser?: GraphQLTypes['ConfirmationResponse'] | undefined;
     deleteUsers?: GraphQLTypes['DeleteUsersResponse'] | undefined;
     /** delete data from the table: "circle_api_keys" */

--- a/src/lib/zod/index.ts
+++ b/src/lib/zod/index.ts
@@ -369,6 +369,7 @@ export const HasuraAdminSessionVariablesRaw = z.object({
 export const HasuraAdminSessionVariables =
   HasuraAdminSessionVariablesRaw.transform(vars => ({
     hasuraRole: vars['x-hasura-role'],
+    hasuraProfileId: undefined,
   }));
 
 export const HasuraApiSessionVariablesRaw = z.object({

--- a/src/pages/AddMembersPage/useCircleTokens.ts
+++ b/src/pages/AddMembersPage/useCircleTokens.ts
@@ -2,26 +2,26 @@ import assert from 'assert';
 
 import { useQuery } from 'react-query';
 
-import { CircleTokenType } from '../../common-lib/circleShareTokens';
+import { ShareTokenType } from '../../common-lib/shareTokens';
 import { client } from '../../lib/gql/client';
 
 export const useInviteToken = (circleId: number) => {
-  return useCircleTokens(circleId, CircleTokenType.Invite);
+  return useCircleTokens(circleId, ShareTokenType.Invite);
 };
 
 export const useWelcomeToken = (circleId: number) => {
-  return useCircleTokens(circleId, CircleTokenType.Welcome);
+  return useCircleTokens(circleId, ShareTokenType.Welcome);
 };
 
 export const deleteInviteToken = (circleId: number) => {
-  return deleteToken(circleId, CircleTokenType.Invite);
+  return deleteToken(circleId, ShareTokenType.Invite);
 };
 
 export const deleteWelcomeToken = (circleId: number) => {
-  return deleteToken(circleId, CircleTokenType.Welcome);
+  return deleteToken(circleId, ShareTokenType.Welcome);
 };
 
-const useCircleTokens = (circleId: number, type: CircleTokenType) => {
+const useCircleTokens = (circleId: number, type: ShareTokenType) => {
   return useQuery(
     ['circle-token-', circleId, type],
     async (): Promise<string> => {
@@ -59,7 +59,7 @@ const useCircleTokens = (circleId: number, type: CircleTokenType) => {
   );
 };
 
-const deleteToken = async (circleId: number, type: CircleTokenType) => {
+const deleteToken = async (circleId: number, type: ShareTokenType) => {
   await client.mutate(
     {
       delete_circle_share_tokens_by_pk: [

--- a/src/pages/JoinPage/JoinPage.test.tsx
+++ b/src/pages/JoinPage/JoinPage.test.tsx
@@ -1,7 +1,7 @@
 import assert from 'assert';
 
 import { render, screen } from '@testing-library/react';
-import { CircleTokenType } from 'common-lib/circleShareTokens';
+import { ShareTokenType } from 'common-lib/shareTokens';
 import { useAuthStore } from 'features/auth';
 import { Route, Routes } from 'react-router-dom';
 
@@ -29,7 +29,7 @@ beforeAll(async () => {
         createJoinToken: {
           insert_circle_share_tokens_one: [
             {
-              object: { circle_id: circle.id, type: CircleTokenType.Invite },
+              object: { circle_id: circle.id, type: ShareTokenType.Invite },
             },
             { uuid: true },
           ],

--- a/src/pages/JoinPage/JoinPage.tsx
+++ b/src/pages/JoinPage/JoinPage.tsx
@@ -7,7 +7,7 @@ import { useNavigate } from 'react-router';
 import { useParams } from 'react-router-dom';
 
 import { TokenJoinInfo } from '../../../api/join/[token]';
-import { CircleTokenType } from '../../common-lib/circleShareTokens';
+import { ShareTokenType } from '../../common-lib/shareTokens';
 import { LoadingModal } from '../../components';
 import { paths } from '../../routes/paths';
 import { CenteredBox, Panel, Text } from '../../ui';
@@ -86,7 +86,7 @@ export const JoinPage = () => {
         return;
       }
 
-      if (tokenJoinInfo.type === CircleTokenType.Welcome) {
+      if (tokenJoinInfo.type === ShareTokenType.Welcome) {
         setWrongAddress(true);
         return;
       }

--- a/src/pages/MembersPage/index.tsx
+++ b/src/pages/MembersPage/index.tsx
@@ -214,7 +214,7 @@ const MembersPage = () => {
       </Modal>
       <Modal
         open={!!deleteUserDialog}
-        title={`Remove ${deleteUserDialog?.name} from circle`}
+        title={`Remove ${deleteUserDialog?.name} from this circle?`}
         onOpenChange={() => setDeleteUserDialog(undefined)}
       >
         <Flex column alignItems="start" css={{ gap: '$md' }}>

--- a/src/pages/OrgMembersPage/index.tsx
+++ b/src/pages/OrgMembersPage/index.tsx
@@ -111,7 +111,12 @@ const OrgMembersPage = () => {
             />
           </Flex>
         </Flex>
-        <OrgMembersTable members={members} filter={filterMember} perPage={15} />
+        <OrgMembersTable
+          members={members}
+          filter={filterMember}
+          perPage={15}
+          isAdmin={isOrgAdmin}
+        />
       </Panel>
     </SingleColumnLayout>
   );


### PR DESCRIPTION
This adds a button in each row on the Org Members page, visible only when that row's member is in 0 circles and the viewing user is an org admin, to remove the member from the org (soft-deleting).

### testing

Add a new member to the org, then use the button to remove them. Verify that they no longer appear in the members list (immediately after, and also upon page reload).

### todo

- [x] prevent removing from org if the member is still in some circle
