### PR TITLE
 fix add contribution description error 

### DIFF
--- a/src/pages/ContributionsPage/ContributionsPage.tsx
+++ b/src/pages/ContributionsPage/ContributionsPage.tsx
@@ -388,7 +388,6 @@ const ContributionsPage = () => {
     setCurrentIntContribution(null);
     resetCreateMutation();
     resetUpdateMutation();
-    reset();
   };
 
   const readyForNewContribution: boolean =


### PR DESCRIPTION
## Motivation and Context
Upon adding a new contribution and closing the drawer before saving, an error is returned in console

## Description
1- The error is caused by calling reset() from the form (react-hook-form) as it tries to update the contribution with empty description
2- reset() is unnecessary because the form is reintialized with the new default data on re-rendering

## Test and Deployment Plan
1- Add a contribution and quickly close the drawer before saving like the below gif

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/34943689/231313189-081f64d9-71c5-4f90-a7f0-ec89a98505e9.png)

![contributions error](https://user-images.githubusercontent.com/34943689/231311720-2a773d8a-c18b-4d30-8693-f38dac9b96c9.gif)


