### PR TITLE
CoSoul Modal only show if logged in

### DIFF
--- a/src/components/MainLayout/MainLayout.tsx
+++ b/src/components/MainLayout/MainLayout.tsx
@@ -3,8 +3,6 @@ import HelpButton from '../HelpButton';
 import { GlobalUi } from 'components/GlobalUi';
 import { Box, Flex } from 'ui';
 
-import { Promos } from './Promos';
-
 export const MainLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <Box
@@ -22,7 +20,6 @@ export const MainLayout = ({ children }: { children: React.ReactNode }) => {
     >
       <Flex css={{ height: 'auto' }}>
         <SideNav />
-        <Promos />
         <Box css={{ width: '100%' }}>
           <GlobalUi />
           <HelpButton />

--- a/src/features/cosoul/CoSoulPromoModal.tsx
+++ b/src/features/cosoul/CoSoulPromoModal.tsx
@@ -8,18 +8,18 @@ import { IN_PRODUCTION } from 'config/env';
 import { paths } from 'routes/paths';
 import { Button, Flex, Modal } from 'ui';
 
-export const Promos = () => {
+export const CoSoulPromoModal = ({ minted = false }: { minted?: boolean }) => {
   const [modal, setModal] = useState(true);
-  const closeCosoulPromoModal = () => {
+  const closeModal = () => {
     window.localStorage.setItem('cosoulPromo', 'hidden');
     setModal(false);
   };
   const suppressCosoulPromo =
-    true || window.localStorage.getItem('cosoulPromo') === 'hidden';
+    window.localStorage.getItem('cosoulPromo') === 'hidden';
   return (
     <>
-      {IN_PRODUCTION && !suppressCosoulPromo && (
-        <Modal loader open={modal} onOpenChange={() => closeCosoulPromoModal()}>
+      {!IN_PRODUCTION && !suppressCosoulPromo && (
+        <Modal loader open={modal} onOpenChange={() => closeModal()}>
           <Flex column css={{ gap: '$1xl' }}>
             <Flex
               css={{
@@ -41,7 +41,7 @@ export const Promos = () => {
               <Button
                 as={NavLink}
                 to={paths.cosoul}
-                onClick={() => closeCosoulPromoModal()}
+                onClick={() => closeModal()}
                 size="large"
                 color="cta"
                 css={{
@@ -62,12 +62,13 @@ export const Promos = () => {
                   },
                 }}
               >
-                Mint Your CoSoul NFT
+                {minted ? 'View ' : 'Mint '}
+                Your CoSoul NFT
               </Button>
               <Button
                 size="large"
                 css={{ background: 'transparent !important' }}
-                onClick={() => closeCosoulPromoModal()}
+                onClick={() => closeModal()}
               >
                 Close
               </Button>

--- a/src/features/cosoul/CoSoulPromoModal.tsx
+++ b/src/features/cosoul/CoSoulPromoModal.tsx
@@ -18,7 +18,7 @@ export const CoSoulPromoModal = ({ minted = false }: { minted?: boolean }) => {
     window.localStorage.getItem('cosoulPromo') === 'hidden';
   return (
     <>
-      {!IN_PRODUCTION && !suppressCosoulPromo && (
+      {IN_PRODUCTION && !suppressCosoulPromo && (
         <Modal loader open={modal} onOpenChange={() => closeModal()}>
           <Flex column css={{ gap: '$1xl' }}>
             <Flex

--- a/src/features/nav/SideNav.tsx
+++ b/src/features/nav/SideNav.tsx
@@ -1,5 +1,6 @@
 import { Suspense, useEffect, useState } from 'react';
 
+import { CoSoulPromoModal } from 'features/cosoul/CoSoulPromoModal';
 import {
   getCoSoulData,
   QUERY_KEY_COSOUL_PAGE,
@@ -198,65 +199,73 @@ export const SideNav = () => {
           </>
         )}
       </Flex>
-      <Flex column css={{ gap: '$sm' }}>
-        {isFeatureEnabled('cosoul') && (
-          <Button
-            color="cta"
-            size="xs"
-            as={NavLink}
-            onClick={() => cosoulCtaClick()}
-            css={{
-              zIndex: 3,
-              position: 'relative',
-              '&:before': {
-                ...pulseStyles,
-                animationDelay: '3s',
-                display: suppressCosoulCtaAnimation ? 'none' : 'block',
-              },
-              '&:after': {
-                ...pulseStyles,
-                animationDelay: '1.5s',
-                zIndex: -1,
-                display: suppressCosoulCtaAnimation ? 'none' : 'block',
-              },
-            }}
-            to={
-              cosoul_data?.mintInfo
-                ? paths.cosoulView(`${data?.profile.address}`)
-                : paths.cosoul
-            }
-          >
-            {cosoul_data?.mintInfo ? 'View ' : 'Mint '}
-            Your CoSoul NFT
-          </Button>
-        )}
-        {showClaimsButton && <NavClaimsButton />}
-      </Flex>
-      <Suspense fallback={null}>
-        <Flex
-          css={{
-            mt: '$sm',
-            width: '100%',
-            position: 'relative',
-            // gradient overlaying overflowing links
-            '&::after': {
-              content: '',
-              position: 'absolute',
-              background: 'linear-gradient(transparent, $navBackground)',
-              width: 'calc(100% + 6px)',
-              height: '100px',
-              top: '-103px',
-              left: '-3px',
-              pointerEvents: 'none',
-              zIndex: '2',
-            },
-          }}
-        >
-          {data && (
-            <NavProfile name={data.profile.name} avatar={data.profile.avatar} />
-          )}
-        </Flex>
-      </Suspense>
+      {data && (
+        <>
+          <Flex column css={{ gap: '$sm' }}>
+            {isFeatureEnabled('cosoul') && (
+              <>
+                <Button
+                  color="cta"
+                  size="xs"
+                  as={NavLink}
+                  onClick={() => cosoulCtaClick()}
+                  css={{
+                    zIndex: 3,
+                    position: 'relative',
+                    '&:before': {
+                      ...pulseStyles,
+                      animationDelay: '3s',
+                      display: suppressCosoulCtaAnimation ? 'none' : 'block',
+                    },
+                    '&:after': {
+                      ...pulseStyles,
+                      animationDelay: '1.5s',
+                      zIndex: -1,
+                      display: suppressCosoulCtaAnimation ? 'none' : 'block',
+                    },
+                  }}
+                  to={
+                    cosoul_data?.mintInfo
+                      ? paths.cosoulView(`${data?.profile.address}`)
+                      : paths.cosoul
+                  }
+                >
+                  {cosoul_data?.mintInfo ? 'View ' : 'Mint '}
+                  Your CoSoul NFT
+                </Button>
+                <CoSoulPromoModal minted={!!cosoul_data?.mintInfo} />
+              </>
+            )}
+            {showClaimsButton && <NavClaimsButton />}
+          </Flex>
+          <Suspense fallback={null}>
+            <Flex
+              css={{
+                mt: '$sm',
+                width: '100%',
+                position: 'relative',
+                // gradient overlaying overflowing links
+                '&::after': {
+                  content: '',
+                  position: 'absolute',
+                  background: 'linear-gradient(transparent, $navBackground)',
+                  width: 'calc(100% + 6px)',
+                  height: '100px',
+                  top: '-103px',
+                  left: '-3px',
+                  pointerEvents: 'none',
+                  zIndex: '2',
+                },
+              }}
+            >
+              <NavProfile
+                name={data.profile.name}
+                avatar={data.profile.avatar}
+              />
+            </Flex>
+          </Suspense>
+        </>
+      )}
     </Flex>
   );
 };


### PR DESCRIPTION
* Scope cosoul promo to alongside other stuff that requires login data, place next to cosoul cta
* change button text according to mint status

## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 453eb75</samp>

This pull request introduces a new feature to promote the CoSoul project, which allows users to mint their own CoSoul NFTs and join a community of like-minded peers. It renames and moves the `Promos` component to `CoSoulPromoModal` and adds logic to show different button text based on the user's CoSoul status. It also adds a new modal component to the side navigation bar and fixes a minor issue with the user profile and claims button.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 453eb75</samp>

> _`CoSoulPromoModal` is the gate to a new world_
> _Where you can mint your soul and join the rebel horde_
> _But beware of the bugs that lurk in the `MainLayout`_
> _They can ruin your profile and your claims without a doubt_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 453eb75</samp>

*  Rename and move `Promos` component to `CoSoulPromoModal` and add `minted` prop ([link](https://github.com/coordinape/coordinape/pull/2249/files?diff=unified&w=0#diff-d21b46f60a2f59cad2eae729a9626c7d1b1554832fa63dec0cd9633f2505a1e2L6-L7), [link](https://github.com/coordinape/coordinape/pull/2249/files?diff=unified&w=0#diff-d21b46f60a2f59cad2eae729a9626c7d1b1554832fa63dec0cd9633f2505a1e2L25), [link](https://github.com/coordinape/coordinape/pull/2249/files?diff=unified&w=0#diff-c74357fed02845ebbe9070d8bd518dab102fbca4f84f11a0aa8fdcb6dbd7119cL11-R22), [link](https://github.com/coordinape/coordinape/pull/2249/files?diff=unified&w=0#diff-c74357fed02845ebbe9070d8bd518dab102fbca4f84f11a0aa8fdcb6dbd7119cL44-R44), [link](https://github.com/coordinape/coordinape/pull/2249/files?diff=unified&w=0#diff-c74357fed02845ebbe9070d8bd518dab102fbca4f84f11a0aa8fdcb6dbd7119cL65-R71))
*  Import and use `CoSoulPromoModal` component in `SideNav` component and pass `minted` prop from `cosoul_data` state ([link](https://github.com/coordinape/coordinape/pull/2249/files?diff=unified&w=0#diff-14c17f2206802b962d016d8a767ac1e68950e89f32310c7371d04c790ed7138cR3), [link](https://github.com/coordinape/coordinape/pull/2249/files?diff=unified&w=0#diff-14c17f2206802b962d016d8a767ac1e68950e89f32310c7371d04c790ed7138cL201-R268))
*  Add conditional rendering for user profile and claims button in `SideNav` component to avoid errors when `data` is undefined ([link](https://github.com/coordinape/coordinape/pull/2249/files?diff=unified&w=0#diff-14c17f2206802b962d016d8a767ac1e68950e89f32310c7371d04c790ed7138cL201-R268))
