### PR TITLE
update queries after removing users

### DIFF
--- a/src/pages/MembersPage/LeaveCircleModal.tsx
+++ b/src/pages/MembersPage/LeaveCircleModal.tsx
@@ -1,4 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod';
+import { QUERY_KEY_NAV } from 'features/nav';
+import { QUERY_KEY_GET_ORG_MEMBERS_DATA } from 'features/orgs/getOrgMembersData';
 import { deleteUser } from 'lib/gql/mutations';
 import { useForm } from 'react-hook-form';
 import { useQueryClient } from 'react-query';
@@ -11,6 +13,8 @@ import useConnectedAddress from 'hooks/useConnectedAddress';
 import { QUERY_KEY_MY_ORGS } from 'pages/CirclesPage/getOrgData';
 import { paths } from 'routes/paths';
 import { Button, Flex, Form, Modal, Text } from 'ui';
+
+import { QUERY_KEY_GET_MEMBERS_PAGE_DATA } from './getMembersPageData';
 
 export const LeaveCircleModal = ({
   epochIsActive,
@@ -54,6 +58,9 @@ export const LeaveCircleModal = ({
     await deleteUser(circleId, address)
       .then(() => {
         queryClient.invalidateQueries(QUERY_KEY_MY_ORGS);
+        queryClient.invalidateQueries(QUERY_KEY_GET_ORG_MEMBERS_DATA);
+        queryClient.invalidateQueries(QUERY_KEY_NAV);
+        queryClient.invalidateQueries(QUERY_KEY_GET_MEMBERS_PAGE_DATA);
         onClose();
         navigate(paths.home);
       })

--- a/src/pages/MembersPage/index.tsx
+++ b/src/pages/MembersPage/index.tsx
@@ -1,8 +1,9 @@
 import assert from 'assert';
 import React, { useState, useMemo, useEffect } from 'react';
 
+import { QUERY_KEY_GET_ORG_MEMBERS_DATA } from 'features/orgs/getOrgMembersData';
 import { isUserAdmin } from 'lib/users';
-import { useQuery } from 'react-query';
+import { useQuery, useQueryClient } from 'react-query';
 import { NavLink } from 'react-router-dom';
 import { disabledStyle } from 'stitches.config';
 
@@ -40,6 +41,7 @@ const MembersPage = () => {
   >(undefined);
   const [newCircle, setNewCircle] = useState<boolean>(false);
 
+  const queryClient = useQueryClient();
   useEffect(() => {
     // do this initialization in useEffect because window is only available client side -g
     if (typeof window !== 'undefined') {
@@ -223,7 +225,12 @@ const MembersPage = () => {
               deleteUserDialog
                 ? () =>
                     deleteUser(deleteUserDialog.address)
-                      .then(() => setDeleteUserDialog(undefined))
+                      .then(() => {
+                        queryClient.invalidateQueries(
+                          QUERY_KEY_GET_ORG_MEMBERS_DATA
+                        );
+                        setDeleteUserDialog(undefined);
+                      })
                       .catch(() => setDeleteUserDialog(undefined))
                 : undefined
             }


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0bb1f2b</samp>

The pull request enhances the data fetching and caching logic for the members page and the leave circle modal. It uses `react-query` hooks and query keys to invalidate and refetch the data when a user deletes or leaves a circle.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0bb1f2b</samp>

> _`useQueryClient`_
> _refreshes circle members_
> _snow melts, data flows_

## Why

1- update org members page after removing circle users.
2- update circle members table after leaving a circle because the user have access now to all org circles member pages

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->


## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0bb1f2b</samp>

*  Invalidate queries related to navigation, organization members, and members page when a user leaves a circle ([link](https://github.com/coordinape/coordinape/pull/2145/files?diff=unified&w=0#diff-8f26d825bed35206580868c19f6db1262fc985c7d50f5e6a121393982bcb0a80R2-R3), [link](https://github.com/coordinape/coordinape/pull/2145/files?diff=unified&w=0#diff-8f26d825bed35206580868c19f6db1262fc985c7d50f5e6a121393982bcb0a80R17-R18), [link](https://github.com/coordinape/coordinape/pull/2145/files?diff=unified&w=0#diff-8f26d825bed35206580868c19f6db1262fc985c7d50f5e6a121393982bcb0a80R61-R63))
* Invalidate query related to members page when a user is deleted from a circle ([link](https://github.com/coordinape/coordinape/pull/2145/files?diff=unified&w=0#diff-3542d8369608d1e2fa5d024ff6c10db3675e17f26cb650a3a4781d8826fa4c5cL4-R6), [link](https://github.com/coordinape/coordinape/pull/2145/files?diff=unified&w=0#diff-3542d8369608d1e2fa5d024ff6c10db3675e17f26cb650a3a4781d8826fa4c5cR44), [link](https://github.com/coordinape/coordinape/pull/2145/files?diff=unified&w=0#diff-3542d8369608d1e2fa5d024ff6c10db3675e17f26cb650a3a4781d8826fa4c5cL226-R233))
