### PR TITLE
added view map button on epoch panel for admin view

### DIFF
--- a/src/pages/HistoryPage/EpochPanel.tsx
+++ b/src/pages/HistoryPage/EpochPanel.tsx
@@ -4,7 +4,7 @@ import { DateTime } from 'luxon';
 import { CSS } from 'stitches.config';
 
 import { paths } from 'routes/paths';
-import { AppLink, Box, Button, Flex, Panel, Text } from 'ui';
+import { AppLink, Button, Flex, Panel, Text } from 'ui';
 
 import type { QueryDistribution, QueryPastEpoch } from './getHistoryData';
 import { NotesSection } from './Notes';
@@ -104,7 +104,7 @@ export const EpochPanel = ({
               epochId={epoch.id}
             />
             {isAdmin && (
-              <Box>
+              <Flex row css={{ gap: '$sm' }}>
                 <Button
                   color="cta"
                   as={AppLink}
@@ -115,7 +115,7 @@ export const EpochPanel = ({
                 <Button color="secondary" as={AppLink} to={paths.map(circleId)}>
                   View Map
                 </Button>
-              </Box>
+              </Flex>
             )}
           </Flex>
         </Flex>

--- a/src/pages/HistoryPage/EpochPanel.tsx
+++ b/src/pages/HistoryPage/EpochPanel.tsx
@@ -3,10 +3,12 @@ import round from 'lodash/round';
 import { DateTime } from 'luxon';
 import { CSS } from 'stitches.config';
 
+import isFeatureEnabled from 'config/features';
+import { useApiAdminCircle } from 'hooks';
 import { paths } from 'routes/paths';
-import { Box, Panel, Text, AppLink, Flex, Button } from 'ui';
+import { AppLink, Box, Button, Flex, Link, Panel, Text } from 'ui';
 
-import type { QueryPastEpoch, QueryDistribution } from './getHistoryData';
+import type { QueryDistribution, QueryPastEpoch } from './getHistoryData';
 import { NotesSection } from './Notes';
 
 type EpochPanelProps = {
@@ -27,6 +29,8 @@ export const EpochPanel = ({
   const startDate = DateTime.fromISO(epoch.start_date);
   const endDate = DateTime.fromISO(epoch.end_date);
   const endDateFormat = endDate.month === startDate.month ? 'd' : 'MMM d';
+
+  const { downloadCSV } = useApiAdminCircle(circleId);
 
   const received = epoch.receivedGifts;
   const sent = epoch.sentGifts;
@@ -105,13 +109,47 @@ export const EpochPanel = ({
             />
             {isAdmin && (
               <Box>
-                <Button
-                  color="cta"
-                  as={AppLink}
-                  to={paths.distributions(circleId, epoch.id)}
-                >
-                  Review & Export
-                </Button>
+                {isFeatureEnabled('vaults') ? (
+                  <Flex css={{ gap: '$sm' }}>
+                    <Button
+                      color="cta"
+                      as={AppLink}
+                      to={paths.distributions(circleId, epoch.id)}
+                    >
+                      Review & Export
+                    </Button>
+                    <Button
+                      color="secondary"
+                      as={AppLink}
+                      to={paths.map(circleId)}
+                    >
+                      View Map
+                    </Button>
+                  </Flex>
+                ) : (
+                  <Link
+                    href="#"
+                    css={{ fontWeight: '$semibold' }}
+                    onClick={e => {
+                      e.stopPropagation(),
+                        (async () => {
+                          // use the authed api to download the CSV
+                          const csv = await downloadCSV(epoch.number, epoch.id);
+
+                          if (csv?.file) {
+                            const a = document.createElement('a');
+                            a.href = csv.file;
+                            a.click();
+                            a.href = '';
+                          }
+
+                          return false;
+                        })();
+                    }}
+                  >
+                    Export CSV
+                  </Link>
+                )}
               </Box>
             )}
           </Flex>

--- a/src/pages/HistoryPage/EpochPanel.tsx
+++ b/src/pages/HistoryPage/EpochPanel.tsx
@@ -103,7 +103,7 @@ export const EpochPanel = ({
               circleId={circleId}
               epochId={epoch.id}
             />
-            {isAdmin && (
+            {isAdmin ? (
               <Flex row css={{ gap: '$sm' }}>
                 <Button
                   color="cta"
@@ -116,6 +116,10 @@ export const EpochPanel = ({
                   View Map
                 </Button>
               </Flex>
+            ) : (
+              <Button color="cta" as={AppLink} to={paths.map(circleId)}>
+                View Map
+              </Button>
             )}
           </Flex>
         </Flex>

--- a/src/pages/HistoryPage/EpochPanel.tsx
+++ b/src/pages/HistoryPage/EpochPanel.tsx
@@ -3,10 +3,8 @@ import round from 'lodash/round';
 import { DateTime } from 'luxon';
 import { CSS } from 'stitches.config';
 
-import isFeatureEnabled from 'config/features';
-import { useApiAdminCircle } from 'hooks';
 import { paths } from 'routes/paths';
-import { AppLink, Box, Button, Flex, Link, Panel, Text } from 'ui';
+import { AppLink, Box, Button, Flex, Panel, Text } from 'ui';
 
 import type { QueryDistribution, QueryPastEpoch } from './getHistoryData';
 import { NotesSection } from './Notes';
@@ -29,8 +27,6 @@ export const EpochPanel = ({
   const startDate = DateTime.fromISO(epoch.start_date);
   const endDate = DateTime.fromISO(epoch.end_date);
   const endDateFormat = endDate.month === startDate.month ? 'd' : 'MMM d';
-
-  const { downloadCSV } = useApiAdminCircle(circleId);
 
   const received = epoch.receivedGifts;
   const sent = epoch.sentGifts;
@@ -109,47 +105,16 @@ export const EpochPanel = ({
             />
             {isAdmin && (
               <Box>
-                {isFeatureEnabled('vaults') ? (
-                  <Flex css={{ gap: '$sm' }}>
-                    <Button
-                      color="cta"
-                      as={AppLink}
-                      to={paths.distributions(circleId, epoch.id)}
-                    >
-                      Review & Export
-                    </Button>
-                    <Button
-                      color="secondary"
-                      as={AppLink}
-                      to={paths.map(circleId)}
-                    >
-                      View Map
-                    </Button>
-                  </Flex>
-                ) : (
-                  <Link
-                    href="#"
-                    css={{ fontWeight: '$semibold' }}
-                    onClick={e => {
-                      e.stopPropagation(),
-                        (async () => {
-                          // use the authed api to download the CSV
-                          const csv = await downloadCSV(epoch.number, epoch.id);
-
-                          if (csv?.file) {
-                            const a = document.createElement('a');
-                            a.href = csv.file;
-                            a.click();
-                            a.href = '';
-                          }
-
-                          return false;
-                        })();
-                    }}
-                  >
-                    Export CSV
-                  </Link>
-                )}
+                <Button
+                  color="cta"
+                  as={AppLink}
+                  to={paths.distributions(circleId, epoch.id)}
+                >
+                  Review & Export
+                </Button>
+                <Button color="secondary" as={AppLink} to={paths.map(circleId)}>
+                  View Map
+                </Button>
               </Box>
             )}
           </Flex>


### PR DESCRIPTION
## What

- admin view
![image](https://user-images.githubusercontent.com/20705520/232252195-b012070a-c120-4995-8336-73f99885c6f4.png)

- non admin view
<img width="979" alt="Screenshot 2023-04-24 at 9 12 19 PM" src="https://user-images.githubusercontent.com/20705520/234150668-09c02a91-6857-47ac-b9df-b61ccffdd08e.png">

Click on view map will go to this page:

<img width="733" alt="Screenshot 2023-04-24 at 9 13 20 PM" src="https://user-images.githubusercontent.com/20705520/234150748-c6638148-3404-4925-b008-0cb8520b28cf.png">


## Why

<!-- Describe your changes and why -->

click on the `view map` button and should go to the map page of the epoch

## Test and Deployment Plan

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->
https://github.com/coordinape/coordinape/issues/2078

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 36b9a8e</samp>

*  Enable a new feature flag for vaults and add a hook to download CSV files from the API ([link](https://github.com/coordinape/coordinape/pull/2098/files?diff=unified&w=0#diff-e3d27b7ad7e6b16d694fc88c0523663c141c03f322914062c6db5cab9e160096L6-R11), [link](https://github.com/coordinape/coordinape/pull/2098/files?diff=unified&w=0#diff-e3d27b7ad7e6b16d694fc88c0523663c141c03f322914062c6db5cab9e160096R33-R34))
*  Change the conditional rendering of the buttons for the admin in `EpochPanel.tsx` based on the feature flag ([link](https://github.com/coordinape/coordinape/pull/2098/files?diff=unified&w=0#diff-e3d27b7ad7e6b16d694fc88c0523663c141c03f322914062c6db5cab9e160096L108-R152))
