### PR TITLE
Add mixpanel interaction events

### DIFF
--- a/api-lib/gql/__generated__/zeus/const.ts
+++ b/api-lib/gql/__generated__/zeus/const.ts
@@ -50,6 +50,9 @@ export const AllTypesProps: Record<string, any> = {
   GuildInfoInput: {},
   IdInput: {},
   Int_comparison_exp: {},
+  InteractionEventInput: {
+    data: 'jsonb',
+  },
   LinkDiscordCircleInput: {},
   LinkDiscordUserInput: {},
   LogVaultTxInput: {},
@@ -4404,6 +4407,9 @@ export const AllTypesProps: Record<string, any> = {
     },
     giveCsv: {
       payload: 'GiveCsvInput',
+    },
+    insertInteractionEvent: {
+      payload: 'InteractionEventInput',
     },
     insert_activities: {
       objects: 'activities_insert_input',
@@ -9610,6 +9616,10 @@ export const ReturnTypes: Record<string, any> = {
     member_count: 'Int',
     name: 'String',
   },
+  InteractionEventResponse: {
+    InsertInteractionEventResponse: 'interaction_events',
+    id: 'ID',
+  },
   LinkDiscordCircleResponse: {
     id: 'Int',
   },
@@ -12519,6 +12529,7 @@ export const ReturnTypes: Record<string, any> = {
     endEpoch: 'EpochResponse',
     generateApiKey: 'GenerateApiKeyResponse',
     giveCsv: 'GiveCsvResponse',
+    insertInteractionEvent: 'InteractionEventResponse',
     insert_activities: 'activities_mutation_response',
     insert_activities_one: 'activities',
     insert_burns: 'burns_mutation_response',

--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -868,6 +868,19 @@ export type ValueTypes = {
     _neq?: number | undefined | null;
     _nin?: Array<number> | undefined | null;
   };
+  ['InteractionEventInput']: {
+    circle_id?: number | undefined | null;
+    data?: ValueTypes['jsonb'] | undefined | null;
+    event_subtype?: string | undefined | null;
+    event_type: string;
+    org_id?: number | undefined | null;
+    profile_id?: number | undefined | null;
+  };
+  ['InteractionEventResponse']: AliasType<{
+    InsertInteractionEventResponse?: ValueTypes['interaction_events'];
+    id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
   ['LinkDiscordCircleInput']: {
     circle_id: number;
     token: string;
@@ -11790,6 +11803,10 @@ export type ValueTypes = {
     giveCsv?: [
       { payload: ValueTypes['GiveCsvInput'] },
       ValueTypes['GiveCsvResponse']
+    ];
+    insertInteractionEvent?: [
+      { payload: ValueTypes['InteractionEventInput'] },
+      ValueTypes['InteractionEventResponse']
     ];
     insert_activities?: [
       {
@@ -26692,6 +26709,13 @@ export type ModelTypes = {
   ['IdInput']: GraphQLTypes['IdInput'];
   /** Boolean expression to compare columns of type "Int". All fields are combined with logical 'AND'. */
   ['Int_comparison_exp']: GraphQLTypes['Int_comparison_exp'];
+  ['InteractionEventInput']: GraphQLTypes['InteractionEventInput'];
+  ['InteractionEventResponse']: {
+    InsertInteractionEventResponse?:
+      | GraphQLTypes['interaction_events']
+      | undefined;
+    id: string;
+  };
   ['LinkDiscordCircleInput']: GraphQLTypes['LinkDiscordCircleInput'];
   ['LinkDiscordCircleResponse']: {
     id: number;
@@ -31472,6 +31496,9 @@ export type ModelTypes = {
     generateApiKey?: GraphQLTypes['GenerateApiKeyResponse'] | undefined;
     /** giveCsv */
     giveCsv?: GraphQLTypes['GiveCsvResponse'] | undefined;
+    insertInteractionEvent?:
+      | GraphQLTypes['InteractionEventResponse']
+      | undefined;
     /** insert data into the table: "activities" */
     insert_activities?:
       | GraphQLTypes['activities_mutation_response']
@@ -36135,6 +36162,21 @@ export type GraphQLTypes = {
     _lte?: number | undefined;
     _neq?: number | undefined;
     _nin?: Array<number> | undefined;
+  };
+  ['InteractionEventInput']: {
+    circle_id?: number | undefined;
+    data?: GraphQLTypes['jsonb'] | undefined;
+    event_subtype?: string | undefined;
+    event_type: string;
+    org_id?: number | undefined;
+    profile_id?: number | undefined;
+  };
+  ['InteractionEventResponse']: {
+    __typename: 'InteractionEventResponse';
+    InsertInteractionEventResponse?:
+      | GraphQLTypes['interaction_events']
+      | undefined;
+    id: string;
   };
   ['LinkDiscordCircleInput']: {
     circle_id: number;
@@ -45364,6 +45406,9 @@ export type GraphQLTypes = {
     generateApiKey?: GraphQLTypes['GenerateApiKeyResponse'] | undefined;
     /** giveCsv */
     giveCsv?: GraphQLTypes['GiveCsvResponse'] | undefined;
+    insertInteractionEvent?:
+      | GraphQLTypes['InteractionEventResponse']
+      | undefined;
     /** insert data into the table: "activities" */
     insert_activities?:
       | GraphQLTypes['activities_mutation_response']

--- a/api/hasura/actions/_handlers/insertInteractionEvent.ts
+++ b/api/hasura/actions/_handlers/insertInteractionEvent.ts
@@ -1,0 +1,59 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { z } from 'zod';
+
+import { getProfilesWithAddress } from '../../../../api-lib/findProfile';
+import { adminClient } from '../../../../api-lib/gql/adminClient';
+import { getInput } from '../../../../api-lib/handlerHelpers';
+import { errorResponse } from '../../../../api-lib/HttpError';
+
+// for json validation
+const literalSchema = z.union([z.string(), z.number(), z.boolean(), z.null()]);
+type Literal = z.infer<typeof literalSchema>;
+type Json = Literal | { [key: string]: Json } | Json[];
+const jsonSchema: z.ZodType<Json> = z.lazy(() =>
+  z.union([literalSchema, z.array(jsonSchema), z.record(jsonSchema)])
+);
+
+const interactionEventInput = z
+  .object({
+    profile_id: z.number().optional(),
+    circle_id: z.number().optional(),
+    org_id: z.number().optional(),
+    event_type: z.string(),
+    event_subtype: z.string().optional(),
+    data: jsonSchema.optional(),
+  })
+  .strict();
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  try {
+    const { payload, session } = await getInput(req, interactionEventInput);
+
+    const address = session.hasuraAddress;
+
+    const profile = await getProfilesWithAddress(address);
+    const { insert_interaction_events_one } = await adminClient.mutate(
+      {
+        insert_interaction_events_one: [
+          {
+            object: {
+              ...payload,
+              profile_id: profile?.id,
+            },
+          },
+          {
+            id: true,
+          },
+        ],
+      },
+      { operationName: 'insertInteractionEvent' }
+    );
+
+    if (!insert_interaction_events_one) {
+      throw new Error('insert interaction event failed');
+    }
+    return res.status(200).json({ id: insert_interaction_events_one.id });
+  } catch (e: any) {
+    return errorResponse(res, e);
+  }
+}

--- a/api/hasura/actions/actionManager.ts
+++ b/api/hasura/actions/actionManager.ts
@@ -25,6 +25,7 @@ import endEpoch from './_handlers/endEpoch';
 import generateApiKey from './_handlers/generateApiKey';
 import guildInfo from './_handlers/getGuildInfo';
 import giveCsv from './_handlers/giveCsv';
+import insertInteractionEvent from './_handlers/insertInteractionEvent';
 import linkDiscordCircle from './_handlers/linkDiscordCircle';
 import linkDiscordUser from './_handlers/linkDiscordUser';
 import logoutUser from './_handlers/logoutUser';
@@ -67,6 +68,7 @@ const HANDLERS: HandlerDict = {
   generateApiKey,
   giveCsv,
   guildInfo,
+  insertInteractionEvent,
   linkDiscordCircle,
   linkDiscordUser,
   logoutUser,

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -87,6 +87,12 @@ type Mutation {
 }
 
 type Mutation {
+  insertInteractionEvent(
+    payload: InteractionEventInput!
+  ): InteractionEventResponse
+}
+
+type Mutation {
   linkDiscordCircle(payload: LinkDiscordCircleInput!): LinkDiscordCircleResponse
 }
 
@@ -457,6 +463,15 @@ input SyncCoSoulInput {
   tx_hash: String!
 }
 
+input InteractionEventInput {
+  profile_id: Int
+  circle_id: Int
+  org_id: Int
+  event_type: String!
+  event_subtype: String
+  data: jsonb
+}
+
 type CreateCircleResponse {
   id: Int!
 }
@@ -609,6 +624,10 @@ type GiveCsvResponse {
 
 type SyncCoSoulOutput {
   token_id: String
+}
+
+type InteractionEventResponse {
+  id: ID!
 }
 
 scalar timestamptz

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -205,6 +205,15 @@ actions:
     permissions:
       - role: user
     comment: giveCsv
+  - name: insertInteractionEvent
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_API_BASE_URL}}/actions/actionManager?action_name=insertInteractionEvent'
+      headers:
+        - name: verification_key
+          value_from_env: HASURA_EVENT_SECRET
+    permissions:
+      - role: user
   - name: linkDiscordCircle
     definition:
       kind: synchronous
@@ -426,6 +435,7 @@ custom_types:
     - name: IdInput
     - name: GiveCsvInput
     - name: SyncCoSoulInput
+    - name: InteractionEventInput
   objects:
     - name: CreateCircleResponse
       relationships:
@@ -650,5 +660,15 @@ custom_types:
     - name: SuccessResponse
     - name: GiveCsvResponse
     - name: SyncCoSoulOutput
+    - name: InteractionEventResponse
+      relationships:
+        - field_mapping:
+            id: id
+          name: InsertInteractionEventResponse
+          remote_table:
+            name: interaction_events
+            schema: public
+          source: default
+          type: object
   scalars:
     - name: timestamptz

--- a/hasura/schema/admin/schema.graphql
+++ b/hasura/schema/admin/schema.graphql
@@ -340,6 +340,20 @@ input Int_comparison_exp {
   _nin: [Int!]
 }
 
+input InteractionEventInput {
+  circle_id: Int
+  data: jsonb
+  event_subtype: String
+  event_type: String!
+  org_id: Int
+  profile_id: Int
+}
+
+type InteractionEventResponse {
+  InsertInteractionEventResponse: interaction_events
+  id: ID!
+}
+
 input LinkDiscordCircleInput {
   circle_id: Int!
   token: String!
@@ -16563,6 +16577,9 @@ type mutation_root {
   giveCsv
   """
   giveCsv(payload: GiveCsvInput!): GiveCsvResponse
+  insertInteractionEvent(
+    payload: InteractionEventInput!
+  ): InteractionEventResponse
 
   """
   insert data into the table: "activities"

--- a/hasura/schema/user/schema.graphql
+++ b/hasura/schema/user/schema.graphql
@@ -306,6 +306,19 @@ input Int_comparison_exp {
   _nin: [Int!]
 }
 
+input InteractionEventInput {
+  circle_id: Int
+  data: jsonb
+  event_subtype: String
+  event_type: String!
+  org_id: Int
+  profile_id: Int
+}
+
+type InteractionEventResponse {
+  id: ID!
+}
+
 input LinkDiscordCircleInput {
   circle_id: Int!
   token: String!
@@ -8087,6 +8100,9 @@ type mutation_root {
   giveCsv
   """
   giveCsv(payload: GiveCsvInput!): GiveCsvResponse
+  insertInteractionEvent(
+    payload: InteractionEventInput!
+  ): InteractionEventResponse
 
   """
   insert data into the table: "circle_integrations"

--- a/src/features/cosoul/CoSoulOverview.tsx
+++ b/src/features/cosoul/CoSoulOverview.tsx
@@ -1,6 +1,9 @@
+import { useEffect } from 'react';
+
 import { Flex, Panel, Text } from 'ui';
 import { numberWithCommas } from 'utils';
 
+import { addInteractionEvent } from './addInteractionEvent';
 import { CoSoulButton } from './CoSoulButton';
 import { QueryCoSoulResult } from './getCoSoulData';
 import { artWidth, artWidthMobile } from './MintPage';
@@ -12,6 +15,15 @@ export const CoSoulOverview = ({
 }: {
   cosoul_data: CoSoulData;
 }) => {
+  useEffect(() => {
+    const insertInteractionEvent = async () => {
+      await addInteractionEvent({
+        event_type: 'visit_cosoul_mint',
+      });
+    };
+    insertInteractionEvent();
+  }, []);
+
   return (
     <Panel
       css={{

--- a/src/features/cosoul/MintOrBurnButton.tsx
+++ b/src/features/cosoul/MintOrBurnButton.tsx
@@ -6,6 +6,7 @@ import { client } from '../../lib/gql/client';
 import { Button, Text } from '../../ui';
 import { sendAndTrackTx } from '../../utils/contractHelpers';
 
+import { addInteractionEvent } from './addInteractionEvent';
 import { Contracts } from './contracts';
 import { useCoSoulToken } from './useCoSoulToken';
 
@@ -79,6 +80,11 @@ const MintButton = ({
   const [awaitingWallet, setAwaitingWallet] = useState(false);
 
   const mint = async () => {
+    await addInteractionEvent({
+      event_type: 'mint_cosoul_clicked',
+      data: { chainId: contracts.chainId },
+    });
+
     try {
       setAwaitingWallet(true);
       const { receipt /*, tx*/ } = await sendAndTrackTx(
@@ -93,10 +99,18 @@ const MintButton = ({
         }
       );
       if (receipt) {
+        await addInteractionEvent({
+          event_type: 'mint_cosoul_success',
+          data: { chainId: contracts.chainId },
+        });
         onSuccess(receipt.transactionHash);
       }
     } catch (e: any) {
       showError('Error Minting: ' + e.message);
+      await addInteractionEvent({
+        event_type: 'mint_cosoul_failure',
+        data: { chainId: contracts.chainId },
+      });
     } finally {
       setAwaitingWallet(false);
     }
@@ -141,10 +155,18 @@ const BurnButton = ({
         }
       );
       if (receipt) {
+        await addInteractionEvent({
+          event_type: 'burn_cosoul_success',
+          data: { chainId: contracts.chainId },
+        });
         onSuccess(receipt.transactionHash);
       }
     } catch (e: any) {
       showError('Error Minting: ' + e.message);
+      await addInteractionEvent({
+        event_type: 'burn_cosoul_failure',
+        data: { chainId: contracts.chainId },
+      });
     }
   };
 

--- a/src/features/cosoul/SplashPage.tsx
+++ b/src/features/cosoul/SplashPage.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import { sync } from 'keyframes';
 import { NavLink } from 'react-router-dom';
 
@@ -7,9 +9,21 @@ import { paths } from 'routes/paths';
 import { Box, Button, Flex, Text } from 'ui';
 import { SingleColumnLayout } from 'ui/layouts';
 
+import { addInteractionEvent } from './addInteractionEvent';
+
 export const SplashPage = () => {
   const address = useConnectedAddress();
   const hasCoSoul = true;
+
+  useEffect(() => {
+    const insertInteractionEvent = async () => {
+      await addInteractionEvent({
+        event_type: 'visit_cosoul_about',
+      });
+    };
+    insertInteractionEvent();
+  }, []);
+
   if (!isFeatureEnabled('cosoul')) {
     return <></>;
   }

--- a/src/features/cosoul/addInteractionEvent.ts
+++ b/src/features/cosoul/addInteractionEvent.ts
@@ -1,0 +1,37 @@
+import { client } from 'lib/gql/client';
+import { z } from 'zod';
+
+// for json validation
+const literalSchema = z.union([z.string(), z.number(), z.boolean(), z.null()]);
+type Literal = z.infer<typeof literalSchema>;
+type Json = Literal | { [key: string]: Json } | Json[];
+const jsonSchema: z.ZodType<Json> = z.lazy(() =>
+  z.union([literalSchema, z.array(jsonSchema), z.record(jsonSchema)])
+);
+
+const interactionEventInput = z
+  .object({
+    profile_id: z.number().optional(),
+    circle_id: z.number().optional(),
+    org_id: z.number().optional(),
+    event_type: z.string(),
+    event_subtype: z.string().optional(),
+    data: jsonSchema.optional(),
+  })
+  .strict();
+
+type addInteractionEventType = z.infer<typeof interactionEventInput>;
+
+export const addInteractionEvent = async (payload: addInteractionEventType) => {
+  await client.mutate(
+    {
+      insertInteractionEvent: [
+        {
+          payload,
+        },
+        { id: true },
+      ],
+    },
+    { operationName: 'addInteractionEvent_insertInteractionEvent' }
+  );
+};

--- a/src/lib/gql/__generated__/zeus/const.ts
+++ b/src/lib/gql/__generated__/zeus/const.ts
@@ -44,6 +44,9 @@ export const AllTypesProps: Record<string, any> = {
   GuildInfoInput: {},
   IdInput: {},
   Int_comparison_exp: {},
+  InteractionEventInput: {
+    data: 'jsonb',
+  },
   LinkDiscordCircleInput: {},
   LinkDiscordUserInput: {},
   LogVaultTxInput: {},
@@ -2667,6 +2670,9 @@ export const AllTypesProps: Record<string, any> = {
     },
     giveCsv: {
       payload: 'GiveCsvInput',
+    },
+    insertInteractionEvent: {
+      payload: 'InteractionEventInput',
     },
     insert_circle_integrations: {
       objects: 'circle_integrations_insert_input',
@@ -5764,6 +5770,9 @@ export const ReturnTypes: Record<string, any> = {
     member_count: 'Int',
     name: 'String',
   },
+  InteractionEventResponse: {
+    id: 'ID',
+  },
   LinkDiscordCircleResponse: {
     id: 'Int',
   },
@@ -6758,6 +6767,7 @@ export const ReturnTypes: Record<string, any> = {
     endEpoch: 'EpochResponse',
     generateApiKey: 'GenerateApiKeyResponse',
     giveCsv: 'GiveCsvResponse',
+    insertInteractionEvent: 'InteractionEventResponse',
     insert_circle_integrations: 'circle_integrations_mutation_response',
     insert_circle_integrations_one: 'circle_integrations',
     insert_circle_share_tokens: 'circle_share_tokens_mutation_response',

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -840,6 +840,18 @@ export type ValueTypes = {
     _neq?: number | undefined | null;
     _nin?: Array<number> | undefined | null;
   };
+  ['InteractionEventInput']: {
+    circle_id?: number | undefined | null;
+    data?: ValueTypes['jsonb'] | undefined | null;
+    event_subtype?: string | undefined | null;
+    event_type: string;
+    org_id?: number | undefined | null;
+    profile_id?: number | undefined | null;
+  };
+  ['InteractionEventResponse']: AliasType<{
+    id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
   ['LinkDiscordCircleInput']: {
     circle_id: number;
     token: string;
@@ -6239,6 +6251,10 @@ export type ValueTypes = {
     giveCsv?: [
       { payload: ValueTypes['GiveCsvInput'] },
       ValueTypes['GiveCsvResponse']
+    ];
+    insertInteractionEvent?: [
+      { payload: ValueTypes['InteractionEventInput'] },
+      ValueTypes['InteractionEventResponse']
     ];
     insert_circle_integrations?: [
       {
@@ -13715,6 +13731,10 @@ export type ModelTypes = {
   ['IdInput']: GraphQLTypes['IdInput'];
   /** Boolean expression to compare columns of type "Int". All fields are combined with logical 'AND'. */
   ['Int_comparison_exp']: GraphQLTypes['Int_comparison_exp'];
+  ['InteractionEventInput']: GraphQLTypes['InteractionEventInput'];
+  ['InteractionEventResponse']: {
+    id: string;
+  };
   ['LinkDiscordCircleInput']: GraphQLTypes['LinkDiscordCircleInput'];
   ['LinkDiscordCircleResponse']: {
     id: number;
@@ -15588,6 +15608,9 @@ export type ModelTypes = {
     generateApiKey?: GraphQLTypes['GenerateApiKeyResponse'] | undefined;
     /** giveCsv */
     giveCsv?: GraphQLTypes['GiveCsvResponse'] | undefined;
+    insertInteractionEvent?:
+      | GraphQLTypes['InteractionEventResponse']
+      | undefined;
     /** insert data into the table: "circle_integrations" */
     insert_circle_integrations?:
       | GraphQLTypes['circle_integrations_mutation_response']
@@ -17690,6 +17713,18 @@ export type GraphQLTypes = {
     _lte?: number | undefined;
     _neq?: number | undefined;
     _nin?: Array<number> | undefined;
+  };
+  ['InteractionEventInput']: {
+    circle_id?: number | undefined;
+    data?: GraphQLTypes['jsonb'] | undefined;
+    event_subtype?: string | undefined;
+    event_type: string;
+    org_id?: number | undefined;
+    profile_id?: number | undefined;
+  };
+  ['InteractionEventResponse']: {
+    __typename: 'InteractionEventResponse';
+    id: string;
   };
   ['LinkDiscordCircleInput']: {
     circle_id: number;
@@ -22135,6 +22170,9 @@ export type GraphQLTypes = {
     generateApiKey?: GraphQLTypes['GenerateApiKeyResponse'] | undefined;
     /** giveCsv */
     giveCsv?: GraphQLTypes['GiveCsvResponse'] | undefined;
+    insertInteractionEvent?:
+      | GraphQLTypes['InteractionEventResponse']
+      | undefined;
     /** insert data into the table: "circle_integrations" */
     insert_circle_integrations?:
       | GraphQLTypes['circle_integrations_mutation_response']


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8a98a2d</samp>

This pull request adds a new feature to track user interactions in the coordinape app using a GraphQL mutation `insertInteractionEvent`. It defines the mutation and its types in the hasura actions metadata and schema files, and implements the handler function in the vercel API. It also updates the zeus library to generate the types and mutation for the frontend, and adds a helper function `addInteractionEvent` to simplify the usage of the mutation. It uses the `addInteractionEvent` function in several components related to the CoSoul feature to record user visits and actions on the CoSoul pages.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8a98a2d</samp>

> _Sing, O Muse, of the skillful code that the heroes wrought_
> _To track the deeds of users in the CoSoul app divine_
> _With `insertInteractionEvent`, a mighty action brought_
> _From Hasura's realm to Zeus's library and GraphQL's shrine_

## Why
1- Add insertInteractionEvent action on hasura

2- add the following events on FE :
- visit about CoSoul page
- visit Mint CoSoul page
- Click mint button
- on mint success
- exception on mint (error)
- on burn success


## Test and Deployment Plan

Visit cosoul page and mint then burn.

## Screenshots (if appropriate):

![image](https://github.com/coordinape/coordinape/assets/34943689/bd13d765-5a07-4360-89a8-4eebbaf58672)



## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8a98a2d</samp>

*  Add a new `insertInteractionEvent` action to record user interactions related to the CoSoul feature ([link](https://github.com/coordinape/coordinape/pull/2196/files?diff=unified&w=0#diff-6c5d0469845164066c90a886cf7108484db73f84790d8bd8f424010543ebddbdR1-R59), [link](https://github.com/coordinape/coordinape/pull/2196/files?diff=unified&w=0#diff-a6a476461d778e69905cd6d1cab214af3b0f749568bce39067fdde541f73a24eR28), [link](https://github.com/coordinape/coordinape/pull/2196/files?diff=unified&w=0#diff-a6a476461d778e69905cd6d1cab214af3b0f749568bce39067fdde541f73a24eR71), [link](https://github.com/coordinape/coordinape/pull/2196/files?diff=unified&w=0#diff-589f402dbb6eb11ea9c28e067ac01d020e1b8f8f087f45d59435eaae684975c3R90-R95), [link](https://github.com/coordinape/coordinape/pull/2196/files?diff=unified&w=0#diff-589f402dbb6eb11ea9c28e067ac01d020e1b8f8f087f45d59435eaae684975c3R466-R474), [link](https://github.com/coordinape/coordinape/pull/2196/files?diff=unified&w=0#diff-589f402dbb6eb11ea9c28e067ac01d020e1b8f8f087f45d59435eaae684975c3R629-R632), [link](https://github.com/coordinape/coordinape/pull/2196/files?diff=unified&w=0#diff-49e7aa4e1112b93bcdbd36419aeb0b64fb23ea532e80c9a0f5ff1c5a585763f9R208-R216), [link](https://github.com/coordinape/coordinape/pull/2196/files?diff=unified&w=0#diff-49e7aa4e1112b93bcdbd36419aeb0b64fb23ea532e80c9a0f5ff1c5a585763f9R438), [link](https://github.com/coordinape/coordinape/pull/2196/files?diff=unified&w=0#diff-49e7aa4e1112b93bcdbd36419aeb0b64fb23ea532e80c9a0f5ff1c5a585763f9R663-R672), [link](https://github.com/coordinape/coordinape/pull/2196/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R343-R356), [link](https://github.com/coordinape/coordinape/pull/2196/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R16580-R16582), [link](https://github.com/coordinape/coordinape/pull/2196/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebR309-R321), [link](https://github.com/coordinape/coordinape/pull/2196/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebR8103-R8105))
*  Add a new `addInteractionEvent` function to wrap the `insertInteractionEvent` mutation and validate the payload with zod ([link](https://github.com/coordinape/coordinape/pull/2196/files?diff=unified&w=0#diff-7daa2d1f971cde2507890f55d362d553e280812eff2066d3b3ff0402b33dfb08R1-R37))
*  Call the `addInteractionEvent` function in various components to record events such as visiting the CoSoul pages, clicking or completing the mint or burn actions, and passing the `chainId` as the `data` argument ([link](https://github.com/coordinape/coordinape/pull/2196/files?diff=unified&w=0#diff-a681f572db71a9fc5e54853ef5e4077020cd20d7005c4ec763b7d942c52f9295R18-R26), [link](https://github.com/coordinape/coordinape/pull/2196/files?diff=unified&w=0#diff-f38e6ed59a7956c585a4215ed549d4216a411629b0e00d8588773733b97503f0R83-R87), [link](https://github.com/coordinape/coordinape/pull/2196/files?diff=unified&w=0#diff-f38e6ed59a7956c585a4215ed549d4216a411629b0e00d8588773733b97503f0L96-R113), [link](https://github.com/coordinape/coordinape/pull/2196/files?diff=unified&w=0#diff-f38e6ed59a7956c585a4215ed549d4216a411629b0e00d8588773733b97503f0L144-R169), [link](https://github.com/coordinape/coordinape/pull/2196/files?diff=unified&w=0#diff-b43ef01230c6952eb46ff957b2ed7655a981448947dfe5db28cd2e373a648e35L10-R26))
*  Update the zeus types to reflect the GraphQL schema changes for the `insertInteractionEvent` action and its input and output types ([link](https://github.com/coordinape/coordinape/pull/2196/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R53-R55), [link](https://github.com/coordinape/coordinape/pull/2196/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R4411-R4413), [link](https://github.com/coordinape/coordinape/pull/2196/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R9619-R9622), [link](https://github.com/coordinape/coordinape/pull/2196/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R12532), [link](https://github.com/coordinape/coordinape/pull/2196/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060R47-R49), [link](https://github.com/coordinape/coordinape/pull/2196/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060R2674-R2676), [link](https://github.com/coordinape/coordinape/pull/2196/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060R5773-R5775), [link](https://github.com/coordinape/coordinape/pull/2196/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060R6770))
