### PR TITLE
Fix gas prices in CoSoul syncing

### DIFF
--- a/src/features/cosoul/api/cosoul.ts
+++ b/src/features/cosoul/api/cosoul.ts
@@ -58,7 +58,10 @@ export const setOnChainPGIVE = async (tokenId: number, amt: number) => {
   console.log(
     'setting on chain PGIVE for tokenId: ' + tokenId + ' to ' + amount
   );
-  return await contract.setSlot(PGIVE_SLOT, amount, tokenId);
+  return await contract.setSlot(PGIVE_SLOT, amount, tokenId, {
+    maxFeePerGas: BigNumber.from('100000000'),
+    maxPriorityFeePerGas: BigNumber.from('50000000'),
+  });
 };
 
 export async function getMintInfo(txHash: string) {

--- a/src/features/cosoul/api/cosoul.ts
+++ b/src/features/cosoul/api/cosoul.ts
@@ -59,7 +59,7 @@ export const setOnChainPGIVE = async (tokenId: number, amt: number) => {
     'setting on chain PGIVE for tokenId: ' + tokenId + ' to ' + amount
   );
   return await contract.setSlot(PGIVE_SLOT, amount, tokenId, {
-    maxFeePerGas: BigNumber.from('100000000'),
+    maxFeePerGas: BigNumber.from('100000'),
     maxPriorityFeePerGas: BigNumber.from('500'),
   });
 };

--- a/src/features/cosoul/api/cosoul.ts
+++ b/src/features/cosoul/api/cosoul.ts
@@ -59,7 +59,7 @@ export const setOnChainPGIVE = async (tokenId: number, amt: number) => {
     'setting on chain PGIVE for tokenId: ' + tokenId + ' to ' + amount
   );
   return await contract.setSlot(PGIVE_SLOT, amount, tokenId, {
-    maxFeePerGas: BigNumber.from('100000'),
+    maxFeePerGas: BigNumber.from('1000000000'),
     maxPriorityFeePerGas: BigNumber.from('500'),
   });
 };

--- a/src/features/cosoul/api/cosoul.ts
+++ b/src/features/cosoul/api/cosoul.ts
@@ -60,7 +60,7 @@ export const setOnChainPGIVE = async (tokenId: number, amt: number) => {
   );
   return await contract.setSlot(PGIVE_SLOT, amount, tokenId, {
     maxFeePerGas: BigNumber.from('100000000'),
-    maxPriorityFeePerGas: BigNumber.from('50000000'),
+    maxPriorityFeePerGas: BigNumber.from('500'),
   });
 };
 


### PR DESCRIPTION
Fix gas prices in CoSoul syncing.

Ethers hardcodes arbirtary values for EIP-1559 transactions: https://github.com/ethers-io/ethers.js/blob/master/packages/abstract-provider/src.ts/index.ts#L252-L253

these hardcoded values are VERY high and are costing us a ton of extra money to sync CoSoul data. Override the defaults with much smaller values.