### PR TITLE
🕷️ bugfix: flexible width toast for mobile

### DIFF
--- a/src/components/ToastContainer.tsx
+++ b/src/components/ToastContainer.tsx
@@ -10,6 +10,13 @@ const StyledContainer = styled(ToastifyContainer, {
     width: '80%',
     minWidth: '400px',
     maxWidth: '660px',
+    '@sm': {
+      width: 'calc(100% - $xs - $xs)',
+      minWidth: 0,
+      mx: '$xs',
+      mb: '$sm',
+      left: 0,
+    },
   },
 
   '.Toastify__toast': {


### PR DESCRIPTION
<img width="480" alt="Screenshot 2023-09-08 at 2 38 32 PM" src="https://github.com/coordinape/coordinape/assets/100873710/6356472b-c11b-4f37-8cb6-602555cf8739">
