### PR TITLE
Bugfix: CoSoul with 0 pgive should look simple

### DIFF
--- a/src/features/cosoul/art/mainparams.js
+++ b/src/features/cosoul/art/mainparams.js
@@ -5,7 +5,7 @@ const OVERFLOW = false;
 const fetch_params = false;
 const log_params = false;
 const fetch_url = 'http://localhost:5000/random';
-const fallback_lev = 2000;
+const fallback_lev = 1;
 /*
     params: 
     'id', 'pgive'or'level', 's' 


### PR DESCRIPTION

<img width="1375" alt="Screenshot 2023-06-29 at 12 22 41 PM" src="https://github.com/coordinape/coordinape/assets/100873710/0be031d1-1170-4c08-9237-305ed009d9c0">


## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6d32ebd</samp>

Reduced the default level of the art generator in `mainparams.js` to improve performance and user experience. This affects the fallback art that is displayed when the fetch request fails.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6d32ebd</samp>

> _`fallback_lev` low_
> _Art generator simplifies_
> _Autumn of code_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6d32ebd</samp>

*  Reduced the default level of the art generator to 1 when the fetch request fails ([link](https://github.com/coordinape/coordinape/pull/2247/files?diff=unified&w=0#diff-9ea7640a0b725fb0ee3b958ddb9a98341518924acdc45390a129c4b515f4bb19L8-R8)). This improves the performance and appearance of the fallback art in `src/features/cosoul/art/mainparams.js`.
