### PR TITLE
Minor CSS: cosoul glow tweaks

### DIFF
--- a/src/stitches.config.ts
+++ b/src/stitches.config.ts
@@ -327,7 +327,7 @@ export const {
       toastifyShadow: '$shadow1',
       modalShadow: '$shadow1',
       coSoulGlow:
-        'rgba(82, 43, 196, 0.4) 0px 0px 15px 3px, rgba(82, 43, 196, 0.5) 0px -2px 4px 0px',
+        'rgba(82, 43, 196, 0.4) 0px 0px .9375em 0.1875em, rgba(82, 43, 196, 0.5) 0px -0.09em .25em 0px',
     },
     transitions: {
       quick: 'all 0.2s',
@@ -586,7 +586,7 @@ export const dark = createTheme({
     toastifyShadow: '0px 5px 25px -5px black',
     modalShadow: '0 5px 70px 28px black',
     coSoulGlow:
-      'rgba(198, 219, 137, 0.5) 0px 0px 15px 3px, rgba(198, 219, 137, 0.5) 0px -2px 6px 0px',
+      'rgba(198, 219, 137, 0.5) 0px 0px .9375em 0.1875em, rgba(198, 219, 137, 0.5) 0px -0.09em .25em 0px',
   },
 });
 

--- a/src/ui/Avatar/Avatar.tsx
+++ b/src/ui/Avatar/Avatar.tsx
@@ -22,6 +22,8 @@ const AvatarRoot = styled(AvatarPrimitive.Root, {
       xxs: {
         width: '16px !important',
         height: '16px',
+        // font size for governing the cosoul glow/shadow size
+        fontSize: '0.3rem',
         '> span': {
           fontSize: '$small',
         },
@@ -29,20 +31,26 @@ const AvatarRoot = styled(AvatarPrimitive.Root, {
       xs: {
         width: '$lg !important',
         height: '$lg',
+        // font size for governing the cosoul glow/shadow size
+        fontSize: '0.4rem',
         '> span': {
-          fontSize: '$medium',
+          fontSize: '$small',
         },
       },
       small: {
         width: '$xl !important',
         height: '$xl',
+        // font size for governing the cosoul glow/shadow size
+        fontSize: '0.5rem',
         '> span': {
-          fontSize: '$medium',
+          fontSize: '$small',
         },
       },
       medium: {
         width: '$1xl !important',
         height: '$1xl',
+        // font size for governing the cosoul glow/shadow size
+        fontSize: '0.6rem',
         '> span': {
           fontSize: '$medium',
         },
@@ -50,6 +58,8 @@ const AvatarRoot = styled(AvatarPrimitive.Root, {
       large: {
         width: '$2xl !important',
         height: '$2xl',
+        // font size for governing the cosoul glow/shadow size
+        fontSize: '0.7rem',
         '> span': {
           fontSize: '$large',
         },
@@ -57,6 +67,8 @@ const AvatarRoot = styled(AvatarPrimitive.Root, {
       xl: {
         width: '$4xl !important',
         height: '$4xl',
+        // font size for governing the cosoul glow/shadow size
+        fontSize: '1rem',
         '> span': {
           fontSize: '$large',
         },


### PR DESCRIPTION
Previously, the same box shadow was being used across all sizes of avatars, which gave the small avatars a glow that was just too darn big.  Here's how they look in this PR:
OLD:
<img width="413" alt="Screenshot 2023-08-03 at 2 01 42 PM" src="https://github.com/coordinape/coordinape/assets/100873710/8c559f45-687a-450d-bea7-8ed1c4a995e0">

NEW:
<img width="435" alt="Screenshot 2023-08-03 at 1 58 14 PM" src="https://github.com/coordinape/coordinape/assets/100873710/6c123cba-da8d-459b-8ab7-b40b8709cb44">

## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6cb1053</samp>

Improved the responsiveness and consistency of the `coSoulGlow` effect for the avatar component. Updated the `src/stitches.config.ts` and `src/ui/Avatar/Avatar.tsx` files to use relative units and size variants.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6cb1053</samp>

> _To make the `coSoulGlow` shine_
> _We used responsive units, not fine_
> _The `fontSize` we set_
> _For the `AvatarRoot` to get_
> _A matching effect and design_
🫰🫰🫰


## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6cb1053</samp>

*  Update `coSoulGlow` property of `light` and `dark` themes to use `em` units for box-shadow ([link](https://github.com/coordinape/coordinape/pull/2280/files?diff=unified&w=0#diff-052276ffd84d1c1b2b1ad948ac1eecce96b266a90da0c3058269cf25856c29ebL330-R330), [link](https://github.com/coordinape/coordinape/pull/2280/files?diff=unified&w=0#diff-052276ffd84d1c1b2b1ad948ac1eecce96b266a90da0c3058269cf25856c29ebL589-R589))
*  Add and update `fontSize` property of `AvatarRoot` component to set font size for avatar element and `coSoulGlow` effect ([link](https://github.com/coordinape/coordinape/pull/2280/files?diff=unified&w=0#diff-31b30120c3bdbbef770d4272ebe9c811534e0eb23020696cdff9bf9cf72c1326R25-R26), [link](https://github.com/coordinape/coordinape/pull/2280/files?diff=unified&w=0#diff-31b30120c3bdbbef770d4272ebe9c811534e0eb23020696cdff9bf9cf72c1326L32-R37), [link](https://github.com/coordinape/coordinape/pull/2280/files?diff=unified&w=0#diff-31b30120c3bdbbef770d4272ebe9c811534e0eb23020696cdff9bf9cf72c1326L39-R46), [link](https://github.com/coordinape/coordinape/pull/2280/files?diff=unified&w=0#diff-31b30120c3bdbbef770d4272ebe9c811534e0eb23020696cdff9bf9cf72c1326R52-R53), [link](https://github.com/coordinape/coordinape/pull/2280/files?diff=unified&w=0#diff-31b30120c3bdbbef770d4272ebe9c811534e0eb23020696cdff9bf9cf72c1326R61-R62), [link](https://github.com/coordinape/coordinape/pull/2280/files?diff=unified&w=0#diff-31b30120c3bdbbef770d4272ebe9c811534e0eb23020696cdff9bf9cf72c1326R70-R71))
*  Adjust `> span` selector of `AvatarRoot` component to use `$small` font size for avatar initials for `$sm` and `$md` size variants ([link](https://github.com/coordinape/coordinape/pull/2280/files?diff=unified&w=0#diff-31b30120c3bdbbef770d4272ebe9c811534e0eb23020696cdff9bf9cf72c1326L32-R37), [link](https://github.com/coordinape/coordinape/pull/2280/files?diff=unified&w=0#diff-31b30120c3bdbbef770d4272ebe9c811534e0eb23020696cdff9bf9cf72c1326L39-R46))
