### PR TITLE
CI Improvements: run tests separately, no localstack

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,4 +1,4 @@
-name: Cypress Integration Test suite
+name: Cypress
 
 on: [push, pull_request]
 

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,4 +1,4 @@
-name: Jest Test suite
+name: Cypress Integration Test suite
 
 on: [push, pull_request]
 
@@ -16,7 +16,7 @@ jobs:
           skip_after_successful_duplicate: false
 
   main:
-    name: Run jest tests
+    name: Run cypress tests
     runs-on: ubuntu-latest
     needs: skip_duplicates
     if: ${{ needs.skip_duplicates.outputs.should_skip != 'true' }}
@@ -54,11 +54,22 @@ jobs:
       - name: Cache Docker images
         uses: ScribeMD/docker-cache@0.2.6
         with:
-          key: docker-${{ runner.os }}-${{ hashFiles('**/docker-compose.yml') }}
+          key: docker-${{ runner.os }}-${{ hashFiles('**/docker-compose.ci.yml') }}
 
       - run: yarn --frozen-lockfile
+      - run: yarn cypress install
+      - run: yarn cypress verify
       - run: ./scripts/setup.sh
-      - run: ./scripts/ci/manager.sh test --jest
+      - run: ./scripts/ci/manager.sh test --cypress
+
+      - name: Save Cypress artifacts
+        uses: actions/upload-artifact@v3.1.1
+        if: failure()
+        with:
+          name: cy-artifacts
+          path: |
+            ./cypress/videos
+            ./cypress/screenshots
 
       - name: Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Cache Docker images
         uses: ScribeMD/docker-cache@0.2.6
         with:
-          key: docker-${{ runner.os }}-${{ hashFiles('**/docker-compose.ci.yml') }}
+          key: docker-${{ runner.os }}-${{ hashFiles('**/docker-compose.yml') }}
 
       - run: yarn --frozen-lockfile
       - run: yarn cypress install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Jest Test suite
+name: Jest
 
 on: [push, pull_request]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       HASURA_GRAPHQL_AUTH_HOOK: http://${DOCKER_GATEWAY_HOST:-host.docker.internal}:${LOCAL_WEB_PORT}/api/hasura/auth
       ## HASURA_GRAPHQL_UNAUTHORIZED_ROLE: public
 
-  # for local s3 storage for images
+  # for local s3 storage for images; not used by CI
   localstack:
     image: localstack/localstack:latest
     restart: always

--- a/scripts/ci/manager.sh
+++ b/scripts/ci/manager.sh
@@ -15,8 +15,9 @@ while [[ "$#" > 0 ]]; do case $1 in
   *) OTHERARGS+=($1);;
 esac; shift; done
 
-DOCKER_PROJECT_NAME=cape-ci-v2
-DOCKER_CMD="docker compose -p $DOCKER_PROJECT_NAME"
+DOCKER_PROJECT_NAME=cape-ci-v3
+DOCKER_CMD="docker compose --project-name $DOCKER_PROJECT_NAME"
+DOCKER_SERVICES="postgres graphql-engine"
 PROJECT_ROOT=$SCRIPT_DIR/../..
 GANACHE_PID=""
 WEB_PID=""
@@ -28,7 +29,8 @@ start_services() {
   fi
 
   # start docker
-  $DOCKER_CMD up -d
+  echo "starting docker with cmd: $DOCKER_CMD"
+  $DOCKER_CMD up --detach $DOCKER_SERVICES
 
   # start ganache
   $SCRIPT_DIR/../../hardhat/scripts/start-ganache.sh -p $HARDHAT_GANACHE_PORT \


### PR DESCRIPTION
- Run cypress and jest tests in separate jobs
- Run CI without localstack

POST MERGE:
- Need to update Github to require both `cypress` and `jest` tests to pass.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ca3fe5a</samp>

### Summary
🚀🧹🐳

<!--
1.  🚀 - This emoji conveys the idea of launching or running something, which is appropriate for adding a new workflow file for cypress integration tests. It also suggests speed and efficiency, which are desirable qualities for testing workflows.
2.  🧹 - This emoji conveys the idea of cleaning or tidying up, which is appropriate for streamlining the jest workflow and removing unnecessary steps. It also suggests simplicity and clarity, which are desirable qualities for workflow files.
3.  🐳 - This emoji conveys the idea of docker, which is the main tool used for running tests with the manager script. It also suggests reliability and scalability, which are desirable qualities for testing environments.
-->
This pull request refactors and enhances the testing workflows for the coordinape project. It splits the jest and cypress tests into separate workflow files, `.github/workflows/tests.yml` and `.github/workflows/cypress.yml`, and optimizes the docker script `scripts/ci/manager.sh` for running the tests.

> _We run the tests of doom, cypress and jest_
> _We trigger them with push and pull, we never rest_
> _We use the docker and hardhat, we streamline the workflow_
> _We are the masters of the code, we debug and grow_

### Walkthrough
* Add a new workflow for running cypress integration tests on push and pull request events ([link](https://github.com/coordinape/coordinape/pull/2097/files?diff=unified&w=0#diff-5da9a41590fb261de0e464c95862528100c42c77dffad53b7c6de228b6afd2bdR1-R77))
* Rename and update the existing workflow for running jest tests to avoid confusion with the cypress workflow ([link](https://github.com/coordinape/coordinape/pull/2097/files?diff=unified&w=0#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL1-R1), [link](https://github.com/coordinape/coordinape/pull/2097/files?diff=unified&w=0#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL19-R19))
  - Remove unnecessary steps and arguments for installing and verifying cypress ([link](https://github.com/coordinape/coordinape/pull/2097/files?diff=unified&w=0#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL60-R62))
* Update the `manager.sh` script to use consistent and non-conflicting docker project names and commands ([link](https://github.com/coordinape/coordinape/pull/2097/files?diff=unified&w=0#diff-e896cd0f0bcd19f2382a5167ff7656d71bf660c909e2a563df32f124f3d4215eL18-R20))
  - Add a debug message and modify the docker command to use the docker services variable ([link](https://github.com/coordinape/coordinape/pull/2097/files?diff=unified&w=0#diff-e896cd0f0bcd19f2382a5167ff7656d71bf660c909e2a563df32f124f3d4215eL31-R33))

