### PR TITLE
feat: Add id column permission to users table

### DIFF
--- a/hasura/metadata/databases/default/tables/public_users.yaml
+++ b/hasura/metadata/databases/default/tables/public_users.yaml
@@ -123,6 +123,7 @@ select_permissions:
     permission:
       columns:
         - circle_id
+        - id
         - role
       filter: {}
   - role: user


### PR DESCRIPTION
## Motivation and Context

<!-- Why is this change required? What problem does it solve? This can be omitted if a linked issue is provided
-->

We need to access the `id` of the user in order to insert a contribution https://github.com/coordinape/discord-bot/pull/116

## Description

<!-- Describe your changes -->

Add the `id` column select permission to the role discord-bot in the users table

`create_contributions` was already being requested here https://github.com/coordinape/coordinape/blob/main/src/pages/DiscordPage/DiscordPage.tsx#L71

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

@crabsinger @CryptoGraffe 
