### PR TITLE
add unique profile id

### DIFF
--- a/hasura/migrations/default/1685490914262_alter_table_public_cosouls_add_unique_profile_id/down.sql
+++ b/hasura/migrations/default/1685490914262_alter_table_public_cosouls_add_unique_profile_id/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."cosouls" drop constraint "cosouls_profile_id_key";

--- a/hasura/migrations/default/1685490914262_alter_table_public_cosouls_add_unique_profile_id/up.sql
+++ b/hasura/migrations/default/1685490914262_alter_table_public_cosouls_add_unique_profile_id/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."cosouls" add constraint "cosouls_profile_id_key" unique ("profile_id");


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0d1af19</samp>

This pull request adds a unique constraint on the `profile_id` column of the `cosouls` table in the database. This prevents duplicate records for the same user profile in the Coordinape platform.