### PR TITLE
New contribution loading indicator

### DIFF
--- a/src/components/LoadingBar.tsx
+++ b/src/components/LoadingBar.tsx
@@ -1,0 +1,46 @@
+import { CSS } from 'stitches.config';
+
+import { keyframes } from '../stitches.config';
+import { Box } from '../ui';
+
+const pusher = keyframes({
+  '0%': {
+    transform: 'translate3d(-100%,0,0)',
+  },
+  '100%': {
+    transform: 'translate3d(250%,0,0)',
+  },
+});
+
+export const LoadingBar = ({ css }: { css?: CSS }) => {
+  return (
+    <Box
+      css={{
+        background: '$contentHeaderBorder',
+        height: '1px',
+        margin: '0 auto',
+        overflow: 'hidden',
+        position: 'relative',
+        width: '100%',
+        '&::before, &::after': {
+          content: '',
+          background: '$cta',
+          display: 'block',
+          height: '1px',
+          left: 0,
+          position: 'absolute',
+          top: 0,
+          transform: 'translate3d(-100%,0,0)',
+          width: '50%',
+        },
+        '&::before': {
+          animation: `${pusher} 2s infinite`,
+        },
+        '&::after': {
+          animation: `${pusher} 2s -1s infinite`,
+        },
+        ...css,
+      }}
+    />
+  );
+};

