### PR TITLE
remove caching on the art handler

### DIFF
--- a/api/cosoul/art/[artTokenId].ts
+++ b/api/cosoul/art/[artTokenId].ts
@@ -4,7 +4,7 @@ import { adminClient } from '../../../api-lib/gql/adminClient';
 import { errorResponse, NotFoundError } from '../../../api-lib/HttpError';
 import { Awaited } from '../../../api-lib/ts4.5shim';
 
-const CACHE_SECONDS = 60 * 5;
+// const CACHE_SECONDS = 60 * 5;
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   try {
     let artTokenId: number | undefined;
@@ -17,7 +17,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
     const data = await getCosoulArtData(artTokenId);
 
-    res.setHeader('Cache-Control', 'max-age=0, s-maxage=' + CACHE_SECONDS);
+    // res.setHeader('Cache-Control', 'max-age=0, s-maxage=' + CACHE_SECONDS);
     return res.status(200).send(data);
   } catch (error: any) {
     return errorResponse(res, error);


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a866422</samp>

Disabled caching of art data API responses to reflect the latest metadata from the Coordinape smart contract. This affects the file `./api/cosoul/art/[artTokenId].ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a866422</samp>

> _No more caching, no more lies_
> _The art data must be fresh and true_
> _We defy the contract's tyranny_
> _We update the metadata anew_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a866422</samp>

*  Disable the caching of the art data API response ([link](https://github.com/coordinape/coordinape/pull/2217/files?diff=unified&w=0#diff-8a513163f8449f612956f9c609b9b079493b1c71f86cd13dc2f8d3902724387aL7-R7), [link](https://github.com/coordinape/coordinape/pull/2217/files?diff=unified&w=0#diff-8a513163f8449f612956f9c609b9b079493b1c71f86cd13dc2f8d3902724387aL20-R20))
