### PR TITLE
hide OtherCircles component behind features flags

### DIFF
--- a/src/features/nav/NavCircles.tsx
+++ b/src/features/nav/NavCircles.tsx
@@ -5,6 +5,7 @@ import { NavLink } from 'react-router-dom';
 import { Eye, EyeOff, PlusCircle } from '../../icons/__generated';
 import { paths } from '../../routes/paths';
 import { IconButton, Text } from '../../ui';
+import isFeatureEnabled from 'config/features';
 
 import { NavCircle, NavOrg } from './getNavData';
 import { NavCircleItem } from './NavCircleItem';
@@ -65,7 +66,7 @@ export const NavCircles = ({
         );
       })}
 
-      {org.otherCircles.length > 0 && (
+      {isFeatureEnabled('org_view') && org.otherCircles.length > 0 && (
         <NavLabel
           key={'othercirclesLabel'}
           label="Other Circles"
@@ -79,7 +80,8 @@ export const NavCircles = ({
           }
         />
       )}
-      {showOtherCircles &&
+      {isFeatureEnabled('org_view') &&
+        showOtherCircles &&
         org.otherCircles.map(c => {
           return (
             <NavCircleItem

--- a/src/pages/CirclesPage/CirclesPage.tsx
+++ b/src/pages/CirclesPage/CirclesPage.tsx
@@ -9,6 +9,7 @@ import type { CSS } from 'stitches.config';
 
 import { LoadingModal } from 'components';
 import HintBanner from 'components/HintBanner';
+import isFeatureEnabled from 'config/features';
 import useConnectedAddress from 'hooks/useConnectedAddress';
 import { User } from 'icons/__generated';
 import {
@@ -117,8 +118,14 @@ type QueryCircle = QueryResult['organizations'][0]['circles'][0];
 
 const buttons = (
   circle: QueryCircle
-): [(circleId: number) => string, string][] => {
-  if (circle.users.length === 0) return [[paths.members, 'Members']];
+): [(circleId: number) => string, string][] | [] => {
+  if (circle.users.length === 0) {
+    if (isFeatureEnabled('org_view')) {
+      return [[paths.members, 'Members']];
+    } else {
+      return [];
+    }
+  }
 
   const b: [(circleId: number) => string, string][] = [
     [paths.contributions, 'Contributions'],

--- a/src/pages/CirclesPage/CirclesPage.tsx
+++ b/src/pages/CirclesPage/CirclesPage.tsx
@@ -121,7 +121,10 @@ const buttons = (
 ): [(circleId: number) => string, string][] | [] => {
   if (circle.users.length === 0) {
     if (isFeatureEnabled('org_view')) {
-      return [[paths.members, 'Members']];
+      return [
+        [(id: number) => paths.map(id), 'Map'],
+        [paths.members, 'Members'],
+      ];
     } else {
       return [];
     }


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6c6ef37</samp>

Added UI elements for the `org_view` feature to the navigation and circle pages. This feature allows users to view and manage multiple circles within an organization.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6c6ef37</samp>

> _We're sailing on the `org_view` feature flag_
> _We'll render what we need and not a thing we don't_
> _Heave away, me hearties, heave away_
> _We'll make the UI shine for every user and circle_

## Why

hide OtherCircles component and members buttons for non members in circles page if org_view flag is false
 

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6c6ef37</samp>

*  Add feature flag checking for `org_view` feature, which allows users to view and manage multiple circles within an organization ([link](https://github.com/coordinape/coordinape/pull/2131/files?diff=unified&w=0#diff-448888a35c7f4e61e46e10a0c60866e0448e6425658c50fb4b4857ee77935971R8), [link](https://github.com/coordinape/coordinape/pull/2131/files?diff=unified&w=0#diff-421fa9c09a7ada013cfda15f9d977e9373efb046e2c52279b29b9e0dc9ddd2b0R12))
*  Conditionally render a label and a list of other circles in the navigation menu, based on the `org_view` feature flag ([link](https://github.com/coordinape/coordinape/pull/2131/files?diff=unified&w=0#diff-448888a35c7f4e61e46e10a0c60866e0448e6425658c50fb4b4857ee77935971L68-R69), [link](https://github.com/coordinape/coordinape/pull/2131/files?diff=unified&w=0#diff-448888a35c7f4e61e46e10a0c60866e0448e6425658c50fb4b4857ee77935971L82-R84))
*  Conditionally render a button for the "Members" page on the circle page, based on the `org_view` feature flag and the number of users in the circle ([link](https://github.com/coordinape/coordinape/pull/2131/files?diff=unified&w=0#diff-421fa9c09a7ada013cfda15f9d977e9373efb046e2c52279b29b9e0dc9ddd2b0L120-R128))
