### PR TITLE
deduplicate middleware calls

### DIFF
--- a/api-lib/circleAdmin.ts
+++ b/api-lib/circleAdmin.ts
@@ -8,11 +8,10 @@ import { z } from 'zod';
 import { getUserFromProfileId } from './findUser';
 import { getInput } from './handlerHelpers';
 import { errorResponseWithStatusCode, UnauthorizedError } from './HttpError';
-import { verifyHasuraRequestMiddleware } from './validate';
 
 const circleIdInput = z.object({ circle_id: z.number() }).strip();
 
-const middleware =
+export const authCircleAdminMiddleware =
   (handler: VercelApiHandler) =>
   async (req: VercelRequest, res: VercelResponse): Promise<void> => {
     const { payload, session } = await getInput(req, circleIdInput, {
@@ -56,6 +55,3 @@ const middleware =
   };
 
 const isCircleAdmin = (role: number): boolean => role === 1;
-
-export const authCircleAdminMiddleware = (handler: VercelApiHandler) =>
-  verifyHasuraRequestMiddleware(middleware(handler));

--- a/api-lib/event_triggers/createCircleCRM.ts
+++ b/api-lib/event_triggers/createCircleCRM.ts
@@ -6,11 +6,10 @@ import { DebugLogger } from '../../src/common-lib/log';
 import { AirtableNotConfiguredError, insertCRMRecord } from '../airtable';
 import { adminClient } from '../gql/adminClient';
 import { EventTriggerPayload } from '../types';
-import { verifyHasuraRequestMiddleware } from '../validate';
 
 const logger = new DebugLogger('createCircleCRM');
 
-async function handler(req: VercelRequest, res: VercelResponse) {
+export default async function handler(req: VercelRequest, res: VercelResponse) {
   const {
     event: { data },
   }: EventTriggerPayload<'circles', 'INSERT'> = req.body;
@@ -61,5 +60,3 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     });
   }
 }
-
-export default verifyHasuraRequestMiddleware(handler);

--- a/api-lib/event_triggers/createNomineeTelegram.ts
+++ b/api-lib/event_triggers/createNomineeTelegram.ts
@@ -1,7 +1,4 @@
 import handleNomineeCreatedMsg from '../handleNomineeCreatedMsg';
 import makeTelegramEventHandler from '../make-telegram-event';
-import { verifyHasuraRequestMiddleware } from '../validate';
 
-const handler = makeTelegramEventHandler(handleNomineeCreatedMsg);
-
-export default verifyHasuraRequestMiddleware(handler);
+export default makeTelegramEventHandler(handleNomineeCreatedMsg);

--- a/api-lib/event_triggers/createVouchedUser.ts
+++ b/api-lib/event_triggers/createVouchedUser.ts
@@ -6,9 +6,8 @@ import { ENTRANCE } from '../../src/common-lib/constants';
 import { adminClient } from '../gql/adminClient';
 import * as queries from '../gql/queries';
 import { EventTriggerPayload } from '../types';
-import { verifyHasuraRequestMiddleware } from '../validate';
 
-async function handler(req: VercelRequest, res: VercelResponse) {
+export default async function handler(req: VercelRequest, res: VercelResponse) {
   const {
     event: { data },
   }: EventTriggerPayload<'nominees', 'INSERT'> = req.body;
@@ -31,14 +30,10 @@ async function handler(req: VercelRequest, res: VercelResponse) {
                 deleted_at: { _is_null: true },
               },
             },
-            {
-              id: true,
-            },
+            { id: true },
           ],
         },
-        {
-          operationName: 'createVouchedUser_findExistingUser',
-        }
+        { operationName: 'createVouchedUser_findExistingUser' }
       );
 
       if (existingUsers.length > 0) {
@@ -58,14 +53,10 @@ async function handler(req: VercelRequest, res: VercelResponse) {
                 entrance: ENTRANCE.NOMINATION,
               },
             },