--- a/src/features/activities/ActivityList.tsx
+++ b/src/features/activities/ActivityList.tsx
@@ -21,10 +21,12 @@ export const ActivityList = ({
   queryKey,
   where,
   drawer,
+  onSettled,
 }: {
   queryKey: QueryKey;
   where: Where;
   drawer?: boolean;
+  onSettled?: () => void;
 }) => {
   const { showError } = useToast();
   const observerRef = useRef<HTMLDivElement>(null);
@@ -37,7 +39,8 @@ export const ActivityList = ({
     useInfiniteActivities(
       [ACTIVITIES_QUERY_KEY, queryKey],
       where,
-      setLatestActivityId
+      setLatestActivityId,
+      onSettled
     );
 
   // TODO: if we handle sort/filters this will need to change

--- a/src/features/activities/useInfiniteActivities.tsx
+++ b/src/features/activities/useInfiniteActivities.tsx
@@ -87,7 +87,8 @@ const getActivities = async (where: Where, page: number) => {
 export const useInfiniteActivities = (
   queryKey: QueryKey,
   where: Where,
-  setLatestActivityId: Dispatch<SetStateAction<number>>
+  setLatestActivityId: Dispatch<SetStateAction<number>>,
+  onSettled?: () => void
 ) => {
   return useInfiniteQuery(
     queryKey,
@@ -102,6 +103,7 @@ export const useInfiniteActivities = (
 
       refetchOnWindowFocus: true,
       refetchInterval: 10000,
+      onSettled: () => onSettled && onSettled(),
     }
   );
 };

--- a/src/pages/CircleActivityPage/CircleActivityPage.tsx
+++ b/src/pages/CircleActivityPage/CircleActivityPage.tsx
@@ -21,7 +21,14 @@ export const CircleActivityPage = () => {
   return (
     <SingleColumnLayout>
       <ContentHeader>
-        <Flex column css={{ gap: '$sm', flexGrow: 1 }}>
+        <Flex
+          column
+          css={{
+            gap: '$sm',
+            flexGrow: 1,
+            width: '100%',
+          }}
+        >
           <Text h1>Activity</Text>
           <Text p as="p">
             The latest in your circle.

--- a/src/pages/CircleActivityPage/CircleActivityPage.tsx
+++ b/src/pages/CircleActivityPage/CircleActivityPage.tsx
@@ -1,4 +1,5 @@
 import assert from 'assert';
+import { useState } from 'react';
 
 import { useParams } from 'react-router-dom';
 
@@ -10,6 +11,7 @@ import { ContributionHelpText } from 'pages/ContributionsPage/ContributionHelpTe
 import { ContentHeader, Flex, Text } from 'ui';
 
 export const CircleActivityPage = () => {
+  const [showLoading, setShowLoading] = useState(false);
   const { circleId: circleIdS } = useParams();
 
   assert(circleIdS);
@@ -26,13 +28,18 @@ export const CircleActivityPage = () => {
           </Text>
           <ContributionHelpText circleId={circleId} />
           {isFeatureEnabled('activity_contributions') && (
-            <ContributionForm circleId={circleId} />
+            <ContributionForm
+              circleId={circleId}
+              showLoading={showLoading}
+              onSave={() => setShowLoading(true)}
+            />
           )}
         </Flex>
       </ContentHeader>
       <ActivityList
         queryKey={['circle-activities', circleId]}
         where={{ circle_id: { _eq: circleId } }}
+        onSettled={() => setShowLoading(false)}
       />
     </SingleColumnLayout>
   );

--- a/src/pages/ContributionsPage/ContributionForm.tsx
+++ b/src/pages/ContributionsPage/ContributionForm.tsx
@@ -8,6 +8,7 @@ import type { CSS } from 'stitches.config';
 import { ACTIVITIES_QUERY_KEY } from '../../features/activities/ActivityList';
 import useConnectedAddress from '../../hooks/useConnectedAddress';
 import { FormInputField } from 'components';
+import { LoadingBar } from 'components/LoadingBar';
 import { useToast } from 'hooks';
 import { QUERY_KEY_ALLOCATE_CONTRIBUTIONS } from 'pages/GivePage/EpochStatementDrawer';
 import { Text, Box, Button, Flex, MarkdownPreview } from 'ui';
@@ -42,6 +43,7 @@ export const ContributionForm = ({
   const contributionExists = !!contributionId;
 
   const [saveState, setSaveState] = useState<{ [key: number]: SaveState }>({});
+  const [contributionSaving, setContributionSaving] = useState(false);
 
   const [showMarkdown, setShowMarkDown] = useState<boolean>(false);
 
@@ -149,6 +151,9 @@ export const ContributionForm = ({
           resetCreateMutation();
         }
       },
+      onSettled: () => {
+        setTimeout(() => setContributionSaving(false), 9000);
+      },
     });
 
   const { mutate: mutateContribution } = useMutation(
@@ -201,17 +206,19 @@ export const ContributionForm = ({
   const saveContribution = useMemo(() => {
     return (value: string) => {
       if (!currentContribution) return;
-      // currentContribution.contribution.id === NEW_CONTRIBUTION_ID
-      contributionExists
-        ? mutateContribution({
-            id: contributionId,
-            description: value,
-          })
-        : createContribution({
-            user_id: currentUserId,
-            circle_id: circleId,
-            description: value,
-          });
+      if (contributionExists) {
+        mutateContribution({
+          id: contributionId,
+          description: value,
+        });
+      } else {
+        setContributionSaving(true);
+        createContribution({
+          user_id: currentUserId,
+          circle_id: circleId,
+          description: value,
+        });
+      }
     };
   }, [currentContribution?.contribution.id]);
 
@@ -349,6 +356,16 @@ export const ContributionForm = ({
                 )}
               </Flex>
             </Flex>
+            {contributionSaving && (
+              <LoadingBar
+                css={{
+                  position: 'absolute',
+                  bottom: `calc((1px + $lg) * -1)`,
+                  left: '-$xl',
+                  width: `calc(100% + $xl)`,
+                }}
+              />
+            )}
           </Flex>
         </>
       )}

--- a/src/pages/ContributionsPage/ContributionForm.tsx
+++ b/src/pages/ContributionsPage/ContributionForm.tsx
@@ -31,19 +31,22 @@ export const ContributionForm = ({
   setEditingContribution,
   circleId,
   css,
+  showLoading,
+  onSave,
 }: {
   description?: string;
   contributionId?: number;
   setEditingContribution?: Dispatch<React.SetStateAction<boolean>>;
   circleId: number;
   css?: CSS;
+  showLoading?: boolean;
+  onSave?: () => void;
 }) => {
   const address = useConnectedAddress();
   const currentUserId = useMyUser(circleId)?.id;
   const contributionExists = !!contributionId;
 
   const [saveState, setSaveState] = useState<{ [key: number]: SaveState }>({});
-  const [contributionSaving, setContributionSaving] = useState(false);
 
   const [showMarkdown, setShowMarkDown] = useState<boolean>(false);
 
@@ -151,9 +154,6 @@ export const ContributionForm = ({
           resetCreateMutation();
         }
       },
-      onSettled: () => {
-        setTimeout(() => setContributionSaving(false), 9000);
-      },
     });
 
   const { mutate: mutateContribution } = useMutation(
@@ -212,7 +212,7 @@ export const ContributionForm = ({
           description: value,
         });
       } else {
-        setContributionSaving(true);
+        onSave && onSave();
         createContribution({
           user_id: currentUserId,
           circle_id: circleId,
@@ -356,7 +356,7 @@ export const ContributionForm = ({
                 )}
               </Flex>
             </Flex>
-            {contributionSaving && (
+            {showLoading && (
               <LoadingBar
                 css={{
                   position: 'absolute',


### PR DESCRIPTION

<img width="1512" alt="Screenshot 2023-08-31 at 4 05 09 PM" src="https://github.com/coordinape/coordinape/assets/100873710/07bb37c6-6fbb-4975-adeb-db9455b9da13">


## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 872b7f2</samp>

This pull request adds loading bars to the activity feed and the contribution form pages, using a new `LoadingBar` component and a callback function for the `useInfiniteActivities` hook. It also improves the layout and responsiveness of the activity feed header.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 872b7f2</samp>

> _We're loading the activities of the circle of doom_
> _With a `LoadingBar` that animates our gloom_
> _We're saving our contributions to the dark lord_
> _With a `ContributionForm` that passes the sword_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 872b7f2</samp>

*  Add a new component `LoadingBar` to render a loading animation ([link](https://github.com/coordinape/coordinape/pull/2308/files?diff=unified&w=0#diff-9ef671a5844c0b55af30f158deca9c6bf544e165e1c1dcbc474f61971f689185R1-R46))
*  Add an optional `onSettled` prop to the `ActivityList` component to trigger side effects after the query for activities is settled ([link](https://github.com/coordinape/coordinape/pull/2308/files?diff=unified&w=0#diff-fdea9c6f538e8e5aa3ce7995d63738e9742aadac9c6fde698457c945e5659b4cL24-R29), [link](https://github.com/coordinape/coordinape/pull/2308/files?diff=unified&w=0#diff-fdea9c6f538e8e5aa3ce7995d63738e9742aadac9c6fde698457c945e5659b4cL40-R43))
*  Pass the `onSettled` prop to the `useInfiniteActivities` hook, which fetches activities using `react-query` ([link](https://github.com/coordinape/coordinape/pull/2308/files?diff=unified&w=0#diff-de71c4ba5014d75c0e22b56c2dea640e7a20fda5614d3928efcc786e8b663391L90-R91), [link](https://github.com/coordinape/coordinape/pull/2308/files?diff=unified&w=0#diff-de71c4ba5014d75c0e22b56c2dea640e7a20fda5614d3928efcc786e8b663391R106))
*  Add a `showLoading` state to the `CircleActivityPage` component to control the visibility of the `LoadingBar` component ([link](https://github.com/coordinape/coordinape/pull/2308/files?diff=unified&w=0#diff-ad4502b0dfe7c31d2c3282e694732d7e7e4d5095133d8274e63f50746492385dR2), [link](https://github.com/coordinape/coordinape/pull/2308/files?diff=unified&w=0#diff-ad4502b0dfe7c31d2c3282e694732d7e7e4d5095133d8274e63f50746492385dR14))
*  Pass the `showLoading` state and an `onSave` function to the `ContributionForm` component, which allows users to add or edit their contributions to the circle ([link](https://github.com/coordinape/coordinape/pull/2308/files?diff=unified&w=0#diff-ad4502b0dfe7c31d2c3282e694732d7e7e4d5095133d8274e63f50746492385dL29-R42))
*  Call the `onSave` function when the user saves a new contribution, and set the `showLoading` state to true ([link](https://github.com/coordinape/coordinape/pull/2308/files?diff=unified&w=0#diff-8c417a5a2b551e89bf1c0521c1718e4fab41f3439b3b638f8aaa32f2ced22e60L204-R221))
*  Render the `LoadingBar` component inside the `ContributionForm` component, if the `showLoading` state is true ([link](https://github.com/coordinape/coordinape/pull/2308/files?diff=unified&w=0#diff-8c417a5a2b551e89bf1c0521c1718e4fab41f3439b3b638f8aaa32f2ced22e60R11), [link](https://github.com/coordinape/coordinape/pull/2308/files?diff=unified&w=0#diff-8c417a5a2b551e89bf1c0521c1718e4fab41f3439b3b638f8aaa32f2ced22e60R42-R43), [link](https://github.com/coordinape/coordinape/pull/2308/files?diff=unified&w=0#diff-8c417a5a2b551e89bf1c0521c1718e4fab41f3439b3b638f8aaa32f2ced22e60R359-R368))
*  Pass the `onSettled` function to the `ActivityList` component, which sets the `showLoading` state to false after the query for activities is settled ([link](https://github.com/coordinape/coordinape/pull/2308/files?diff=unified&w=0#diff-ad4502b0dfe7c31d2c3282e694732d7e7e4d5095133d8274e63f50746492385dR49))
*  Add some css styles to the `Flex` component that wraps the content header of the `CircleActivityPage` component, to make it full width and responsive ([link](https://github.com/coordinape/coordinape/pull/2308/files?diff=unified&w=0#diff-ad4502b0dfe7c31d2c3282e694732d7e7e4d5095133d8274e63f50746492385dL22-R31))
