### PR TITLE
cosoul splash copy changes

### DIFF
--- a/src/features/cosoul/CoSoulArtContainer.tsx
+++ b/src/features/cosoul/CoSoulArtContainer.tsx
@@ -108,7 +108,9 @@ export const CoSoulArtContainer = ({
           )}
           <Box css={{ position: 'absolute', bottom: '-1.5rem', right: 0 }}>
             {minted_date && (
-              <Text size="small">CoSoul minted on {minted_date}</Text>
+              <Text size="small" color="dim">
+                CoSoul minted on {minted_date}
+              </Text>
             )}
           </Box>
         </Box>

--- a/src/features/cosoul/CoSoulLayout.tsx
+++ b/src/features/cosoul/CoSoulLayout.tsx
@@ -1,6 +1,9 @@
+import { useEffect } from 'react';
+
 import { NavLogo } from 'features/nav/NavLogo';
 import { dark } from 'stitches.config';
 
+import { scrollToTop } from 'components';
 import { GlobalUi } from 'components/GlobalUi';
 import HelpButton from 'components/HelpButton';
 import { Box, Flex } from 'ui';
@@ -9,6 +12,9 @@ import { SingleColumnLayout } from 'ui/layouts';
 import { CoSoulNav } from '.';
 
 const CoSoulLayout = ({ children }: { children: React.ReactNode }) => {
+  useEffect(() => {
+    scrollToTop();
+  });
   return (
     <Box
       className={dark}

--- a/src/features/cosoul/CoSoulPromo.tsx
+++ b/src/features/cosoul/CoSoulPromo.tsx
@@ -33,7 +33,7 @@ export const CoSoulPromo = ({
           }}
         >
           <Text p as="p" color="secondary">
-            CoSoul is your avatar in the Coordinape universe. It&apos;s a
+            Bring your GIVE onchain my minting your CoSoul. It&apos;s a
             free-to-mint SoulBound NFT that grants you access and reputation
             into untold web3 worlds!
           </Text>

--- a/src/features/cosoul/SplashPage.tsx
+++ b/src/features/cosoul/SplashPage.tsx
@@ -88,14 +88,13 @@ export const SplashPage = () => {
                 borderBottom: '1px solid $linkHover',
                 pb: '$xs',
                 mb: '$sm',
+                mt: '$3xl',
               }}
             >
               CoSoul
             </Text>
             <Text h1 display color="cta">
-              Your avatar in the
-              <br />
-              Coordinape universe
+              Bring your GIVE onchain
             </Text>
           </Flex>
           <Text h2 display color="secondary" css={{ maxWidth: '20em' }}>

--- a/src/stitches.config.ts
+++ b/src/stitches.config.ts
@@ -93,6 +93,7 @@ export const colors = {
   activePanel: figmaColors.secondary1,
 
   dim: figmaColors.grey1,
+  dimText: figmaColors.grey4,
   dimButtonHover: '#FFFFFF',
   textOnDim: figmaColors.grey5,
 
@@ -456,6 +457,7 @@ export const dark = createTheme({
 
     neutral: figmaColors.grey6,
     dim: figmaColors.grey8,
+    dimText: figmaColors.grey7,
     dimButtonHover: figmaColors.grey9,
     textOnDim: figmaColors.grey5,
     modalBackground: '#0000007d',

--- a/src/ui/Text/Text.tsx
+++ b/src/ui/Text/Text.tsx
@@ -111,6 +111,7 @@ export const Text = styled('span', {
       active: { color: '$tagActiveText' },
       complete: { color: '$complete' },
       inherit: { color: 'inherit' },
+      dim: { color: '$dimText' },
     },
     bold: { true: { fontWeight: '$bold !important' } },
     normal: { true: { fontWeight: '$normal !important' } },

--- a/src/ui/Text/Text.tsx
+++ b/src/ui/Text/Text.tsx
@@ -70,7 +70,7 @@ export const Text = styled('span', {
         color: '$text !default',
         fontSize: '$medium',
         lineHeight: '$base',
-        mb: '$sm',
+        mb: '$xs',
         '&:last-of-type': {
           mb: 0,
         },


### PR DESCRIPTION

<img width="1095" alt="Screenshot 2023-06-23 at 3 16 36 PM" src="https://github.com/coordinape/coordinape/assets/100873710/988ccd5d-1336-441f-bb74-e31b639cd7b4">


## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dae21a9</samp>

Improved the UI and copy of the CoSoul feature to make it more appealing and informative for users. Adjusted the `SplashPage` and `CoSoulPromo` components and the `Text` component used by them.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at dae21a9</samp>

> _Oh, we're the CoSoul crew and we mint NFTs_
> _We bring the GIVE token onchain for web3_
> _We heave and ho and tweak the `SplashPage` layout_
> _We make the `CoSoulPromo` text stand out_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dae21a9</samp>

*  Update the text and layout of the `CoSoulPromo` component to highlight the benefit of minting a CoSoul NFT ([link](https://github.com/coordinape/coordinape/pull/2229/files?diff=unified&w=0#diff-697c57597bf47d9114f4b5312da22ef6f1088988d8cb161758e17b0122df3e86L36-R36), [link](https://github.com/coordinape/coordinape/pull/2229/files?diff=unified&w=0#diff-b43ef01230c6952eb46ff957b2ed7655a981448947dfe5db28cd2e373a648e35L96-R97), [link](https://github.com/coordinape/coordinape/pull/2229/files?diff=unified&w=0#diff-8f7f4832e549bd24f176bc0eafb9f62b1eb7b9c752708493db3fe77ff0a84856L73-R73))
*  Add more margin to the `SplashPage` component to create more space between the logo and the headline ([link](https://github.com/coordinape/coordinape/pull/2229/files?diff=unified&w=0#diff-b43ef01230c6952eb46ff957b2ed7655a981448947dfe5db28cd2e373a648e35R91))
