### PR TITLE
BUGFIX: don't show `add from org` button if adding members to the org

### DIFF
--- a/api-test/hasura/actions/_handlers/createEpoch.test.ts
+++ b/api-test/hasura/actions/_handlers/createEpoch.test.ts
@@ -1040,7 +1040,9 @@ describe('createEpoch', () => {
 
     test('creates a new epoch on the correct day of the month for negative time zones', async () => {
       let result;
-      const startDate = DateTime.fromISO('2023-07-04T00:00:00.000-06:00');
+      const startDate = DateTime.fromISO(
+        `${DateTime.now().year + 1}-07-04T00:00:00.000-06:00`
+      );
       const params = {
         type: 'monthly',
         start_date: startDate.toISO(),

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useMemo, useState } from 'react';
+import { ReactNode, useEffect, useMemo, useState } from 'react';
 
 import sortBy from 'lodash/sortBy';
 import type { CSS } from 'stitches.config';
@@ -16,6 +16,7 @@ export function makeTable<T>(displayName: string) {
     sortByColumn: (index: number) => (dataItem: T) => any;
     perPage?: number;
     css?: CSS;
+    filtering?: boolean;
     headers: {
       title: string | React.ReactNode;
       css?: CSS;
@@ -31,12 +32,16 @@ export function makeTable<T>(displayName: string) {
     startingSortIndex = 0,
     startingSortDesc = false,
     perPage = 10,
+    filtering = false,
     css,
   }: TableProps<T>) {
     const [sortIndex, setSortIndex] = useState(startingSortIndex);
     const [sortDesc, setSortDesc] = useState(startingSortDesc);
     const [page, setPage] = useState<number>(0);
 
+    useEffect(() => {
+      if (filtering) setPage(0);
+    }, [filtering]);
     const resort = (index: number) => {
       if (index === sortIndex) {
         setSortDesc(!sortDesc);

--- a/src/pages/AddMembersPage/AddMembersPage.tsx
+++ b/src/pages/AddMembersPage/AddMembersPage.tsx
@@ -342,7 +342,7 @@ export const AddMembersContents = ({
                 currentCircleId={group.id}
                 members={organization ? organization.members : []}
                 filter={filterMember}
-                // perPage={10}
+                filtering={!!keyword.length}
                 save={save}
                 welcomeLink={welcomeLink}
               />

--- a/src/pages/AddMembersPage/AddMembersPage.tsx
+++ b/src/pages/AddMembersPage/AddMembersPage.tsx
@@ -297,7 +297,7 @@ export const AddMembersContents = ({
 
       <Flex css={{ flexWrap: 'wrap', gap: '$sm', mb: '$sm' }}>
         <TabEth />
-        <TabOrg />
+        {groupType == 'circle' && <TabOrg />}
         <TabLink />
         <TabCsv />
         <TabGuild />
@@ -305,7 +305,7 @@ export const AddMembersContents = ({
 
       <Box css={{ width: '70%', '@md': { width: '100%' } }}>
         <Panel>
-          {currentTab === Tab.ORG && (
+          {groupType == 'circle' && currentTab === Tab.ORG && (
             <Box>
               <Text css={{ pb: '$lg', pt: '$sm' }} size="medium">
                 Select organization members and add them to this circle.

--- a/src/pages/AddMembersPage/AddMembersPage.tsx
+++ b/src/pages/AddMembersPage/AddMembersPage.tsx
@@ -258,7 +258,8 @@ export const AddMembersContents = ({
   };
 
   const TabEth = makeTab(Tab.ETH, 'ETH Address');
-  const TabOrg = makeTab(Tab.ORG, 'Add From Org');
+  const TabOrg =
+    groupType == 'circle' ? makeTab(Tab.ORG, 'Add From Org') : () => null;
   const TabLink = makeTab(Tab.LINK, 'Invite Link');
   const TabCsv = makeTab(Tab.CSV, 'CSV Import');
   const TabGuild = showGuild ? makeTab(Tab.GUILD, 'Guild.xyz') : () => null;
@@ -297,7 +298,7 @@ export const AddMembersContents = ({
 
       <Flex css={{ flexWrap: 'wrap', gap: '$sm', mb: '$sm' }}>
         <TabEth />
-        {groupType == 'circle' && <TabOrg />}
+        <TabOrg />
         <TabLink />
         <TabCsv />
         <TabGuild />
@@ -307,7 +308,7 @@ export const AddMembersContents = ({
         <Panel>
           {groupType == 'circle' && currentTab === Tab.ORG && (
             <Box>
-              <Text css={{ pb: '$lg', pt: '$sm' }} size="medium">
+              <Text p as="p" css={{ pb: '$lg', pt: '$sm' }} size="medium">
                 Select organization members and add them to this circle.
               </Text>
               <Flex css={{ justifyContent: 'space-between', mb: '$md' }}>
@@ -330,7 +331,7 @@ export const AddMembersContents = ({
                   />
                 </Flex>
               </Flex>
-              <Text css={{ pb: '$md' }} size="small">
+              <Text p as="p" css={{ pb: '$md' }} size="small">
                 Remove circle members on the&nbsp;
                 <Link inlineLink as={NavLink} to={paths.members(group.id)}>
                   members page
@@ -358,7 +359,7 @@ export const AddMembersContents = ({
           )}
           {currentTab === Tab.LINK && (
             <Box>
-              <Text css={{ pb: '$lg', pt: '$sm' }} size="medium">
+              <Text p as="p" css={{ pb: '$lg', pt: '$sm' }} size="medium">
                 Add new members by sharing an invite link.
               </Text>
               <InviteLink {...{ inviteLink, groupType }} />
@@ -366,7 +367,7 @@ export const AddMembersContents = ({
           )}
           {currentTab === Tab.CSV && (
             <Box>
-              <Text css={{ pb: '$lg', pt: '$sm' }}>
+              <Text p as="p" css={{ pb: '$lg', pt: '$sm' }}>
                 Please import a .CSV file with only these two columns: Name,
                 Address. &nbsp;
                 <Link inlineLink href="/resources/example.csv" download>
@@ -417,8 +418,8 @@ export const AddMembersContents = ({
                   )}
                 </Flex>
               ) : (
-                <Text css={{ pb: '$lg', pt: '$sm' }}>
-                  You can integrate with{' '}
+                <Text p as="p" css={{ pb: '$lg', pt: '$sm' }}>
+                  You can integrate with
                   <Link
                     css={{ mx: '$xs' }}
                     target="_blank"

--- a/src/pages/AddMembersPage/AddOrgMembersTable.tsx
+++ b/src/pages/AddMembersPage/AddOrgMembersTable.tsx
@@ -104,6 +104,7 @@ export const AddOrgMembersTable = ({
   perPage,
   save,
   welcomeLink,
+  filtering = false,
 }: {
   currentCircleId: number;
   members: QueryMember[];
@@ -111,6 +112,7 @@ export const AddOrgMembersTable = ({
   perPage?: number;
   save: (members: NewMember[]) => Promise<ChangedUser[]>;
   welcomeLink?: string;
+  filtering?: boolean;
 }) => {
   const { isMobile } = useMobileDetect();
   const [view, setView] = useState<QueryMember[]>([]);
@@ -206,6 +208,7 @@ export const AddOrgMembersTable = ({
         sortByColumn={() => {
           return (m: QueryMember) => m.profile.name.toLowerCase();
         }}
+        filtering={filtering}
       >
         {member => (
           <MemberRow

--- a/src/pages/AddMembersPage/TabButton.tsx
+++ b/src/pages/AddMembersPage/TabButton.tsx
@@ -7,7 +7,7 @@ export const enum Tab {
   ORG,
   CSV,
   LINK,
-  GUILD = 3,
+  GUILD,
 }
 
 const TabButton = ({


### PR DESCRIPTION
"add from org" should only be possible when adding members to the circle

## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 83210c7</samp>

Hide `TabOrg` tab for non-circle groups in `AddMembersPage`. This simplifies the UI and avoids confusion for users who are adding members to different types of groups.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 83210c7</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A clever way to render `TabOrg` for the wise_
> _Who lead the noble circles of the platform, and conceal_
> _The useless tab from other groups, enhancing their appeal._

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 83210c7</samp>

*  Add conditional rendering of `TabOrg` and its content for circle groups only ([link](https://github.com/coordinape/coordinape/pull/2274/files?diff=unified&w=0#diff-55b839895ad7ab38d72feef621e328ad31f586d502d7d5561293b642c65b8032L300-R300), [link](https://github.com/coordinape/coordinape/pull/2274/files?diff=unified&w=0#diff-55b839895ad7ab38d72feef621e328ad31f586d502d7d5561293b642c65b8032L308-R308))
