### PR TITLE
change get started in circles page to a tag

### DIFF
--- a/src/pages/CirclesPage/CirclesPage.tsx
+++ b/src/pages/CirclesPage/CirclesPage.tsx
@@ -170,14 +170,11 @@ const GetStarted = () => {
           <Button as={NavLink} to={paths.createCircle} color="cta">
             Create New Circle
           </Button>
-          <Button
-            as={NavLink}
-            to={`//${EXTERNAL_URL_GET_STARTED}`}
-            target="_blank"
-            color="secondary"
-          >
-            Get Started Guide
-          </Button>
+          <Link href={EXTERNAL_URL_GET_STARTED} target="_blank">
+            <Button color="secondary" inline>
+              Get Started Guide
+            </Button>
+          </Link>
         </Flex>
       </HintBanner>
       <Image


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dceeb46</samp>

Fixed a bug and improved the UI of the `Get Started Guide` button on the `CirclesPage`. Changed the button component and added a prop in `src/pages/CirclesPage/CirclesPage.tsx`.

## Why

it's an external link so I changed it to a tag (Link component) to avoid appended http 


## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dceeb46</samp>

* Changed the `Get Started Guide` button to use a `Link` component and have an `inline` prop ([link](https://github.com/coordinape/coordinape/pull/2193/files?diff=unified&w=0#diff-421fa9c09a7ada013cfda15f9d977e9373efb046e2c52279b29b9e0dc9ddd2b0L173-R177))
