### PR TITLE
Feature flag showing org members

### DIFF
--- a/src/features/nav/NavCurrentOrg.tsx
+++ b/src/features/nav/NavCurrentOrg.tsx
@@ -1,12 +1,12 @@
 import { Activity, DollarSign, Member } from '../../icons/__generated';
 import { paths } from '../../routes/paths';
 import { Box } from '../../ui';
+import isFeatureEnabled from 'config/features';
 
 import { NavOrg } from './getNavData';
 import { NavItem } from './NavItem';
 
 export const NavCurrentOrg = ({ org }: { org: NavOrg }) => {
-  const isInOrg = org.members.length > 0;
   return (
     <Box
       css={{
@@ -27,7 +27,7 @@ export const NavCurrentOrg = ({ org }: { org: NavOrg }) => {
         to={paths.vaultsForOrg(org.id)}
         icon={<DollarSign />}
       />
-      {isInOrg && (
+      {isFeatureEnabled('org_view') && (
         <NavItem
           label={'Members'}
           to={paths.orgMembers(org.id)}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 810e545</samp>

Add feature flag for organization view feature. Hide `Members` nav item unless the flag is enabled. 