### PR TITLE
ignore sample dao in airtable trigger

### DIFF
--- a/api-lib/event_triggers/createCircleCRM.ts
+++ b/api-lib/event_triggers/createCircleCRM.ts
@@ -17,10 +17,21 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const { id, name, organization_id, contact } = data.new;
   try {
     const { organizations_by_pk } = await adminClient.query(
-      { organizations_by_pk: [{ id: organization_id }, { name: true }] },
+      {
+        organizations_by_pk: [
+          { id: organization_id },
+          { name: true, sample: true },
+        ],
+      },
       { operationName: 'getOrgNameForCRM' }
     );
     assert(organizations_by_pk);
+
+    if (organizations_by_pk.sample) {
+      const message = `crm data ignored because organization is sample - for circle ${name}`;
+      res.status(200).json({ message });
+      return;
+    }
 
     const { users } = await adminClient.query(
       {


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0297b79</samp>

Updated `createCircleCRM.ts` to skip CRM creation for sample organizations. This prevents cluttering the CRM with test data and respects the `sample` field in the `organizations` table.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0297b79</samp>

> _`sample` field added_
> _to query `organizations`_
> _no CRM for them_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0297b79</samp>

*  Add a `sample` field to the query for `organizations_by_pk` and return early if the organization is a sample ([link](https://github.com/coordinape/coordinape/pull/2254/files?diff=unified&w=0#diff-c8a40932b54f5c4ccb00fd441b14bc2d6193f65d10e3fed5053603554a8f6ea0L20-R35)). This prevents creating CRM records for sample organizations that are used for testing or demonstration purposes. The `sample` field was recently added to the `organizations` table in the database schema.
