### PR TITLE
Cosoul/recover mint txs

### DIFF
--- a/api-lib/config.ts
+++ b/api-lib/config.ts
@@ -116,3 +116,7 @@ export const PGIVE_CIRCLE_MAX_PER_CRON = getEnvValue(
   'PGIVE_CIRCLE_MAX_PER_CRON',
   10
 );
+export const TENDERLY_WEBHOOK_SECRET: string = getEnvValue(
+  'TENDERLY_WEBHOOK_SECRET',
+  ''
+);

--- a/api-lib/pgives.ts
+++ b/api-lib/pgives.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { DateTime, Settings } from 'luxon';
 
 import {

--- a/api/cosoul/verify.ts
+++ b/api/cosoul/verify.ts
@@ -1,0 +1,24 @@
+/* eslint-disable no-console */
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+import { errorResponse } from '../../api-lib/HttpError';
+import { getMintInfo } from '../../src/features/cosoul/api/cosoul';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  try {
+    const payload = req.body;
+    const { event_type, transaction } = payload;
+
+    console.log({ event_type, transaction });
+
+    // fetch mintInfo
+    const mintInfo = await getMintInfo(transaction.hash);
+
+    console.log(mintInfo);
+    // TODO: verify info and reestablish database sanity
+
+    return res.status(200).send({ success: true });
+  } catch (error: any) {
+    return errorResponse(res, error);
+  }
+}

--- a/api/cosoul/verify.ts
+++ b/api/cosoul/verify.ts
@@ -1,19 +1,32 @@
-/* eslint-disable no-console */
+import assert from 'assert';
+import { createHmac, timingSafeEqual } from 'crypto';
+
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
+import { TENDERLY_WEBHOOK_SECRET } from '../../api-lib/config';
 import { errorResponse } from '../../api-lib/HttpError';
 import { getMintInfofromLogs } from '../../src/features/cosoul/api/cosoul';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   try {
+    const signature = req.headers['x-tenderly-signature'] as string;
+    const timestamp = req.headers['date'] as string;
+
+    assert(signature, 'Missing signature');
+    assert(timestamp, 'Missing timestamp');
+    if (!isValidSignature(signature, JSON.stringify(req.body), timestamp)) {
+      res.status(400).send('Webhook signature not valid');
+      return;
+    }
+
     const payload = req.body;
     const { event_type, transaction } = payload;
 
+    // eslint-disable-next-line no-console
     console.log({ event_type, transaction });
-
-    // fetch mintInfo
     const mintInfo = await getMintInfofromLogs(transaction.logs[0]);
 
+    // eslint-disable-next-line no-console
     console.log(mintInfo);
     // TODO: verify info and reestablish database sanity
 
@@ -21,4 +34,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   } catch (error: any) {
     return errorResponse(res, error);
   }
+}
+
+function isValidSignature(signature: string, body: string, timestamp: string) {
+  const signingKey = TENDERLY_WEBHOOK_SECRET;
+
+  const hmac = createHmac('sha256', signingKey); // Create a HMAC SHA256 hash using the signing key
+  hmac.update(body.toString(), 'utf8'); // Update the hash with the request body using utf8
+  hmac.update(timestamp); // Update the hash with the request timestamp
+  const digest = hmac.digest('hex');
+  return timingSafeEqual(Buffer.from(signature), Buffer.from(digest));
 }

--- a/api/cosoul/verify.ts
+++ b/api/cosoul/verify.ts
@@ -2,7 +2,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
 import { errorResponse } from '../../api-lib/HttpError';
