### PR TITLE
Route for still image of CoSoul

### DIFF
--- a/src/features/cosoul/MintPage.tsx
+++ b/src/features/cosoul/MintPage.tsx
@@ -73,11 +73,7 @@ export const MintPage = () => {
               />
               <CoSoulComposition cosoul_data={cosoul_data} minted={minted}>
                 <CoSoulArtContainer cosoul_data={cosoul_data} minted={minted}>
-                  <CoSoulArt
-                    pGive={cosoul_data.totalPgive}
-                    address={address}
-                    animate={true}
-                  />
+                  <CoSoulArt pGive={cosoul_data.totalPgive} address={address} />
                 </CoSoulArtContainer>
               </CoSoulComposition>
               <CoSoulDetails cosoul_data={cosoul_data} minted={minted} />

--- a/src/features/cosoul/art/CoSoulArt.stories.tsx
+++ b/src/features/cosoul/art/CoSoulArt.stories.tsx
@@ -20,6 +20,4 @@ export const CoSoulArt = Template.bind({});
 CoSoulArt.args = {
   pGive: 9999,
   address: '0x6959A0e3C5486222cB8Ba3ab94e4f9444Df4F3bC',
-  // showGui: true,
-  // animate: true,
 };

--- a/src/features/cosoul/art/CoSoulArt.tsx
+++ b/src/features/cosoul/art/CoSoulArt.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { artWidth, artWidthMobile } from '../constants';
 
 import Display from './CoSoulArtDisplay.js';
@@ -9,13 +8,11 @@ const linewidth = 3;
 export const CoSoulArt = ({
   pGive,
   address,
-  showGui = false,
   animate = true,
   width,
 }: {
   pGive?: number;
   address?: string;
-  showGui?: boolean;
   animate?: boolean;
   width?: string;
 }) => {
@@ -35,8 +32,7 @@ export const CoSoulArt = ({
       resolution={resolution}
       lineWidth={linewidth}
       canvasStyles={canvasStyles}
-      // showGui={showGui}
-      // animate={animate}
+      animate={animate}
     />
   );
 };

--- a/src/features/cosoul/art/CoSoulArt2.stories.tsx
+++ b/src/features/cosoul/art/CoSoulArt2.stories.tsx
@@ -18,6 +18,4 @@ export const CoSoulArt2 = Template.bind({});
 CoSoulArt2.args = {
   pGive: 9999,
   address: '0x6959A0e3C5486222cB8Ba3ab94e4f9444Df4F3bC',
-  // showGui: true,
-  // animate: true,
 };

--- a/src/features/cosoul/art/CoSoulArtDisplay.js
+++ b/src/features/cosoul/art/CoSoulArtDisplay.js
@@ -6,14 +6,14 @@ import initDisplay from './initdisplay.js';
 import { genParamsObj } from './mainparams.js';
 
 var glview = undefined;
-const animate = true; // <keep this locked to true for now.
-const useGui = false;
 
 export default function Display({
   params = {},
   resolution = [2000, 2000],
   lineWidth = 1,
   canvasStyles = {},
+  animate = true,
+  useGui = false,
 }) {
   const canvasForegroundRef = useRef(null);
   const canvasBackgroundRef = useRef(null);

--- a/src/features/cosoul/art/CoSoulArtPublic.tsx
+++ b/src/features/cosoul/art/CoSoulArtPublic.tsx
@@ -5,7 +5,7 @@ import { CosoulArtData } from '../../../../api/cosoul/art/[artTokenId]';
 
 import { CoSoulArt } from './CoSoulArt';
 
-export const CoSoulArtPublic = () => {
+export const CoSoulArtPublic = ({ animate = true }: { animate?: boolean }) => {
   const params = useParams();
   const artTokenId = Number(params.tokenId);
 
@@ -35,7 +35,7 @@ export const CoSoulArtPublic = () => {
 
   if (!!data?.address && data?.pGive >= 0) {
     return (
-      <CoSoulArt pGive={data.pGive} address={data.address} animate={true} />
+      <CoSoulArt pGive={data.pGive} address={data.address} animate={animate} />
     );
   } else {
     return <>No CoSoul exists for this tokenId</>;

--- a/src/pages/ProfilePage/ProfilePage.tsx
+++ b/src/pages/ProfilePage/ProfilePage.tsx
@@ -276,7 +276,6 @@ const ProfilePageContent = ({
                 <CoSoulArt
                   pGive={coSoul.totalPgive}
                   address={profile.address}
-                  animate={true}
                   width={artWidth}
                 />
                 <Button

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -71,6 +71,7 @@ export const paths = {
   mint: '/cosoul/mint',
   cosoulView: (address: string) => `/cosoul/${address}`,
   cosoulArt: (tokenId: string) => `/cosoul/art/${tokenId}`,
+  cosoulStill: (tokenId: string) => `/cosoul/still/${tokenId}`,
   cosoulGallery: '/cosoul/gallery',
 
   profile: (address: string) => `/profile/${address}`,

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -71,7 +71,7 @@ export const paths = {
   mint: '/cosoul/mint',
   cosoulView: (address: string) => `/cosoul/${address}`,
   cosoulArt: (tokenId: string) => `/cosoul/art/${tokenId}`,
-  cosoulStill: (tokenId: string) => `/cosoul/still/${tokenId}`,
+  cosoulImage: (tokenId: string) => `/cosoul/image/${tokenId}`,
   cosoulGallery: '/cosoul/gallery',
 
   profile: (address: string) => `/profile/${address}`,

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -151,6 +151,10 @@ export const AppRoutes = () => {
             path={paths.cosoulArt(':tokenId')}
             element={<CoSoulArtPublic />}
           />
+          <Route
+            path={paths.cosoulStill(':tokenId')}
+            element={<CoSoulArtPublic animate={false} />}
+          />
           <Route path={paths.cosoulGallery} element={<CoSoulGalleryPage />} />
         </Route>
       )}

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -152,7 +152,7 @@ export const AppRoutes = () => {
             element={<CoSoulArtPublic />}
           />
           <Route
-            path={paths.cosoulStill(':tokenId')}
+            path={paths.cosoulImage(':tokenId')}
             element={<CoSoulArtPublic animate={false} />}
           />
           <Route path={paths.cosoulGallery} element={<CoSoulGalleryPage />} />


### PR DESCRIPTION
* `http.../cosoul/still/[token_id]` for still image of cosoul
* animation no longer hard coded, true by defaul

## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 456a16f</samp>

Added animation and GUI options to the `CoSoulArt` component and its display variants. Refactored the code to remove unused props and constants. Created a new route and path for displaying a still version of the CoSoul art.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 456a16f</samp>

> _Sing, O Muse, of the skillful coder who removed_
> _The `showGui` and `animate` props from the `CoSoulArt`_
> _Like Zeus who stripped away the clouds and thunder_
> _To reveal the clear and shining sky to mortal eyes._

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 456a16f</samp>

*  Remove `showGui` prop from `CoSoulArt` and `CoSoulArt2` components and their stories ([link](https://github.com/coordinape/coordinape/pull/2230/files?diff=unified&w=0#diff-14a3646edeee4afe79fe96428e00d64d6dc99a4e0b0b1e5ed90ff238778a877dL23-L24), [link](https://github.com/coordinape/coordinape/pull/2230/files?diff=unified&w=0#diff-0d32f46ad080049e96febbbed420394d392db3af9f64f964210bee3bab9d91feL12), [link](https://github.com/coordinape/coordinape/pull/2230/files?diff=unified&w=0#diff-0d32f46ad080049e96febbbed420394d392db3af9f64f964210bee3bab9d91feL18), [link](https://github.com/coordinape/coordinape/pull/2230/files?diff=unified&w=0#diff-b9fe896f0b40a9c39404a59dfa03e770f0b0d1cf3d92488a65428d9f70113a69L21-L22))
*  Remove `animate` and `useGui` constants from `CoSoulArtDisplay.js` and pass them as props from `CoSoulArt` ([link](https://github.com/coordinape/coordinape/pull/2230/files?diff=unified&w=0#diff-5d755008a9ce54739b8fe2334cde9cb1e3aae91920c99d564d9937d0096cb382L9-L10), [link](https://github.com/coordinape/coordinape/pull/2230/files?diff=unified&w=0#diff-5d755008a9ce54739b8fe2334cde9cb1e3aae91920c99d564d9937d0096cb382R15-R16))
*  Add optional `animate` prop to `CoSoulArtPublic` and pass it to `CoSoulArt` based on the route ([link](https://github.com/coordinape/coordinape/pull/2230/files?diff=unified&w=0#diff-92b5ca8f39f680ccbd0ad803deb384daa76a397984fbb9bd6226d9552f5d08ffL8-R8), [link](https://github.com/coordinape/coordinape/pull/2230/files?diff=unified&w=0#diff-92b5ca8f39f680ccbd0ad803deb384daa76a397984fbb9bd6226d9552f5d08ffL38-R38))
*  Remove `animate` prop from `CoSoulArt` in `MintPage` and `ProfilePageContent` components, as it is now handled by `CoSoulArtPublic` ([link](https://github.com/coordinape/coordinape/pull/2230/files?diff=unified&w=0#diff-a9d33a03447e2b96e70bddf1ebde47791709f7845cfffb8c05a3ee3dacf0348fL76-R76), [link](https://github.com/coordinape/coordinape/pull/2230/files?diff=unified&w=0#diff-bb52971d8c2a4e27cacc22c03efd7d49b214af77d7451e9e67e1cc3b485ad6f0L279))
*  Add new path `/cosoul/still/:tokenId` to `paths.ts` and `routes.tsx` to display non-animated CoSoul art ([link](https://github.com/coordinape/coordinape/pull/2230/files?diff=unified&w=0#diff-26212c7e58b310fe67e20a7cd969dce535cc31c1f843f741c71641dddc7320ddR74), [link](https://github.com/coordinape/coordinape/pull/2230/files?diff=unified&w=0#diff-0005a5feea8701ddb5aef0d57e1a5a03c36dae6cd62fc3ecf35fd15a88bb5c03R154-R157))
