### PR TITLE
ignore 404 errors for sentry

### DIFF
--- a/api-lib/HttpError.ts
+++ b/api-lib/HttpError.ts
@@ -109,7 +109,9 @@ export async function errorResponseWithStatusCode(
     if (error.causeMessage) {
       scope.setExtra('cause', error.causeMessage);
     }
-    if (error instanceof Error) {
+    if (error instanceof NotFoundError) {
+      // these are noisy and not actionable
+    } else if (error instanceof Error) {
       Sentry.captureException(error);
     } else if (error.message) {
       // Sentry much prefers an Error object to a string/object


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e447646</samp>

Reduce Sentry noise by ignoring NotFoundError instances in `api-lib/HttpError.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e447646</samp>

> _`NotFoundError`s_
> _skipped by Sentry reports now_
> _autumn leaves fall fast_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e447646</samp>

* Skip sending Sentry reports for `NotFoundError` instances to reduce noise and clutter ([link](https://github.com/coordinape/coordinape/pull/2253/files?diff=unified&w=0#diff-48d28f350b42735e90cd80caf40d84c5c219c5f701e3bc3fa9e9ad44f43b7318L112-R114))
