### PR TITLE
change giving to Gives in members table

### DIFF
--- a/src/pages/MembersPage/MembersTable.tsx
+++ b/src/pages/MembersPage/MembersTable.tsx
@@ -586,7 +586,7 @@ export const MemberRow = ({
                           content={
                             <div>
                               Gives the member the ability to reward circle
-                              members with giving{' '}
+                              members with GIVE{' '}
                               <Link
                                 inlineLink
                                 href={GIFT_CIRCLE_DOCS_URL}
@@ -632,7 +632,7 @@ export const MemberRow = ({
                           content={
                             <div>
                               Allows the Contributor to get paid based on the
-                              amount of giving allocated by circle members.{' '}
+                              amount of GIVE allocated by circle members.{' '}
                               <Link
                                 inlineLink
                                 href={GIFT_CIRCLE_DOCS_URL}
@@ -705,7 +705,7 @@ export const MemberRow = ({
                     control={control}
                     defaultValue={user.starting_tokens}
                     label="Give Allotment"
-                    infoTooltip="The maximum amount of giving a user can allocate in an epoch"
+                    infoTooltip="The maximum amount of GIVE a user can allocate in an epoch"
                     showFieldErrors
                     css={{ width: '140px' }}
                   />


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0fd9beb</samp>

This pull request improves the clarity and consistency of the tooltip texts in `MembersTable.tsx` by using the proper name of the GIVE token.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0fd9beb</samp>

> _Sing, O Muse, of the Coordinape project, the noble work of many_
> _Who strive to share their tokens with their peers in circles friendly_
> _And how they changed their tooltip texts, to make them clear and true_
> _And honor GIVE, the sacred word, that binds their actions through_

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0fd9beb</samp>

*  Capitalize the word "giving" to "GIVE" in tooltip texts to match the project branding and terminology ([link](https://github.com/coordinape/coordinape/pull/2289/files?diff=unified&w=0#diff-78d01a2e57bf19eec5b09a8a8cef8c5729d24b40ab6604cb0067843aa53bf280L589-R589), [link](https://github.com/coordinape/coordinape/pull/2289/files?diff=unified&w=0#diff-78d01a2e57bf19eec5b09a8a8cef8c5729d24b40ab6604cb0067843aa53bf280L635-R635), [link](https://github.com/coordinape/coordinape/pull/2289/files?diff=unified&w=0#diff-78d01a2e57bf19eec5b09a8a8cef8c5729d24b40ab6604cb0067843aa53bf280L708-R708)) in `src/pages/MembersPage/MembersTable.tsx`