-            {
-              id: true,
-            },
+            { id: true },
           ],
         },
-        {
-          operationName: 'createVouchedUser_insertUser',
-        }
+        { operationName: 'createVouchedUser_insertUser' }
       );
 
       if (insert_users_one) {
@@ -75,20 +66,12 @@ async function handler(req: VercelRequest, res: VercelResponse) {
             update_nominees: [
               {
                 _set: { ended: true, user_id: insert_users_one.id },
-                where: {
-                  id: { _eq: id },
-                },
+                where: { id: { _eq: id } },
               },
-              {
-                returning: {
-                  id: true,
-                },
-              },
+              { returning: { id: true } },
             ],
           },
-          {
-            operationName: 'createVouchedUser_updateNominees',
-          }
+          { operationName: 'createVouchedUser_updateNominees' }
         );
       }
 
@@ -103,5 +86,3 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     });
   }
 }
-
-export default verifyHasuraRequestMiddleware(handler);

--- a/api-lib/orgAdmin.ts
+++ b/api-lib/orgAdmin.ts
@@ -8,11 +8,10 @@ import { z } from 'zod';
 import { isOrgAdmin } from './findUser';
 import { getInput } from './handlerHelpers';
 import { UnauthorizedError } from './HttpError';
-import { verifyHasuraRequestMiddleware } from './validate';
 
 const schema = z.object({ org_id: z.number() }).strip();
 
-const middleware =
+export const authOrgAdminMiddleware =
   (handler: VercelApiHandler) =>
   async (req: VercelRequest, res: VercelResponse): Promise<void> => {
     const { payload, session } = await getInput(req, schema, {
@@ -36,6 +35,3 @@ const middleware =
       }
     }
   };
-
-export const authOrgAdminMiddleware = (handler: VercelApiHandler) =>
-  verifyHasuraRequestMiddleware(middleware(handler));

--- a/api-lib/userDeleter.ts
+++ b/api-lib/userDeleter.ts
@@ -10,13 +10,12 @@ import { zEthAddressOnly } from '../src/lib/zod/formHelpers';
 import { getUserFromProfileId } from './findUser';
 import { getInput } from './handlerHelpers';
 import { errorResponseWithStatusCode, UnauthorizedError } from './HttpError';
-import { verifyHasuraRequestMiddleware } from './validate';
 
 export const deleteUserInput = z
   .object({ circle_id: z.number(), address: zEthAddressOnly })
   .strict();
 
