### PR TITLE
fix: `null` epoch number

### DIFF
--- a/api/hasura/cron/epochs.ts
+++ b/api/hasura/cron/epochs.ts
@@ -223,9 +223,12 @@ export async function notifyEpochStart({
   notifyStartEpochs: epochs,
 }: EpochsToNotify) {
   const sendNotifications = epochs.map(async epoch => {
-    const { start_date, end_date, circle, number: epochNumber } = epoch;
+    const { start_date, end_date, circle, number } = epoch;
 
-    if (epochNumber == null) await setNextEpochNumber(epoch);
+    let epochNumber = number;
+    if (epochNumber == null) {
+      epochNumber = await setNextEpochNumber(epoch);
+    }
 
     assert(circle, 'panic: no circle for epoch');
     const epochStartDate = DateTime.fromISO(start_date);
@@ -807,6 +810,8 @@ async function setNextEpochNumber({
         operationName: 'cron_setNextEpochNumber_update',
       }
     );
+
+    return currentEpochNumber;
   } catch (e: unknown) {
     if (e instanceof Error)
       throw `Error setting next number for epoch id ${epochId}: ${e.message}`;

--- a/api/hasura/cron/epochs.ts
+++ b/api/hasura/cron/epochs.ts
@@ -256,7 +256,7 @@ export async function notifyEpochStart({
             type: 'start' as const,
             channelId,
             roleId,
-            epochName: `Epoch ${epoch.number}`,
+            epochName: `Epoch ${epochNumber}`,
             circleId: circle.id,
             circleName: `${circle.organization?.name}/${circle.name}`,
             startTime: start_date,


### PR DESCRIPTION
Return the newly set epoch number in `setNextEpochNumber()`