### PR TITLE
fix add members from org user exists issue

### DIFF
--- a/src/pages/AddMembersPage/AddOrgMembersTable.tsx
+++ b/src/pages/AddMembersPage/AddOrgMembersTable.tsx
@@ -151,6 +151,7 @@ export const AddOrgMembersTable = ({
     } catch (error) {
       showError(error);
     } finally {
+      setMembersToAdd({});
       setIsSubmitting(false);
       setLoading(false);
     }


### PR DESCRIPTION
## What

copilot:summary

copilot:poem

## Why
After adding members to a circle using "Add from Org' options if the user tried to add other members without refreshing an error indicating that the user is still trying to add the previously added user is thrown.
solution:
clear the list of members to add after submitting

## How

copilot:walkthrough
