### PR TITLE
add a sneaky way to login with wallet connect on mainnet

### DIFF
--- a/src/features/auth/connectors.ts
+++ b/src/features/auth/connectors.ts
@@ -12,6 +12,7 @@ import { INFURA_PROJECT_ID, WALLET_CONNECT_V2_PROJECT_ID } from 'config/env';
 import { WalletConnectV2Connector } from './walletconnectv2';
 
 const OPTIMISM_RPC_URL = `https://optimism-mainnet.infura.io/v3/${INFURA_PROJECT_ID}`;
+const ETHEREUM_RPC_URL = `https://mainnet.infura.io/v3/${INFURA_PROJECT_ID}`;
 
 const injected = new InjectedConnector({
   supportedChainIds: Object.keys(loginSupportedChainIds).map(n =>
@@ -28,11 +29,18 @@ export const makeWalletConnectConnector = () => {
    * This is a bit of a hack but stops the requirement to upgrade web3-react to v8.
    * WalletConnect cannot switch chains, each chain requires a new connection.
    */
+
+  const mainnet = localStorage.getItem('walletconnect:mainnet');
+  const chainId = mainnet === 'true' ? 1 : 10;
+
   const wc = new WalletConnectV2Connector({
     showQrModal: true,
     projectId: WALLET_CONNECT_V2_PROJECT_ID,
-    chains: [10],
-    rpcMap: { 10: OPTIMISM_RPC_URL },
+    chains: [chainId],
+    rpcMap: {
+      1: ETHEREUM_RPC_URL,
+      10: OPTIMISM_RPC_URL,
+    },
   });
   return wc;
 };


### PR DESCRIPTION
## What

Quick fix to let a user force wallet connect to use mainnet, so they can claim from a vault. 

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b3601f9</samp>

*  Add support for connecting to Ethereum mainnet or Optimism network using WalletConnect ([link](https://github.com/coordinape/coordinape/pull/2315/files?diff=unified&w=0#diff-5337af434751ecff46d36101dee396bc3b53368ff2bb3c08b19faf9d406de6e2R15), [link](https://github.com/coordinape/coordinape/pull/2315/files?diff=unified&w=0#diff-5337af434751ecff46d36101dee396bc3b53368ff2bb3c08b19faf9d406de6e2L31-R43))
