### PR TITLE
Bugfix: Filter epoch statements to exclude blank ones

### DIFF
--- a/src/pages/HistoryPage/Notes.tsx
+++ b/src/pages/HistoryPage/Notes.tsx
@@ -24,7 +24,10 @@ export const NotesSection = ({
 }) => {
   const receivedLength = received.filter(g => g.gift_private?.note).length;
   const sentLength = sent?.filter(g => g.gift_private?.note).length;
-  const epochStatementsLength = epochStatements?.length;
+  const filteredEpochStatements = epochStatements?.filter(
+    e => e.bio && e.bio.length > 0
+  );
+  const epochStatementsLength = filteredEpochStatements?.length;
   const [tab, setTab] = useState<
     'sent' | 'received' | 'epochStatements' | null
   >(null);
@@ -67,7 +70,7 @@ export const NotesSection = ({
             )}
           </Box>
         </Flex>
-        {!!epochStatements?.length && (
+        {!!epochStatementsLength && (
           <Flex
             column
             css={{
@@ -120,9 +123,9 @@ export const NotesSection = ({
           {!!sent?.length && tab === 'sent' && (
             <Notes tokenName={tokenName} data={sent} />
           )}
-          {!!epochStatements?.length && tab === 'epochStatements' && (
+          {!!epochStatementsLength && tab === 'epochStatements' && (
             <>
-              <EpochStatements epochStatements={epochStatements} />
+              <EpochStatements epochStatements={filteredEpochStatements} />
             </>
           )}
         </Flex>


### PR DESCRIPTION
Here's the bug:
<img width="832" alt="Screenshot 2023-04-26 at 9 50 54 AM" src="https://user-images.githubusercontent.com/100873710/234665305-bd8322c6-1403-4efe-b5bb-9f8fa0099312.png">
blank ones should't be included