### PR TITLE
add glow to profile menu avatar if got a cosoul

### DIFF
--- a/src/features/nav/NavProfile.tsx
+++ b/src/features/nav/NavProfile.tsx
@@ -14,9 +14,11 @@ import { NavItem } from './NavItem';
 export const NavProfile = ({
   name,
   avatar,
+  hasCoSoul,
 }: {
   name: string | undefined;
   avatar: string | undefined;
+  hasCoSoul: boolean;
 }) => {
   const [open, setOpen] = useState(false);
   const [showTxModal, setShowTxModal] = useState(false);
@@ -82,6 +84,7 @@ export const NavProfile = ({
             mt: '$xs',
           }}
           path={avatar}
+          hasCoSoul={hasCoSoul}
         />
         <Box css={{ minWidth: 0 }}>
           <Text semibold ellipsis>

--- a/src/features/nav/SideNav.tsx
+++ b/src/features/nav/SideNav.tsx
@@ -261,6 +261,7 @@ export const SideNav = () => {
               <NavProfile
                 name={data.profile.name}
                 avatar={data.profile.avatar}
+                hasCoSoul={!!data.profile.cosoul}
               />
             </Flex>
           </Suspense>

--- a/src/features/nav/getNavData.ts
+++ b/src/features/nav/getNavData.ts
@@ -71,7 +71,15 @@ export const getNavData = (profileId: number, chainId: number) =>
       ],
       profiles: [
         { limit: 1, where: { id: { _eq: profileId } } },
-        { name: true, id: true, avatar: true, address: true },
+        {
+          name: true,
+          id: true,
+          avatar: true,
+          address: true,
+          cosoul: {
+            id: true,
+          },
+        },
       ],
     },
     { operationName: 'getNavData' }


### PR DESCRIPTION

<img width="296" alt="Screenshot 2023-07-26 at 3 09 25 PM" src="https://github.com/coordinape/coordinape/assets/100873710/e21814c7-b427-4221-bdad-0e4572997ec0">

## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ea8a172</samp>

Added a feature to display a co-soul badge for users who have a co-soul in the navigation profile menu. Updated the `NavProfile`, `ProfileMenu`, `SideNav`, and `getNavData` components and functions to fetch and render the co-soul data from the backend.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ea8a172</samp>

> _Sing, O Muse, of the skillful coder who updated the `getNavData` function_
> _To include the `cosoul` field, a nested object of the user's companion_
> _And who passed the `hasCoSoul` prop to the `NavProfile` component_
> _To show a badge of honor, like a starry crown from Zeus, the omnipotent_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ea8a172</samp>

*  Add `cosoul` field to profile data query in `getNavData` function ([link](https://github.com/coordinape/coordinape/pull/2271/files?diff=unified&w=0#diff-3d9a03b54ad93690c81777568ce7ff0088669d823dcda73b47b5cdf0d823868fL74-R82))
*  Pass `hasCoSoul` prop to `NavProfile` component from `SideNav` component based on `cosoul` field ([link](https://github.com/coordinape/coordinape/pull/2271/files?diff=unified&w=0#diff-14c17f2206802b962d016d8a767ac1e68950e89f32310c7371d04c790ed7138cR264))
*  Render co-soul badge in `ProfileMenu` component if `hasCoSoul` prop is true ([link](https://github.com/coordinape/coordinape/pull/2271/files?diff=unified&w=0#diff-ff5587a26c300b31456b98aa1acf190199e13251c67922e758f873b3ec8fe093R87))
*  Conditionally show co-soul badge in `NavProfile` component based on `hasCoSoul` prop ([link](https://github.com/coordinape/coordinape/pull/2271/files?diff=unified&w=0#diff-ff5587a26c300b31456b98aa1acf190199e13251c67922e758f873b3ec8fe093L17-R21))
