### PR TITLE
Bugfix: fix invite link race condition

### DIFF
--- a/src/pages/MembersPage/LeaveCircleModal.tsx
+++ b/src/pages/MembersPage/LeaveCircleModal.tsx
@@ -45,7 +45,7 @@ export const LeaveCircleModal = ({
     handleSubmit,
     control,
     reset,
-    formState: { isValid },
+    formState: { isValid, isSubmitting },
   } = useForm<LeaveCircleFormSchema>({
     mode: 'all',
     resolver: zodResolver(schema),
@@ -119,7 +119,7 @@ export const LeaveCircleModal = ({
               color="destructive"
               size="large"
               css={{ width: '50%' }}
-              disabled={!isValid}
+              disabled={!isValid || isSubmitting}
               type="submit"
             >
               Leave Circle


### PR DESCRIPTION
## What

Ensure user is in org after creation via invite link

This fixes a race-condition bug where you join the circle, but not the
org (until the async trigger insertOrgMember ran) and so the getNavData
query returned no circle, breakign the experince. This fixes that by
waiting until the user and the org are populated.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bf7a34d</samp>

This pull request enhances the user authentication and membership features by refactoring the code for inserting an org_member, improving the UI of the `LeaveCircleModal` component, and updating the `createUserWithToken` handler.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bf7a34d</samp>

> _Sing, O Muse, of the code that was changed by the skillful coder_
> _Who sought to avoid repetition and enhance the user's pleasure_
> _He crafted a function, `insertOrgMemberIdempotent`, swift and wise_
> _Like Hephaestus forging tools for the gods in his fiery workshop_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bf7a34d</samp>

* Extract code for inserting org_member into a separate function `insertOrgMemberIdempotent` ([link](https://github.com/coordinape/coordinape/pull/2285/files?diff=unified&w=0#diff-8f70946c90bdfa7a4ab075dd7164928ce345f071c81839074dde83bc0d7e3801L21-R89))
* Use `insertOrgMemberIdempotent` in `createUserWithToken` handler to add user to org_member table after creating or updating user ([link](https://github.com/coordinape/coordinape/pull/2285/files?diff=unified&w=0#diff-facdccf70ca95c8fd27abae06840850cc36d240dec8aeab36d3607bf89d79018R8), [link](https://github.com/coordinape/coordinape/pull/2285/files?diff=unified&w=0#diff-facdccf70ca95c8fd27abae06840850cc36d240dec8aeab36d3607bf89d79018L102-R111))
* Use `isSubmitting` property from `useForm` hook to disable submit button in `LeaveCircleModal` component when form is being submitted ([link](https://github.com/coordinape/coordinape/pull/2285/files?diff=unified&w=0#diff-8f26d825bed35206580868c19f6db1262fc985c7d50f5e6a121393982bcb0a80L48-R48), [link](https://github.com/coordinape/coordinape/pull/2285/files?diff=unified&w=0#diff-8f26d825bed35206580868c19f6db1262fc985c7d50f5e6a121393982bcb0a80L122-R122))
