### PR TITLE
Add a link to the map view in epoch panels

### DIFF
--- a/src/features/map/AMDrawer.tsx
+++ b/src/features/map/AMDrawer.tsx
@@ -30,9 +30,13 @@ interface MetricOption {
 export const AMDrawer = ({
   circleId,
   showPending,
+  epochId,
+  setEpochId,
 }: {
   circleId: number;
   showPending: boolean;
+  epochId?: number;
+  setEpochId: (epochId: number) => void;
 }) => {
   const role = useRoleInCircle(circleId);
 
@@ -57,8 +61,12 @@ export const AMDrawer = ({
       setAmEpochId(-1);
       return;
     }
-    setAmEpochId(amEpochs[amEpochs.length - 1]?.id);
-  }, [amEpochs.length]);
+    if (epochId) {
+      setAmEpochId(epochId);
+    } else {
+      setAmEpochId(amEpochs[amEpochs.length - 1]?.id);
+    }
+  }, [amEpochs.length, epochId]);
 
   const epochOptions = useMemo(() => {
     return amEpochs.length > 0
@@ -138,7 +146,7 @@ export const AMDrawer = ({
             <Select
               value={String(amEpochId)}
               options={epochOptions}
-              onValueChange={value => setAmEpochId(Number(value))}
+              onValueChange={value => setEpochId(Number(value))}
             />
             {showHiddenFeatures && (
               <Select

--- a/src/pages/HistoryPage/CurrentEpochPanel.tsx
+++ b/src/pages/HistoryPage/CurrentEpochPanel.tsx
@@ -14,7 +14,7 @@ import { FormInputField } from 'components';
 import { useToast } from 'hooks';
 import { Edit, Give, PlusCircle } from 'icons/__generated';
 import { paths } from 'routes/paths';
-import { Box, Panel, Text, Button, Flex, IconButton, HR } from 'ui';
+import { Box, Panel, Text, Button, Flex, IconButton, HR, AppLink } from 'ui';
 
 import { NotesSection } from './Notes';
 import { useReceiveInfo } from './useReceiveInfo';
@@ -96,16 +96,27 @@ export const CurrentEpochPanel = ({
             epochId={epoch.id}
             setDescriptionText={setEpochDescriptionText}
           />
-          {!isEditing && isAdmin && (
+          <Flex css={{ gap: '$xs' }}>
+            {!isEditing && isAdmin && (
+              <Button
+                css={{ mt: '$md' }}
+                color="secondary"
+                size="small"
+                onClick={() => editCurrentEpoch()}
+              >
+                Edit Epoch
+              </Button>
+            )}
             <Button
+              color="cta"
               css={{ mt: '$md' }}
-              color="secondary"
               size="small"
-              onClick={() => editCurrentEpoch()}
+              as={AppLink}
+              to={paths.map(circleId, { epochId: epoch.id })}
             >
-              Edit Epoch
+              View Map
             </Button>
-          )}
+          </Flex>
         </Flex>
         <Flex
           column

--- a/src/pages/HistoryPage/CurrentEpochPanel.tsx
+++ b/src/pages/HistoryPage/CurrentEpochPanel.tsx
@@ -96,7 +96,7 @@ export const CurrentEpochPanel = ({
             epochId={epoch.id}
             setDescriptionText={setEpochDescriptionText}
           />
-          <Flex css={{ gap: '$xs' }}>
+          <Flex css={{ gap: '$sm' }}>
             {!isEditing && isAdmin && (
               <Button
                 css={{ mt: '$md' }}

--- a/src/pages/HistoryPage/EpochPanel.tsx
+++ b/src/pages/HistoryPage/EpochPanel.tsx
@@ -104,17 +104,26 @@ export const EpochPanel = ({
               circleId={circleId}
               epochId={epoch.id}
             />
-            {isAdmin && (
-              <Box>
-                <Button
-                  color="cta"
-                  as={AppLink}
-                  to={paths.distributions(circleId, epoch.id)}
-                >
-                  Review & Export
-                </Button>
-              </Box>
-            )}
+            <Flex css={{ gap: '$sm' }}>
+              {isAdmin && (
+                <Box>
+                  <Button
+                    color="cta"
+                    as={AppLink}
+                    to={paths.distributions(circleId, epoch.id)}
+                  >
+                    Review & Export
+                  </Button>
+                </Box>
+              )}
+              <Button
+                color="cta"
+                as={AppLink}
+                to={paths.map(circleId, { epochId: epoch.id })}
+              >
+                View Map
+              </Button>
+            </Flex>
           </Flex>
         </Flex>
         <NotesSection

--- a/src/pages/MapPage/index.tsx
+++ b/src/pages/MapPage/index.tsx
@@ -5,7 +5,7 @@ import { AMForceGraph } from 'features/map/AMForceGraph';
 import { useFetchCircle } from 'features/map/queries';
 import { rMapEgoAddress } from 'features/map/state';
 import { ThemeContext } from 'features/theming/ThemeProvider';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation, useSearchParams } from 'react-router-dom';
 import { useRecoilCallback, useSetRecoilState } from 'recoil';
 
 import { Box } from '../../ui';
@@ -22,6 +22,11 @@ export default function MapPage() {
   const setAmEgoAddress = useSetRecoilState(rMapEgoAddress);
   const fetchCircle = useFetchCircle();
   const circleId = useCircleIdParam();
+  const [searchParams, setSearchParams] = useSearchParams();
+  let epochId = undefined;
+  if (searchParams.get('epochId')) {
+    epochId = Number(searchParams.get('epochId'));
+  }
   const [showPending, setShowPending] = useState(false);
   const [circle, setCircle] = useState<IApiCircle>();
 
@@ -44,10 +49,18 @@ export default function MapPage() {
   }, [location]);
 
   if (!circle) return null;
+  const setEpochId = (epochId: number) => {
+    setSearchParams({ epochId: String(epochId) });
+  };
 
   return (
     <Box css={{ position: 'relative', height: '100vh' }}>
-      <AMDrawer circleId={circle.id} showPending={showPending} />
+      <AMDrawer
+        circleId={circle.id}
+        showPending={showPending}
+        epochId={epochId}
+        setEpochId={setEpochId}
+      />
       <ThemeContext.Consumer>
         {({ stitchesTheme }) => <AMForceGraph stitchesTheme={stitchesTheme} />}
       </ThemeContext.Consumer>

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -58,7 +58,7 @@ export const paths = {
   vouching: circlePath('vouching'),
   distributions: (circleId: number, epochId: number | string) =>
     `/circles/${circleId}/distributions/${epochId}`,
-  map: (circleId: number, params?: { highlight?: string }) =>
+  map: (circleId: number, params?: { highlight?: string; epochId?: number }) =>
     withSearchParams(`/circles/${circleId}/map`, params),
 
   // other


### PR DESCRIPTION
added view map buttons to epoch panels
added query parameter for Epoch Id to map route
updated map epoch selector to change the query parameter

## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 460ad46</samp>

No summary available (An error occurred while summarizing these changes: Gave up after 3 retries: Failed to read error response)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 64916a1</samp>

> _To view epochs on the map with ease_
> _We added some buttons and queries_
> _The `AMDrawer` and `MapPage`_
> _Now share the same state_
> _And the `paths.map` function agrees_

## Why

resolves #2078

## Test and Deployment Plan
Navigate to map page from epoch panel and side bar

## Screenshots (if appropriate):
![image](https://github.com/coordinape/coordinape/assets/34943689/27686931-506d-4fd3-9ef9-ef177f8ba53d)

non admin
![image](https://github.com/coordinape/coordinape/assets/34943689/f268868c-b9ba-46bf-ac07-5d98e8fe326b)

admin
![image](https://github.com/coordinape/coordinape/assets/34943689/3942d3a2-2d3a-482a-af97-da85e263c752)


## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 460ad46</samp>

No walkthrough available (An error occurred while summarizing these changes: Gave up after 3 retries: Failed to read error response)
