### PR TITLE
exclude sample circles pgives

### DIFF
--- a/api-lib/pgives.ts
+++ b/api-lib/pgives.ts
@@ -377,6 +377,7 @@ const getCircleGifts = async (
           order_by: [{ id: order_by.asc }],
           where: {
             id: { _in: circleIds },
+            organization: { sample: { _eq: false } },
             epochs: {
               ended: { _eq: true },
             },


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a94d163</samp>

Exclude sample gifts from gift history query. This improves the accuracy and relevance of the gift history page by filtering out test data from the `api-lib/pgives.ts` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a94d163</samp>

> _`getCircleGifts` query_
> _Filters out sample org gifts_
> _No test data in spring_

## Why
exclude sample circles pgives

## Test and Deployment Plan
1- create a new sample circle
2- add another user to the sample circle
3- start an epoch in the sample circle
4- allocate some gives to the added user
5- end the epoch
6- run syncCirclePGive('sample circle number')
expected :
the sample circle data shouldn't appear in cosoul view page for that user
in hasura the epoch shouldn't have pgive data
7- repeat the same for a normal circle and the pgive data should appear in that circle

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a94d163</samp>

*  Exclude sample organization gifts from gift history query ([link](https://github.com/coordinape/coordinape/pull/2232/files?diff=unified&w=0#diff-529369fc17f643d067656b4ee8c29b7fc4b7e9eeff1bb7251756fa4658ed0d95R380))