-import { getMintInfo } from '../../src/features/cosoul/api/cosoul';
+import { getMintInfofromLogs } from '../../src/features/cosoul/api/cosoul';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   try {
@@ -12,7 +12,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     console.log({ event_type, transaction });
 
     // fetch mintInfo
-    const mintInfo = await getMintInfo(transaction.hash);
+    const mintInfo = await getMintInfofromLogs(transaction.logs[0]);
 
     console.log(mintInfo);
     // TODO: verify info and reestablish database sanity

--- a/scripts/serve_dev.ts
+++ b/scripts/serve_dev.ts
@@ -73,7 +73,10 @@ app.post('/api/hasura/remote/vaults', tf(vaults));
 app.get('/api/join/:token', (req, res) => {
   return tf(join)({ ...req, query: req.params }, res);
 });
-app.post('/api/cosoul/verify', tf(verify));
+
+// TODO: probably rename these to match prod, but this overlaps with :address route
+app.post('/api/_cosoul/verify', tf(verify));
+app.get('/api/_cosoul/verify', tf(verify));
 app.get('/api/cosoul/:address', (req, res) => {
   return tf(address)({ ...req, query: req.params }, res);
 });

--- a/scripts/serve_dev.ts
+++ b/scripts/serve_dev.ts
@@ -6,6 +6,7 @@ import morgan from 'morgan';
 import address from '../api/cosoul/[address]';
 import artTokenId from '../api/cosoul/art/[artTokenId]';
 import tokenId from '../api/cosoul/metadata/[tokenId]';
+import verify from '../api/cosoul/verify';
 import discord from '../api/discord/oauth';
 import actionManager from '../api/hasura/actions/actionManager';
 import auth from '../api/hasura/auth';
@@ -72,6 +73,7 @@ app.post('/api/hasura/remote/vaults', tf(vaults));
 app.get('/api/join/:token', (req, res) => {
   return tf(join)({ ...req, query: req.params }, res);
 });
+app.post('/api/cosoul/verify', tf(verify));
 app.get('/api/cosoul/:address', (req, res) => {
   return tf(address)({ ...req, query: req.params }, res);
 });

--- a/src/features/cosoul/api/cosoul.test.ts
+++ b/src/features/cosoul/api/cosoul.test.ts
@@ -6,7 +6,12 @@ import { CoSoul } from '@coordinape/hardhat/dist/typechain';
 import { Contracts } from '../contracts';
 import { provider, restoreSnapshot, takeSnapshot } from 'utils/testing';
 
-import { getOnChainPGIVE, getTokenId, setOnChainPGIVE } from './cosoul';
+import {
+  getOnChainPGIVE,
+  getTokenId,
+  setOnChainPGIVE,
+  getMintInfo,
+} from './cosoul';
 
 import { Awaited } from 'types/shim';
 
@@ -29,6 +34,16 @@ afterEach(async () => {
 test('getTokenId returns undefined if no nft exists', async () => {
   const tokenIdFetch = await getTokenId(mainAccount);
   expect(tokenIdFetch).toEqual(undefined);
+});
+
+test('getMintInfo returns mint info', async () => {
+  const tx = await contract.mint();
+  const data = await getMintInfo(tx.hash);
+  expect(data).toEqual({
+    from: '0x0000000000000000000000000000000000000000',
+    to: mainAccount,
+    tokenId: 1,
+  });
 });
 
 describe('with a minted nft', () => {

--- a/src/features/cosoul/api/cosoul.ts
+++ b/src/features/cosoul/api/cosoul.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { BigNumber, ethers, Wallet } from 'ethers';
 
 import { COSOUL_SIGNER_ADDR_PK } from '../../../../api-lib/config';
@@ -92,11 +91,11 @@ export async function getMintInfo(txHash: string) {
 }
 
 export async function getMintInfofromLogs(log: any) {
+  if (log === undefined) return null;
   const iface = getCoSoulContract().interface;
   const {
     args: { from, to, tokenId: tokenIdBN },
   } = iface.parseLog(log);
   const tokenId = tokenIdBN.toNumber();
-  console.log({ from, to, tokenId });
   return { from, to, tokenId };
 }

--- a/src/features/cosoul/api/cosoul.ts
+++ b/src/features/cosoul/api/cosoul.ts
@@ -72,6 +72,10 @@ export async function getMintInfo(txHash: string) {
 
   const iface = getCoSoulContract().interface;
 
+  if (receipt.logs === undefined) {
+    throw new Error('No logs found in the transaction receipt');
+  }
+
   for (const log of receipt.logs) {
     if (log.topics[0] === transferEventSignature) {
       const {

--- a/src/features/cosoul/api/cosoul.ts
+++ b/src/features/cosoul/api/cosoul.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { BigNumber, ethers, Wallet } from 'ethers';
 
 import { COSOUL_SIGNER_ADDR_PK } from '../../../../api-lib/config';
@@ -88,4 +89,14 @@ export async function getMintInfo(txHash: string) {
   }
 
   throw new Error('No Transfer event found in the transaction receipt');
+}
+
+export async function getMintInfofromLogs(log: any) {
+  const iface = getCoSoulContract().interface;
+  const {
+    args: { from, to, tokenId: tokenIdBN },
+  } = iface.parseLog(log);
+  const tokenId = tokenIdBN.toNumber();
+  console.log({ from, to, tokenId });
+  return { from, to, tokenId };
 }


### PR DESCRIPTION
## What

Create functionality to re-add cosouls minted off our site (or otherwise missed) to our database.

- Wrote (with tests) a helper function `getMintInfo` that returns the mint info given a txHash (by parsing the logs on the receipt)
- Setup a basic api handler to receive webhook info from tenderly
- TODO: make the database work again if a cosoul is missed.

You can view these in DD here: https://app.datadoghq.com/logs?query=%40proxy.path%3A%22%2Fapi%2Fcosoul%2Fverify%22%20&cols=host%2Cservice&index=%2A&messageDisplay=inline&saved-view-id=1757448&stream_sort=desc&viz=stream&from_ts=1687638444056&to_ts=1687897644056&live=true