### PR TITLE
set errors on adding existing members

### DIFF
--- a/src/pages/AddMembersPage/AddMembersPage.tsx
+++ b/src/pages/AddMembersPage/AddMembersPage.tsx
@@ -45,6 +45,17 @@ import {
   useWelcomeToken,
 } from './useCircleTokens';
 
+export type Group = {
+  id: number;
+  guild_id?: number;
+  guild_role_id?: number;
+  name: string;
+  organization_id?: number;
+  organization?: any;
+};
+
+export type GroupType = 'circle' | 'organization';
+
 const AddMembersPage = () => {
   const circleId = useCircleIdParam();
   const queryClient = useQueryClient();
@@ -176,15 +187,8 @@ export const AddMembersContents = ({
   save,
   showGuild = true,
 }: {
-  group: {
-    id: number;
-    guild_id?: number;
-    guild_role_id?: number;
-    name: string;
-    organization_id?: number;
-    organization?: any;
-  };
-  groupType: 'circle' | 'organization';
+  group: Group;
+  groupType: GroupType;
   welcomeLink?: string;
   inviteLink: string;
   revokeInvite(): void;
@@ -354,7 +358,11 @@ export const AddMembersContents = ({
                 Add new members by wallet address.
               </Text>
 
-              <NewMemberList {...{ welcomeLink, preloadedMembers, save }} />
+              <NewMemberList
+                {...{ welcomeLink, preloadedMembers, save }}
+                group={group}
+                groupType={groupType}
+              />
             </Box>
           )}
           {currentTab === Tab.LINK && (

--- a/src/pages/AddMembersPage/NewMemberEntry.tsx
+++ b/src/pages/AddMembersPage/NewMemberEntry.tsx
@@ -83,7 +83,7 @@ const NewMemberEntry = ({
                   }),
                   ...(groupType === 'organization' && {
                     org_members: [
-                      { where: { org_id: { _eq: group.organization_id } } },
+                      { where: { org_id: { _eq: group.id } } },
                       { id: true },
                     ],
                   }),

--- a/src/pages/AddMembersPage/NewMemberList.test.tsx
+++ b/src/pages/AddMembersPage/NewMemberList.test.tsx
@@ -11,7 +11,7 @@ const save = async () => {
 };
 
 const group: Group = {
-  id: 1,
+  id: 788,
   name: 'test',
 };
 
@@ -19,15 +19,15 @@ jest.mock('lib/gql/client', () => ({
   client: { query: jest.fn() },
 }));
 
-beforeEach(() => {
+afterEach(() => {
   jest.clearAllMocks();
 });
 
-describe('adding an existing org member will show an error if exists only', () => {
-  test('display an error if the the address exists in the org', async () => {
+describe('when an org member already exists', () => {
+  test('it displays an error upon trying to add them again to the same org', async () => {
     (client.query as jest.Mock).mockImplementation(() =>
       Promise.resolve({
-        profiles: [{ name: 'user', org_members: [{ id: 1 }] }],
+        profiles: [{ name: 'user', org_members: [{ id: 10 }] }],
       })
     );
 
@@ -61,7 +61,7 @@ describe('adding an existing org member will show an error if exists only', () =
           },
           {
             name: true,
-            org_members: [{ where: { org_id: { _eq: 1 } } }, { id: true }],
+            org_members: [{ where: { org_id: { _eq: 788 } } }, { id: true }],
           },
         ],
       },
@@ -71,7 +71,7 @@ describe('adding an existing org member will show an error if exists only', () =
     await screen.findByText('existing org member');
   });
 
-  test('display an error if the address does not exists in the org', async () => {
+  test('it does not display an error upon trying to add them to another org', async () => {
     (client.query as jest.Mock).mockImplementation(() =>
       Promise.resolve({
         profiles: [{ name: 'user' }],
@@ -97,15 +97,17 @@ describe('adding an existing org member will show an error if exists only', () =
       target: { value: '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45' },
     });
     expect(client.query).toBeCalled();
-    await expect(screen.findByText('existing org member')).rejects.toThrow();
+    await expect(screen.findByText('existing org member')).rejects.toThrow(
+      /Unable to find an element with the text: existing org member./
+    );
   });
 });
 
-describe('adding an existing circle member will show an error if exists only', () => {
-  test('display an error if the the address exists in the circle', async () => {
+describe('when a circle member already exists', () => {
+  test('it displays an error upon trying to add them again to the same circle', async () => {
     (client.query as jest.Mock).mockImplementation(() =>
       Promise.resolve({
-        profiles: [{ name: 'user', users: [{ id: 1 }] }],
+        profiles: [{ name: 'user', users: [{ id: 11 }] }],
       })
     );
 
@@ -139,7 +141,7 @@ describe('adding an existing circle member will show an error if exists only', (
           },
           {
             name: true,
-            users: [{ where: { circle_id: { _eq: 1 } } }, { id: true }],
+            users: [{ where: { circle_id: { _eq: 788 } } }, { id: true }],
           },
         ],
       },
@@ -149,7 +151,7 @@ describe('adding an existing circle member will show an error if exists only', (
     await screen.findByText('existing circle member');
   });
 
-  test('display an error if the address does not exists in the circle', async () => {
+  test('it does not display an error upon trying to add them to a different circle', async () => {
     (client.query as jest.Mock).mockImplementation(() =>
       Promise.resolve({
         profiles: [{ name: 'user' }],
@@ -175,6 +177,8 @@ describe('adding an existing circle member will show an error if exists only', (
       target: { value: '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45' },
     });
     expect(client.query).toBeCalled();
-    await expect(screen.findByText('existing circle member')).rejects.toThrow();
+    await expect(screen.findByText('existing circle member')).rejects.toThrow(
+      /Unable to find an element with the text: existing circle member./
+    );
   });
 });

--- a/src/pages/AddMembersPage/NewMemberList.test.tsx
+++ b/src/pages/AddMembersPage/NewMemberList.test.tsx
@@ -49,7 +49,25 @@ describe('adding an existing org member will show an error if exists only', () =
     fireEvent.change(screen.getAllByPlaceholderText('ETH Address or ENS')[0], {
       target: { value: '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45' },
     });
-    expect(client.query).toBeCalled();
+
+    expect(client.query).toBeCalledWith(
+      {
+        profiles: [
+          {
+            limit: 1,
+            where: {
+              address: { _ilike: '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45' },
+            },
+          },
+          {
+            name: true,
+            org_members: [{ where: { org_id: { _eq: 1 } } }, { id: true }],
+          },
+        ],
+      },
+      { operationName: 'NewMemberEntry_getUserName' }
+    );
+
     await screen.findByText('existing org member');
   });
 
@@ -80,5 +98,83 @@ describe('adding an existing org member will show an error if exists only', () =
     });
     expect(client.query).toBeCalled();
     await expect(screen.findByText('existing org member')).rejects.toThrow();
+  });
+});
+
+describe('adding an existing circle member will show an error if exists only', () => {
+  test('display an error if the the address exists in the circle', async () => {
+    (client.query as jest.Mock).mockImplementation(() =>
+      Promise.resolve({
+        profiles: [{ name: 'user', users: [{ id: 1 }] }],
+      })
+    );
+
+    await act(async () => {
+      render(
+        <TestWrapper>
+          <NewMemberList
+            welcomeLink=""
+            preloadedMembers={[]}
+            save={save}
+            group={group}
+            groupType="circle"
+          />
+        </TestWrapper>
+      );
+    });
+
+    await screen.findByText('Wallet Address');
+    fireEvent.change(screen.getAllByPlaceholderText('ETH Address or ENS')[0], {
+      target: { value: '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45' },
+    });
+
+    expect(client.query).toBeCalledWith(
+      {
+        profiles: [
+          {
+            limit: 1,
+            where: {
+              address: { _ilike: '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45' },
+            },
+          },
+          {
+            name: true,
+            users: [{ where: { circle_id: { _eq: 1 } } }, { id: true }],
+          },
+        ],
+      },
+      { operationName: 'NewMemberEntry_getUserName' }
+    );
+
+    await screen.findByText('existing circle member');
+  });
+
+  test('display an error if the address does not exists in the circle', async () => {
+    (client.query as jest.Mock).mockImplementation(() =>
+      Promise.resolve({
+        profiles: [{ name: 'user' }],
+      })
+    );
+
+    await act(async () => {
+      render(
+        <TestWrapper>
+          <NewMemberList
+            welcomeLink=""
+            preloadedMembers={[]}
+            save={save}
+            group={group}
+            groupType="circle"
+          />
+        </TestWrapper>
+      );
+    });
+
+    await screen.findByText('Wallet Address');
+    fireEvent.change(screen.getAllByPlaceholderText('ETH Address or ENS')[0], {
+      target: { value: '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45' },
+    });
+    expect(client.query).toBeCalled();
+    await expect(screen.findByText('existing circle member')).rejects.toThrow();
   });
 });

--- a/src/pages/AddMembersPage/NewMemberList.test.tsx
+++ b/src/pages/AddMembersPage/NewMemberList.test.tsx
@@ -1,0 +1,84 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { client } from 'lib/gql/client';
+
+import { TestWrapper } from 'utils/testing';
+
+import { Group } from './AddMembersPage';
+import NewMemberList from './NewMemberList';
+
+const save = async () => {
+  return [];
+};
+
+const group: Group = {
+  id: 1,
+  name: 'test',
+};
+
+jest.mock('lib/gql/client', () => ({
+  client: { query: jest.fn() },
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('adding an existing org member will show an error if exists only', () => {
+  test('display an error if the the address exists in the org', async () => {
+    (client.query as jest.Mock).mockImplementation(() =>
+      Promise.resolve({
+        profiles: [{ name: 'user', org_members: [{ id: 1 }] }],
+      })
+    );
+
+    await act(async () => {
+      render(
+        <TestWrapper>
+          <NewMemberList
+            welcomeLink=""
+            preloadedMembers={[]}
+            save={save}
+            group={group}
+            groupType="organization"
+          />
+        </TestWrapper>
+      );
+    });
+
+    await screen.findByText('Wallet Address');
+    fireEvent.change(screen.getAllByPlaceholderText('ETH Address or ENS')[0], {
+      target: { value: '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45' },
+    });
+    expect(client.query).toBeCalled();
+    await screen.findByText('existing org member');
+  });
+
+  test('display an error if the address does not exists in the org', async () => {
+    (client.query as jest.Mock).mockImplementation(() =>
+      Promise.resolve({
+        profiles: [{ name: 'user' }],
+      })
+    );
+
+    await act(async () => {
+      render(
+        <TestWrapper>
+          <NewMemberList
+            welcomeLink=""
+            preloadedMembers={[]}
+            save={save}
+            group={group}
+            groupType="organization"
+          />
+        </TestWrapper>
+      );
+    });
+
+    await screen.findByText('Wallet Address');
+    fireEvent.change(screen.getAllByPlaceholderText('ETH Address or ENS')[0], {
+      target: { value: '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45' },
+    });
+    expect(client.query).toBeCalled();
+    await expect(screen.findByText('existing org member')).rejects.toThrow();
+  });
+});

--- a/src/pages/AddMembersPage/NewMemberList.tsx
+++ b/src/pages/AddMembersPage/NewMemberList.tsx
@@ -14,6 +14,7 @@ import { zEthAddress, zUsername } from '../../lib/zod/formHelpers';
 import { Box, Button, Flex, Panel, Text } from '../../ui';
 import { Check } from 'icons/__generated';
 
+import { Group, GroupType } from './AddMembersPage';
 import NewMemberEntry from './NewMemberEntry';
 import NewMemberGridBox from './NewMemberGridBox';
 
@@ -36,11 +37,15 @@ const NewMemberList = ({
   welcomeLink,
   preloadedMembers,
   save,
+  group,
+  groupType,
 }: {
   welcomeLink?: string;
   // revokeWelcome: () => void;
   preloadedMembers: NewMember[];
   save: (members: NewMember[]) => Promise<ChangedUser[]>;
+  group: Group;
+  groupType: GroupType;
 }) => {
   const { showError } = useToast();
 
@@ -234,6 +239,9 @@ const NewMemberList = ({
                   error={err}
                   control={control}
                   setValue={setValue}
+                  setError={setError}
+                  group={group}
+                  groupType={groupType}
                 />
               );
             })}
@@ -244,6 +252,7 @@ const NewMemberList = ({
               disabled={
                 loading ||
                 !isValid ||
+                !!errors.newMembers?.length ||
                 newMembers.filter(m => m.address != '' && m.name != '')
                   .length == 0
               }


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dce6d0e</samp>

This pull request improves the functionality and usability of the `AddMembersPage` by adding new types for groups and categories, validating the addresses of new members, and displaying custom errors. It also passes the group data as parameters to the child components to enable adding members to different types of groups.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at dce6d0e</samp>

> _Sing, O Muse, of the code that the wise developer wrought_
> _To display and to save the new members of the groups,_
> _The groups that had categories, distinct and well-defined,_
> _And passed them as parameters to the components fine._

## Why

set error in address field if the address already exists in the circle or the org

## Test and Deployment Plan
1- add a new member to an org
2- Try to add it again to the org, it should disable submitting and show error at address field
3- try to add the user to a circle in the org- it should be accepted
4- try to add it again to the same circle - it should be rejected
5- try to add it to another circle in the org - it should be accepted


## Screenshots (if appropriate):
![image](https://github.com/coordinape/coordinape/assets/34943689/ca6eca85-3ae0-447d-8b91-ab765da11147)
![image](https://github.com/coordinape/coordinape/assets/34943689/b67f7350-193f-4034-b433-451301c08b22)

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dce6d0e</samp>

*  Define new types `Group` and `GroupType` to represent the data structure and the category of a group that can add members ([link](https://github.com/coordinape/coordinape/pull/2293/files?diff=unified&w=0#diff-55b839895ad7ab38d72feef621e328ad31f586d502d7d5561293b642c65b8032R48-R58))
*  Replace explicit properties of the `group` parameter with the `Group` type in the `AddMembersPage` component ([link](https://github.com/coordinape/coordinape/pull/2293/files?diff=unified&w=0#diff-55b839895ad7ab38d72feef621e328ad31f586d502d7d5561293b642c65b8032L179-R191))
*  Pass the `group` and `groupType` parameters to the `NewMemberList` component in the `AddMembersPage` component ([link](https://github.com/coordinape/coordinape/pull/2293/files?diff=unified&w=0#diff-55b839895ad7ab38d72feef621e328ad31f586d502d7d5561293b642c65b8032L357-R365))
*  Import the `UseFormSetError` type from the `react-hook-form` library and the `Group` and `GroupType` types from the `AddMembersPage` component in the `NewMemberEntry` component ([link](https://github.com/coordinape/coordinape/pull/2293/files?diff=unified&w=0#diff-39828da3b1c60dc64d454fa58f16929b9d1e3241e1234edef7a266002af8249cR12), [link](https://github.com/coordinape/coordinape/pull/2293/files?diff=unified&w=0#diff-39828da3b1c60dc64d454fa58f16929b9d1e3241e1234edef7a266002af8249cR20))
*  Add the `setError`, `group`, and `groupType` parameters and define their types in the `NewMemberEntry` component ([link](https://github.com/coordinape/coordinape/pull/2293/files?diff=unified&w=0#diff-39828da3b1c60dc64d454fa58f16929b9d1e3241e1234edef7a266002af8249cR42-R44), [link](https://github.com/coordinape/coordinape/pull/2293/files?diff=unified&w=0#diff-39828da3b1c60dc64d454fa58f16929b9d1e3241e1234edef7a266002af8249cR53-R55))
*  Modify the query to fetch the profile of the address entered by the user to include conditional fields `users` and `org_members` based on the `groupType` in the `NewMemberEntry` component ([link](https://github.com/coordinape/coordinape/pull/2293/files?diff=unified&w=0#diff-39828da3b1c60dc64d454fa58f16929b9d1e3241e1234edef7a266002af8249cL68-R90))
*  Check if the address entered by the user is already a member of the group or the organization and set custom errors for the address field using the `setError` function in the `NewMemberEntry` component ([link](https://github.com/coordinape/coordinape/pull/2293/files?diff=unified&w=0#diff-39828da3b1c60dc64d454fa58f16929b9d1e3241e1234edef7a266002af8249cR102-R116))
*  Import the `Group` and `GroupType` types from the `AddMembersPage` component in the `NewMemberList` component ([link](https://github.com/coordinape/coordinape/pull/2293/files?diff=unified&w=0#diff-1069257ea6b0200ecd79cb31093f737edec0d134fab4b490ae4336b4ead1faaeR17))
*  Add the `group` and `groupType` parameters and define their types in the `NewMemberList` component ([link](https://github.com/coordinape/coordinape/pull/2293/files?diff=unified&w=0#diff-1069257ea6b0200ecd79cb31093f737edec0d134fab4b490ae4336b4ead1faaeR40-R41), [link](https://github.com/coordinape/coordinape/pull/2293/files?diff=unified&w=0#diff-1069257ea6b0200ecd79cb31093f737edec0d134fab4b490ae4336b4ead1faaeR47-R48))
*  Pass the `setError`, `group`, and `groupType` parameters to the `NewMemberEntry` component in the `NewMemberList` component ([link](https://github.com/coordinape/coordinape/pull/2293/files?diff=unified&w=0#diff-1069257ea6b0200ecd79cb31093f737edec0d134fab4b490ae4336b4ead1faaeR242-R244))
*  Disable the `save` button if there are any errors in the `newMembers` array in the `NewMemberList` component ([link](https://github.com/coordinape/coordinape/pull/2293/files?diff=unified&w=0#diff-1069257ea6b0200ecd79cb31093f737edec0d134fab4b490ae4336b4ead1faaeR255))
