### PR TITLE
Add animation_url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,8 @@ NODE_HASURA_URL=http://localhost:8080/v1/graphql
 TELEGRAM_BOT_TOKEN=your-telegramt-testing-bot-token
 IMAGES_AWS_ENDPOINT=http://s3.localhost.localstack.cloud:4566
 
+WEB_APP_BASE_URL=http://localhost:3000
+
 # Staging Environment
 #REACT_APP_HASURA_URL=https://coordinape-staging.hasura.app/v1/graphql
 #REACT_APP_S3_BASE_URL=https://coordinape-staging.s3.amazonaws.com/

--- a/api/cosoul/metadata/[tokenId].ts
+++ b/api/cosoul/metadata/[tokenId].ts
@@ -55,8 +55,12 @@ async function getCosoulMetaData(tokenId: number) {
   const coSoulData = cosouls.pop();
   assert(coSoulData?.pgive !== undefined, 'error fetching cosoul data');
 
-  const createdAtUnix = new Date(coSoulData.created_at).getTime() / 1000;
+  const createdAtUnix = Math.floor(
+    new Date(coSoulData.created_at).getTime() / 1000
+  );
   const pgiveLevel = Math.floor(coSoulData.pgive / 1000) + 1;
+
+  const animation_url = `${WEB_APP_BASE_URL}/cosoul/art?address=${coSoulData.profile.address}&pgive=${coSoulData.pgive}&animate=true`;
 
   return {
     description: 'A Coordinape Cosoul',
@@ -64,9 +68,14 @@ async function getCosoulMetaData(tokenId: number) {
     //TODO: This will be a static S3 Thumbnail image path
     image: 'path',
     name: `${coSoulData.profile.name}'s Cosoul`,
+    animation_url: animation_url,
     attributes: [
       { trait_type: 'pGive', value: coSoulData.pgive },
-      { display_type: 'date', trait_type: 'mint date', value: createdAtUnix },
+      {
+        display_type: 'date',
+        trait_type: 'mint date',
+        value: createdAtUnix,
+      },
       { trait_type: 'level', value: pgiveLevel },
     ],
   };


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 319963b</samp>

This pull request adds support for animated CoSoul NFTs by generating and formatting the `animation_url` property in the metadata endpoint and adding a new environment variable `WEB_APP_BASE_URL` to the `.env.example` file.

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 319963b</samp>

* Add a new environment variable `WEB_APP_BASE_URL` to the `.env.example` file for constructing the animation URL for the CoSoul NFTs ([link](https://github.com/coordinape/coordinape/pull/2179/files?diff=unified&w=0#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR73-R74))
  - Use the `WEB_APP_BASE_URL` variable and the `coSoulData` object to generate the `animation_url` for the CoSoul NFT ([link](https://github.com/coordinape/coordinape/pull/2179/files?diff=unified&w=0#diff-e8f0277d6e465db91324fc6ac3dce8949d80850e95e0bb69a92a326a9b0799c8L58-R64))
  - Return the `animation_url` as part of the metadata object for the NFT ([link](https://github.com/coordinape/coordinape/pull/2179/files?diff=unified&w=0#diff-e8f0277d6e465db91324fc6ac3dce8949d80850e95e0bb69a92a326a9b0799c8L67-R78))
  - Format the `createdAtUnix` variable using `Math.floor` instead of `new Date` ([link](https://github.com/coordinape/coordinape/pull/2179/files?diff=unified&w=0#diff-e8f0277d6e465db91324fc6ac3dce8949d80850e95e0bb69a92a326a9b0799c8L58-R64))
  - Format the `attributes` array with consistent indentation and line breaks ([link](https://github.com/coordinape/coordinape/pull/2179/files?diff=unified&w=0#diff-e8f0277d6e465db91324fc6ac3dce8949d80850e95e0bb69a92a326a9b0799c8L67-R78))
