### PR TITLE
Fix switchnetwork reload bug

### DIFF
--- a/src/hooks/useRequireSupportedChain.ts
+++ b/src/hooks/useRequireSupportedChain.ts
@@ -1,14 +1,16 @@
 import { useEffect } from 'react';
 
+import { findConnectorName } from 'features/auth/connectors';
 import { supportedChainIds } from 'lib/vaults';
 
+import { EConnectorNames } from 'config/constants';
 import { useToast } from 'hooks';
 import { switchNetwork } from 'utils/provider';
 
 import { useWeb3React } from './useWeb3React';
 
 export default function useRequireSupportedChain() {
-  const { chainId } = useWeb3React();
+  const { chainId, connector, providerType } = useWeb3React();
   const { showError } = useToast();
 
   useEffect(() => {
@@ -18,7 +20,15 @@ export default function useRequireSupportedChain() {
       showError(
         `Contract interactions do not support chain ${chainId}. Please switch to Ethereum Mainnet.`
       );
-      switchNetwork('1');
+
+      // Only prompt to switch networks if using Injected connector
+      const connectorName = connector
+        ? findConnectorName(connector)
+        : providerType;
+
+      if (connectorName === EConnectorNames.Injected) {
+        switchNetwork('1');
+      }
     }
   }, [chainId]);
 }


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ccb60ed</samp>

Improve UX of switching to a supported network by checking connector type and prompting only Injected users. Use helper modules to get connector name in `useRequireSupportedChain.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ccb60ed</samp>

> _Sing, O Muse, of the code that enhances the user's choice_
> _Of network, when they interact with the dapp of renown,_
> _And how the code discerns the connector's name and voice,_
> _Whether `Injected` or another, and prompts them to switch or stay down._

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ccb60ed</samp>

*  Import modules to identify connector type ([link](https://github.com/coordinape/coordinape/pull/2295/files?diff=unified&w=0#diff-003028282517c99aafb3a5c57e29276c1b27726782aabd2e96f2cf8b6d00a8cbL3-R6))
*  Destructure connector and providerType from useWeb3React hook ([link](https://github.com/coordinape/coordinape/pull/2295/files?diff=unified&w=0#diff-003028282517c99aafb3a5c57e29276c1b27726782aabd2e96f2cf8b6d00a8cbL11-R13))
*  Add logic to prompt network switch only for Injected connector ([link](https://github.com/coordinape/coordinape/pull/2295/files?diff=unified&w=0#diff-003028282517c99aafb3a5c57e29276c1b27726782aabd2e96f2cf8b6d00a8cbL21-R31))
