### PR TITLE
Address cosoul bug: no webgl 

### DIFF
--- a/src/features/cosoul/art/CoSoulArtDisplay.js
+++ b/src/features/cosoul/art/CoSoulArtDisplay.js
@@ -17,19 +17,23 @@ export default function Display({
 }) {
   const canvasForegroundRef = useRef(null);
   const canvasBackgroundRef = useRef(null);
+  const webglTest = useRef(null);
 
   // on init
   useEffect(() => {
     if (canvasForegroundRef.current && canvasBackgroundRef.current) {
-      let paramObj = genParamsObj(params);
-      glview = initDisplay(
-        canvasForegroundRef.current,
-        canvasBackgroundRef.current,
-        resolution,
-        paramObj,
-        useGui,
-        lineWidth
-      );
+      const webglEnabled = !!webglTest.current.getContext('webgl2');
+      if (webglEnabled) {
+        let paramObj = genParamsObj(params);
+        glview = initDisplay(
+          canvasForegroundRef.current,
+          canvasBackgroundRef.current,
+          resolution,
+          paramObj,
+          useGui,
+          lineWidth
+        );
+      }
     }
     return () => {
       // important:
@@ -53,6 +57,13 @@ export default function Display({
         position: 'relative',
       }}
     >
+      <Canvas
+        ref={webglTest}
+        css={{
+          position: 'absolute',
+          zIndex: -1,
+        }}
+      />
       <Canvas
         ref={canvasForegroundRef}
         css={{


### PR DESCRIPTION
* This is just a fix so that it doesn't fail miserably. 
* I want to add a friendly message, but I'm having some TS problems.  Will address it tomorrow.


## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 899c733</samp>

Improved CoSoulArtDisplay component to handle WebGL 2.0 support. Added a `webglTest` ref and a hidden canvas element to check the browser's WebGL capabilities.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 899c733</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A cunning test to probe the web's elusive glories,_
> _And with a `webglTest` ref he checked the might_
> _Of WebGL 2.0, that wondrous art of graphics._

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 899c733</samp>

*  Add a `webglTest` ref to check WebGL 2.0 support before initializing the display ([link](https://github.com/coordinape/coordinape/pull/2250/files?diff=unified&w=0#diff-5d755008a9ce54739b8fe2334cde9cb1e3aae91920c99d564d9937d0096cb382L20-R36), [link](https://github.com/coordinape/coordinape/pull/2250/files?diff=unified&w=0#diff-5d755008a9ce54739b8fe2334cde9cb1e3aae91920c99d564d9937d0096cb382R61-R67))
*  Assign the `webglTest` ref to a hidden canvas element in `CoSoulArtDisplay.js` ([link](https://github.com/coordinape/coordinape/pull/2250/files?diff=unified&w=0#diff-5d755008a9ce54739b8fe2334cde9cb1e3aae91920c99d564d9937d0096cb382R61-R67))
