### PR TITLE
Animate cosoul by default / show cosoul conditionally on Profile Page

### DIFF
--- a/src/features/cosoul/art/CoSoulArt.tsx
+++ b/src/features/cosoul/art/CoSoulArt.tsx
@@ -9,7 +9,7 @@ export const CoSoulArt = ({
   pGive,
   address,
   showGui = false,
-  animate = false,
+  animate = true,
   width,
 }: {
   pGive?: number;

--- a/src/pages/ProfilePage/ProfilePage.tsx
+++ b/src/pages/ProfilePage/ProfilePage.tsx
@@ -65,7 +65,7 @@ export const ProfilePage = () => {
   );
 };
 
-const MyProfilePage = ({ totalPgive }: { totalPgive: QueryProfilePgive }) => {
+const MyProfilePage = ({ totalPgive }: { totalPgive: number }) => {
   const myProfile = useMyProfile();
 
   return (
@@ -78,7 +78,7 @@ const OtherProfilePage = ({
   totalPgive,
 }: {
   address: string;
-  totalPgive: QueryProfilePgive;
+  totalPgive: number;
 }) => {
   const { data: profile } = useQuery(
     ['profile', address],

--- a/src/pages/ProfilePage/ProfilePage.tsx
+++ b/src/pages/ProfilePage/ProfilePage.tsx
@@ -20,17 +20,16 @@ import isFeatureEnabled from 'config/features';
 import { useImageUploader, useToast } from 'hooks';
 import { useFetchManifest } from 'hooks/legacyApi';
 import useMobileDetect from 'hooks/useMobileDetect';
-import { ExternalLink, Edit3 } from 'icons/__generated';
+import { Edit3, ExternalLink } from 'icons/__generated';
 import { useMyProfile } from 'recoilState';
 import { EXTERNAL_URL_WHY_COORDINAPE_IN_CIRCLE, paths } from 'routes/paths';
 import { Avatar, Box, Button, Flex, Link, MarkdownPreview, Text } from 'ui';
 import { getAvatarPath } from 'utils/domain';
 
 import {
-  queryProfilePgive,
-  queryProfile,
   QUERY_KEY_PROFILE_TOTAL_PGIVE,
-  QueryProfilePgive,
+  queryProfile,
+  queryProfilePgive,
 } from './queries';
 
 import type { IMyProfile, IProfile } from 'types';
@@ -41,45 +40,20 @@ export const ProfilePage = () => {
   // FIXME replace this with react-query
   const myProfile = useMyProfile();
 
-  const query = useQuery(
-    [QUERY_KEY_PROFILE_TOTAL_PGIVE, address],
-    () => queryProfilePgive(address),
-    {
-      enabled: !!address,
-      staleTime: Infinity,
-    }
-  );
-  const cosoul_data = query.data;
-  // eslint-disable-next-line no-console
-  console.log({ cosoul_data });
-  const totalPgive = cosoul_data?.totalPgive;
-
   const isMe = address === 'me' || address === myProfile.address;
   if (!(isMe || address?.startsWith('0x'))) {
     return <></>; // todo better 404?
   }
-  return isMe ? (
-    <MyProfilePage totalPgive={totalPgive} />
-  ) : (
-    <OtherProfilePage address={address} totalPgive={totalPgive} />
-  );
+  return isMe ? <MyProfilePage /> : <OtherProfilePage address={address} />;
 };
 
-const MyProfilePage = ({ totalPgive }: { totalPgive: number }) => {
+const MyProfilePage = () => {
   const myProfile = useMyProfile();
 
-  return (
-    <ProfilePageContent profile={myProfile} totalPgive={totalPgive} isMe />
-  );
+  return <ProfilePageContent profile={myProfile} isMe />;
 };
 
-const OtherProfilePage = ({
-  address,
-  totalPgive,
-}: {
-  address: string;
-  totalPgive: number;
-}) => {
+const OtherProfilePage = ({ address }: { address: string }) => {
   const { data: profile } = useQuery(
     ['profile', address],
     () => queryProfile(address),
@@ -89,18 +63,16 @@ const OtherProfilePage = ({
   return !profile ? (
     <LoadingModal visible note="profile" />
   ) : (
-    <ProfilePageContent profile={profile} totalPgive={totalPgive} />
+    <ProfilePageContent profile={profile} />
   );
 };
 
 const ProfilePageContent = ({
   profile,
   isMe,
-  totalPgive,
 }: {
   profile: IMyProfile | IProfile;
   isMe?: boolean;
-  totalPgive: QueryProfilePgive;
 }) => {
   const users = (profile as IMyProfile)?.myUsers ?? profile?.users ?? [];
   const user = users[0];
@@ -128,6 +100,16 @@ const ProfilePageContent = ({
 
   const { showError } = useToast();
   const artWidth = '320px';
+
+  const { data: coSoul } = useQuery(
+    [QUERY_KEY_PROFILE_TOTAL_PGIVE, profile.address],
+    () => queryProfilePgive(profile.address),
+    {
+      staleTime: Infinity,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+    }
+  );
 
   useEffect(() => {
     if (name === 'unknown') {
@@ -276,7 +258,7 @@ const ProfilePageContent = ({
                 </Suspense>
               </Flex>
             </Flex>
-            {isFeatureEnabled('cosoul') && (
+            {isFeatureEnabled('cosoul') && coSoul?.mintInfo && (
               <Flex
                 column
                 css={{
@@ -292,7 +274,7 @@ const ProfilePageContent = ({
                 }}
               >
                 <CoSoulArt
-                  pGive={totalPgive}
+                  pGive={coSoul.totalPgive}
                   address={profile.address}
                   animate={true}
                   width={artWidth}

--- a/src/pages/ProfilePage/ProfilePage.tsx
+++ b/src/pages/ProfilePage/ProfilePage.tsx
@@ -41,7 +41,7 @@ export const ProfilePage = () => {
   // FIXME replace this with react-query
   const myProfile = useMyProfile();
 
-  const { data: totalPgive } = useQuery(
+  const query = useQuery(
     [QUERY_KEY_PROFILE_TOTAL_PGIVE, address],
     () => queryProfilePgive(address),
     {
@@ -49,6 +49,10 @@ export const ProfilePage = () => {
       staleTime: Infinity,
     }
   );
+  const cosoul_data = query.data;
+  // eslint-disable-next-line no-console
+  console.log({ cosoul_data });
+  const totalPgive = cosoul_data?.totalPgive;
 
   const isMe = address === 'me' || address === myProfile.address;
   if (!(isMe || address?.startsWith('0x'))) {

--- a/src/pages/ProfilePage/queries.ts
+++ b/src/pages/ProfilePage/queries.ts
@@ -101,7 +101,7 @@ export const queryProfile = async (address: string): Promise<IProfile> => {
 
 export const queryProfilePgive = async (address?: string) => {
   assert(address, 'no address provided');
-  const { totalPgive } = await client.query(
+  const { totalPgive, mintInfo } = await client.query(
     {
       __alias: {
         totalPgive: {
@@ -114,12 +114,29 @@ export const queryProfilePgive = async (address?: string) => {
             { aggregate: { sum: [{}, { normalized_pgive: true }] } },
           ],
         },
+        mintInfo: {
+          cosouls: [
+            {
+              where: {
+                profile: { address: { _eq: address } },
+              },
+            },
+            {
+              created_at: true,
+              token_id: true,
+            },
+          ],
+        },
       },
     },
     { operationName: 'getProfile_totalPgive' }
   );
-
-  return (totalPgive.aggregate?.sum as any).normalized_pgive;
+  const totalPgiver: number | undefined = (totalPgive.aggregate?.sum as any)
+    .normalized_pgive;
+  return {
+    totalPgive: totalPgiver ?? 0,
+    mintInfo: mintInfo?.[0],
+  };
 };
 
 export type QueryProfilePgive = Awaited<ReturnType<typeof queryProfilePgive>>;

--- a/src/pages/ProfilePage/queries.ts
+++ b/src/pages/ProfilePage/queries.ts
@@ -4,7 +4,7 @@ import { client } from 'lib/gql/client';
 
 import { extraProfile } from 'utils/modelExtenders';
 
-import { IProfile, IApiUser } from 'types';
+import { IApiUser, IProfile } from 'types';
 import { Awaited } from 'types/shim';
 
 export const queryProfile = async (address: string): Promise<IProfile> => {
@@ -135,7 +135,7 @@ export const queryProfilePgive = async (address?: string) => {
     .normalized_pgive;
   return {
     totalPgive: totalPgiver ?? 0,
-    mintInfo: mintInfo?.[0],
+    mintInfo: mintInfo.length > 0 ? mintInfo[0] : undefined,
   };
 };
 


### PR DESCRIPTION
Fixes:
* Art should animate
* don't show cosoul art on profile page if there isn't mintInfo on the cosoul data

## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5cb8ef7</samp>

Updated the `ProfilePage` to show the CoSoul art and the mint button for each user, based on their `mintInfo` data from the Hasura API. Changed the default animation behavior of the `CoSoulArt` component to start automatically.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5cb8ef7</samp>

> _`CoSoulArt` animates_
> _Fetching `mintInfo` with queries_
> _Winter minting time_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5cb8ef7</samp>

*  Enable automatic animation of CoSoul art by changing the default value of the `animate` prop in the `CoSoulArt` component ([link](https://github.com/coordinape/coordinape/pull/2215/files?diff=unified&w=0#diff-0d32f46ad080049e96febbbed420394d392db3af9f64f964210bee3bab9d91feL12-R12))
*  Remove `totalPgive` data and prop from the `ProfilePage`, `OtherProfilePage`, and `ProfilePageContent` components, as it is no longer needed to render the CoSoul art ([link](https://github.com/coordinape/coordinape/pull/2215/files?diff=unified&w=0#diff-bb52971d8c2a4e27cacc22c03efd7d49b214af77d7451e9e67e1cc3b485ad6f0L44-R56), [link](https://github.com/coordinape/coordinape/pull/2215/files?diff=unified&w=0#diff-bb52971d8c2a4e27cacc22c03efd7d49b214af77d7451e9e67e1cc3b485ad6f0L88-R66), [link](https://github.com/coordinape/coordinape/pull/2215/files?diff=unified&w=0#diff-bb52971d8c2a4e27cacc22c03efd7d49b214af77d7451e9e67e1cc3b485ad6f0L95-R75), [link](https://github.com/coordinape/coordinape/pull/2215/files?diff=unified&w=0#diff-bb52971d8c2a4e27cacc22c03efd7d49b214af77d7451e9e67e1cc3b485ad6f0L291-R277))
*  Add `coSoul` data to the `ProfilePageContent` component using the `useQuery` hook and the `queryProfilePgive` function, which fetches the `totalPgive` and the `mintInfo` of the profile from the Hasura API ([link](https://github.com/coordinape/coordinape/pull/2215/files?diff=unified&w=0#diff-bb52971d8c2a4e27cacc22c03efd7d49b214af77d7451e9e67e1cc3b485ad6f0R104-R113), [link](https://github.com/coordinape/coordinape/pull/2215/files?diff=unified&w=0#diff-f61a16992f4882d5c7fda4f376be7159119cd56227a70f5a398985ed0a9ccc62L104-R104), [link](https://github.com/coordinape/coordinape/pull/2215/files?diff=unified&w=0#diff-f61a16992f4882d5c7fda4f376be7159119cd56227a70f5a398985ed0a9ccc62L117-R139))
*  Change the condition for rendering the CoSoul art and the mint button to check if the `coSoul` data has a `mintInfo` property, which indicates if the profile has already minted a CoSoul token or not ([link](https://github.com/coordinape/coordinape/pull/2215/files?diff=unified&w=0#diff-bb52971d8c2a4e27cacc22c03efd7d49b214af77d7451e9e67e1cc3b485ad6f0L275-R261))
*  Reorder the imports in the `ProfilePage` and `queries` files to follow the alphabetical order of the imported names, as a minor code style improvement ([link](https://github.com/coordinape/coordinape/pull/2215/files?diff=unified&w=0#diff-bb52971d8c2a4e27cacc22c03efd7d49b214af77d7451e9e67e1cc3b485ad6f0L23-R23), [link](https://github.com/coordinape/coordinape/pull/2215/files?diff=unified&w=0#diff-bb52971d8c2a4e27cacc22c03efd7d49b214af77d7451e9e67e1cc3b485ad6f0L30-R32), [link](https://github.com/coordinape/coordinape/pull/2215/files?diff=unified&w=0#diff-f61a16992f4882d5c7fda4f376be7159119cd56227a70f5a398985ed0a9ccc62L7-R7))
