### PR TITLE
Minor UI fix for sidenav label cursor hover

### DIFF
--- a/src/features/nav/NavLabel.tsx
+++ b/src/features/nav/NavLabel.tsx
@@ -16,7 +16,7 @@ export const NavLabel = ({
       onClick={onClick}
       css={{
         my: '$md',
-        cursor: onClick ? 'pointer' : 'default',
+        cursor: onClick ? 'pointer' : 'inherit',
         '&:hover svg': { color: '$cta' },
         '@lg': {
           my: '$sm',


### PR DESCRIPTION
org and circle labels in side nav did not have pointer cursor.

Hovering over the labels in side nav should inherit the cursor style of the parent, not use browser default. 