### PR TITLE
Setup optimismGoerli deploy and contracts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,8 @@ HARDHAT_FORK_BLOCK=13500000
 HARDHAT_OWNER_ADDRESS=0xYOUR_DEV_ADDRESS
 TEST_ON_HARDHAT_NODE=
 
+#OPTIMISM_GOERLI_MNEMONIC=add a mnemonic for use deploying to optimism goerli
+
 # used to fork mainnet when testing
 HARDHAT_ARCHIVE_RPC_URL=https://mainnet.infura.io/v3/your_infura_project_id
 

--- a/hardhat/deploymentInfo.json
+++ b/hardhat/deploymentInfo.json
@@ -93,6 +93,14 @@
       "address": "0xcf744802f65d2030b1168526f8f2a8d0703bac00"
     }
   },
+  "420": {
+    "CoSoul": {
+      "address": "0x05D38f3E361b0dDC716BB7093F7Bb97cC6AaACE2"
+    },
+    "SoulProxy": {
+      "address": "0x1bD182105856bFa5Be32230516a7bfb6f8A890D0"
+    }
+  },
   "1337": {
     "ApeDistributor": {
       "address": "0xc5a5C42992dECbae36851359345FE25997F5C42d"

--- a/hardhat/dist/deploymentInfo.json
+++ b/hardhat/dist/deploymentInfo.json
@@ -93,6 +93,14 @@
             "address": "0xcf744802f65d2030b1168526f8f2a8d0703bac00"
         }
     },
+    "420": {
+        "CoSoul": {
+            "address": "0x05D38f3E361b0dDC716BB7093F7Bb97cC6AaACE2"
+        },
+        "SoulProxy": {
+            "address": "0x1bD182105856bFa5Be32230516a7bfb6f8A890D0"
+        }
+    },
     "1337": {
         "ApeDistributor": {
             "address": "0xc5a5C42992dECbae36851359345FE25997F5C42d"

--- a/hardhat/dist/hardhat.config.js
+++ b/hardhat/dist/hardhat.config.js
@@ -18,6 +18,7 @@ const unlockSigner_1 = require("./utils/unlockSigner");
         console.log(`(${accountId}) ${account.address} (${ethers_1.ethers.utils.formatEther(balance)} ETH)`);
     });
 });
