### PR TITLE
Enable orgs

### DIFF
--- a/scripts/db_seed_test.ts
+++ b/scripts/db_seed_test.ts
@@ -2,6 +2,7 @@ import { DateTime } from 'luxon';
 
 import { adminClient } from '../api-lib/gql/adminClient';
 
+import { init as initOrgMembership } from './repl/org_membership';
 import {
   createContributions,
   createGifts,
@@ -31,6 +32,7 @@ async function main() {
   await createFreshOpenEpochDevAdminWithFixedPaymentToken();
   await createEndedEpochWithGiftsForClaims();
   await getAvatars();
+  await (await initOrgMembership()).createMembersForAllOrgs();
 }
 
 main()

--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -14,7 +14,7 @@ const staticFeatureFlags: Partial<Record<FeatureName, boolean>> = {
   cosoul: false,
   email_login: !!process.env.REACT_APP_FEATURE_FLAG_EMAIL_LOGIN,
   epoch_timing_banner: !!process.env.REACT_APP_FEATURE_FLAG_EPOCH_TIMING_BANNER,
-  org_view: !!process.env.REACT_APP_FEATURE_FLAG_ORG_VIEW,
+  org_view: true,
 };
 
 // this code is safe to use in a non-browser environment because of the typeof


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d445a8a</samp>

Enable the `org_view` feature for all users by setting its flag to `true` in `features.ts`. This feature improves the organization management experience in Coordinape.