-const middleware =
+export const authUserDeleterMiddleware =
   (handler: VercelApiHandler) =>
   async (req: VercelRequest, res: VercelResponse): Promise<void> => {
     const { payload, session } = await getInput(req, deleteUserInput, {
@@ -64,6 +63,3 @@ const middleware =
   };
 
 const isCircleAdmin = (role: number): boolean => role === 1;
-
-export const authUserDeleterMiddleware = (handler: VercelApiHandler) =>
-  verifyHasuraRequestMiddleware(middleware(handler));

--- a/api/hasura/actions/_handlers/createCircle.ts
+++ b/api/hasura/actions/_handlers/createCircle.ts
@@ -8,7 +8,6 @@ import { UnauthorizedError } from '../../../../api-lib/HttpError';
 import { resizeCircleLogo } from '../../../../api-lib/images';
 import { ImageUpdater } from '../../../../api-lib/ImageUpdater';
 import { Awaited } from '../../../../api-lib/ts4.5shim';
-import { verifyHasuraRequestMiddleware } from '../../../../api-lib/validate';
 import { zCircleName, zUsername } from '../../../../src/lib/zod/formHelpers';
 
 const createCircleSchemaInput = z
@@ -26,7 +25,7 @@ const createCircleSchemaInput = z
     'Either Protocol name should be filled in or a Protocol should be selected.'
   );
 
-async function handler(req: VercelRequest, res: VercelResponse) {
+export default async function handler(req: VercelRequest, res: VercelResponse) {
   const { payload, session } = await getInput(req, createCircleSchemaInput);
 
   if (payload.organization_id) {
@@ -90,4 +89,3 @@ function createCircleFn(
     return circle;
   };
 }
-export default verifyHasuraRequestMiddleware(handler);

--- a/api/hasura/actions/_handlers/createNominee.ts
+++ b/api/hasura/actions/_handlers/createNominee.ts
@@ -22,7 +22,6 @@ import {
   getUserFromProfileIdWithCircle,
   getNomineeFromAddress,
 } from '../../../../api-lib/nominees';
-import { verifyHasuraRequestMiddleware } from '../../../../api-lib/validate';
 import {
   zUsername,
   zEthAddressOnly,
@@ -37,7 +36,7 @@ export const createNomineeInputSchema = z
   })
   .strict();
 
-async function handler(req: VercelRequest, res: VercelResponse) {
+export default async function handler(req: VercelRequest, res: VercelResponse) {
   const {
     payload: { circle_id, address, name, description },
     session: { hasuraProfileId: profileId },
@@ -139,5 +138,3 @@ async function handler(req: VercelRequest, res: VercelResponse) {
 
   return res.status(200).json(nominee);
 }
-
-export default verifyHasuraRequestMiddleware(handler);

--- a/api/hasura/actions/_handlers/createSampleCircle.ts
+++ b/api/hasura/actions/_handlers/createSampleCircle.ts
@@ -6,7 +6,6 @@ import { adminClient } from '../../../../api-lib/gql/adminClient';
 import * as mutations from '../../../../api-lib/gql/mutations';
 import { getInput } from '../../../../api-lib/handlerHelpers';
 import { UnprocessableError } from '../../../../api-lib/HttpError';
-import { verifyHasuraRequestMiddleware } from '../../../../api-lib/validate';
 
 import {
   sampleCircleDefaults,
@@ -15,7 +14,7 @@ import {
   sampleMemberData,
 } from './createSampleCircle_data';
 
-async function handler(req: VercelRequest, res: VercelResponse) {
+export default async function handler(req: VercelRequest, res: VercelResponse) {
   const { session } = await getInput(req);
 
   const ret = await createSampleCircleForProfile(
@@ -293,5 +292,3 @@ const addSampleAllocation = async (
   }
   return;
 };
-
-export default verifyHasuraRequestMiddleware(handler);

--- a/api/hasura/actions/_handlers/createUserWithToken.ts
+++ b/api/hasura/actions/_handlers/createUserWithToken.ts
@@ -9,7 +9,6 @@ import { adminClient } from '../../../../api-lib/gql/adminClient';
 import { getAddress } from '../../../../api-lib/gql/queries';
 import { getInput } from '../../../../api-lib/handlerHelpers';
 import { UnprocessableError } from '../../../../api-lib/HttpError';
-import { verifyHasuraRequestMiddleware } from '../../../../api-lib/validate';
 import { ENTRANCE } from '../../../../src/common-lib/constants';
 import { isGuildMember } from '../../../../src/features/guild/guild-api';
 
@@ -21,7 +20,7 @@ const createUserFromTokenInput = z
   })
   .strict();
 
-async function handler(req: VercelRequest, res: VercelResponse) {
+export default async function handler(req: VercelRequest, res: VercelResponse) {
   const { payload, session } = await getInput(req, createUserFromTokenInput);
 
   const address = await getAddress(session.hasuraProfileId);
@@ -176,5 +175,3 @@ const handleOrg = async (
   res.status(200).json({ id: newMember?.id });
   return true;
 };
-
-export default verifyHasuraRequestMiddleware(handler);

--- a/api/hasura/actions/_handlers/createVault.ts
+++ b/api/hasura/actions/_handlers/createVault.ts
@@ -11,7 +11,6 @@ import {
   InternalServerError,
 } from '../../../../api-lib/HttpError';
 import { getProvider } from '../../../../api-lib/provider';
-import { verifyHasuraRequestMiddleware } from '../../../../api-lib/validate';
 import { Contracts } from '../../../../src/lib/vaults/contracts';
 import { zEthAddressOnly } from '../../../../src/lib/zod/formHelpers';
 
@@ -25,7 +24,7 @@ const inputSchema = z
   })
   .strict();
 
-async function handler(req: VercelRequest, res: VercelResponse) {
+export default async function handler(req: VercelRequest, res: VercelResponse) {
   const { session, payload } = await getInput(req, inputSchema);
 
   const { org_id, chain_id, vault_address, deployment_block, tx_hash } =
@@ -89,8 +88,6 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     );
   res.status(200).json(result);
 }
-
-export default verifyHasuraRequestMiddleware(handler);
 
 export const insert = ({
   symbol,

--- a/api/hasura/actions/_handlers/createVaultTx.ts
+++ b/api/hasura/actions/_handlers/createVaultTx.ts
@@ -13,9 +13,8 @@ import {
 import { adminClient } from '../../../../api-lib/gql/adminClient';
 import { getInput } from '../../../../api-lib/handlerHelpers';
 import { UnprocessableError } from '../../../../api-lib/HttpError';
-import { verifyHasuraRequestMiddleware } from '../../../../api-lib/validate';
 
-async function handler(req: VercelRequest, res: VercelResponse) {
+export default async function handler(req: VercelRequest, res: VercelResponse) {
   const {
     session: { hasuraProfileId, hasuraAddress },
     payload,
@@ -64,8 +63,6 @@ async function handler(req: VercelRequest, res: VercelResponse) {
   });
   return res.json(result);
 }
-
-export default verifyHasuraRequestMiddleware(handler);
 
 export const logVaultTx = async (
   txInfo: ValueTypes['vault_transactions_insert_input'] &

--- a/api/hasura/actions/_handlers/deleteContribution.ts
+++ b/api/hasura/actions/_handlers/deleteContribution.ts
@@ -4,7 +4,6 @@ import { z } from 'zod';
 import { fetchAndVerifyContribution } from '../../../../api-lib/contributions';
 import { adminClient } from '../../../../api-lib/gql/adminClient';
 import { getInput } from '../../../../api-lib/handlerHelpers';
-import { verifyHasuraRequestMiddleware } from '../../../../api-lib/validate';
 
 const deleteContributionInput = z
   .object({
@@ -12,7 +11,7 @@ const deleteContributionInput = z
   })
   .strict();
 
-async function handler(req: VercelRequest, res: VercelResponse) {
+export default async function handler(req: VercelRequest, res: VercelResponse) {
   const {
     action,
     session: { hasuraAddress: userAddress },
@@ -44,5 +43,3 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     success: true,
   });
 }
-
-export default verifyHasuraRequestMiddleware(handler);

--- a/api/hasura/actions/_handlers/deleteOrgMember.ts
+++ b/api/hasura/actions/_handlers/deleteOrgMember.ts
@@ -8,9 +8,8 @@ import {
   UnauthorizedError,
   UnprocessableError,
 } from '../../../../api-lib/HttpError';
-import { verifyHasuraRequestMiddleware } from '../../../../api-lib/validate';
 
-async function handler(req: VercelRequest, res: VercelResponse) {
+export default async function handler(req: VercelRequest, res: VercelResponse) {
   const {
     payload,
     session: { hasuraProfileId: profileId },
@@ -71,5 +70,3 @@ async function handler(req: VercelRequest, res: VercelResponse) {
 
   return res.status(200).json({ success: true });
 }
-
-export default verifyHasuraRequestMiddleware(handler);

--- a/api/hasura/actions/_handlers/getGuildInfo.ts
+++ b/api/hasura/actions/_handlers/getGuildInfo.ts
@@ -4,7 +4,6 @@ import { z } from 'zod';
 import { getAddress } from '../../../../api-lib/gql/queries';
 import { getInput } from '../../../../api-lib/handlerHelpers';
 import { InternalServerError } from '../../../../api-lib/HttpError';
-import { verifyHasuraRequestMiddleware } from '../../../../api-lib/validate';
 import {
   guildInfoFromAPI,
   isGuildMember,
@@ -14,7 +13,7 @@ const guildInfoInputSchema = z.object({
   id: z.string().or(z.number()),
 });
 
-async function handler(req: VercelRequest, res: VercelResponse) {
+export default async function handler(req: VercelRequest, res: VercelResponse) {
   const { payload, session } = await getInput(req, guildInfoInputSchema);
   const address = await getAddress(session.hasuraProfileId);
 
@@ -27,5 +26,3 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     throw new InternalServerError('Unable to fetch info from guild', e);
   }
 }
-
-export default verifyHasuraRequestMiddleware(handler);

--- a/api/hasura/actions/_handlers/linkDiscordUser.ts
+++ b/api/hasura/actions/_handlers/linkDiscordUser.ts
@@ -9,11 +9,10 @@ import {
 } from '../../../../api-lib/gql/__generated__/zeus';
 import { adminClient } from '../../../../api-lib/gql/adminClient';
 import { getInput } from '../../../../api-lib/handlerHelpers';
-import { verifyHasuraRequestMiddleware } from '../../../../api-lib/validate';
 
 const linkDiscordInputSchema = z.object({ discord_id: z.string() }).strict();
 
-async function handler(req: VercelRequest, res: VercelResponse) {
+export default async function handler(req: VercelRequest, res: VercelResponse) {
   const { session, payload } = await getInput(req, linkDiscordInputSchema, {
     allowAdmin: true,
   });
@@ -44,5 +43,3 @@ async function handler(req: VercelRequest, res: VercelResponse) {
   res.status(200).json(returnResult);
   return;
 }
-
-export default verifyHasuraRequestMiddleware(handler);

--- a/api/hasura/actions/_handlers/logoutUser.ts
+++ b/api/hasura/actions/_handlers/logoutUser.ts
@@ -2,9 +2,8 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 
 import { adminClient } from '../../../../api-lib/gql/adminClient';
 import { HasuraUserSessionVariables } from '../../../../api-lib/requests/schema';
-import { verifyHasuraRequestMiddleware } from '../../../../api-lib/validate';
 
-async function handler(req: VercelRequest, res: VercelResponse) {
+export default async function handler(req: VercelRequest, res: VercelResponse) {
   const { hasuraProfileId } = HasuraUserSessionVariables.parse(
     req.body.session_variables
   );
@@ -24,5 +23,3 @@ async function handler(req: VercelRequest, res: VercelResponse) {
   );
   return res.status(200).json({ id: hasuraProfileId });
 }
-
-export default verifyHasuraRequestMiddleware(handler);

--- a/api/hasura/actions/_handlers/markClaimed.ts
+++ b/api/hasura/actions/_handlers/markClaimed.ts
@@ -6,7 +6,6 @@ import { getInput } from '../../../../api-lib/handlerHelpers';
 import { UnprocessableError } from '../../../../api-lib/HttpError';
 import { getProvider } from '../../../../api-lib/provider';
 import { Awaited } from '../../../../api-lib/ts4.5shim';
-import { verifyHasuraRequestMiddleware } from '../../../../api-lib/validate';
 import { Contracts, hasSimpleToken } from '../../../../src/lib/vaults';
 
 const MarkClaimedInputSchema = z.object({
@@ -14,7 +13,7 @@ const MarkClaimedInputSchema = z.object({
   tx_hash: z.string(),
 });
 
-async function handler(req: VercelRequest, res: VercelResponse) {
+export default async function handler(req: VercelRequest, res: VercelResponse) {
   const {
     session: { hasuraProfileId },
     payload: { tx_hash, claim_id },
@@ -23,8 +22,6 @@ async function handler(req: VercelRequest, res: VercelResponse) {
   const ids = await updateClaims(hasuraProfileId, claim_id, tx_hash);
   return res.json({ ids });
 }
-
-export default verifyHasuraRequestMiddleware(handler);
 
 export const updateClaims = async (
   profileId: number,

--- a/api/hasura/actions/_handlers/updateAllocations.ts
+++ b/api/hasura/actions/_handlers/updateAllocations.ts
@@ -19,7 +19,6 @@ import {
   getUserWithCircle,
   UserWithCircleResponse,
 } from '../../../../api-lib/nominees';
-import { verifyHasuraRequestMiddleware } from '../../../../api-lib/validate';
 
 const updateAllocationsInput = z.object({
   allocations: z
@@ -36,7 +35,7 @@ const updateAllocationsApiInput = updateAllocationsInput.extend({
   user_id: z.number().int().positive().optional(),
 });
 
-async function handler(req: VercelRequest, res: VercelResponse) {
+export default async function handler(req: VercelRequest, res: VercelResponse) {
   const {
     payload: { circle_id, allocations },
     payload,
@@ -267,5 +266,3 @@ async function handler(req: VercelRequest, res: VercelResponse) {
 
   return res.status(200).json({ user_id: user.id });
 }
-
-export default verifyHasuraRequestMiddleware(handler);

--- a/api/hasura/actions/_handlers/updateContribution.ts
+++ b/api/hasura/actions/_handlers/updateContribution.ts
@@ -4,7 +4,6 @@ import { z } from 'zod';
 import { fetchAndVerifyContribution } from '../../../../api-lib/contributions';
 import { adminClient } from '../../../../api-lib/gql/adminClient';
 import { getInput } from '../../../../api-lib/handlerHelpers';
-import { verifyHasuraRequestMiddleware } from '../../../../api-lib/validate';
 
 export const updateContributionInput = z
   .object({
@@ -14,7 +13,7 @@ export const updateContributionInput = z
   })
   .strict();
 
-async function handler(req: VercelRequest, res: VercelResponse) {
+export default async function handler(req: VercelRequest, res: VercelResponse) {
   const {
     action,
     session: { hasuraAddress: userAddress },
@@ -42,5 +41,3 @@ async function handler(req: VercelRequest, res: VercelResponse) {
 
   return res.status(200).json(mutationResult.update_contributions_by_pk);
 }
-
-export default verifyHasuraRequestMiddleware(handler);

--- a/api/hasura/actions/_handlers/updateProfile.ts
+++ b/api/hasura/actions/_handlers/updateProfile.ts
@@ -7,7 +7,6 @@ import { getProfilesWithName } from '../../../../api-lib/findProfile';
 import { adminClient } from '../../../../api-lib/gql/adminClient';
 import { getInput } from '../../../../api-lib/handlerHelpers';
 import { errorResponseWithStatusCode } from '../../../../api-lib/HttpError';
-import { verifyHasuraRequestMiddleware } from '../../../../api-lib/validate';
 import { isValidENS } from '../../../../api-lib/validateENS';
 
 const updateProfileSchemaInput = z
@@ -24,7 +23,7 @@ const updateProfileSchemaInput = z
   })
   .strict();
 
-async function handler(req: VercelRequest, res: VercelResponse) {
+export default async function handler(req: VercelRequest, res: VercelResponse) {
   const { session, payload } = await getInput(req, updateProfileSchemaInput);
   const { name } = payload;
 
@@ -71,5 +70,3 @@ async function handler(req: VercelRequest, res: VercelResponse) {
   res.status(200).json(mutationResult.update_profiles_by_pk);
   return;
 }
-
-export default verifyHasuraRequestMiddleware(handler);

--- a/api/hasura/actions/_handlers/updateTeammates.ts
+++ b/api/hasura/actions/_handlers/updateTeammates.ts
@@ -7,7 +7,6 @@ import { adminClient } from '../../../../api-lib/gql/adminClient';
 import { getInput } from '../../../../api-lib/handlerHelpers';
 import { errorResponseWithStatusCode } from '../../../../api-lib/HttpError';
 import { getUserFromProfileIdWithCircle } from '../../../../api-lib/nominees';
-import { verifyHasuraRequestMiddleware } from '../../../../api-lib/validate';
 
 const updateTeammatesInput = z
   .object({
@@ -16,7 +15,7 @@ const updateTeammatesInput = z
   })
   .strict();
 
-async function handler(req: VercelRequest, res: VercelResponse) {
+export default async function handler(req: VercelRequest, res: VercelResponse) {
   const {
     payload: { circle_id, teammates },
     session: { hasuraProfileId: profileId },
@@ -65,5 +64,3 @@ async function handler(req: VercelRequest, res: VercelResponse) {
 
   return res.status(200).json({ user_id: user.id });
 }
-
-export default verifyHasuraRequestMiddleware(handler);

--- a/api/hasura/actions/_handlers/updateUser.ts
+++ b/api/hasura/actions/_handlers/updateUser.ts
@@ -6,7 +6,6 @@ import { z } from 'zod';
 import { adminClient } from '../../../../api-lib/gql/adminClient';
 import { getInput } from '../../../../api-lib/handlerHelpers';
 import { errorResponse } from '../../../../api-lib/HttpError';
-import { verifyHasuraRequestMiddleware } from '../../../../api-lib/validate';
 
 const updateUserSchemaInput = z
   .object({
@@ -17,7 +16,7 @@ const updateUserSchemaInput = z
   })
   .strict();
 
-async function handler(req: VercelRequest, res: VercelResponse) {
+export default async function handler(req: VercelRequest, res: VercelResponse) {
   const { session, payload } = await getInput(req, updateUserSchemaInput);
 
   // Validate no epoches are active for the requested user
@@ -90,5 +89,3 @@ async function handler(req: VercelRequest, res: VercelResponse) {
   res.status(200).json(returnResult);
   return;
 }
-
-export default verifyHasuraRequestMiddleware(handler);

--- a/api/hasura/actions/_handlers/uploadOrgLogo.ts
+++ b/api/hasura/actions/_handlers/uploadOrgLogo.ts
@@ -5,13 +5,12 @@ import { adminClient } from '../../../../api-lib/gql/adminClient';
 import { getInput } from '../../../../api-lib/handlerHelpers';
 import { resizeCircleLogo } from '../../../../api-lib/images';
 import { ImageUpdater } from '../../../../api-lib/ImageUpdater';
-import { verifyHasuraRequestMiddleware } from '../../../../api-lib/validate';
 
 const uploadOrgImageInput = z
   .object({ org_id: z.number(), image_data_base64: z.string() })
   .strict();
 
-const handler = async function (req: VercelRequest, res: VercelResponse) {
+export default async function handler(req: VercelRequest, res: VercelResponse) {
   const { payload } = await getInput(req, uploadOrgImageInput, {
     allowAdmin: true,
   });
@@ -28,7 +27,7 @@ const handler = async function (req: VercelRequest, res: VercelResponse) {
     previousLogo
   );
   return res.status(200).json(updatedProfile);
-};
+}
 
 async function getPreviousLogo(id: number): Promise<string | undefined> {
   const { organizations_by_pk } = await adminClient.query(
@@ -59,5 +58,3 @@ function logoUpdater(id: number) {
     };
   };
 }
-
-export default verifyHasuraRequestMiddleware(handler);

--- a/api/hasura/actions/_handlers/uploadProfileAvatar.ts
+++ b/api/hasura/actions/_handlers/uploadProfileAvatar.ts
@@ -7,9 +7,8 @@ import {
   profileUpdateAvatarMutation,
   userAndImageData,
 } from '../../../../api-lib/profileImages';
-import { verifyHasuraRequestMiddleware } from '../../../../api-lib/validate';
 
-async function handler(req: VercelRequest, res: VercelResponse) {
+export default async function handler(req: VercelRequest, res: VercelResponse) {
   const { input, hasuraProfileId } = await userAndImageData(req);
   const { avatar: previousAvatar } = await profileImages(hasuraProfileId);
 
@@ -24,5 +23,3 @@ async function handler(req: VercelRequest, res: VercelResponse) {
   );
   return res.status(200).json(updatedProfile);
 }
-
-export default verifyHasuraRequestMiddleware(handler);

--- a/api/hasura/actions/_handlers/uploadProfileBackground.ts
+++ b/api/hasura/actions/_handlers/uploadProfileBackground.ts
@@ -7,9 +7,8 @@ import {
   profileUpdateBackgroundMutation,
   userAndImageData,
 } from '../../../../api-lib/profileImages';
-import { verifyHasuraRequestMiddleware } from '../../../../api-lib/validate';
 
-async function handler(req: VercelRequest, res: VercelResponse) {
+export default async function handler(req: VercelRequest, res: VercelResponse) {
   const { input, hasuraProfileId } = await userAndImageData(req);
   const { background: previousBackground } = await profileImages(
     hasuraProfileId
@@ -26,5 +25,3 @@ async function handler(req: VercelRequest, res: VercelResponse) {
   );
   return res.status(200).json(updatedProfile);
 }
-
-export default verifyHasuraRequestMiddleware(handler);

--- a/api/hasura/actions/_handlers/vouch.ts
+++ b/api/hasura/actions/_handlers/vouch.ts
@@ -18,7 +18,6 @@ import {
   UnprocessableError,
 } from '../../../../api-lib/HttpError';
 import { Awaited } from '../../../../api-lib/ts4.5shim';
-import { verifyHasuraRequestMiddleware } from '../../../../api-lib/validate';
 import { ENTRANCE } from '../../../../src/common-lib/constants';
 
 const vouchApiInput = z
@@ -33,7 +32,7 @@ type Nominee = Required<
   NonNullable<Awaited<ReturnType<typeof mutations.insertVouch>>>
 >['nominee'];
 
-async function handler(req: VercelRequest, res: VercelResponse) {
+export default async function handler(req: VercelRequest, res: VercelResponse) {
   try {
     const { payload, session } = await getInput(req, vouchApiInput, {
       apiPermissions: ['create_vouches'],
@@ -192,5 +191,3 @@ async function getNominee(nomineeId: number) {
   }
   return nom.nominees_by_pk;
 }
-
-export default verifyHasuraRequestMiddleware(handler);

--- a/api/hasura/actions/actionManager.ts
+++ b/api/hasura/actions/actionManager.ts
@@ -2,6 +2,7 @@ import { VercelApiHandler, VercelRequest, VercelResponse } from '@vercel/node';
 
 import { GraphQLTypes } from '../../../api-lib/gql/__generated__/zeus';
 import { ActionPayload } from '../../../api-lib/types';
+import { verifyHasuraRequestMiddleware } from '../../../api-lib/validate';
 
 import adminUpdateUser from './_handlers/adminUpdateUser';
 import allocationCsv from './_handlers/allocationCsv';
@@ -82,10 +83,7 @@ const HANDLERS: HandlerDict = {
   vouch,
 };
 
-export default async function actionHandler(
-  req: VercelRequest,
-  res: VercelResponse
-) {
+async function actionHandler(req: VercelRequest, res: VercelResponse) {
   const {
     action: { name: actionName },
   }: ActionPayload<keyof GraphQLTypes> = req.body;
@@ -100,3 +98,5 @@ export default async function actionHandler(
 
   await handlerMap[actionName](req, res);
 }
+
+export default verifyHasuraRequestMiddleware(actionHandler);


### PR DESCRIPTION
See commit comments. Just taking advantage of the existing centralization in `actionManager` and `eventManager` to define middleware there rather than in each handler file.
