### PR TITLE
Fix art cors

### DIFF
--- a/api/cosoul/art/[artTokenId].ts
+++ b/api/cosoul/art/[artTokenId].ts
@@ -6,6 +6,21 @@ import { Awaited } from '../../../api-lib/ts4.5shim';
 
 const CACHE_SECONDS = 60 * 5;
 export default async function handler(req: VercelRequest, res: VercelResponse) {
+  // CORS stuff is necessary for OpenSea embedding
+  res.setHeader('Access-Control-Allow-Credentials', 'true');
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  // another common pattern
+  // res.setHeader('Access-Control-Allow-Origin', req.headers.origin);
+  res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS');
+  res.setHeader(
+    'Access-Control-Allow-Headers',
+    'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version'
+  );
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
+
   try {
     let artTokenId: number | undefined;
     if (typeof req.query.artTokenId == 'string') {

--- a/api/cosoul/art/[artTokenId].ts
+++ b/api/cosoul/art/[artTokenId].ts
@@ -7,8 +7,10 @@ import { Awaited } from '../../../api-lib/ts4.5shim';
 const CACHE_SECONDS = 60 * 5;
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   // CORS stuff is necessary for OpenSea embedding
+
   res.setHeader('Access-Control-Allow-Credentials', 'true');
   res.setHeader('Access-Control-Allow-Origin', '*');
+
   // another common pattern
   // res.setHeader('Access-Control-Allow-Origin', req.headers.origin);
   res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS');

--- a/api/cosoul/art/[artTokenId].ts
+++ b/api/cosoul/art/[artTokenId].ts
@@ -6,23 +6,6 @@ import { Awaited } from '../../../api-lib/ts4.5shim';
 
 const CACHE_SECONDS = 60 * 5;
 export default async function handler(req: VercelRequest, res: VercelResponse) {
-  // CORS stuff is necessary for OpenSea embedding
-
-  res.setHeader('Access-Control-Allow-Credentials', 'true');
-  res.setHeader('Access-Control-Allow-Origin', '*');
-
-  // another common pattern
-  // res.setHeader('Access-Control-Allow-Origin', req.headers.origin);
-  res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS');
-  res.setHeader(
-    'Access-Control-Allow-Headers',
-    'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version'
-  );
-  if (req.method === 'OPTIONS') {
-    res.status(200).end();
-    return;
-  }
-
   try {
     let artTokenId: number | undefined;
     if (typeof req.query.artTokenId == 'string') {

--- a/vercel.json
+++ b/vercel.json
@@ -24,7 +24,7 @@
       "headers": [
         { "key": "Access-Control-Allow-Credentials", "value": "true" },
         { "key": "Access-Control-Allow-Origin", "value": "*" },
-        { "key": "Access-Control-Allow-Methods", "value": "GET,OPTIONS" },
+        { "key": "Access-Control-Allow-Methods", "value": "GET,OPTIONS,HEAD" },
         {
           "key": "Access-Control-Allow-Headers",
           "value": "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version"

--- a/vercel.json
+++ b/vercel.json
@@ -24,7 +24,8 @@
       "headers": [
         { "key": "Access-Control-Allow-Credentials", "value": "true" },
         { "key": "Access-Control-Allow-Origin", "value": "*" },
-        { "key": "Access-Control-Allow-Methods", "value": "GET,OPTIONS,HEAD" },
+        { "key": "Access-Control-Allow-Methods", "value": "*" },
+        { "key": "Allow", "value": "*" },
         {
           "key": "Access-Control-Allow-Headers",
           "value": "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version"

--- a/vercel.json
+++ b/vercel.json
@@ -18,6 +18,22 @@
           "value": "public, max-age=31536000"
         }
       ]
+    },
+    {
+      "headers": [
+        {
+          "source": "/api/cosoul/art/(.*)",
+          "headers": [
+            { "key": "Access-Control-Allow-Credentials", "value": "true" },
+            { "key": "Access-Control-Allow-Origin", "value": "*" },
+            { "key": "Access-Control-Allow-Methods", "value": "GET,OPTIONS" },
+            {
+              "key": "Access-Control-Allow-Headers",
+              "value": "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -20,18 +20,14 @@
       ]
     },
     {
+      "source": "/api/cosoul/art/(.*)",
       "headers": [
+        { "key": "Access-Control-Allow-Credentials", "value": "true" },
+        { "key": "Access-Control-Allow-Origin", "value": "*" },
+        { "key": "Access-Control-Allow-Methods", "value": "GET,OPTIONS" },
         {
-          "source": "/api/cosoul/art/(.*)",
-          "headers": [
-            { "key": "Access-Control-Allow-Credentials", "value": "true" },
-            { "key": "Access-Control-Allow-Origin", "value": "*" },
-            { "key": "Access-Control-Allow-Methods", "value": "GET,OPTIONS" },
-            {
-              "key": "Access-Control-Allow-Headers",
-              "value": "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version"
-            }
-          ]
+          "key": "Access-Control-Allow-Headers",
+          "value": "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version"
         }
       ]
     }

--- a/vercel.json
+++ b/vercel.json
@@ -28,7 +28,7 @@
         { "key": "Allow", "value": "*" },
         {
           "key": "Access-Control-Allow-Headers",
-          "value": "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version, Baggage"
+          "value": "*"
         }
       ]
     }

--- a/vercel.json
+++ b/vercel.json
@@ -28,7 +28,7 @@
         { "key": "Allow", "value": "*" },
         {
           "key": "Access-Control-Allow-Headers",
-          "value": "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version"
+          "value": "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version, Baggage"
         }
       ]
     }


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 051e3ae</samp>

Add a new serverless route to enable CORS for the CoSoul art API. This allows the app to generate and display art based on the user's profile and preferences.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 051e3ae</samp>

> _`vercel.json` changed_
> _CoSoul art API route_
> _CORS for winter_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 051e3ae</samp>

*  Add a new route to enable CORS for CoSoul art API requests ([link](https://github.com/coordinape/coordinape/pull/2214/files?diff=unified&w=0#diff-a3265310f552fb66876e8bfe8809737e59e5ba946bdf39138b44d9baf4e21240R21-R33))
