### PR TITLE
Show minting action modal before big reveal

### DIFF
--- a/src/components/LoadingIndicator.tsx
+++ b/src/components/LoadingIndicator.tsx
@@ -1,3 +1,5 @@
+import { CSS } from 'stitches.config';
+
 import { keyframes } from '../stitches.config';
 import { Box, Text } from '../ui';
 
@@ -16,10 +18,12 @@ export const LoadingIndicator = ({
   size,
   text,
   note,
+  css,
 }: {
   size?: number;
   note?: string;
   text?: string;
+  css?: CSS;
 }) => {
   if (!size) {
     size = defaultSize;
@@ -62,6 +66,7 @@ export const LoadingIndicator = ({
             backgroundColor: '#fff',
             transform: `scale(0.5) translate(-${size}px, -${size}px)`,
           },
+          ...css,
         }}
       ></Box>
       {text && <Text>{text}</Text>}

--- a/src/features/cosoul/CoSoulArtContainer.tsx
+++ b/src/features/cosoul/CoSoulArtContainer.tsx
@@ -6,8 +6,8 @@ import { CSSTransition } from 'react-transition-group';
 
 import { Box, Flex, Text } from 'ui';
 
+import { artWidth, artWidthMobile } from './constants';
 import { QueryCoSoulResult } from './getCoSoulData';
-import { artWidth, artWidthMobile } from './MintPage';
 
 type CoSoulData = QueryCoSoulResult;
 
@@ -18,13 +18,13 @@ export const coSoulCloud = {
   background: 'linear-gradient(#6c47d7, #311974)',
   animation: `${rotate} 50s cubic-bezier(0.8, 0.2, 0.2, 0.8) alternate infinite`,
   borderRadius: '30% 70% 70% 30% / 30% 30% 70% 70%;',
-  width: '500px',
-  height: '500px',
-  filter: 'blur(calc(500px / 5))',
+  width: artWidth,
+  height: artWidth,
+  filter: `blur(calc(${artWidth} / 5))`,
   '@sm': {
-    maxWidth: '320px',
-    height: '320px',
-    filter: 'blur(calc(320px / 5))',
+    maxWidth: artWidthMobile,
+    height: artWidthMobile,
+    filter: `blur(calc(${artWidthMobile} / 5))`,
   },
 };
 

--- a/src/features/cosoul/CoSoulArtContainer.tsx
+++ b/src/features/cosoul/CoSoulArtContainer.tsx
@@ -11,6 +11,23 @@ import { artWidth, artWidthMobile } from './MintPage';
 
 type CoSoulData = QueryCoSoulResult;
 
+export const coSoulCloud = {
+  position: 'absolute',
+  top: '$lg',
+  zIndex: -1,
+  background: 'linear-gradient(#6c47d7, #311974)',
+  animation: `${rotate} 50s cubic-bezier(0.8, 0.2, 0.2, 0.8) alternate infinite`,
+  borderRadius: '30% 70% 70% 30% / 30% 30% 70% 70%;',
+  width: '500px',
+  height: '500px',
+  filter: 'blur(calc(500px / 5))',
+  '@sm': {
+    maxWidth: '320px',
+    height: '320px',
+    filter: 'blur(calc(320px / 5))',
+  },
+};
+
 export const CoSoulArtContainer = ({
   cosoul_data,
   children,
@@ -96,24 +113,7 @@ export const CoSoulArtContainer = ({
           </Box>
         </Box>
       </CSSTransition>
-      <Box
-        css={{
-          position: 'absolute',
-          top: '$lg',
-          zIndex: -1,
-          background: 'linear-gradient(#6c47d7, #311974)',
-          animation: `${rotate} 50s cubic-bezier(0.8, 0.2, 0.2, 0.8) alternate infinite`,
-          borderRadius: '30% 70% 70% 30% / 30% 30% 70% 70%;',
-          width: `${artWidth}`,
-          height: `${artWidth}`,
-          filter: `blur(calc(${artWidth} / 5))`,
-          '@sm': {
-            maxWidth: `${artWidthMobile}`,
-            height: `${artWidthMobile}`,
-            filter: `blur(calc(${artWidthMobile} / 5))`,
-          },
-        }}
-      />
+      <Box css={{ ...coSoulCloud }} />
     </>
   );
 };

--- a/src/features/cosoul/CoSoulCreate.tsx
+++ b/src/features/cosoul/CoSoulCreate.tsx
@@ -50,7 +50,7 @@ export const CoSoulCreate = ({
           width: '100%',
           minWidth: '180px',
           maxWidth: `${artWidth}`,
-          height: '440px',
+          // height: '440px',
           pb: '$xl',
           mb: '$xl',
           gap: '$3xl',

--- a/src/features/cosoul/CoSoulCreate.tsx
+++ b/src/features/cosoul/CoSoulCreate.tsx
@@ -5,9 +5,9 @@ import { CSSTransition } from 'react-transition-group';
 import { Flex, Panel, Text } from 'ui';
 import { numberWithCommas } from 'utils';
 
+import { artWidth, artWidthMobile } from './constants';
 import { CoSoulButton } from './CoSoulButton';
 import { QueryCoSoulResult } from './getCoSoulData';
-import { artWidth, artWidthMobile } from './MintPage';
 import { generateRandomNumber, scrambleNumber } from './numberScramble';
 
 import './glitch.css';

--- a/src/features/cosoul/CoSoulManagement.tsx
+++ b/src/features/cosoul/CoSoulManagement.tsx
@@ -4,9 +4,9 @@ import { useNavigate } from 'react-router';
 import { paths } from 'routes/paths';
 import { Button, Flex, Panel, Text } from 'ui';
 
+import { artWidth, artWidthMobile } from './constants';
 import { CoSoulButton } from './CoSoulButton';
 import { QueryCoSoulResult } from './getCoSoulData';
-import { artWidth, artWidthMobile } from './MintPage';
 
 type CoSoulData = QueryCoSoulResult;
 

--- a/src/features/cosoul/CoSoulProfileInfo.tsx
+++ b/src/features/cosoul/CoSoulProfileInfo.tsx
@@ -2,8 +2,8 @@ import { DateTime } from 'luxon';
 
 import { Avatar, Flex, Panel, Text } from 'ui';
 
+import { artWidth, artWidthMobile } from './constants';
 import { QueryCoSoulResult } from './getCoSoulData';
-import { artWidth, artWidthMobile } from './MintPage';
 
 type CoSoulData = QueryCoSoulResult;
 

--- a/src/features/cosoul/CoSoulPromo.tsx
+++ b/src/features/cosoul/CoSoulPromo.tsx
@@ -4,8 +4,8 @@ import type { CSS } from 'stitches.config';
 import { paths } from 'routes/paths';
 import { Button, Panel, Text } from 'ui';
 
+import { artWidth, artWidthMobile } from './constants';
 import { QueryCoSoulResult } from './getCoSoulData';
-import { artWidth, artWidthMobile } from './MintPage';
 
 type CoSoulData = QueryCoSoulResult;
 export const CoSoulPromo = ({

--- a/src/features/cosoul/MintingModal.tsx
+++ b/src/features/cosoul/MintingModal.tsx
@@ -36,7 +36,8 @@ export const MintingModal = ({
       showClose={false}
       css={{
         position: 'relative',
-        top: '-100px',
+        top: '-$lg ',
+        overflow: 'hidden',
         '&:before': {
           content: '',
           ...coSoulCloud,
@@ -48,7 +49,7 @@ export const MintingModal = ({
           background:
             'radial-gradient(circle, rgba(0,0,0,1) 25%, rgba(226,226,226,0) 100%)',
           width: '100vw',
-          height: '100vw',
+          height: '100vh',
           position: 'absolute',
           zIndex: '0 !important',
         },

--- a/src/features/cosoul/MintingModal.tsx
+++ b/src/features/cosoul/MintingModal.tsx
@@ -1,0 +1,88 @@
+import { LoadingIndicator } from '../../components/LoadingIndicator';
+import { Check } from '../../icons/__generated';
+import { Button, Flex, Modal } from 'ui';
+
+export const MINTING_STEPS = [
+  'Build a Reputation on Coordinape',
+  'Connect to Optimism',
+  'Approve Transaction',
+  // 'Reticulate Splines',
+  'Engrave on the Blockchain',
+  // 'Commission the Artist',
+] as const;
+
+export type MintingStep = typeof MINTING_STEPS[number];
+
+const isDone = (step: MintingStep, currentStep: MintingStep) => {
+  return MINTING_STEPS.indexOf(step) <= MINTING_STEPS.indexOf(currentStep);
+};
+
+export const MintingModal = ({
+  onReveal,
+  currentStep,
+}: {
+  onReveal: () => void;
+  currentStep: MintingStep;
+}) => {
+  return (
+    <Modal open={true} showClose={false}>
+      <Flex column css={{ gap: '$lg' }}>
+        {MINTING_STEPS.map(step => (
+          <MintingStepRow
+            key={step}
+            step={step}
+            done={isDone(step, currentStep)}
+            activeStep={
+              MINTING_STEPS.indexOf(step) ===
+              MINTING_STEPS.indexOf(currentStep) + 1
+            }
+          />
+        ))}
+
+        <Flex css={{ mt: '$2xl', justifyContent: 'center' }}>
+          {MINTING_STEPS.indexOf(currentStep) === MINTING_STEPS.length - 1 ? (
+            <Button color="cta" onClick={onReveal}>
+              Reveal Your CoSoul
+            </Button>
+          ) : (
+            <></>
+          )}
+        </Flex>
+      </Flex>
+    </Modal>
+  );
+};
+
+const MintingStepRow = ({
+  step,
+  done,
+  activeStep,
+}: {
+  step: string;
+  done: boolean;
+  activeStep: boolean;
+}) => {
+  return (
+    <Flex alignItems="center">
+      <Flex css={{ width: 48, justifyContent: 'right', mr: '$md' }}>
+        {done ? (
+          <Check color="cta" />
+        ) : (
+          activeStep && <LoadingIndicator size={24} />
+        )}
+      </Flex>
+      <Flex
+        css={{
+          ...(activeStep
+            ? {
+                fontWeight: '$semibold',
+                fontSize: '$large',
+              }
+            : {}),
+        }}
+      >
+        {step}
+      </Flex>
+    </Flex>
+  );
+};

--- a/src/features/cosoul/MintingModal.tsx
+++ b/src/features/cosoul/MintingModal.tsx
@@ -1,6 +1,10 @@
+import { pulseStyles } from 'features/nav/SideNav';
+
 import { LoadingIndicator } from '../../components/LoadingIndicator';
 import { Check } from '../../icons/__generated';
 import { Button, Flex, Modal } from 'ui';
+
+import { coSoulCloud } from './CoSoulArtContainer';
 
 export const MINTING_STEPS = [
   'Build a Reputation on Coordinape',
@@ -25,8 +29,40 @@ export const MintingModal = ({
   currentStep: MintingStep;
 }) => {
   return (
-    <Modal open={true} showClose={false}>
-      <Flex column css={{ gap: '$lg' }}>
+    <Modal
+      loader
+      forceTheme="dark"
+      open={true}
+      showClose={false}
+      css={{
+        position: 'relative',
+        top: '-100px',
+        '&:before': {
+          content: '',
+          ...coSoulCloud,
+          zIndex: '1 !important',
+          top: 'calc(50% - 250px) !important',
+        },
+        '&:after': {
+          content: '',
+          background:
+            'radial-gradient(circle, rgba(0,0,0,1) 25%, rgba(226,226,226,0) 100%)',
+          width: '100vw',
+          height: '100vw',
+          position: 'absolute',
+          zIndex: '0 !important',
+        },
+      }}
+    >
+      <Flex
+        column
+        css={{
+          gap: '$xs',
+          position: 'relative',
+          zIndex: '2',
+          mt: '$lg',
+        }}
+      >
         {MINTING_STEPS.map(step => (
           <MintingStepRow
             key={step}
@@ -39,13 +75,49 @@ export const MintingModal = ({
           />
         ))}
 
-        <Flex css={{ mt: '$2xl', justifyContent: 'center' }}>
+        <Flex
+          css={{
+            mt: '$2xl',
+            justifyContent: 'center',
+          }}
+        >
           {MINTING_STEPS.indexOf(currentStep) === MINTING_STEPS.length - 1 ? (
-            <Button color="cta" onClick={onReveal}>
+            <Button
+              size="large"
+              color="cta"
+              onClick={onReveal}
+              css={{
+                zIndex: 3,
+                position: 'relative',
+                borderRadius: '$3',
+                width: '100%',
+                '&:before': {
+                  ...pulseStyles,
+                  borderRadius: '$3',
+                },
+                '&:after': {
+                  ...pulseStyles,
+                  borderRadius: '$3',
+                  animationDelay: '1.5s',
+                  zIndex: -1,
+                },
+              }}
+            >
               Reveal Your CoSoul
             </Button>
           ) : (
-            <></>
+            <Button
+              size="large"
+              css={{
+                zIndex: 3,
+                position: 'relative',
+                borderRadius: '$3',
+                width: '100%',
+                visibility: 'hidden',
+              }}
+            >
+              Reveal Your CoSoul
+            </Button>
           )}
         </Flex>
       </Flex>
@@ -63,20 +135,24 @@ const MintingStepRow = ({
   activeStep: boolean;
 }) => {
   return (
-    <Flex alignItems="center">
+    <Flex alignItems="center" css={{ width: '22rem', margin: 'auto' }}>
       <Flex css={{ width: 48, justifyContent: 'right', mr: '$md' }}>
         {done ? (
           <Check color="cta" />
         ) : (
-          activeStep && <LoadingIndicator size={24} />
+          activeStep && <LoadingIndicator size={24} css={{ margin: 'auto' }} />
         )}
       </Flex>
       <Flex
         css={{
+          padding: '$md $md $md $3xl',
+          ml: '-$3xl',
+          width: '100%',
+          borderRadius: '$1',
           ...(activeStep
             ? {
-                fontWeight: '$semibold',
-                fontSize: '$large',
+                background: 'rgba(0,0,0,0.6)',
+                color: '$cta ',
               }
             : {}),
         }}

--- a/src/features/cosoul/ViewPage.tsx
+++ b/src/features/cosoul/ViewPage.tsx
@@ -1,5 +1,4 @@
 import { useAuthStateMachine } from 'features/auth/RequireAuth';
-import { rotate } from 'keyframes';
 import { useQuery } from 'react-query';
 import { useParams } from 'react-router-dom';
 
@@ -9,9 +8,9 @@ import isFeatureEnabled from 'config/features';
 import { Box, Flex, Text } from 'ui';
 import { SingleColumnLayout } from 'ui/layouts';
 
-import { artWidth, artWidthMobile } from '.';
+import { artWidth } from '.';
 import { CoSoulArt } from './art/CoSoulArt';
-import { CoSoulArtContainer } from './CoSoulArtContainer';
+import { CoSoulArtContainer, coSoulCloud } from './CoSoulArtContainer';
 import { CoSoulComposition } from './CoSoulComposition';
 import { CoSoulDetails } from './CoSoulDetails';
 import { CoSoulProfileInfo } from './CoSoulProfileInfo';
@@ -107,24 +106,7 @@ export const ViewPage = () => {
           {data && (
             <CoSoulPromo css={{ mt: 0 }} cosoul_data={data} address={address} />
           )}
-          <Box
-            css={{
-              position: 'absolute',
-              top: '$lg',
-              zIndex: -1,
-              background: 'linear-gradient(#6c47d7, #311974)',
-              animation: `${rotate} 50s cubic-bezier(0.8, 0.2, 0.2, 0.8) alternate infinite`,
-              borderRadius: '30% 70% 70% 30% / 30% 30% 70% 70%;',
-              width: `${artWidth}`,
-              height: `${artWidth}`,
-              filter: `blur(calc(${artWidth} / 5))`,
-              '@sm': {
-                maxWidth: `${artWidthMobile}`,
-                height: `${artWidthMobile}`,
-                filter: `blur(calc(${artWidthMobile} / 5))`,
-              },
-            }}
-          />
+          <Box css={{ ...coSoulCloud }} />
         </Flex>
       )}
     </SingleColumnLayout>

--- a/src/features/cosoul/art/CoSoulArt.tsx
+++ b/src/features/cosoul/art/CoSoulArt.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 
-import { artWidth, artWidthMobile } from '../MintPage';
+import { artWidth, artWidthMobile } from '../constants';
 import { Box, Canvas } from 'ui';
 
 import { generateCoSoulArt } from './main';

--- a/src/features/cosoul/constants.ts
+++ b/src/features/cosoul/constants.ts
@@ -1,0 +1,2 @@
+export const artWidth = '500px';
+export const artWidthMobile = '320px';

--- a/src/features/nav/SideNav.tsx
+++ b/src/features/nav/SideNav.tsx
@@ -20,6 +20,18 @@ import { NavLogo } from './NavLogo';
 import { NavOrgs } from './NavOrgs';
 import { NavProfile } from './NavProfile';
 
+export const pulseStyles = {
+  content: '',
+  zIndex: -1,
+  borderRadius: '$2',
+  position: 'absolute',
+  width: '100%',
+  height: '100%',
+  backgroundColor: '$cta',
+  animation: `${pulse} 3s linear infinite`,
+  pointerEvents: 'none',
+};
+
 export const SideNav = () => {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [currentCircle, setCurrentCircle] = useState<NavCircle | undefined>(
@@ -51,18 +63,6 @@ export const SideNav = () => {
   const suppressCosoulCtaAnimation =
     cosoul_data?.mintInfo ||
     window.localStorage.getItem('cosoulCtaAnimation') === 'hidden';
-  const pulseStyles = {
-    content: '',
-    zIndex: -1,
-    borderRadius: '$2',
-    position: 'absolute',
-    width: '100%',
-    height: '100%',
-    backgroundColor: '$cta',
-    animation: `${pulse} 3s linear infinite`,
-    display: suppressCosoulCtaAnimation ? 'none' : 'block',
-    pointerEvents: 'none',
-  };
   const setCircleAndOrgIfMatch = (orgs: NavOrg[]) => {
     const circleId = getCircleFromPath(location);
     const orgId = getOrgFromPath(location);
@@ -210,11 +210,13 @@ export const SideNav = () => {
               '&:before': {
                 ...pulseStyles,
                 animationDelay: '3s',
+                display: suppressCosoulCtaAnimation ? 'none' : 'block',
               },
               '&:after': {
                 ...pulseStyles,
                 animationDelay: '1.5s',
                 zIndex: -1,
+                display: suppressCosoulCtaAnimation ? 'none' : 'block',
               },
             }}
             to={


### PR DESCRIPTION

<img width="2560" alt="Screenshot 2023-06-20 at 4 21 04 PM" src="https://github.com/coordinape/coordinape/assets/100873710/07e433a2-4498-44d4-ac28-703fc8b8fb19">
<img width="2560" alt="Screenshot 2023-06-20 at 4 21 35 PM" src="https://github.com/coordinape/coordinape/assets/100873710/796bd6ae-e00b-4bc2-92ac-e1fc3ed2a6d8">


## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 16e1306</samp>

This pull request refactors and enhances various components related to the CoSoul feature, which allows users to create and mint unique art pieces. It introduces a `constants.ts` file to store common values for the art size, a `MintingModal.tsx` file to show the minting steps and the reveal button, and a `css` prop for the `LoadingIndicator.tsx` component to enable custom styling. It also improves the code readability, consistency, and maintainability by using appropriate sources for constants and styles, removing unused code, and fixing a mobile layout bug.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 16e1306</samp>

> _Sing, O Muse, of the skillful coder who refactored the code_
> _Of the CoSoul art, the wondrous creation of the blockchain gods_
> _He imported the constants from a common source, avoiding the circular snare_
> _Like Theseus escaping the labyrinth with Ariadne's thread_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 16e1306</samp>

*  Add the MintingModal component to display the progress of the minting process and the reveal button in the MintButton component ([link](https://github.com/coordinape/coordinape/pull/2211/files?diff=unified&w=0#diff-66d30e0e4662d9641c0ac98c4604782dbf36f6292b8229c8847e94b0efc16707R1-R164), [link](https://github.com/coordinape/coordinape/pull/2211/files?diff=unified&w=0#diff-f38e6ed59a7956c585a4215ed549d4216a411629b0e00d8588773733b97503f0R10), [link](https://github.com/coordinape/coordinape/pull/2211/files?diff=unified&w=0#diff-f38e6ed59a7956c585a4215ed549d4216a411629b0e00d8588773733b97503f0L122-R161))
*  Refactor the sendTransaction function to store the transaction hash and advance through the minting steps in the MintButton component ([link](https://github.com/coordinape/coordinape/pull/2211/files?diff=unified&w=0#diff-f38e6ed59a7956c585a4215ed549d4216a411629b0e00d8588773733b97503f0L1-R1), [link](https://github.com/coordinape/coordinape/pull/2211/files?diff=unified&w=0#diff-f38e6ed59a7956c585a4215ed549d4216a411629b0e00d8588773733b97503f0L92-R124), [link](https://github.com/coordinape/coordinape/pull/2211/files?diff=unified&w=0#diff-f38e6ed59a7956c585a4215ed549d4216a411629b0e00d8588773733b97503f0L102-R131), [link](https://github.com/coordinape/coordinape/pull/2211/files?diff=unified&w=0#diff-f38e6ed59a7956c585a4215ed549d4216a411629b0e00d8588773733b97503f0L110-R142))
*  Add the reveal function to close the minting modal, call the onSuccess function, and update the history with the minted CoSoul address in the MintButton component ([link](https://github.com/coordinape/coordinape/pull/2211/files?diff=unified&w=0#diff-f38e6ed59a7956c585a4215ed549d4216a411629b0e00d8588773733b97503f0L122-R161))
*  Import the artWidth and artWidthMobile constants from the constants file instead of the MintPage file in various components, which is more consistent and avoids circular dependencies ([link](https://github.com/coordinape/coordinape/pull/2211/files?diff=unified&w=0#diff-0d32f46ad080049e96febbbed420394d392db3af9f64f964210bee3bab9d91feL3-R3), [link](https://github.com/coordinape/coordinape/pull/2211/files?diff=unified&w=0#diff-e8191801bbac4b1d968ff5b1204797939e7140ac402bd72ad3d2d84cf1bd050fR1-R2), [link](https://github.com/coordinape/coordinape/pull/2211/files?diff=unified&w=0#diff-f7fcaa3872a811151e30263372938dca6e8205eccc8ab7c3633b330fecdb11abL9-R30), [link](https://github.com/coordinape/coordinape/pull/2211/files?diff=unified&w=0#diff-977da59b488c5f16f8b27e21dde7c7f7cb4f774074fe9c8b33ff78cf89077e88L8-R10), [link](https://github.com/coordinape/coordinape/pull/2211/files?diff=unified&w=0#diff-0f9d60e4d2b8dcc61dfe3d0f8fdc71368df81319a2b6613d96a5ff17941e69bbL7-R9), [link](https://github.com/coordinape/coordinape/pull/2211/files?diff=unified&w=0#diff-dd6ba4de04802adf50051ad5e6f24ead95af52cde2e4a23b008b2805d3d63efdL5-R6), [link](https://github.com/coordinape/coordinape/pull/2211/files?diff=unified&w=0#diff-697c57597bf47d9114f4b5312da22ef6f1088988d8cb161758e17b0122df3e86L7-R8))
*  Import the coSoulCloud object from the CoSoulArtContainer file, which contains the common styles for the background gradient and animation of the CoSoul art, and use it to replace the inline styles in various components ([link](https://github.com/coordinape/coordinape/pull/2211/files?diff=unified&w=0#diff-f7fcaa3872a811151e30263372938dca6e8205eccc8ab7c3633b330fecdb11abL99-R116), [link](https://github.com/coordinape/coordinape/pull/2211/files?diff=unified&w=0#diff-07a5e546156e72d3af4da968af148298858d1943242859c44c28aea5e4b3c5b5L12-R13), [link](https://github.com/coordinape/coordinape/pull/2211/files?diff=unified&w=0#diff-07a5e546156e72d3af4da968af148298858d1943242859c44c28aea5e4b3c5b5L110-R109))
*  Remove the height property from the Flex component in the CoSoulCreate component, which is not needed and causes a layout issue on mobile devices ([link](https://github.com/coordinape/coordinape/pull/2211/files?diff=unified&w=0#diff-977da59b488c5f16f8b27e21dde7c7f7cb4f774074fe9c8b33ff78cf89077e88L53-R53))
*  Remove the import of the rotate keyframes from the ViewPage file, which is not used in this file and is already imported in the CoSoulArtContainer file ([link](https://github.com/coordinape/coordinape/pull/2211/files?diff=unified&w=0#diff-07a5e546156e72d3af4da968af148298858d1943242859c44c28aea5e4b3c5b5L2))
*  Export the pulseStyles object from the SideNav file, which contains the common styles for the pulsing animation of the buttons, and use it to style the reveal button in the MintingModal component ([link](https://github.com/coordinape/coordinape/pull/2211/files?diff=unified&w=0#diff-14c17f2206802b962d016d8a767ac1e68950e89f32310c7371d04c790ed7138cR23-R34), [link](https://github.com/coordinape/coordinape/pull/2211/files?diff=unified&w=0#diff-66d30e0e4662d9641c0ac98c4604782dbf36f6292b8229c8847e94b0efc16707R1-R164))
*  Remove the definition of the pulseStyles object from the SideNav component, which is already exported from the SideNav file and imported in the component ([link](https://github.com/coordinape/coordinape/pull/2211/files?diff=unified&w=0#diff-14c17f2206802b962d016d8a767ac1e68950e89f32310c7371d04c790ed7138cL54-L65))
*  Add the display property to the before and after pseudo-elements of the CoSoulButton component, which is used to hide or show the pulsing animation based on the suppressCosoulCtaAnimation prop in the SideNav component ([link](https://github.com/coordinape/coordinape/pull/2211/files?diff=unified&w=0#diff-14c17f2206802b962d016d8a767ac1e68950e89f32310c7371d04c790ed7138cR213), [link](https://github.com/coordinape/coordinape/pull/2211/files?diff=unified&w=0#diff-14c17f2206802b962d016d8a767ac1e68950e89f32310c7371d04c790ed7138cR219))
*  Import the CSS type from the stitches.config file and add the css prop to the LoadingIndicator component, which allows passing custom styles to the component ([link](https://github.com/coordinape/coordinape/pull/2211/files?diff=unified&w=0#diff-83c12448ccfac98ca13930aa4fed2b01ceb54b1e0b0d24f3db0e4b5eff87dbacR1-R2), [link](https://github.com/coordinape/coordinape/pull/2211/files?diff=unified&w=0#diff-83c12448ccfac98ca13930aa4fed2b01ceb54b1e0b0d24f3db0e4b5eff87dbacL19-R26), [link](https://github.com/coordinape/coordinape/pull/2211/files?diff=unified&w=0#diff-83c12448ccfac98ca13930aa4fed2b01ceb54b1e0b0d24f3db0e4b5eff87dbacR69))
