### PR TITLE
Use handler for accept TOS confirmation

### DIFF
--- a/api-lib/gql/__generated__/zeus/const.ts
+++ b/api-lib/gql/__generated__/zeus/const.ts
@@ -9585,6 +9585,9 @@ export const ReturnTypes: Record<string, any> = {
     ttl: 'Int',
     refresh: 'Boolean',
   },
+  AcceptTOSOutput: {
+    tos_agreed_at: 'String',
+  },
   AllocationCsvResponse: {
     file: 'String',
   },
@@ -12456,6 +12459,7 @@ export const ReturnTypes: Record<string, any> = {
     user_id: 'Float',
   },
   mutation_root: {
+    acceptTOS: 'AcceptTOSOutput',
     adminUpdateUser: 'UserResponse',
     allocationCsv: 'AllocationCsvResponse',
     createCircle: 'CreateCircleResponse',

--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -591,6 +591,10 @@ type ZEUS_INTERFACES = never;
 type ZEUS_UNIONS = never;
 
 export type ValueTypes = {
+  ['AcceptTOSOutput']: AliasType<{
+    tos_agreed_at?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
   ['AdminUpdateUserInput']: {
     address: string;
     circle_id: number;
@@ -11325,6 +11329,8 @@ export type ValueTypes = {
   };
   /** mutation root */
   ['mutation_root']: AliasType<{
+    /** Accept Terms of Service action */
+    acceptTOS?: ValueTypes['AcceptTOSOutput'];
     adminUpdateUser?: [
       { payload: ValueTypes['AdminUpdateUserInput'] },
       ValueTypes['UserResponse']
@@ -26654,6 +26660,9 @@ export type ValueTypes = {
 };
 
 export type ModelTypes = {
+  ['AcceptTOSOutput']: {
+    tos_agreed_at: string;
+  };
   ['AdminUpdateUserInput']: GraphQLTypes['AdminUpdateUserInput'];
   ['Allocation']: GraphQLTypes['Allocation'];
   ['AllocationCsvInput']: GraphQLTypes['AllocationCsvInput'];
@@ -31263,6 +31272,8 @@ export type ModelTypes = {
   ['member_epoch_pgives_variance_order_by']: GraphQLTypes['member_epoch_pgives_variance_order_by'];
   /** mutation root */
   ['mutation_root']: {
+    /** Accept Terms of Service action */
+    acceptTOS?: GraphQLTypes['AcceptTOSOutput'] | undefined;
     adminUpdateUser?: GraphQLTypes['UserResponse'] | undefined;
     allocationCsv?: GraphQLTypes['AllocationCsvResponse'] | undefined;
     createCircle?: GraphQLTypes['CreateCircleResponse'] | undefined;
@@ -35970,6 +35981,10 @@ export type ModelTypes = {
 };
 
 export type GraphQLTypes = {
+  ['AcceptTOSOutput']: {
+    __typename: 'AcceptTOSOutput';
+    tos_agreed_at: string;
+  };
   ['AdminUpdateUserInput']: {
     address: string;
     circle_id: number;
@@ -45198,6 +45213,8 @@ export type GraphQLTypes = {
   /** mutation root */
   ['mutation_root']: {
     __typename: 'mutation_root';
+    /** Accept Terms of Service action */
+    acceptTOS?: GraphQLTypes['AcceptTOSOutput'] | undefined;
     adminUpdateUser?: GraphQLTypes['UserResponse'] | undefined;
     allocationCsv?: GraphQLTypes['AllocationCsvResponse'] | undefined;
     createCircle?: GraphQLTypes['CreateCircleResponse'] | undefined;

--- a/api/hasura/actions/_handlers/acceptTOS.ts
+++ b/api/hasura/actions/_handlers/acceptTOS.ts
@@ -1,0 +1,37 @@
+/* eslint-disable no-console */
+import assert from 'assert';
+
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+import { adminClient } from '../../../../api-lib/gql/adminClient';
+import { errorResponse } from '../../../../api-lib/HttpError';
+import { HasuraUserSessionVariables } from '../../../../api-lib/requests/schema';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  try {
+    const { hasuraProfileId } = HasuraUserSessionVariables.parse(
+      req.body.session_variables
+    );
+
+    const { update_profiles_by_pk } = await adminClient.mutate(
+      {
+        update_profiles_by_pk: [
+          {
+            pk_columns: { id: hasuraProfileId },
+            _set: { tos_agreed_at: 'now()' },
+          },
+          { tos_agreed_at: true },
+        ],
+      },
+      { operationName: 'acceptTOS__set_tos_agreed_at' }
+    );
+
+    assert(update_profiles_by_pk);
+
+    return res
+      .status(200)
+      .json({ tos_agreed_at: update_profiles_by_pk.tos_agreed_at });
+  } catch (e: any) {
+    return errorResponse(res, e);
+  }
+}

--- a/api/hasura/actions/actionManager.ts
+++ b/api/hasura/actions/actionManager.ts
@@ -4,6 +4,7 @@ import { GraphQLTypes } from '../../../api-lib/gql/__generated__/zeus';
 import { ActionPayload } from '../../../api-lib/types';
 import { verifyHasuraRequestMiddleware } from '../../../api-lib/validate';
 
+import acceptTOS from './_handlers/acceptTOS';
 import adminUpdateUser from './_handlers/adminUpdateUser';
 import allocationCsv from './_handlers/allocationCsv';
 import createCircle from './_handlers/createCircle';
@@ -47,6 +48,7 @@ import vouch from './_handlers/vouch';
 
 type HandlerDict = { [handlerName: string]: VercelApiHandler };
 const HANDLERS: HandlerDict = {
+  acceptTOS,
   adminUpdateUser,
   allocationCsv,
   createCircle,

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -1,4 +1,8 @@
 type Mutation {
+  acceptTOS: AcceptTOSOutput
+}
+
+type Mutation {
   adminUpdateUser(payload: AdminUpdateUserInput!): UserResponse
 }
 
@@ -468,6 +472,10 @@ input UpdateCircleStartingGiveInput {
   starting_tokens: Int!
 }
 
+input AcceptTOSInput {
+  profile_id: Int!
+}
+
 type CreateCircleResponse {
   id: Int!
 }
@@ -620,6 +628,10 @@ type GiveCsvResponse {
 
 type SyncCoSoulOutput {
   token_id: String
+}
+
+type AcceptTOSOutput {
+  tos_agreed_at: String!
 }
 
 scalar timestamptz

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -1,4 +1,15 @@
 actions:
+  - name: acceptTOS
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_API_BASE_URL}}/actions/actionManager?action_name=acceptTOS'
+      forward_client_headers: true
+      headers:
+        - name: verification_key
+          value_from_env: HASURA_EVENT_SECRET
+    permissions:
+      - role: user
+    comment: Accept Terms of Service action
   - name: adminUpdateUser
     definition:
       kind: synchronous
@@ -438,6 +449,7 @@ custom_types:
     - name: GiveCsvInput
     - name: SyncCoSoulInput
     - name: UpdateCircleStartingGiveInput
+    - name: AcceptTOSInput
   objects:
     - name: CreateCircleResponse
       relationships:
@@ -662,5 +674,6 @@ custom_types:
     - name: SuccessResponse
     - name: GiveCsvResponse
     - name: SyncCoSoulOutput
+    - name: AcceptTOSOutput
   scalars:
     - name: timestamptz

--- a/hasura/metadata/databases/default/tables/public_profiles.yaml
+++ b/hasura/metadata/databases/default/tables/public_profiles.yaml
@@ -175,7 +175,6 @@ update_permissions:
         - medium_username
         - skills
         - telegram_username
-        - tos_agreed_at
         - twitter_username
         - website
       filter:

--- a/hasura/metadata/databases/default/tables/public_vaults.yaml
+++ b/hasura/metadata/databases/default/tables/public_vaults.yaml
@@ -26,8 +26,8 @@ array_relationships:
 remote_relationships:
   - definition:
       hasura_fields:
-        - token_address
         - chain_id
+        - token_address
       remote_field:
         price_per_share:
           arguments:

--- a/hasura/schema/admin/schema.graphql
+++ b/hasura/schema/admin/schema.graphql
@@ -19,6 +19,10 @@ directive @cached(
   refresh: Boolean! = false
 ) on QUERY
 
+type AcceptTOSOutput {
+  tos_agreed_at: String!
+}
+
 input AdminUpdateUserInput {
   address: String!
   circle_id: Int!
@@ -15975,6 +15979,10 @@ input member_epoch_pgives_variance_order_by {
 mutation root
 """
 type mutation_root {
+  """
+  Accept Terms of Service action
+  """
+  acceptTOS: AcceptTOSOutput
   adminUpdateUser(payload: AdminUpdateUserInput!): UserResponse
   allocationCsv(payload: AllocationCsvInput!): AllocationCsvResponse
   createCircle(payload: CreateCircleInput!): CreateCircleResponse

--- a/hasura/schema/user/schema.graphql
+++ b/hasura/schema/user/schema.graphql
@@ -19,6 +19,10 @@ directive @cached(
   refresh: Boolean! = false
 ) on QUERY
 
+type AcceptTOSOutput {
+  tos_agreed_at: String!
+}
+
 input AdminUpdateUserInput {
   address: String!
   circle_id: Int!
@@ -7965,6 +7969,10 @@ input member_epoch_pgives_variance_order_by {
 mutation root
 """
 type mutation_root {
+  """
+  Accept Terms of Service action
+  """
+  acceptTOS: AcceptTOSOutput
   adminUpdateUser(payload: AdminUpdateUserInput!): UserResponse
   allocationCsv(payload: AllocationCsvInput!): AllocationCsvResponse
   createCircle(payload: CreateCircleInput!): CreateCircleResponse
@@ -11340,7 +11348,6 @@ input profiles_set_input {
   medium_username: String
   skills: String
   telegram_username: String
-  tos_agreed_at: timestamp
   twitter_username: String
   website: String
 }

--- a/src/features/auth/TermsGate.tsx
+++ b/src/features/auth/TermsGate.tsx
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import { useEffect, useState } from 'react';
 
 import { QUERY_KEY_NAV, useNavQuery } from 'features/nav/getNavData';
@@ -19,19 +20,14 @@ const TermsGate = ({ children }: { children: React.ReactNode }) => {
   }, [data?.profile?.tos_agreed_at]);
 
   const acceptTos = async (profileId: number) => {
-    const { update_profiles_by_pk } = await client.mutate(
-      {
-        update_profiles_by_pk: [
-          {
-            pk_columns: { id: profileId },
-            _set: { tos_agreed_at: 'now()' },
-          },
-          { id: true, tos_agreed_at: true },
-        ],
-      },
-      { operationName: 'updateProfile__tos_agreed_at' }
+    const { acceptTOS } = await client.mutate(
+      { acceptTOS: { tos_agreed_at: true } },
+      { operationName: 'acceptTOS__termsGate' }
     );
-    return update_profiles_by_pk;
+
+    assert(acceptTOS);
+
+    return { tos_agreed_at: acceptTOS.tos_agreed_at, profile_id: profileId };
   };
 
   // TODO: perhaps use a handler for better validation

--- a/src/lib/gql/__generated__/zeus/const.ts
+++ b/src/lib/gql/__generated__/zeus/const.ts
@@ -3731,9 +3731,7 @@ export const AllTypesProps: Record<string, any> = {
     id: 'bigint',
   },
   profiles_select_column: true,
-  profiles_set_input: {
-    tos_agreed_at: 'timestamp',
-  },
+  profiles_set_input: {},
   profiles_stream_cursor_input: {
     initial_value: 'profiles_stream_cursor_value_input',
     ordering: 'cursor_ordering',
@@ -5728,6 +5726,9 @@ export const ReturnTypes: Record<string, any> = {
     ttl: 'Int',
     refresh: 'Boolean',
   },
+  AcceptTOSOutput: {
+    tos_agreed_at: 'String',
+  },
   AllocationCsvResponse: {
     file: 'String',
   },
@@ -6748,6 +6749,7 @@ export const ReturnTypes: Record<string, any> = {
     user_id: 'Float',
   },
   mutation_root: {
+    acceptTOS: 'AcceptTOSOutput',
     adminUpdateUser: 'UserResponse',
     allocationCsv: 'AllocationCsvResponse',
     createCircle: 'CreateCircleResponse',

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -589,6 +589,10 @@ type ZEUS_INTERFACES = never;
 type ZEUS_UNIONS = never;
 
 export type ValueTypes = {
+  ['AcceptTOSOutput']: AliasType<{
+    tos_agreed_at?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
   ['AdminUpdateUserInput']: {
     address: string;
     circle_id: number;
@@ -6104,6 +6108,8 @@ export type ValueTypes = {
   };
   /** mutation root */
   ['mutation_root']: AliasType<{
+    /** Accept Terms of Service action */
+    acceptTOS?: ValueTypes['AcceptTOSOutput'];
     adminUpdateUser?: [
       { payload: ValueTypes['AdminUpdateUserInput'] },
       ValueTypes['UserResponse']
@@ -8453,7 +8459,6 @@ export type ValueTypes = {
     medium_username?: string | undefined | null;
     skills?: string | undefined | null;
     telegram_username?: string | undefined | null;
-    tos_agreed_at?: ValueTypes['timestamp'] | undefined | null;
     twitter_username?: string | undefined | null;
     website?: string | undefined | null;
   };
@@ -13658,6 +13663,9 @@ export type ValueTypes = {
 };
 
 export type ModelTypes = {
+  ['AcceptTOSOutput']: {
+    tos_agreed_at: string;
+  };
   ['AdminUpdateUserInput']: GraphQLTypes['AdminUpdateUserInput'];
   ['Allocation']: GraphQLTypes['Allocation'];
   ['AllocationCsvInput']: GraphQLTypes['AllocationCsvInput'];
@@ -15547,6 +15555,8 @@ export type ModelTypes = {
   ['member_epoch_pgives_variance_order_by']: GraphQLTypes['member_epoch_pgives_variance_order_by'];
   /** mutation root */
   ['mutation_root']: {
+    /** Accept Terms of Service action */
+    acceptTOS?: GraphQLTypes['AcceptTOSOutput'] | undefined;
     adminUpdateUser?: GraphQLTypes['UserResponse'] | undefined;
     allocationCsv?: GraphQLTypes['AllocationCsvResponse'] | undefined;
     createCircle?: GraphQLTypes['CreateCircleResponse'] | undefined;
@@ -17499,6 +17509,10 @@ export type ModelTypes = {
 };
 
 export type GraphQLTypes = {
+  ['AcceptTOSOutput']: {
+    __typename: 'AcceptTOSOutput';
+    tos_agreed_at: string;
+  };
   ['AdminUpdateUserInput']: {
     address: string;
     circle_id: number;
@@ -22117,6 +22131,8 @@ export type GraphQLTypes = {
   /** mutation root */
   ['mutation_root']: {
     __typename: 'mutation_root';
+    /** Accept Terms of Service action */
+    acceptTOS?: GraphQLTypes['AcceptTOSOutput'] | undefined;
     adminUpdateUser?: GraphQLTypes['UserResponse'] | undefined;
     allocationCsv?: GraphQLTypes['AllocationCsvResponse'] | undefined;
     createCircle?: GraphQLTypes['CreateCircleResponse'] | undefined;
@@ -23631,7 +23647,6 @@ export type GraphQLTypes = {
     medium_username?: string | undefined;
     skills?: string | undefined;
     telegram_username?: string | undefined;
-    tos_agreed_at?: GraphQLTypes['timestamp'] | undefined;
     twitter_username?: string | undefined;
     website?: string | undefined;
   };


### PR DESCRIPTION
## What

Use action handler to enforce validation on TOS acceptance.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 97f0273</samp>

This pull request adds a new feature that allows users and admins to accept the terms of service and records the timestamp of their agreement. It implements a new GraphQL mutation `acceptTOS` as a Hasura action and updates the frontend component `TermsGate.tsx` to use it. It also removes the redundant `tos_agreed_at` field from the `profiles` table and schema. Additionally, it fixes a minor issue with the remote schema join for the `price_per_share` field in the `vaults` table.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 97f0273</samp>

> _To accept the terms of service now_
> _Users can use the `acceptTOS` action_
> _It updates the field with a timestamp_
> _And returns it as a JSON response_
> _No need for the field in the `profiles` table now_



## Test and Deployment Plan

Go through Terms Gate and ensure it functions properly.



## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 97f0273</samp>

*  Add a new `acceptTOS` action to the Hasura metadata and schema that updates the profile's `tos_agreed_at` field and returns it as output ([link](https://github.com/coordinape/coordinape/pull/2294/files?diff=unified&w=0#diff-589f402dbb6eb11ea9c28e067ac01d020e1b8f8f087f45d59435eaae684975c3R2-R5), [link](https://github.com/coordinape/coordinape/pull/2294/files?diff=unified&w=0#diff-589f402dbb6eb11ea9c28e067ac01d020e1b8f8f087f45d59435eaae684975c3R475-R478), [link](https://github.com/coordinape/coordinape/pull/2294/files?diff=unified&w=0#diff-589f402dbb6eb11ea9c28e067ac01d020e1b8f8f087f45d59435eaae684975c3R633-R636), [link](https://github.com/coordinape/coordinape/pull/2294/files?diff=unified&w=0#diff-49e7aa4e1112b93bcdbd36419aeb0b64fb23ea532e80c9a0f5ff1c5a585763f9R2-R12), [link](https://github.com/coordinape/coordinape/pull/2294/files?diff=unified&w=0#diff-49e7aa4e1112b93bcdbd36419aeb0b64fb23ea532e80c9a0f5ff1c5a585763f9R452), [link](https://github.com/coordinape/coordinape/pull/2294/files?diff=unified&w=0#diff-49e7aa4e1112b93bcdbd36419aeb0b64fb23ea532e80c9a0f5ff1c5a585763f9R677), [link](https://github.com/coordinape/coordinape/pull/2294/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R15982-R15985), [link](https://github.com/coordinape/coordinape/pull/2294/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebR7972-R7975))
* Define a handler function for the `acceptTOS` action in the `api/hasura/actions/_handlers/acceptTOS.ts` file that uses the admin GraphQL client to update the profile's `tos_agreed_at` field ([link](https://github.com/coordinape/coordinape/pull/2294/files?diff=unified&w=0#diff-5ae0a33867a2928cd69002339a81f7539ced6c26ba58dd099fb42add8fde88f0R1-R37))
* Import and register the `acceptTOS` handler function in the `api/hasura/actions/actionManager.ts` file that manages the routing of the Hasura actions ([link](https://github.com/coordinape/coordinape/pull/2294/files?diff=unified&w=0#diff-a6a476461d778e69905cd6d1cab214af3b0f749568bce39067fdde541f73a24eR7), [link](https://github.com/coordinape/coordinape/pull/2294/files?diff=unified&w=0#diff-a6a476461d778e69905cd6d1cab214af3b0f749568bce39067fdde541f73a24eR51))
* Remove the `tos_agreed_at` field from the `profiles` table and type metadata as it is no longer needed ([link](https://github.com/coordinape/coordinape/pull/2294/files?diff=unified&w=0#diff-8a805eab88da264de96c08096667337e06066993a6aa70395cd913c3c3feffaeL178), [link](https://github.com/coordinape/coordinape/pull/2294/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebL11343))
* Add a new type `AcceptTOSOutput` to the generated TypeScript files `api-lib/gql/__generated__/zeus/const.ts` and `src/lib/gql/__generated__/zeus/const.ts` that represents the output of the `acceptTOS` mutation ([link](https://github.com/coordinape/coordinape/pull/2294/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R9588-R9590), [link](https://github.com/coordinape/coordinape/pull/2294/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060R5729-R5731))
* Add a new field `acceptTOS` to the `ReturnTypes` object in the generated TypeScript files `api-lib/gql/__generated__/zeus/const.ts` and `src/lib/gql/__generated__/zeus/const.ts` that maps to the type `AcceptTOSOutput` ([link](https://github.com/coordinape/coordinape/pull/2294/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R12462), [link](https://github.com/coordinape/coordinape/pull/2294/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060R6752))
* Modify the `acceptTos` function in the `src/features/auth/TermsGate.tsx` file that defines the React component for the terms of service gate to use the `acceptTOS` mutation instead of the `update_profiles_by_pk` mutation and return an object with the updated field and the profile ID ([link](https://github.com/coordinape/coordinape/pull/2294/files?diff=unified&w=0#diff-5a0d1c5c5cea7d47bbd9eb95dea66275810a95cc8728657ca3c1a4ed5b32e3e0L22-R30))
* Import the `assert` function from the `assert` module to the `src/features/auth/TermsGate.tsx` file to check the existence of the `acceptTOS` mutation result ([link](https://github.com/coordinape/coordinape/pull/2294/files?diff=unified&w=0#diff-5a0d1c5c5cea7d47bbd9eb95dea66275810a95cc8728657ca3c1a4ed5b32e3e0R1))
* Remove the `tos_agreed_at` field from the `profiles_set_input` type in the generated TypeScript file `src/lib/gql/__generated__/zeus/const.ts` that represents the input type for the `update_profiles_by_pk` mutation as it is no longer needed ([link](https://github.com/coordinape/coordinape/pull/2294/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060L3734-R3734))
* Swap the order of the `hasura_fields` array in the `remote_field` definition for the `price_per_share` field in the `hasura/metadata/databases/default/tables/public_vaults.yaml` file as a minor fix for the remote schema join with the Coingecko API ([link](https://github.com/coordinape/coordinape/pull/2294/files?diff=unified&w=0#diff-65e516d5538b89c9e4590622c3ee0b4f8ff3ea29daf6b21e000577ccae984e66L29-R30))