+const defaultMnemonic = 'test test test test test test test test test test test junk';
 // FIXME: DRY
 const tokens = {
     DAI: {
@@ -120,7 +121,7 @@ const sharedNetworkSettings = {
     gasPrice: 'auto',
     gasMultiplier: 1,
     accounts: {
-        mnemonic: 'test test test test test test test test test test test junk',
+        mnemonic: defaultMnemonic,
         initialBalance: '10900000000000000000',
     },
     deploy: ['./scripts/deploy'],
@@ -179,7 +180,7 @@ const config = {
             chainId: 420,
             url: 'https://goerli.optimism.io',
             accounts: {
-                mnemonic: process.env.OPTIMISM_GOERLI_MNEMONIC,
+                mnemonic: process.env.OPTIMISM_GOERLI_MNEMONIC || defaultMnemonic,
             },
             deploy: ['./scripts/deploy/03-cosoul/'],
             live: true,

--- a/hardhat/dist/hardhat.config.js
+++ b/hardhat/dist/hardhat.config.js
@@ -146,6 +146,12 @@ const config = {
         proxyAdmin: {
             default: 10,
         },
+        pgiveSyncer: {
+            default: 11,
+        },
+        coSoulSigner: {
+            default: 12,
+        },
     },
     paths: {
         sources: './contracts/coordinape-protocol/contracts',
@@ -168,6 +174,15 @@ const config = {
             ...sharedNetworkSettings,
             chainId: +(process.env.HARDHAT_GANACHE_CHAIN_ID || 1338),
             url: constants_1.GANACHE_URL,
+        },
+        optimismGoerli: {
+            chainId: 420,
+            url: 'https://goerli.optimism.io',
+            accounts: {
+                mnemonic: process.env.OPTIMISM_GOERLI_MNEMONIC,
+            },
+            deploy: ['./scripts/deploy/03-cosoul/'],
+            live: true,
         },
     },
 };

--- a/hardhat/hardhat.config.ts
+++ b/hardhat/hardhat.config.ts
@@ -31,6 +31,9 @@ task('accounts', 'Prints the list of accounts', async (args, hre) => {
   });
 });
 
+const defaultMnemonic =
+  'test test test test test test test test test test test junk';
+
 // FIXME: DRY
 const tokens = {
   DAI: {
@@ -164,7 +167,7 @@ const sharedNetworkSettings = {
   gasPrice: 'auto' as const,
   gasMultiplier: 1,
   accounts: {
-    mnemonic: 'test test test test test test test test test test test junk',
+    mnemonic: defaultMnemonic,
     initialBalance: '10900000000000000000',
   },
   deploy: ['./scripts/deploy'],
@@ -224,7 +227,7 @@ const config: HardhatUserConfig = {
       chainId: 420,
       url: 'https://goerli.optimism.io',
       accounts: {
-        mnemonic: process.env.OPTIMISM_GOERLI_MNEMONIC,
+        mnemonic: process.env.OPTIMISM_GOERLI_MNEMONIC || defaultMnemonic,
       },
       deploy: ['./scripts/deploy/03-cosoul/'],
       live: true,

--- a/hardhat/hardhat.config.ts
+++ b/hardhat/hardhat.config.ts
@@ -220,6 +220,15 @@ const config: HardhatUserConfig = {
       chainId: +(process.env.HARDHAT_GANACHE_CHAIN_ID || 1338),
       url: GANACHE_URL,
     },
+    optimismGoerli: {
+      chainId: 420,
+      url: 'https://goerli.optimism.io',
+      accounts: {
+        mnemonic: process.env.OPTIMISM_GOERLI_MNEMONIC,
+      },
+      deploy: ['./scripts/deploy/03-cosoul/'],
+      live: true,
+    },
   },
 };
 

--- a/hardhat/package.json
+++ b/hardhat/package.json
@@ -10,6 +10,7 @@
     "codegen": "ts-node scripts/generate-deployment-info.ts",
     "dev": "./scripts/start-node.sh",
     "deploy": "hardhat deploy",
+    "deploy:optimismgoerli": "hardhat deploy --network optimismGoerli",
     "typecheck": "tsc --noEmit"
   },
   "files": [

--- a/hardhat/scripts/deploy/03-cosoul/00-cosoul-deploy.ts
+++ b/hardhat/scripts/deploy/03-cosoul/00-cosoul-deploy.ts
@@ -43,7 +43,13 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     cosoul_implementation.address,
     deployerSigner
   ).attach(cosoul_proxy.address);
-  await cosoul.setCallers(pgiveSyncer, true);
+
+  const setCaller = await cosoul.setCallers(pgiveSyncer, true);
+  // eslint-disable-next-line no-console
+  console.log(
+    `cosoul.setCallers set to ${pgiveSyncer} via tx: `,
+    setCaller.hash
+  );
 };
 export default func;
 func.id = 'deploy_cosoul';

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -14,6 +14,9 @@ export const IN_PRODUCTION =
   process.env.NODE_ENV === 'production' &&
   process.env.REACT_APP_VERCEL_ENV !== 'preview';
 
+export const IN_PREVIEW = process.env.REACT_APP_VERCEL_ENV === 'preview';
+
+// IN_DEVELOPMENT is true for localhost and vercel staging
 export const IN_DEVELOPMENT =
   process.env.NODE_ENV === 'development' ||
   process.env.REACT_APP_VERCEL_ENV !== 'production';

--- a/src/features/cosoul/chains.ts
+++ b/src/features/cosoul/chains.ts
@@ -1,6 +1,4 @@
-import { IN_DEVELOPMENT } from '../../config/env';
-
-const TEST_NETWORK = true;
+import { IN_PREVIEW, IN_PRODUCTION } from '../../config/env';
 
 const optimism = {
   chainId: '0xa',
@@ -14,7 +12,7 @@ const optimism = {
   },
 };
 
-const optimismTestNetwork = {
+const optimismGoerli = {
   chainId: '0x1A4',
   chainName: 'Optimism Goerli',
   rpcUrls: ['https://goerli.optimism.io'],
@@ -37,8 +35,12 @@ const localhost = {
   },
 };
 
-export const chain = IN_DEVELOPMENT
-  ? localhost
-  : TEST_NETWORK
-  ? optimismTestNetwork
-  : optimism;
+// Get the proper chain based on the environment
+// production: optimism
+// staging: optimismGoerlu
+// localhost: localhost ganache
+export const chain = IN_PRODUCTION
+  ? optimism
+  : IN_PREVIEW
+  ? optimismGoerli
+  : localhost;


### PR DESCRIPTION
- add support for deploying the `CoSoul` contract on Optimism Goerli via `yarn deploy:optimismgoerli`.
- adds optimism goerli deploy to deploymentInfo and dist/ and sets up app for testing on goerli
- [x] set COSOUL env var feature flag to true on staging

Testing:
- go to staging: https://coordinape-git-add-deploy-command-coordinape.vercel.app/
- mint a cosoul on goerli
- rejoice
