### PR TITLE
Setup Tenderly CoSoul Webhooks

### DIFF
--- a/api-lib/tenderlySignature.ts
+++ b/api-lib/tenderlySignature.ts
@@ -1,13 +1,12 @@
-import { TENDERLY_WEBHOOK_SECRET } from './config';
 import { createHmac, timingSafeEqual } from 'crypto';
+
+import { TENDERLY_WEBHOOK_SECRET } from './config';
 
 export function isValidSignature(
   signature: string,
   body: string,
   timestamp: string
 ) {
-  // eslint-disable-next-line no-console
-  console.log('realz $$$ invoked', { signature, body, timestamp });
   const signingKey = TENDERLY_WEBHOOK_SECRET;
 
   const hmac = createHmac('sha256', signingKey); // Create a HMAC SHA256 hash using the signing key

--- a/api-lib/tenderlySignature.ts
+++ b/api-lib/tenderlySignature.ts
@@ -1,0 +1,18 @@
+import { TENDERLY_WEBHOOK_SECRET } from './config';
+import { createHmac, timingSafeEqual } from 'crypto';
+
+export function isValidSignature(
+  signature: string,
+  body: string,
+  timestamp: string
+) {
+  // eslint-disable-next-line no-console
+  console.log('realz $$$ invoked', { signature, body, timestamp });
+  const signingKey = TENDERLY_WEBHOOK_SECRET;
+
+  const hmac = createHmac('sha256', signingKey); // Create a HMAC SHA256 hash using the signing key
+  hmac.update(body.toString(), 'utf8'); // Update the hash with the request body using utf8
+  hmac.update(timestamp); // Update the hash with the request timestamp
+  const digest = hmac.digest('hex');
+  return timingSafeEqual(Buffer.from(signature), Buffer.from(digest));
+}

--- a/api/cosoul/verify.test.ts
+++ b/api/cosoul/verify.test.ts
@@ -1,0 +1,87 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { DateTime } from 'luxon';
+
+import { createProfile } from '../../api-test/helpers';
+import handler from './verify';
+import { isValidSignature } from '../../api-lib/tenderlySignature';
+import { adminClient } from '../../api-lib/gql/adminClient';
+
+const req = {
+  headers: {
+    'x-tenderly-signature': 'bad-sig',
+    // set the date header to current time as a string
+    date: DateTime.now().toISO(),
+  },
+  body: {
+    event_type: 'ALERT',
+    transaction: {
+      network: '10',
+      block_hash:
+        '0x1c8e15d6b991c627e6a6df696f5e25c12adb6bb8eb2902776e87c147d679aff4',
+      block_number: 107617119,
+      logs: [
+        {
+          address: '0x47c2A56176335fB2B1deD8e7B5acB136d307dc2d',
+          topics: [
+            '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+            '0x0000000000000000000000000000000000000000000000000000000000000000',
+            '0x000000000000000000000000c081165e1de6bcdcf22b8132ceb7c3e8a2929e83',
+            '0x0000000000000000000000000000000000000000000000000000000000002ae4',
+          ],
+          data: '0x',
+        },
+      ],
+    },
+  },
+} as unknown as VercelRequest;
+
+const res = {
+  status: jest.fn(() => res),
+  json: jest.fn(),
+  send: jest.fn(),
+} as unknown as VercelResponse;
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+jest.mock('../../api-lib/tenderlySignature');
+
+let profile;
+
+describe('CoSoul Verify', () => {
+  describe('with invalid signature', () => {
+    it('errors without valid tenderly signatures', async () => {
+      (isValidSignature as jest.Mock).mockReturnValue(false);
+      await handler(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+  });
+
+  describe('with valid signature', () => {});
+  describe('unknown address ', () => {});
+  describe('address with existing profile', () => {
+    beforeAll(async () => {
+      profile = await createProfile(adminClient);
+    });
+    it('returns 200 success', async () => {
+      (isValidSignature as jest.Mock).mockReturnValue(true);
+      await handler(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it('cosoul minted with a profile', async () => {
+      (isValidSignature as jest.Mock).mockReturnValue(true);
+      // getMintInfofromLogs as jest.Mock).mockReturnValue({})
+      await handler(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it('cosoul minted with no profile', async () => {
+      (isValidSignature as jest.Mock).mockReturnValue(true);
+      // getMintInfofromLogs as jest.Mock).mockReturnValue({})
+      await handler(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+  });
+});

--- a/api/cosoul/verify.test.ts
+++ b/api/cosoul/verify.test.ts
@@ -1,10 +1,14 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
+import faker from 'faker';
 import { DateTime } from 'luxon';
 
-import { createProfile } from '../../api-test/helpers';
-import handler from './verify';
-import { isValidSignature } from '../../api-lib/tenderlySignature';
 import { adminClient } from '../../api-lib/gql/adminClient';
+import { isValidSignature } from '../../api-lib/tenderlySignature';
+import { createProfile } from '../../api-test/helpers';
+
+import handler from './verify';
+
+const address = faker.unique(faker.finance.ethereumAddress);
 
 const req = {
   headers: {
@@ -16,6 +20,7 @@ const req = {
     event_type: 'ALERT',
     transaction: {
       network: '10',
+      hash: '0x7055dd157be7e0fba1e5587dc1c065f51a3c3ca9cc749d96b97322c0718939a9',
       block_hash:
         '0x1c8e15d6b991c627e6a6df696f5e25c12adb6bb8eb2902776e87c147d679aff4',
       block_number: 107617119,
@@ -25,7 +30,7 @@ const req = {
           topics: [
             '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
             '0x0000000000000000000000000000000000000000000000000000000000000000',
-            '0x000000000000000000000000c081165e1de6bcdcf22b8132ceb7c3e8a2929e83',
+            `0x000000000000000000000000${address.slice(2)}`,
             '0x0000000000000000000000000000000000000000000000000000000000002ae4',
           ],
           data: '0x',
@@ -58,30 +63,79 @@ describe('CoSoul Verify', () => {
     });
   });
 
-  describe('with valid signature', () => {});
-  describe('unknown address ', () => {});
-  describe('address with existing profile', () => {
-    beforeAll(async () => {
-      profile = await createProfile(adminClient);
-    });
-    it('returns 200 success', async () => {
+  describe('with valid signature', () => {
+    beforeEach(async () => {
       (isValidSignature as jest.Mock).mockReturnValue(true);
-      await handler(req, res);
-      expect(res.status).toHaveBeenCalledWith(200);
     });
 
-    it('cosoul minted with a profile', async () => {
-      (isValidSignature as jest.Mock).mockReturnValue(true);
-      // getMintInfofromLogs as jest.Mock).mockReturnValue({})
-      await handler(req, res);
-      expect(res.status).toHaveBeenCalledWith(200);
+    afterEach(async () => {
+      await deleteCosouls();
     });
 
-    it('cosoul minted with no profile', async () => {
-      (isValidSignature as jest.Mock).mockReturnValue(true);
-      // getMintInfofromLogs as jest.Mock).mockReturnValue({})
-      await handler(req, res);
-      expect(res.status).toHaveBeenCalledWith(200);
+    describe('unknown address without profile ', () => {
+      it('creates cosoul without profile', async () => {
+        expect(await getCosouls()).toHaveLength(0);
+        await handler(req, res);
+        expect(res.status).toHaveBeenCalledWith(200);
+
+        const cosouls = await getCosouls();
+
+        expect(cosouls).toHaveLength(1);
+        expect(cosouls[0].profile).toEqual(null);
+      });
+    });
+    describe('address with existing profile', () => {
+      it('creates cosoul with profile', async () => {
+        expect(await getCosouls()).toHaveLength(0);
+        profile = await createProfile(adminClient, {
+          address: address,
+        });
+
+        await handler(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(200);
+
+        const cosouls = await getCosouls();
+        expect(cosouls).toHaveLength(1);
+        expect(cosouls[0]?.profile?.id).toEqual(profile?.id);
+      });
     });
   });
 });
+
+const deleteCosouls = async () => {
+  await adminClient.mutate(
+    {
+      delete_cosouls: [
+        {
+          where: {},
+        },
+        // something needs to be returned in the mutation
+        { __typename: true, affected_rows: true },
+      ],
+    },
+    { operationName: 'test__DeleteCosouls' }
+  );
+};
+
+const getCosouls = async () => {
+  const { cosouls } = await adminClient.query(
+    {
+      cosouls: [
+        {
+          where: {},
+        },
+        {
+          __typename: true,
+          id: true,
+          token_id: true,
+          address: true,
+          profile: { id: true, address: true },
+        },
+      ],
+    },
+    { operationName: 'test__GetCosouls' }
+  );
+
+  return cosouls;
+};

--- a/api/cosoul/verify.ts
+++ b/api/cosoul/verify.ts
@@ -1,11 +1,10 @@
 import assert from 'assert';
-import { createHmac, timingSafeEqual } from 'crypto';
 
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
-import { TENDERLY_WEBHOOK_SECRET } from '../../api-lib/config';
 import { errorResponse } from '../../api-lib/HttpError';
 import { getMintInfofromLogs } from '../../src/features/cosoul/api/cosoul';
+import { isValidSignature } from '../../api-lib/tenderlySignature';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   try {
@@ -34,14 +33,4 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   } catch (error: any) {
     return errorResponse(res, error);
   }
-}
-
-function isValidSignature(signature: string, body: string, timestamp: string) {
-  const signingKey = TENDERLY_WEBHOOK_SECRET;
-
-  const hmac = createHmac('sha256', signingKey); // Create a HMAC SHA256 hash using the signing key
-  hmac.update(body.toString(), 'utf8'); // Update the hash with the request body using utf8
-  hmac.update(timestamp); // Update the hash with the request timestamp
-  const digest = hmac.digest('hex');
-  return timingSafeEqual(Buffer.from(signature), Buffer.from(digest));
 }

--- a/api/hasura/actions/_handlers/syncCoSoul.ts
+++ b/api/hasura/actions/_handlers/syncCoSoul.ts
@@ -62,7 +62,7 @@ export const minted = async (
             address: address.toLowerCase(),
           },
           on_conflict: {
-            constraint: cosouls_constraint.cosouls_pkey,
+            constraint: cosouls_constraint.cosouls_token_id_key,
             update_columns: [
               cosouls_update_column.token_id,
               cosouls_update_column.created_tx_hash,

--- a/api/hasura/actions/_handlers/syncCoSoul.ts
+++ b/api/hasura/actions/_handlers/syncCoSoul.ts
@@ -36,7 +36,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       // no tokenId on chain, lets clean up
       await burned(address, session.hasuraProfileId);
     } else {
-      await minted(address, session.hasuraProfileId, payload.tx_hash, tokenId);
+      await minted(address, payload.tx_hash, tokenId, session.hasuraProfileId);
     }
 
     return res.status(200).json({ token_id: tokenId });
@@ -45,11 +45,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 }
 
-const minted = async (
+export const minted = async (
   address: string,
-  profileId: number,
   txHash: string,
-  tokenId: number
+  tokenId: number,
+  profileId?: number
 ) => {
   // make sure its inserted
   const { insert_cosouls_one } = await adminClient.mutate(
@@ -59,7 +59,7 @@ const minted = async (
           object: {
             created_tx_hash: txHash,
             token_id: tokenId,
-            address: address,
+            address: address.toLowerCase(),
           },
           on_conflict: {
             constraint: cosouls_constraint.cosouls_pkey,


### PR DESCRIPTION
Change tenderly webhook API to:

- add all on-chain cosouls to our cosouls table
- If no profile exists, that's fine, still add it.

Added test coverage