### PR TITLE
sync database right after mint instead of after reveal

### DIFF
--- a/src/features/cosoul/CoSoulButton.tsx
+++ b/src/features/cosoul/CoSoulButton.tsx
@@ -8,7 +8,7 @@ import { chain } from './chains';
 import { MintOrBurnButton } from './MintOrBurnButton';
 import { useCoSoulContracts } from './useCoSoulContracts';
 
-export const CoSoulButton = ({ onMint }: { onMint(): void }) => {
+export const CoSoulButton = ({ onReveal }: { onReveal(): void }) => {
   const { library, chainId, account } = useWeb3React();
   const contracts = useCoSoulContracts();
   const { showError } = useToast();
@@ -39,6 +39,10 @@ export const CoSoulButton = ({ onMint }: { onMint(): void }) => {
   }
 
   return (
-    <MintOrBurnButton contracts={contracts} address={account} onMint={onMint} />
+    <MintOrBurnButton
+      contracts={contracts}
+      address={account}
+      onReveal={onReveal}
+    />
   );
 };

--- a/src/features/cosoul/CoSoulCreate.tsx
+++ b/src/features/cosoul/CoSoulCreate.tsx
@@ -126,7 +126,7 @@ export const CoSoulCreate = ({
           </Text>
         </Flex>
         <Flex column css={{ gap: '$sm' }}>
-          <CoSoulButton onMint={onMint} />
+          <CoSoulButton onReveal={onMint} />
           <Text color="secondary">
             There are no fees to mint CoSouls, and gas costs are minimal.
           </Text>

--- a/src/features/cosoul/CoSoulCreate.tsx
+++ b/src/features/cosoul/CoSoulCreate.tsx
@@ -17,11 +17,11 @@ type CoSoulData = QueryCoSoulResult;
 export const CoSoulCreate = ({
   cosoul_data,
   minted,
-  onMint,
+  onReveal,
 }: {
   cosoul_data: CoSoulData;
   minted?: boolean;
-  onMint(): void;
+  onReveal(): void;
 }) => {
   const coSoulMinted = Boolean(cosoul_data.mintInfo ?? minted);
   const pgiveScrambler = useRef<HTMLSpanElement>(null);
@@ -126,7 +126,7 @@ export const CoSoulCreate = ({
           </Text>
         </Flex>
         <Flex column css={{ gap: '$sm' }}>
-          <CoSoulButton onReveal={onMint} />
+          <CoSoulButton onReveal={onReveal} />
           <Text color="secondary">
             There are no fees to mint CoSouls, and gas costs are minimal.
           </Text>

--- a/src/features/cosoul/CoSoulManagement.tsx
+++ b/src/features/cosoul/CoSoulManagement.tsx
@@ -12,11 +12,11 @@ type CoSoulData = QueryCoSoulResult;
 
 export const CoSoulManagement = ({
   cosoul_data,
-  onMint,
+  onReveal,
   address,
 }: {
   cosoul_data: CoSoulData;
-  onMint(): void;
+  onReveal(): void;
   address: string;
 }) => {
   const minted_date =
@@ -57,7 +57,7 @@ export const CoSoulManagement = ({
         >
           View Your CoSoul
         </Button>
-        <CoSoulButton onReveal={onMint} />
+        <CoSoulButton onReveal={onReveal} />
       </Flex>
     </Panel>
   );

--- a/src/features/cosoul/CoSoulManagement.tsx
+++ b/src/features/cosoul/CoSoulManagement.tsx
@@ -57,7 +57,7 @@ export const CoSoulManagement = ({
         >
           View Your CoSoul
         </Button>
-        <CoSoulButton onMint={onMint} />
+        <CoSoulButton onReveal={onMint} />
       </Flex>
     </Panel>
   );

--- a/src/features/cosoul/MintPage.tsx
+++ b/src/features/cosoul/MintPage.tsx
@@ -56,7 +56,7 @@ export const MintPage = () => {
               <CoSoulProfileInfo cosoul_data={cosoul_data} />
               <CoSoulManagement
                 cosoul_data={cosoul_data}
-                onMint={() => setMinted(true)}
+                onReveal={() => setMinted(true)}
                 address={address}
               />
             </>
@@ -69,7 +69,7 @@ export const MintPage = () => {
               <CoSoulCreate
                 cosoul_data={cosoul_data}
                 minted={minted}
-                onMint={() => setMinted(true)}
+                onReveal={() => setMinted(true)}
               />
               <CoSoulComposition cosoul_data={cosoul_data} minted={minted}>
                 <CoSoulArtContainer cosoul_data={cosoul_data} minted={minted}>

--- a/src/features/cosoul/MintingModal.tsx
+++ b/src/features/cosoul/MintingModal.tsx
@@ -11,7 +11,8 @@ export const MINTING_STEPS = [
   'Connect to Optimism',
   'Approve Transaction',
   // 'Reticulate Splines',
-  'Engrave on the Blockchain',
+  'Minting your CoSoul',
+  'Etching your pGIVE on the Blockchain',
   // 'Commission the Artist',
 ] as const;
 


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 259711c</samp>

Refactored the CoSoul minting and revealing logic to use separate components and props. Improved the user interface and the code readability by renaming the minting steps and the `onMint` prop to `onReveal`. Affected files include `CoSoulButton.tsx`, `MintOrBurnButton.tsx`, `CoSoulCreate.tsx`, `CoSoulManagement.tsx`, and `MintingModal.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 259711c</samp>

> _Oh, we're the CoSoul crew and we mint and reveal_
> _We use the `onReveal` prop to etch our pGIVE_
> _We heave and we ho and we refactor our code_
> _We simplify our logic and we lighten our load_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 259711c</samp>

*  Rename `onMint` prop to `onReveal` in `CoSoulButton` component to reflect new logic of revealing CoSoul after minting ([link](https://github.com/coordinape/coordinape/pull/2220/files?diff=unified&w=0#diff-f7c2d440a5cadbf60bb711e3b997d2b71abfc3d6b079d9821f62650b02f36707L11-R11))
*  Replace `onMint` prop with `onReveal` prop in `CoSoulButton` component in `CoSoulCreate` and `CoSoulManagement` components to match the change in `CoSoulButton` ([link](https://github.com/coordinape/coordinape/pull/2220/files?diff=unified&w=0#diff-977da59b488c5f16f8b27e21dde7c7f7cb4f774074fe9c8b33ff78cf89077e88L129-R129), [link](https://github.com/coordinape/coordinape/pull/2220/files?diff=unified&w=0#diff-0f9d60e4d2b8dcc61dfe3d0f8fdc71368df81319a2b6613d96a5ff17941e69bbL60-R60))
*  Update `MINTING_STEPS` array in `MintingModal` component to describe new minting and revealing steps more clearly ([link](https://github.com/coordinape/coordinape/pull/2220/files?diff=unified&w=0#diff-66d30e0e4662d9641c0ac98c4604782dbf36f6292b8229c8847e94b0efc16707L14-R15))
*  Remove `onSuccess` prop and replace it with `onReveal` and `onMint` props in `MintOrBurnButton` component to handle minting and revealing logic separately ([link](https://github.com/coordinape/coordinape/pull/2220/files?diff=unified&w=0#diff-f38e6ed59a7956c585a4215ed549d4216a411629b0e00d8588773733b97503f0L16-R20))
*  Remove `refresh` and `onMint` function calls from `minted` function in `MintOrBurnButton` component as they are no longer needed after minting transaction is completed ([link](https://github.com/coordinape/coordinape/pull/2220/files?diff=unified&w=0#diff-f38e6ed59a7956c585a4215ed549d4216a411629b0e00d8588773733b97503f0L30), [link](https://github.com/coordinape/coordinape/pull/2220/files?diff=unified&w=0#diff-f38e6ed59a7956c585a4215ed549d4216a411629b0e00d8588773733b97503f0L58-R59))
*  Move `syncing` state and `LoadingModal` component from `MintOrBurnButton` component to `BurnButton` component as they are only relevant for burning logic ([link](https://github.com/coordinape/coordinape/pull/2220/files?diff=unified&w=0#diff-f38e6ed59a7956c585a4215ed549d4216a411629b0e00d8588773733b97503f0L58-R59), [link](https://github.com/coordinape/coordinape/pull/2220/files?diff=unified&w=0#diff-f38e6ed59a7956c585a4215ed549d4216a411629b0e00d8588773733b97503f0L75-R89))
*  Add `onMint` function call to `BurnButton` component as a prop to pass minting transaction hash to `MintOrBurnButton` component ([link](https://github.com/coordinape/coordinape/pull/2220/files?diff=unified&w=0#diff-f38e6ed59a7956c585a4215ed549d4216a411629b0e00d8588773733b97503f0L75-R89))
*  Add `refresh` function call to `onSuccess` prop of `BurnButton` component to update CoSoul token state after burning transaction is completed ([link](https://github.com/coordinape/coordinape/pull/2220/files?diff=unified&w=0#diff-f38e6ed59a7956c585a4215ed549d4216a411629b0e00d8588773733b97503f0L75-R89))
*  Remove `txHash` state and `setTxHash` function from `MintButton` component as they are no longer needed to store minting transaction hash ([link](https://github.com/coordinape/coordinape/pull/2220/files?diff=unified&w=0#diff-f38e6ed59a7956c585a4215ed549d4216a411629b0e00d8588773733b97503f0L87-R105))
*  Add `onReveal` and `onMint` props to `MintButton` component to pass reveal and mint functions from `CoSoulButton` and `MintOrBurnButton` components respectively ([link](https://github.com/coordinape/coordinape/pull/2220/files?diff=unified&w=0#diff-f38e6ed59a7956c585a4215ed549d4216a411629b0e00d8588773733b97503f0L87-R105))
*  Add `onMint` function call to `minted` function in `MintButton` component to pass minting transaction hash to `MintOrBurnButton` component ([link](https://github.com/coordinape/coordinape/pull/2220/files?diff=unified&w=0#diff-f38e6ed59a7956c585a4215ed549d4216a411629b0e00d8588773733b97503f0L140-R151))
*  Add `showProgress` function call to `minted` function in `MintButton` component to advance minting step to the next one after minting transaction is confirmed ([link](https://github.com/coordinape/coordinape/pull/2220/files?diff=unified&w=0#diff-f38e6ed59a7956c585a4215ed549d4216a411629b0e00d8588773733b97503f0L140-R151))
*  Remove `txHash` variable check from `reveal` function in `MintButton` component as it is no longer needed to store minting transaction hash ([link](https://github.com/coordinape/coordinape/pull/2220/files?diff=unified&w=0#diff-f38e6ed59a7956c585a4215ed549d4216a411629b0e00d8588773733b97503f0L151-R163))
*  Add `onReveal` function call to `reveal` function in `MintButton` component to trigger reveal logic from `CoSoulButton` component ([link](https://github.com/coordinape/coordinape/pull/2220/files?diff=unified&w=0#diff-f38e6ed59a7956c585a4215ed549d4216a411629b0e00d8588773733b97503f0L151-R163))
