### PR TITLE
Don't send sample org/circle events to Mixpanel

### DIFF
--- a/api-test/helpers/organizations.ts
+++ b/api-test/helpers/organizations.ts
@@ -1,18 +1,23 @@
 import faker from 'faker';
+import merge from 'lodash/merge';
 
 import type { GQLClientType } from './common';
 
 export async function createOrganization(
   client: GQLClientType,
-  object?: { name: string }
+  object?: { name?: string; sample?: boolean }
 ) {
   const { insert_organizations_one } = await client.mutate(
     {
       insert_organizations_one: [
         {
-          object: object || {
-            name: faker.company.companyName(),
-          },
+          object: merge(
+            {
+              name: faker.company.companyName(),
+              sample: false,
+            },
+            object || {}
+          ),
         },
         { id: true, name: true },
       ],


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1814a87</samp>

Improved the Mixpanel event handler and its test file to handle sample events and return more informative responses. Enhanced the `createOrganization` helper function to support more test scenarios.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1814a87</samp>

> _We mock the events of Mixpanel_
> _We skip the samples with our skill_
> _We create our own organizations_
> _We merge them with the power of `lodash`_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1814a87</samp>

* Skip tracking events from sample organizations in Mixpanel ([link](https://github.com/coordinape/coordinape/pull/2181/files?diff=unified&w=0#diff-6d30572651263bedc825deaa2e2f35d0da7bf93588b7241c81f281fe1b056fd6R82-R84),[link](https://github.com/coordinape/coordinape/pull/2181/files?diff=unified&w=0#diff-76d86fe16e4c0c8dd5976007145bc1f962a3fea9f80a041237e265d81cf52eefR81-R115))
  - Modify `addPropsAndTrack` function to return false and exit early if event data has `sample` property ([link](https://github.com/coordinape/coordinape/pull/2181/files?diff=unified&w=0#diff-6d30572651263bedc825deaa2e2f35d0da7bf93588b7241c81f281fe1b056fd6R82-R84))
  - Modify handler function to return different response message based on return value of `addPropsAndTrack` function ([link](https://github.com/coordinape/coordinape/pull/2181/files?diff=unified&w=0#diff-6d30572651263bedc825deaa2e2f35d0da7bf93588b7241c81f281fe1b056fd6L25-R29),[link](https://github.com/coordinape/coordinape/pull/2181/files?diff=unified&w=0#diff-6d30572651263bedc825deaa2e2f35d0da7bf93588b7241c81f281fe1b056fd6L36-R38))
  - Add test case to check that handler function ignores events from sample organizations and sends appropriate response message ([link](https://github.com/coordinape/coordinape/pull/2181/files?diff=unified&w=0#diff-76d86fe16e4c0c8dd5976007145bc1f962a3fea9f80a041237e265d81cf52eefR81-R115))
* Import and use `createOrganization` helper function in test file ([link](https://github.com/coordinape/coordinape/pull/2181/files?diff=unified&w=0#diff-76d86fe16e4c0c8dd5976007145bc1f962a3fea9f80a041237e265d81cf52eefL4-R12),[link](https://github.com/coordinape/coordinape/pull/2181/files?diff=unified&w=0#diff-fd01498ea64d87e786bfc31eb5d365f5cafc2ebdb4a9bc15291764d04dea587cR2),[link](https://github.com/coordinape/coordinape/pull/2181/files?diff=unified&w=0#diff-fd01498ea64d87e786bfc31eb5d365f5cafc2ebdb4a9bc15291764d04dea587cL7-R8),[link](https://github.com/coordinape/coordinape/pull/2181/files?diff=unified&w=0#diff-fd01498ea64d87e786bfc31eb5d365f5cafc2ebdb4a9bc15291764d04dea587cL13-R20))
  - Import `createOrganization` helper function from `api-test/helpers` to create test organizations ([link](https://github.com/coordinape/coordinape/pull/2181/files?diff=unified&w=0#diff-76d86fe16e4c0c8dd5976007145bc1f962a3fea9f80a041237e265d81cf52eefL4-R12),[link](https://github.com/coordinape/coordinape/pull/2181/files?diff=unified&w=0#diff-fd01498ea64d87e786bfc31eb5d365f5cafc2ebdb4a9bc15291764d04dea587cR2))
  - Modify `createOrganization` helper function to accept optional object parameter with `name` and `sample` properties ([link](https://github.com/coordinape/coordinape/pull/2181/files?diff=unified&w=0#diff-fd01498ea64d87e786bfc31eb5d365f5cafc2ebdb4a9bc15291764d04dea587cL7-R8),[link](https://github.com/coordinape/coordinape/pull/2181/files?diff=unified&w=0#diff-fd01498ea64d87e786bfc31eb5d365f5cafc2ebdb4a9bc15291764d04dea587cL13-R20))
  - Use `createOrganization` helper function to create sample and non-sample organizations in test case ([link](https://github.com/coordinape/coordinape/pull/2181/files?diff=unified&w=0#diff-76d86fe16e4c0c8dd5976007145bc1f962a3fea9f80a041237e265d81cf52eefL22-R30))
* Move test variables from `beforeAll` hook to individual test case and add `afterEach` hook ([link](https://github.com/coordinape/coordinape/pull/2181/files?diff=unified&w=0#diff-76d86fe16e4c0c8dd5976007145bc1f962a3fea9f80a041237e265d81cf52eefL22-R30),[link](https://github.com/coordinape/coordinape/pull/2181/files?diff=unified&w=0#diff-76d86fe16e4c0c8dd5976007145bc1f962a3fea9f80a041237e265d81cf52eefR81-R115))
  - Move `circle` and `user` variables from `beforeAll` hook to individual test case to avoid side effects and make test more isolated ([link](https://github.com/coordinape/coordinape/pull/2181/files?diff=unified&w=0#diff-76d86fe16e4c0c8dd5976007145bc1f962a3fea9f80a041237e265d81cf52eefL22-R30))
  - Add `afterEach` hook to clear mock calls after each test to prevent interference between tests ([link](https://github.com/coordinape/coordinape/pull/2181/files?diff=unified&w=0#diff-76d86fe16e4c0c8dd5976007145bc1f962a3fea9f80a041237e265d81cf52eefL22-R30),[link](https://github.com/coordinape/coordinape/pull/2181/files?diff=unified&w=0#diff-76d86fe16e4c0c8dd5976007145bc1f962a3fea9f80a041237e265d81cf52eefR81-R115))
* Return true at the end of `addPropsAndTrack` function to indicate event was processed ([link](https://github.com/coordinape/coordinape/pull/2181/files?diff=unified&w=0#diff-6d30572651263bedc825deaa2e2f35d0da7bf93588b7241c81f281fe1b056fd6R104))
  - Modify `addPropsAndTrack` function to return true at the end of the function, after tracking the event, to provide consistent return value ([link](https://github.com/coordinape/coordinape/pull/2181/files?diff=unified&w=0#diff-6d30572651263bedc825deaa2e2f35d0da7bf93588b7241c81f281fe1b056fd6R104))
