### PR TITLE
cranking up frequency and count of cosoul syncing

### DIFF
--- a/api/hasura/cron/syncCoSouls.ts
+++ b/api/hasura/cron/syncCoSouls.ts
@@ -15,7 +15,7 @@ import { getLocalPGIVE } from '../../../src/features/cosoul/api/pgive';
 
 Settings.defaultZone = 'utc';
 
-const LIMIT_USERS_TO_SYNC = 10;
+const LIMIT_USERS_TO_SYNC = 100;
 
 type CoSoul = Awaited<ReturnType<typeof getCoSoulsToUpdate>>[number];
 

--- a/hasura/metadata/cron_triggers.yaml
+++ b/hasura/metadata/cron_triggers.yaml
@@ -85,7 +85,7 @@
   comment: tracks pending vault transactions in case the frontend doesn't update the state upon deployment
 - name: syncCoSouls
   webhook: '{{HASURA_API_BASE_URL}}/cron/syncCoSouls'
-  schedule: '*/2 * * * *'
+  schedule: '* * * * *'
   include_in_metadata: true
   payload: {}
   headers:


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 19e435d</samp>

Increased the frequency and the number of users that are synced for the CoSouls feature. This improves the performance and user experience of the feature by showing more up-to-date and accurate connections between users.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 19e435d</samp>

> _`syncCoSouls` faster_
> _More users see connections_
> _Winter of loneliness_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 19e435d</samp>

* Increase the number of users to sync CoSouls in each cron job run from 10 to 100 ([link](https://github.com/coordinape/coordinape/pull/2244/files?diff=unified&w=0#diff-bec200d548388ad9691f929432061db782d0630390749744eaabb7a4c71928ebL18-R18))
* Reduce the schedule of the `syncCoSouls` cron trigger from every 2 minutes to every minute ([link](https://github.com/coordinape/coordinape/pull/2244/files?diff=unified&w=0#diff-04d72cab6282bd0e7c1a13021a29b0efdd45cdda4be6fe1ea9d821b2c5e0ae1eL88-R88))
