### PR TITLE
add emails table and addEmail handler

### DIFF
--- a/api-lib/gql/__generated__/zeus/const.ts
+++ b/api-lib/gql/__generated__/zeus/const.ts
@@ -2805,6 +2805,146 @@ export const AllTypesProps: Record<string, any> = {
     id: 'order_by',
     vault_id: 'order_by',
   },
+  emails_aggregate_bool_exp: {
+    bool_and: 'emails_aggregate_bool_exp_bool_and',
+    bool_or: 'emails_aggregate_bool_exp_bool_or',
+    count: 'emails_aggregate_bool_exp_count',
+  },
+  emails_aggregate_bool_exp_bool_and: {
+    arguments:
+      'emails_select_column_emails_aggregate_bool_exp_bool_and_arguments_columns',
+    filter: 'emails_bool_exp',
+    predicate: 'Boolean_comparison_exp',
+  },
+  emails_aggregate_bool_exp_bool_or: {
+    arguments:
+      'emails_select_column_emails_aggregate_bool_exp_bool_or_arguments_columns',
+    filter: 'emails_bool_exp',
+    predicate: 'Boolean_comparison_exp',
+  },
+  emails_aggregate_bool_exp_count: {
+    arguments: 'emails_select_column',
+    filter: 'emails_bool_exp',
+    predicate: 'Int_comparison_exp',
+  },
+  emails_aggregate_fields: {
+    count: {
+      columns: 'emails_select_column',
+    },
+  },
+  emails_aggregate_order_by: {
+    avg: 'emails_avg_order_by',
+    count: 'order_by',
+    max: 'emails_max_order_by',
+    min: 'emails_min_order_by',
+    stddev: 'emails_stddev_order_by',
+    stddev_pop: 'emails_stddev_pop_order_by',
+    stddev_samp: 'emails_stddev_samp_order_by',
+    sum: 'emails_sum_order_by',
+    var_pop: 'emails_var_pop_order_by',
+    var_samp: 'emails_var_samp_order_by',
+    variance: 'emails_variance_order_by',
+  },
+  emails_arr_rel_insert_input: {
+    data: 'emails_insert_input',
+    on_conflict: 'emails_on_conflict',
+  },
+  emails_avg_order_by: {
+    profile_id: 'order_by',
+  },
+  emails_bool_exp: {
+    _and: 'emails_bool_exp',
+    _not: 'emails_bool_exp',
+    _or: 'emails_bool_exp',
+    email: 'citext_comparison_exp',
+    primary: 'Boolean_comparison_exp',
+    profile: 'profiles_bool_exp',
+    profile_id: 'Int_comparison_exp',
+    verification_code: 'uuid_comparison_exp',
+    verified_at: 'timestamp_comparison_exp',
+  },
+  emails_constraint: true,
+  emails_inc_input: {},
+  emails_insert_input: {
+    email: 'citext',
+    profile: 'profiles_obj_rel_insert_input',
+    verification_code: 'uuid',
+    verified_at: 'timestamp',
+  },
+  emails_max_order_by: {
+    email: 'order_by',
+    profile_id: 'order_by',
+    verification_code: 'order_by',
+    verified_at: 'order_by',
+  },
+  emails_min_order_by: {
+    email: 'order_by',
+    profile_id: 'order_by',
+    verification_code: 'order_by',
+    verified_at: 'order_by',
+  },
+  emails_on_conflict: {
+    constraint: 'emails_constraint',
+    update_columns: 'emails_update_column',
+    where: 'emails_bool_exp',
+  },
+  emails_order_by: {
+    email: 'order_by',
+    primary: 'order_by',
+    profile: 'profiles_order_by',
+    profile_id: 'order_by',
+    verification_code: 'order_by',
+    verified_at: 'order_by',
+  },
+  emails_pk_columns_input: {
+    email: 'citext',
+  },
+  emails_select_column: true,
+  emails_select_column_emails_aggregate_bool_exp_bool_and_arguments_columns:
+    true,
+  emails_select_column_emails_aggregate_bool_exp_bool_or_arguments_columns:
+    true,
+  emails_set_input: {
+    email: 'citext',
+    verification_code: 'uuid',
+    verified_at: 'timestamp',
+  },
+  emails_stddev_order_by: {
+    profile_id: 'order_by',
+  },
+  emails_stddev_pop_order_by: {
+    profile_id: 'order_by',
+  },
+  emails_stddev_samp_order_by: {
+    profile_id: 'order_by',
+  },
+  emails_stream_cursor_input: {
+    initial_value: 'emails_stream_cursor_value_input',
+    ordering: 'cursor_ordering',
+  },
+  emails_stream_cursor_value_input: {
+    email: 'citext',
+    verification_code: 'uuid',
+    verified_at: 'timestamp',
+  },
+  emails_sum_order_by: {
+    profile_id: 'order_by',
+  },
+  emails_update_column: true,
+  emails_updates: {
+    _inc: 'emails_inc_input',
+    _set: 'emails_set_input',
+    where: 'emails_bool_exp',
+  },
+  emails_var_pop_order_by: {
+    profile_id: 'order_by',
+  },
+  emails_var_samp_order_by: {
+    profile_id: 'order_by',
+  },
+  emails_variance_order_by: {
+    profile_id: 'order_by',
+  },
   epoch_pgive_data_aggregate_fields: {
     count: {
       columns: 'epoch_pgive_data_select_column',
@@ -4287,6 +4427,12 @@ export const AllTypesProps: Record<string, any> = {
     delete_distributions_by_pk: {
       id: 'bigint',
     },
+    delete_emails: {
+      where: 'emails_bool_exp',
+    },
+    delete_emails_by_pk: {
+      email: 'citext',
+    },
     delete_epoch_pgive_data: {
       where: 'epoch_pgive_data_bool_exp',
     },
@@ -4555,6 +4701,14 @@ export const AllTypesProps: Record<string, any> = {
     insert_distributions_one: {
       object: 'distributions_insert_input',
       on_conflict: 'distributions_on_conflict',
+    },
+    insert_emails: {
+      objects: 'emails_insert_input',
+      on_conflict: 'emails_on_conflict',
+    },
+    insert_emails_one: {
+      object: 'emails_insert_input',
+      on_conflict: 'emails_on_conflict',
     },
     insert_epoch_pgive_data: {
       objects: 'epoch_pgive_data_insert_input',
@@ -5013,6 +5167,19 @@ export const AllTypesProps: Record<string, any> = {
     },
     update_distributions_many: {
       updates: 'distributions_updates',
+    },
+    update_emails: {
+      _inc: 'emails_inc_input',
+      _set: 'emails_set_input',
+      where: 'emails_bool_exp',
+    },
+    update_emails_by_pk: {
+      _inc: 'emails_inc_input',
+      _set: 'emails_set_input',
+      pk_columns: 'emails_pk_columns_input',
+    },
+    update_emails_many: {
+      updates: 'emails_updates',
     },
     update_epoch_pgive_data: {
       _inc: 'epoch_pgive_data_inc_input',
@@ -6489,6 +6656,16 @@ export const AllTypesProps: Record<string, any> = {
       order_by: 'distributions_order_by',
       where: 'distributions_bool_exp',
     },
+    emails: {
+      distinct_on: 'emails_select_column',
+      order_by: 'emails_order_by',
+      where: 'emails_bool_exp',
+    },
+    emails_aggregate: {
+      distinct_on: 'emails_select_column',
+      order_by: 'emails_order_by',
+      where: 'emails_bool_exp',
+    },
     nominees: {
       distinct_on: 'nominees_select_column',
       order_by: 'nominees_order_by',
@@ -6562,6 +6739,8 @@ export const AllTypesProps: Record<string, any> = {
     discord_username: 'String_comparison_exp',
     distributions: 'distributions_bool_exp',
     distributions_aggregate: 'distributions_aggregate_bool_exp',
+    emails: 'emails_bool_exp',
+    emails_aggregate: 'emails_aggregate_bool_exp',
     github_username: 'String_comparison_exp',
     id: 'bigint_comparison_exp',
     medium_username: 'String_comparison_exp',
@@ -6593,6 +6772,7 @@ export const AllTypesProps: Record<string, any> = {
     cosoul: 'cosouls_obj_rel_insert_input',
     created_at: 'timestamp',
     distributions: 'distributions_arr_rel_insert_input',
+    emails: 'emails_arr_rel_insert_input',
     id: 'bigint',
     name: 'citext',
     nominees: 'nominees_arr_rel_insert_input',
@@ -6625,6 +6805,7 @@ export const AllTypesProps: Record<string, any> = {
     created_at: 'order_by',
     discord_username: 'order_by',
     distributions_aggregate: 'distributions_aggregate_order_by',
+    emails_aggregate: 'emails_aggregate_order_by',
     github_username: 'order_by',
     id: 'order_by',
     medium_username: 'order_by',
@@ -6881,6 +7062,19 @@ export const AllTypesProps: Record<string, any> = {
     },
     distributions_by_pk: {
       id: 'bigint',
+    },
+    emails: {
+      distinct_on: 'emails_select_column',
+      order_by: 'emails_order_by',
+      where: 'emails_bool_exp',
+    },
+    emails_aggregate: {
+      distinct_on: 'emails_select_column',
+      order_by: 'emails_order_by',
+      where: 'emails_bool_exp',
+    },
+    emails_by_pk: {
+      email: 'citext',
     },
     epoch_pgive_data: {
       distinct_on: 'epoch_pgive_data_select_column',
@@ -7654,6 +7848,23 @@ export const AllTypesProps: Record<string, any> = {
     distributions_stream: {
       cursor: 'distributions_stream_cursor_input',
       where: 'distributions_bool_exp',
+    },
+    emails: {
+      distinct_on: 'emails_select_column',
+      order_by: 'emails_order_by',
+      where: 'emails_bool_exp',
+    },
+    emails_aggregate: {
+      distinct_on: 'emails_select_column',
+      order_by: 'emails_order_by',
+      where: 'emails_bool_exp',
+    },
+    emails_by_pk: {
+      email: 'citext',
+    },
+    emails_stream: {
+      cursor: 'emails_stream_cursor_input',
+      where: 'emails_bool_exp',
     },
     epoch_pgive_data: {
       distinct_on: 'epoch_pgive_data_select_column',
@@ -11441,6 +11652,71 @@ export const ReturnTypes: Record<string, any> = {
     id: 'Float',
     vault_id: 'Float',
   },
+  emails: {
+    email: 'citext',
+    primary: 'Boolean',
+    profile: 'profiles',
+    profile_id: 'Int',
+    verification_code: 'uuid',
+    verified_at: 'timestamp',
+  },
+  emails_aggregate: {
+    aggregate: 'emails_aggregate_fields',
+    nodes: 'emails',
+  },
+  emails_aggregate_fields: {
+    avg: 'emails_avg_fields',
+    count: 'Int',
+    max: 'emails_max_fields',
+    min: 'emails_min_fields',
+    stddev: 'emails_stddev_fields',
+    stddev_pop: 'emails_stddev_pop_fields',
+    stddev_samp: 'emails_stddev_samp_fields',
+    sum: 'emails_sum_fields',
+    var_pop: 'emails_var_pop_fields',
+    var_samp: 'emails_var_samp_fields',
+    variance: 'emails_variance_fields',
+  },
+  emails_avg_fields: {
+    profile_id: 'Float',
+  },
+  emails_max_fields: {
+    email: 'citext',
+    profile_id: 'Int',
+    verification_code: 'uuid',
+    verified_at: 'timestamp',
+  },
+  emails_min_fields: {
+    email: 'citext',
+    profile_id: 'Int',
+    verification_code: 'uuid',
+    verified_at: 'timestamp',
+  },
+  emails_mutation_response: {
+    affected_rows: 'Int',
+    returning: 'emails',
+  },
+  emails_stddev_fields: {
+    profile_id: 'Float',
+  },
+  emails_stddev_pop_fields: {
+    profile_id: 'Float',
+  },
+  emails_stddev_samp_fields: {
+    profile_id: 'Float',
+  },
+  emails_sum_fields: {
+    profile_id: 'Int',
+  },
+  emails_var_pop_fields: {
+    profile_id: 'Float',
+  },
+  emails_var_samp_fields: {
+    profile_id: 'Float',
+  },
+  emails_variance_fields: {
+    profile_id: 'Float',
+  },
   epoch_pgive_data: {
     active_months: 'Int',
     active_months_bonus: 'numeric',
@@ -12530,6 +12806,8 @@ export const ReturnTypes: Record<string, any> = {
     delete_discord_users_by_pk: 'discord_users',
     delete_distributions: 'distributions_mutation_response',
     delete_distributions_by_pk: 'distributions',
+    delete_emails: 'emails_mutation_response',
+    delete_emails_by_pk: 'emails',
     delete_epoch_pgive_data: 'epoch_pgive_data_mutation_response',
     delete_epoch_pgive_data_by_pk: 'epoch_pgive_data',
     delete_epochs: 'epochs_mutation_response',
@@ -12618,6 +12896,8 @@ export const ReturnTypes: Record<string, any> = {
     insert_discord_users_one: 'discord_users',
     insert_distributions: 'distributions_mutation_response',
     insert_distributions_one: 'distributions',
+    insert_emails: 'emails_mutation_response',
+    insert_emails_one: 'emails',
     insert_epoch_pgive_data: 'epoch_pgive_data_mutation_response',
     insert_epoch_pgive_data_one: 'epoch_pgive_data',
     insert_epochs: 'epochs_mutation_response',
@@ -12737,6 +13017,9 @@ export const ReturnTypes: Record<string, any> = {
     update_distributions: 'distributions_mutation_response',
     update_distributions_by_pk: 'distributions',
     update_distributions_many: 'distributions_mutation_response',
+    update_emails: 'emails_mutation_response',
+    update_emails_by_pk: 'emails',
+    update_emails_many: 'emails_mutation_response',
     update_epoch_pgive_data: 'epoch_pgive_data_mutation_response',
     update_epoch_pgive_data_by_pk: 'epoch_pgive_data',
     update_epoch_pgive_data_many: 'epoch_pgive_data_mutation_response',
@@ -13719,6 +14002,8 @@ export const ReturnTypes: Record<string, any> = {
     discord_username: 'String',
     distributions: 'distributions',
     distributions_aggregate: 'distributions_aggregate',
+    emails: 'emails',
+    emails_aggregate: 'emails_aggregate',
     github_username: 'String',
     id: 'bigint',
     medium_username: 'String',
@@ -13876,6 +14161,9 @@ export const ReturnTypes: Record<string, any> = {
     distributions: 'distributions',
     distributions_aggregate: 'distributions_aggregate',
     distributions_by_pk: 'distributions',
+    emails: 'emails',
+    emails_aggregate: 'emails_aggregate',
+    emails_by_pk: 'emails',
     epoch_pgive_data: 'epoch_pgive_data',
     epoch_pgive_data_aggregate: 'epoch_pgive_data_aggregate',
     epoch_pgive_data_by_pk: 'epoch_pgive_data',
@@ -14115,6 +14403,10 @@ export const ReturnTypes: Record<string, any> = {
     distributions_aggregate: 'distributions_aggregate',
     distributions_by_pk: 'distributions',
     distributions_stream: 'distributions',
+    emails: 'emails',
+    emails_aggregate: 'emails_aggregate',
+    emails_by_pk: 'emails',
+    emails_stream: 'emails',
     epoch_pgive_data: 'epoch_pgive_data',
     epoch_pgive_data_aggregate: 'epoch_pgive_data_aggregate',
     epoch_pgive_data_by_pk: 'epoch_pgive_data',

--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -7736,6 +7736,289 @@ export type ValueTypes = {
     id?: ValueTypes['order_by'] | undefined | null;
     vault_id?: ValueTypes['order_by'] | undefined | null;
   };
+  /** columns and relationships of "emails" */
+  ['emails']: AliasType<{
+    email?: boolean | `@${string}`;
+    primary?: boolean | `@${string}`;
+    /** An object relationship */
+    profile?: ValueTypes['profiles'];
+    profile_id?: boolean | `@${string}`;
+    verification_code?: boolean | `@${string}`;
+    verified_at?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregated selection of "emails" */
+  ['emails_aggregate']: AliasType<{
+    aggregate?: ValueTypes['emails_aggregate_fields'];
+    nodes?: ValueTypes['emails'];
+    __typename?: boolean | `@${string}`;
+  }>;
+  ['emails_aggregate_bool_exp']: {
+    bool_and?:
+      | ValueTypes['emails_aggregate_bool_exp_bool_and']
+      | undefined
+      | null;
+    bool_or?:
+      | ValueTypes['emails_aggregate_bool_exp_bool_or']
+      | undefined
+      | null;
+    count?: ValueTypes['emails_aggregate_bool_exp_count'] | undefined | null;
+  };
+  ['emails_aggregate_bool_exp_bool_and']: {
+    arguments: ValueTypes['emails_select_column_emails_aggregate_bool_exp_bool_and_arguments_columns'];
+    distinct?: boolean | undefined | null;
+    filter?: ValueTypes['emails_bool_exp'] | undefined | null;
+    predicate: ValueTypes['Boolean_comparison_exp'];
+  };
+  ['emails_aggregate_bool_exp_bool_or']: {
+    arguments: ValueTypes['emails_select_column_emails_aggregate_bool_exp_bool_or_arguments_columns'];
+    distinct?: boolean | undefined | null;
+    filter?: ValueTypes['emails_bool_exp'] | undefined | null;
+    predicate: ValueTypes['Boolean_comparison_exp'];
+  };
+  ['emails_aggregate_bool_exp_count']: {
+    arguments?: Array<ValueTypes['emails_select_column']> | undefined | null;
+    distinct?: boolean | undefined | null;
+    filter?: ValueTypes['emails_bool_exp'] | undefined | null;
+    predicate: ValueTypes['Int_comparison_exp'];
+  };
+  /** aggregate fields of "emails" */
+  ['emails_aggregate_fields']: AliasType<{
+    avg?: ValueTypes['emails_avg_fields'];
+    count?: [
+      {
+        columns?: Array<ValueTypes['emails_select_column']> | undefined | null;
+        distinct?: boolean | undefined | null;
+      },
+      boolean | `@${string}`
+    ];
+    max?: ValueTypes['emails_max_fields'];
+    min?: ValueTypes['emails_min_fields'];
+    stddev?: ValueTypes['emails_stddev_fields'];
+    stddev_pop?: ValueTypes['emails_stddev_pop_fields'];
+    stddev_samp?: ValueTypes['emails_stddev_samp_fields'];
+    sum?: ValueTypes['emails_sum_fields'];
+    var_pop?: ValueTypes['emails_var_pop_fields'];
+    var_samp?: ValueTypes['emails_var_samp_fields'];
+    variance?: ValueTypes['emails_variance_fields'];
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** order by aggregate values of table "emails" */
+  ['emails_aggregate_order_by']: {
+    avg?: ValueTypes['emails_avg_order_by'] | undefined | null;
+    count?: ValueTypes['order_by'] | undefined | null;
+    max?: ValueTypes['emails_max_order_by'] | undefined | null;
+    min?: ValueTypes['emails_min_order_by'] | undefined | null;
+    stddev?: ValueTypes['emails_stddev_order_by'] | undefined | null;
+    stddev_pop?: ValueTypes['emails_stddev_pop_order_by'] | undefined | null;
+    stddev_samp?: ValueTypes['emails_stddev_samp_order_by'] | undefined | null;
+    sum?: ValueTypes['emails_sum_order_by'] | undefined | null;
+    var_pop?: ValueTypes['emails_var_pop_order_by'] | undefined | null;
+    var_samp?: ValueTypes['emails_var_samp_order_by'] | undefined | null;
+    variance?: ValueTypes['emails_variance_order_by'] | undefined | null;
+  };
+  /** input type for inserting array relation for remote table "emails" */
+  ['emails_arr_rel_insert_input']: {
+    data: Array<ValueTypes['emails_insert_input']>;
+    /** upsert condition */
+    on_conflict?: ValueTypes['emails_on_conflict'] | undefined | null;
+  };
+  /** aggregate avg on columns */
+  ['emails_avg_fields']: AliasType<{
+    profile_id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** order by avg() on columns of table "emails" */
+  ['emails_avg_order_by']: {
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+  };
+  /** Boolean expression to filter rows from the table "emails". All fields are combined with a logical 'AND'. */
+  ['emails_bool_exp']: {
+    _and?: Array<ValueTypes['emails_bool_exp']> | undefined | null;
+    _not?: ValueTypes['emails_bool_exp'] | undefined | null;
+    _or?: Array<ValueTypes['emails_bool_exp']> | undefined | null;
+    email?: ValueTypes['citext_comparison_exp'] | undefined | null;
+    primary?: ValueTypes['Boolean_comparison_exp'] | undefined | null;
+    profile?: ValueTypes['profiles_bool_exp'] | undefined | null;
+    profile_id?: ValueTypes['Int_comparison_exp'] | undefined | null;
+    verification_code?: ValueTypes['uuid_comparison_exp'] | undefined | null;
+    verified_at?: ValueTypes['timestamp_comparison_exp'] | undefined | null;
+  };
+  /** unique or primary key constraints on table "emails" */
+  ['emails_constraint']: emails_constraint;
+  /** input type for incrementing numeric columns in table "emails" */
+  ['emails_inc_input']: {
+    profile_id?: number | undefined | null;
+  };
+  /** input type for inserting data into table "emails" */
+  ['emails_insert_input']: {
+    email?: ValueTypes['citext'] | undefined | null;
+    primary?: boolean | undefined | null;
+    profile?: ValueTypes['profiles_obj_rel_insert_input'] | undefined | null;
+    profile_id?: number | undefined | null;
+    verification_code?: ValueTypes['uuid'] | undefined | null;
+    verified_at?: ValueTypes['timestamp'] | undefined | null;
+  };
+  /** aggregate max on columns */
+  ['emails_max_fields']: AliasType<{
+    email?: boolean | `@${string}`;
+    profile_id?: boolean | `@${string}`;
+    verification_code?: boolean | `@${string}`;
+    verified_at?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** order by max() on columns of table "emails" */
+  ['emails_max_order_by']: {
+    email?: ValueTypes['order_by'] | undefined | null;
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+    verification_code?: ValueTypes['order_by'] | undefined | null;
+    verified_at?: ValueTypes['order_by'] | undefined | null;
+  };
+  /** aggregate min on columns */
+  ['emails_min_fields']: AliasType<{
+    email?: boolean | `@${string}`;
+    profile_id?: boolean | `@${string}`;
+    verification_code?: boolean | `@${string}`;
+    verified_at?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** order by min() on columns of table "emails" */
+  ['emails_min_order_by']: {
+    email?: ValueTypes['order_by'] | undefined | null;
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+    verification_code?: ValueTypes['order_by'] | undefined | null;
+    verified_at?: ValueTypes['order_by'] | undefined | null;
+  };
+  /** response of any mutation on the table "emails" */
+  ['emails_mutation_response']: AliasType<{
+    /** number of rows affected by the mutation */
+    affected_rows?: boolean | `@${string}`;
+    /** data from the rows affected by the mutation */
+    returning?: ValueTypes['emails'];
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** on_conflict condition type for table "emails" */
+  ['emails_on_conflict']: {
+    constraint: ValueTypes['emails_constraint'];
+    update_columns: Array<ValueTypes['emails_update_column']>;
+    where?: ValueTypes['emails_bool_exp'] | undefined | null;
+  };
+  /** Ordering options when selecting data from "emails". */
+  ['emails_order_by']: {
+    email?: ValueTypes['order_by'] | undefined | null;
+    primary?: ValueTypes['order_by'] | undefined | null;
+    profile?: ValueTypes['profiles_order_by'] | undefined | null;
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+    verification_code?: ValueTypes['order_by'] | undefined | null;
+    verified_at?: ValueTypes['order_by'] | undefined | null;
+  };
+  /** primary key columns input for table: emails */
+  ['emails_pk_columns_input']: {
+    email: ValueTypes['citext'];
+    profile_id: number;
+  };
+  /** select columns of table "emails" */
+  ['emails_select_column']: emails_select_column;
+  /** select "emails_aggregate_bool_exp_bool_and_arguments_columns" columns of table "emails" */
+  ['emails_select_column_emails_aggregate_bool_exp_bool_and_arguments_columns']: emails_select_column_emails_aggregate_bool_exp_bool_and_arguments_columns;
+  /** select "emails_aggregate_bool_exp_bool_or_arguments_columns" columns of table "emails" */
+  ['emails_select_column_emails_aggregate_bool_exp_bool_or_arguments_columns']: emails_select_column_emails_aggregate_bool_exp_bool_or_arguments_columns;
+  /** input type for updating data in table "emails" */
+  ['emails_set_input']: {
+    email?: ValueTypes['citext'] | undefined | null;
+    primary?: boolean | undefined | null;
+    profile_id?: number | undefined | null;
+    verification_code?: ValueTypes['uuid'] | undefined | null;
+    verified_at?: ValueTypes['timestamp'] | undefined | null;
+  };
+  /** aggregate stddev on columns */
+  ['emails_stddev_fields']: AliasType<{
+    profile_id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** order by stddev() on columns of table "emails" */
+  ['emails_stddev_order_by']: {
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+  };
+  /** aggregate stddev_pop on columns */
+  ['emails_stddev_pop_fields']: AliasType<{
+    profile_id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** order by stddev_pop() on columns of table "emails" */
+  ['emails_stddev_pop_order_by']: {
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+  };
+  /** aggregate stddev_samp on columns */
+  ['emails_stddev_samp_fields']: AliasType<{
+    profile_id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** order by stddev_samp() on columns of table "emails" */
+  ['emails_stddev_samp_order_by']: {
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+  };
+  /** Streaming cursor of the table "emails" */
+  ['emails_stream_cursor_input']: {
+    /** Stream column input with initial value */
+    initial_value: ValueTypes['emails_stream_cursor_value_input'];
+    /** cursor ordering */
+    ordering?: ValueTypes['cursor_ordering'] | undefined | null;
+  };
+  /** Initial value of the column from where the streaming should start */
+  ['emails_stream_cursor_value_input']: {
+    email?: ValueTypes['citext'] | undefined | null;
+    primary?: boolean | undefined | null;
+    profile_id?: number | undefined | null;
+    verification_code?: ValueTypes['uuid'] | undefined | null;
+    verified_at?: ValueTypes['timestamp'] | undefined | null;
+  };
+  /** aggregate sum on columns */
+  ['emails_sum_fields']: AliasType<{
+    profile_id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** order by sum() on columns of table "emails" */
+  ['emails_sum_order_by']: {
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+  };
+  /** update columns of table "emails" */
+  ['emails_update_column']: emails_update_column;
+  ['emails_updates']: {
+    /** increments the numeric columns with given value of the filtered values */
+    _inc?: ValueTypes['emails_inc_input'] | undefined | null;
+    /** sets the columns of the filtered rows to the given values */
+    _set?: ValueTypes['emails_set_input'] | undefined | null;
+    /** filter the rows which have to be updated */
+    where: ValueTypes['emails_bool_exp'];
+  };
+  /** aggregate var_pop on columns */
+  ['emails_var_pop_fields']: AliasType<{
+    profile_id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** order by var_pop() on columns of table "emails" */
+  ['emails_var_pop_order_by']: {
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+  };
+  /** aggregate var_samp on columns */
+  ['emails_var_samp_fields']: AliasType<{
+    profile_id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** order by var_samp() on columns of table "emails" */
+  ['emails_var_samp_order_by']: {
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+  };
+  /** aggregate variance on columns */
+  ['emails_variance_fields']: AliasType<{
+    profile_id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** order by variance() on columns of table "emails" */
+  ['emails_variance_order_by']: {
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+  };
   /** columns and relationships of "epoch_pgive_data" */
   ['epoch_pgive_data']: AliasType<{
     active_months?: boolean | `@${string}`;
@@ -11563,6 +11846,17 @@ export type ValueTypes = {
       { id: ValueTypes['bigint'] },
       ValueTypes['distributions']
     ];
+    delete_emails?: [
+      {
+        /** filter the rows which have to be deleted */
+        where: ValueTypes['emails_bool_exp'];
+      },
+      ValueTypes['emails_mutation_response']
+    ];
+    delete_emails_by_pk?: [
+      { email: ValueTypes['citext']; profile_id: number },
+      ValueTypes['emails']
+    ];
     delete_epoch_pgive_data?: [
       {
         /** filter the rows which have to be deleted */
@@ -12176,6 +12470,24 @@ export type ValueTypes = {
           | null;
       },
       ValueTypes['distributions']
+    ];
+    insert_emails?: [
+      {
+        /** the rows to be inserted */
+        objects: Array<
+          ValueTypes['emails_insert_input']
+        > /** upsert condition */;
+        on_conflict?: ValueTypes['emails_on_conflict'] | undefined | null;
+      },
+      ValueTypes['emails_mutation_response']
+    ];
+    insert_emails_one?: [
+      {
+        /** the row to be inserted */
+        object: ValueTypes['emails_insert_input'] /** upsert condition */;
+        on_conflict?: ValueTypes['emails_on_conflict'] | undefined | null;
+      },
+      ValueTypes['emails']
     ];
     insert_epoch_pgive_data?: [
       {
@@ -13361,6 +13673,40 @@ export type ValueTypes = {
         updates: Array<ValueTypes['distributions_updates']>;
       },
       ValueTypes['distributions_mutation_response']
+    ];
+    update_emails?: [
+      {
+        /** increments the numeric columns with given value of the filtered values */
+        _inc?:
+          | ValueTypes['emails_inc_input']
+          | undefined
+          | null /** sets the columns of the filtered rows to the given values */;
+        _set?:
+          | ValueTypes['emails_set_input']
+          | undefined
+          | null /** filter the rows which have to be updated */;
+        where: ValueTypes['emails_bool_exp'];
+      },
+      ValueTypes['emails_mutation_response']
+    ];
+    update_emails_by_pk?: [
+      {
+        /** increments the numeric columns with given value of the filtered values */
+        _inc?:
+          | ValueTypes['emails_inc_input']
+          | undefined
+          | null /** sets the columns of the filtered rows to the given values */;
+        _set?: ValueTypes['emails_set_input'] | undefined | null;
+        pk_columns: ValueTypes['emails_pk_columns_input'];
+      },
+      ValueTypes['emails']
+    ];
+    update_emails_many?: [
+      {
+        /** updates to execute, in order */
+        updates: Array<ValueTypes['emails_updates']>;
+      },
+      ValueTypes['emails_mutation_response']
     ];
     update_epoch_pgive_data?: [
       {
@@ -17267,6 +17613,52 @@ export type ValueTypes = {
       },
       ValueTypes['distributions_aggregate']
     ];
+    emails?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['emails_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['emails_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ValueTypes['emails_bool_exp'] | undefined | null;
+      },
+      ValueTypes['emails']
+    ];
+    emails_aggregate?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['emails_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['emails_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ValueTypes['emails_bool_exp'] | undefined | null;
+      },
+      ValueTypes['emails_aggregate']
+    ];
     github_username?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
     medium_username?: boolean | `@${string}`;
@@ -17570,6 +17962,11 @@ export type ValueTypes = {
       | ValueTypes['distributions_aggregate_bool_exp']
       | undefined
       | null;
+    emails?: ValueTypes['emails_bool_exp'] | undefined | null;
+    emails_aggregate?:
+      | ValueTypes['emails_aggregate_bool_exp']
+      | undefined
+      | null;
     github_username?: ValueTypes['String_comparison_exp'] | undefined | null;
     id?: ValueTypes['bigint_comparison_exp'] | undefined | null;
     medium_username?: ValueTypes['String_comparison_exp'] | undefined | null;
@@ -17629,6 +18026,7 @@ export type ValueTypes = {
       | ValueTypes['distributions_arr_rel_insert_input']
       | undefined
       | null;
+    emails?: ValueTypes['emails_arr_rel_insert_input'] | undefined | null;
     github_username?: string | undefined | null;
     id?: ValueTypes['bigint'] | undefined | null;
     medium_username?: string | undefined | null;
@@ -17733,6 +18131,10 @@ export type ValueTypes = {
     discord_username?: ValueTypes['order_by'] | undefined | null;
     distributions_aggregate?:
       | ValueTypes['distributions_aggregate_order_by']
+      | undefined
+      | null;
+    emails_aggregate?:
+      | ValueTypes['emails_aggregate_order_by']
       | undefined
       | null;
     github_username?: ValueTypes['order_by'] | undefined | null;
@@ -18700,6 +19102,56 @@ export type ValueTypes = {
     distributions_by_pk?: [
       { id: ValueTypes['bigint'] },
       ValueTypes['distributions']
+    ];
+    emails?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['emails_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['emails_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ValueTypes['emails_bool_exp'] | undefined | null;
+      },
+      ValueTypes['emails']
+    ];
+    emails_aggregate?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['emails_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['emails_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ValueTypes['emails_bool_exp'] | undefined | null;
+      },
+      ValueTypes['emails_aggregate']
+    ];
+    emails_by_pk?: [
+      { email: ValueTypes['citext']; profile_id: number },
+      ValueTypes['emails']
     ];
     epoch_pgive_data?: [
       {
@@ -21440,6 +21892,67 @@ export type ValueTypes = {
         where?: ValueTypes['distributions_bool_exp'] | undefined | null;
       },
       ValueTypes['distributions']
+    ];
+    emails?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['emails_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['emails_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ValueTypes['emails_bool_exp'] | undefined | null;
+      },
+      ValueTypes['emails']
+    ];
+    emails_aggregate?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['emails_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['emails_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ValueTypes['emails_bool_exp'] | undefined | null;
+      },
+      ValueTypes['emails_aggregate']
+    ];
+    emails_by_pk?: [
+      { email: ValueTypes['citext']; profile_id: number },
+      ValueTypes['emails']
+    ];
+    emails_stream?: [
+      {
+        /** maximum number of rows returned in a single batch */
+        batch_size: number /** cursor to stream the results returned by the query */;
+        cursor: Array<
+          ValueTypes['emails_stream_cursor_input'] | undefined | null
+        > /** filter the rows returned */;
+        where?: ValueTypes['emails_bool_exp'] | undefined | null;
+      },
+      ValueTypes['emails']
     ];
     epoch_pgive_data?: [
       {
@@ -29683,6 +30196,145 @@ export type ModelTypes = {
   };
   /** order by variance() on columns of table "distributions" */
   ['distributions_variance_order_by']: GraphQLTypes['distributions_variance_order_by'];
+  /** columns and relationships of "emails" */
+  ['emails']: {
+    email: GraphQLTypes['citext'];
+    primary: boolean;
+    /** An object relationship */
+    profile: GraphQLTypes['profiles'];
+    profile_id: number;
+    verification_code: GraphQLTypes['uuid'];
+    verified_at?: GraphQLTypes['timestamp'] | undefined;
+  };
+  /** aggregated selection of "emails" */
+  ['emails_aggregate']: {
+    aggregate?: GraphQLTypes['emails_aggregate_fields'] | undefined;
+    nodes: Array<GraphQLTypes['emails']>;
+  };
+  ['emails_aggregate_bool_exp']: GraphQLTypes['emails_aggregate_bool_exp'];
+  ['emails_aggregate_bool_exp_bool_and']: GraphQLTypes['emails_aggregate_bool_exp_bool_and'];
+  ['emails_aggregate_bool_exp_bool_or']: GraphQLTypes['emails_aggregate_bool_exp_bool_or'];
+  ['emails_aggregate_bool_exp_count']: GraphQLTypes['emails_aggregate_bool_exp_count'];
+  /** aggregate fields of "emails" */
+  ['emails_aggregate_fields']: {
+    avg?: GraphQLTypes['emails_avg_fields'] | undefined;
+    count: number;
+    max?: GraphQLTypes['emails_max_fields'] | undefined;
+    min?: GraphQLTypes['emails_min_fields'] | undefined;
+    stddev?: GraphQLTypes['emails_stddev_fields'] | undefined;
+    stddev_pop?: GraphQLTypes['emails_stddev_pop_fields'] | undefined;
+    stddev_samp?: GraphQLTypes['emails_stddev_samp_fields'] | undefined;
+    sum?: GraphQLTypes['emails_sum_fields'] | undefined;
+    var_pop?: GraphQLTypes['emails_var_pop_fields'] | undefined;
+    var_samp?: GraphQLTypes['emails_var_samp_fields'] | undefined;
+    variance?: GraphQLTypes['emails_variance_fields'] | undefined;
+  };
+  /** order by aggregate values of table "emails" */
+  ['emails_aggregate_order_by']: GraphQLTypes['emails_aggregate_order_by'];
+  /** input type for inserting array relation for remote table "emails" */
+  ['emails_arr_rel_insert_input']: GraphQLTypes['emails_arr_rel_insert_input'];
+  /** aggregate avg on columns */
+  ['emails_avg_fields']: {
+    profile_id?: number | undefined;
+  };
+  /** order by avg() on columns of table "emails" */
+  ['emails_avg_order_by']: GraphQLTypes['emails_avg_order_by'];
+  /** Boolean expression to filter rows from the table "emails". All fields are combined with a logical 'AND'. */
+  ['emails_bool_exp']: GraphQLTypes['emails_bool_exp'];
+  /** unique or primary key constraints on table "emails" */
+  ['emails_constraint']: GraphQLTypes['emails_constraint'];
+  /** input type for incrementing numeric columns in table "emails" */
+  ['emails_inc_input']: GraphQLTypes['emails_inc_input'];
+  /** input type for inserting data into table "emails" */
+  ['emails_insert_input']: GraphQLTypes['emails_insert_input'];
+  /** aggregate max on columns */
+  ['emails_max_fields']: {
+    email?: GraphQLTypes['citext'] | undefined;
+    profile_id?: number | undefined;
+    verification_code?: GraphQLTypes['uuid'] | undefined;
+    verified_at?: GraphQLTypes['timestamp'] | undefined;
+  };
+  /** order by max() on columns of table "emails" */
+  ['emails_max_order_by']: GraphQLTypes['emails_max_order_by'];
+  /** aggregate min on columns */
+  ['emails_min_fields']: {
+    email?: GraphQLTypes['citext'] | undefined;
+    profile_id?: number | undefined;
+    verification_code?: GraphQLTypes['uuid'] | undefined;
+    verified_at?: GraphQLTypes['timestamp'] | undefined;
+  };
+  /** order by min() on columns of table "emails" */
+  ['emails_min_order_by']: GraphQLTypes['emails_min_order_by'];
+  /** response of any mutation on the table "emails" */
+  ['emails_mutation_response']: {
+    /** number of rows affected by the mutation */
+    affected_rows: number;
+    /** data from the rows affected by the mutation */
+    returning: Array<GraphQLTypes['emails']>;
+  };
+  /** on_conflict condition type for table "emails" */
+  ['emails_on_conflict']: GraphQLTypes['emails_on_conflict'];
+  /** Ordering options when selecting data from "emails". */
+  ['emails_order_by']: GraphQLTypes['emails_order_by'];
+  /** primary key columns input for table: emails */
+  ['emails_pk_columns_input']: GraphQLTypes['emails_pk_columns_input'];
+  /** select columns of table "emails" */
+  ['emails_select_column']: GraphQLTypes['emails_select_column'];
+  /** select "emails_aggregate_bool_exp_bool_and_arguments_columns" columns of table "emails" */
+  ['emails_select_column_emails_aggregate_bool_exp_bool_and_arguments_columns']: GraphQLTypes['emails_select_column_emails_aggregate_bool_exp_bool_and_arguments_columns'];
+  /** select "emails_aggregate_bool_exp_bool_or_arguments_columns" columns of table "emails" */
+  ['emails_select_column_emails_aggregate_bool_exp_bool_or_arguments_columns']: GraphQLTypes['emails_select_column_emails_aggregate_bool_exp_bool_or_arguments_columns'];
+  /** input type for updating data in table "emails" */
+  ['emails_set_input']: GraphQLTypes['emails_set_input'];
+  /** aggregate stddev on columns */
+  ['emails_stddev_fields']: {
+    profile_id?: number | undefined;
+  };
+  /** order by stddev() on columns of table "emails" */
+  ['emails_stddev_order_by']: GraphQLTypes['emails_stddev_order_by'];
+  /** aggregate stddev_pop on columns */
+  ['emails_stddev_pop_fields']: {
+    profile_id?: number | undefined;
+  };
+  /** order by stddev_pop() on columns of table "emails" */
+  ['emails_stddev_pop_order_by']: GraphQLTypes['emails_stddev_pop_order_by'];
+  /** aggregate stddev_samp on columns */
+  ['emails_stddev_samp_fields']: {
+    profile_id?: number | undefined;
+  };
+  /** order by stddev_samp() on columns of table "emails" */
+  ['emails_stddev_samp_order_by']: GraphQLTypes['emails_stddev_samp_order_by'];
+  /** Streaming cursor of the table "emails" */
+  ['emails_stream_cursor_input']: GraphQLTypes['emails_stream_cursor_input'];
+  /** Initial value of the column from where the streaming should start */
+  ['emails_stream_cursor_value_input']: GraphQLTypes['emails_stream_cursor_value_input'];
+  /** aggregate sum on columns */
+  ['emails_sum_fields']: {
+    profile_id?: number | undefined;
+  };
+  /** order by sum() on columns of table "emails" */
+  ['emails_sum_order_by']: GraphQLTypes['emails_sum_order_by'];
+  /** update columns of table "emails" */
+  ['emails_update_column']: GraphQLTypes['emails_update_column'];
+  ['emails_updates']: GraphQLTypes['emails_updates'];
+  /** aggregate var_pop on columns */
+  ['emails_var_pop_fields']: {
+    profile_id?: number | undefined;
+  };
+  /** order by var_pop() on columns of table "emails" */
+  ['emails_var_pop_order_by']: GraphQLTypes['emails_var_pop_order_by'];
+  /** aggregate var_samp on columns */
+  ['emails_var_samp_fields']: {
+    profile_id?: number | undefined;
+  };
+  /** order by var_samp() on columns of table "emails" */
+  ['emails_var_samp_order_by']: GraphQLTypes['emails_var_samp_order_by'];
+  /** aggregate variance on columns */
+  ['emails_variance_fields']: {
+    profile_id?: number | undefined;
+  };
+  /** order by variance() on columns of table "emails" */
+  ['emails_variance_order_by']: GraphQLTypes['emails_variance_order_by'];
   /** columns and relationships of "epoch_pgive_data" */
   ['epoch_pgive_data']: {
     active_months: number;
@@ -31422,6 +32074,10 @@ export type ModelTypes = {
       | undefined;
     /** delete single row from the table: "distributions" */
     delete_distributions_by_pk?: GraphQLTypes['distributions'] | undefined;
+    /** delete data from the table: "emails" */
+    delete_emails?: GraphQLTypes['emails_mutation_response'] | undefined;
+    /** delete single row from the table: "emails" */
+    delete_emails_by_pk?: GraphQLTypes['emails'] | undefined;
     /** delete data from the table: "epoch_pgive_data" */
     delete_epoch_pgive_data?:
       | GraphQLTypes['epoch_pgive_data_mutation_response']
@@ -31673,6 +32329,10 @@ export type ModelTypes = {
       | undefined;
     /** insert a single row into the table: "distributions" */
     insert_distributions_one?: GraphQLTypes['distributions'] | undefined;
+    /** insert data into the table: "emails" */
+    insert_emails?: GraphQLTypes['emails_mutation_response'] | undefined;
+    /** insert a single row into the table: "emails" */
+    insert_emails_one?: GraphQLTypes['emails'] | undefined;
     /** insert data into the table: "epoch_pgive_data" */
     insert_epoch_pgive_data?:
       | GraphQLTypes['epoch_pgive_data_mutation_response']
@@ -32008,6 +32668,14 @@ export type ModelTypes = {
     /** update multiples rows of table: "distributions" */
     update_distributions_many?:
       | Array<GraphQLTypes['distributions_mutation_response'] | undefined>
+      | undefined;
+    /** update data of the table: "emails" */
+    update_emails?: GraphQLTypes['emails_mutation_response'] | undefined;
+    /** update single row of the table: "emails" */
+    update_emails_by_pk?: GraphQLTypes['emails'] | undefined;
+    /** update multiples rows of table: "emails" */
+    update_emails_many?:
+      | Array<GraphQLTypes['emails_mutation_response'] | undefined>
       | undefined;
     /** update data of the table: "epoch_pgive_data" */
     update_epoch_pgive_data?:
@@ -33688,6 +34356,10 @@ export type ModelTypes = {
     distributions: Array<GraphQLTypes['distributions']>;
     /** An aggregate relationship */
     distributions_aggregate: GraphQLTypes['distributions_aggregate'];
+    /** An array relationship */
+    emails: Array<GraphQLTypes['emails']>;
+    /** An aggregate relationship */
+    emails_aggregate: GraphQLTypes['emails_aggregate'];
     github_username?: string | undefined;
     id: GraphQLTypes['bigint'];
     medium_username?: string | undefined;
@@ -33953,6 +34625,12 @@ export type ModelTypes = {
     distributions_aggregate: GraphQLTypes['distributions_aggregate'];
     /** fetch data from the table: "distributions" using primary key columns */
     distributions_by_pk?: GraphQLTypes['distributions'] | undefined;
+    /** An array relationship */
+    emails: Array<GraphQLTypes['emails']>;
+    /** An aggregate relationship */
+    emails_aggregate: GraphQLTypes['emails_aggregate'];
+    /** fetch data from the table: "emails" using primary key columns */
+    emails_by_pk?: GraphQLTypes['emails'] | undefined;
     /** fetch data from the table: "epoch_pgive_data" */
     epoch_pgive_data: Array<GraphQLTypes['epoch_pgive_data']>;
     /** fetch aggregated fields from the table: "epoch_pgive_data" */
@@ -34427,6 +35105,14 @@ export type ModelTypes = {
     distributions_by_pk?: GraphQLTypes['distributions'] | undefined;
     /** fetch data from the table in a streaming manner: "distributions" */
     distributions_stream: Array<GraphQLTypes['distributions']>;
+    /** An array relationship */
+    emails: Array<GraphQLTypes['emails']>;
+    /** An aggregate relationship */
+    emails_aggregate: GraphQLTypes['emails_aggregate'];
+    /** fetch data from the table: "emails" using primary key columns */
+    emails_by_pk?: GraphQLTypes['emails'] | undefined;
+    /** fetch data from the table in a streaming manner: "emails" */
+    emails_stream: Array<GraphQLTypes['emails']>;
     /** fetch data from the table: "epoch_pgive_data" */
     epoch_pgive_data: Array<GraphQLTypes['epoch_pgive_data']>;
     /** fetch aggregated fields from the table: "epoch_pgive_data" */
@@ -42146,6 +42832,277 @@ export type GraphQLTypes = {
     id?: GraphQLTypes['order_by'] | undefined;
     vault_id?: GraphQLTypes['order_by'] | undefined;
   };
+  /** columns and relationships of "emails" */
+  ['emails']: {
+    __typename: 'emails';
+    email: GraphQLTypes['citext'];
+    primary: boolean;
+    /** An object relationship */
+    profile: GraphQLTypes['profiles'];
+    profile_id: number;
+    verification_code: GraphQLTypes['uuid'];
+    verified_at?: GraphQLTypes['timestamp'] | undefined;
+  };
+  /** aggregated selection of "emails" */
+  ['emails_aggregate']: {
+    __typename: 'emails_aggregate';
+    aggregate?: GraphQLTypes['emails_aggregate_fields'] | undefined;
+    nodes: Array<GraphQLTypes['emails']>;
+  };
+  ['emails_aggregate_bool_exp']: {
+    bool_and?: GraphQLTypes['emails_aggregate_bool_exp_bool_and'] | undefined;
+    bool_or?: GraphQLTypes['emails_aggregate_bool_exp_bool_or'] | undefined;
+    count?: GraphQLTypes['emails_aggregate_bool_exp_count'] | undefined;
+  };
+  ['emails_aggregate_bool_exp_bool_and']: {
+    arguments: GraphQLTypes['emails_select_column_emails_aggregate_bool_exp_bool_and_arguments_columns'];
+    distinct?: boolean | undefined;
+    filter?: GraphQLTypes['emails_bool_exp'] | undefined;
+    predicate: GraphQLTypes['Boolean_comparison_exp'];
+  };
+  ['emails_aggregate_bool_exp_bool_or']: {
+    arguments: GraphQLTypes['emails_select_column_emails_aggregate_bool_exp_bool_or_arguments_columns'];
+    distinct?: boolean | undefined;
+    filter?: GraphQLTypes['emails_bool_exp'] | undefined;
+    predicate: GraphQLTypes['Boolean_comparison_exp'];
+  };
+  ['emails_aggregate_bool_exp_count']: {
+    arguments?: Array<GraphQLTypes['emails_select_column']> | undefined;
+    distinct?: boolean | undefined;
+    filter?: GraphQLTypes['emails_bool_exp'] | undefined;
+    predicate: GraphQLTypes['Int_comparison_exp'];
+  };
+  /** aggregate fields of "emails" */
+  ['emails_aggregate_fields']: {
+    __typename: 'emails_aggregate_fields';
+    avg?: GraphQLTypes['emails_avg_fields'] | undefined;
+    count: number;
+    max?: GraphQLTypes['emails_max_fields'] | undefined;
+    min?: GraphQLTypes['emails_min_fields'] | undefined;
+    stddev?: GraphQLTypes['emails_stddev_fields'] | undefined;
+    stddev_pop?: GraphQLTypes['emails_stddev_pop_fields'] | undefined;
+    stddev_samp?: GraphQLTypes['emails_stddev_samp_fields'] | undefined;
+    sum?: GraphQLTypes['emails_sum_fields'] | undefined;
+    var_pop?: GraphQLTypes['emails_var_pop_fields'] | undefined;
+    var_samp?: GraphQLTypes['emails_var_samp_fields'] | undefined;
+    variance?: GraphQLTypes['emails_variance_fields'] | undefined;
+  };
+  /** order by aggregate values of table "emails" */
+  ['emails_aggregate_order_by']: {
+    avg?: GraphQLTypes['emails_avg_order_by'] | undefined;
+    count?: GraphQLTypes['order_by'] | undefined;
+    max?: GraphQLTypes['emails_max_order_by'] | undefined;
+    min?: GraphQLTypes['emails_min_order_by'] | undefined;
+    stddev?: GraphQLTypes['emails_stddev_order_by'] | undefined;
+    stddev_pop?: GraphQLTypes['emails_stddev_pop_order_by'] | undefined;
+    stddev_samp?: GraphQLTypes['emails_stddev_samp_order_by'] | undefined;
+    sum?: GraphQLTypes['emails_sum_order_by'] | undefined;
+    var_pop?: GraphQLTypes['emails_var_pop_order_by'] | undefined;
+    var_samp?: GraphQLTypes['emails_var_samp_order_by'] | undefined;
+    variance?: GraphQLTypes['emails_variance_order_by'] | undefined;
+  };
+  /** input type for inserting array relation for remote table "emails" */
+  ['emails_arr_rel_insert_input']: {
+    data: Array<GraphQLTypes['emails_insert_input']>;
+    /** upsert condition */
+    on_conflict?: GraphQLTypes['emails_on_conflict'] | undefined;
+  };
+  /** aggregate avg on columns */
+  ['emails_avg_fields']: {
+    __typename: 'emails_avg_fields';
+    profile_id?: number | undefined;
+  };
+  /** order by avg() on columns of table "emails" */
+  ['emails_avg_order_by']: {
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+  };
+  /** Boolean expression to filter rows from the table "emails". All fields are combined with a logical 'AND'. */
+  ['emails_bool_exp']: {
+    _and?: Array<GraphQLTypes['emails_bool_exp']> | undefined;
+    _not?: GraphQLTypes['emails_bool_exp'] | undefined;
+    _or?: Array<GraphQLTypes['emails_bool_exp']> | undefined;
+    email?: GraphQLTypes['citext_comparison_exp'] | undefined;
+    primary?: GraphQLTypes['Boolean_comparison_exp'] | undefined;
+    profile?: GraphQLTypes['profiles_bool_exp'] | undefined;
+    profile_id?: GraphQLTypes['Int_comparison_exp'] | undefined;
+    verification_code?: GraphQLTypes['uuid_comparison_exp'] | undefined;
+    verified_at?: GraphQLTypes['timestamp_comparison_exp'] | undefined;
+  };
+  /** unique or primary key constraints on table "emails" */
+  ['emails_constraint']: emails_constraint;
+  /** input type for incrementing numeric columns in table "emails" */
+  ['emails_inc_input']: {
+    profile_id?: number | undefined;
+  };
+  /** input type for inserting data into table "emails" */
+  ['emails_insert_input']: {
+    email?: GraphQLTypes['citext'] | undefined;
+    primary?: boolean | undefined;
+    profile?: GraphQLTypes['profiles_obj_rel_insert_input'] | undefined;
+    profile_id?: number | undefined;
+    verification_code?: GraphQLTypes['uuid'] | undefined;
+    verified_at?: GraphQLTypes['timestamp'] | undefined;
+  };
+  /** aggregate max on columns */
+  ['emails_max_fields']: {
+    __typename: 'emails_max_fields';
+    email?: GraphQLTypes['citext'] | undefined;
+    profile_id?: number | undefined;
+    verification_code?: GraphQLTypes['uuid'] | undefined;
+    verified_at?: GraphQLTypes['timestamp'] | undefined;
+  };
+  /** order by max() on columns of table "emails" */
+  ['emails_max_order_by']: {
+    email?: GraphQLTypes['order_by'] | undefined;
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+    verification_code?: GraphQLTypes['order_by'] | undefined;
+    verified_at?: GraphQLTypes['order_by'] | undefined;
+  };
+  /** aggregate min on columns */
+  ['emails_min_fields']: {
+    __typename: 'emails_min_fields';
+    email?: GraphQLTypes['citext'] | undefined;
+    profile_id?: number | undefined;
+    verification_code?: GraphQLTypes['uuid'] | undefined;
+    verified_at?: GraphQLTypes['timestamp'] | undefined;
+  };
+  /** order by min() on columns of table "emails" */
+  ['emails_min_order_by']: {
+    email?: GraphQLTypes['order_by'] | undefined;
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+    verification_code?: GraphQLTypes['order_by'] | undefined;
+    verified_at?: GraphQLTypes['order_by'] | undefined;
+  };
+  /** response of any mutation on the table "emails" */
+  ['emails_mutation_response']: {
+    __typename: 'emails_mutation_response';
+    /** number of rows affected by the mutation */
+    affected_rows: number;
+    /** data from the rows affected by the mutation */
+    returning: Array<GraphQLTypes['emails']>;
+  };
+  /** on_conflict condition type for table "emails" */
+  ['emails_on_conflict']: {
+    constraint: GraphQLTypes['emails_constraint'];
+    update_columns: Array<GraphQLTypes['emails_update_column']>;
+    where?: GraphQLTypes['emails_bool_exp'] | undefined;
+  };
+  /** Ordering options when selecting data from "emails". */
+  ['emails_order_by']: {
+    email?: GraphQLTypes['order_by'] | undefined;
+    primary?: GraphQLTypes['order_by'] | undefined;
+    profile?: GraphQLTypes['profiles_order_by'] | undefined;
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+    verification_code?: GraphQLTypes['order_by'] | undefined;
+    verified_at?: GraphQLTypes['order_by'] | undefined;
+  };
+  /** primary key columns input for table: emails */
+  ['emails_pk_columns_input']: {
+    email: GraphQLTypes['citext'];
+    profile_id: number;
+  };
+  /** select columns of table "emails" */
+  ['emails_select_column']: emails_select_column;
+  /** select "emails_aggregate_bool_exp_bool_and_arguments_columns" columns of table "emails" */
+  ['emails_select_column_emails_aggregate_bool_exp_bool_and_arguments_columns']: emails_select_column_emails_aggregate_bool_exp_bool_and_arguments_columns;
+  /** select "emails_aggregate_bool_exp_bool_or_arguments_columns" columns of table "emails" */
+  ['emails_select_column_emails_aggregate_bool_exp_bool_or_arguments_columns']: emails_select_column_emails_aggregate_bool_exp_bool_or_arguments_columns;
+  /** input type for updating data in table "emails" */
+  ['emails_set_input']: {
+    email?: GraphQLTypes['citext'] | undefined;
+    primary?: boolean | undefined;
+    profile_id?: number | undefined;
+    verification_code?: GraphQLTypes['uuid'] | undefined;
+    verified_at?: GraphQLTypes['timestamp'] | undefined;
+  };
+  /** aggregate stddev on columns */
+  ['emails_stddev_fields']: {
+    __typename: 'emails_stddev_fields';
+    profile_id?: number | undefined;
+  };
+  /** order by stddev() on columns of table "emails" */
+  ['emails_stddev_order_by']: {
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+  };
+  /** aggregate stddev_pop on columns */
+  ['emails_stddev_pop_fields']: {
+    __typename: 'emails_stddev_pop_fields';
+    profile_id?: number | undefined;
+  };
+  /** order by stddev_pop() on columns of table "emails" */
+  ['emails_stddev_pop_order_by']: {
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+  };
+  /** aggregate stddev_samp on columns */
+  ['emails_stddev_samp_fields']: {
+    __typename: 'emails_stddev_samp_fields';
+    profile_id?: number | undefined;
+  };
+  /** order by stddev_samp() on columns of table "emails" */
+  ['emails_stddev_samp_order_by']: {
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+  };
+  /** Streaming cursor of the table "emails" */
+  ['emails_stream_cursor_input']: {
+    /** Stream column input with initial value */
+    initial_value: GraphQLTypes['emails_stream_cursor_value_input'];
+    /** cursor ordering */
+    ordering?: GraphQLTypes['cursor_ordering'] | undefined;
+  };
+  /** Initial value of the column from where the streaming should start */
+  ['emails_stream_cursor_value_input']: {
+    email?: GraphQLTypes['citext'] | undefined;
+    primary?: boolean | undefined;
+    profile_id?: number | undefined;
+    verification_code?: GraphQLTypes['uuid'] | undefined;
+    verified_at?: GraphQLTypes['timestamp'] | undefined;
+  };
+  /** aggregate sum on columns */
+  ['emails_sum_fields']: {
+    __typename: 'emails_sum_fields';
+    profile_id?: number | undefined;
+  };
+  /** order by sum() on columns of table "emails" */
+  ['emails_sum_order_by']: {
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+  };
+  /** update columns of table "emails" */
+  ['emails_update_column']: emails_update_column;
+  ['emails_updates']: {
+    /** increments the numeric columns with given value of the filtered values */
+    _inc?: GraphQLTypes['emails_inc_input'] | undefined;
+    /** sets the columns of the filtered rows to the given values */
+    _set?: GraphQLTypes['emails_set_input'] | undefined;
+    /** filter the rows which have to be updated */
+    where: GraphQLTypes['emails_bool_exp'];
+  };
+  /** aggregate var_pop on columns */
+  ['emails_var_pop_fields']: {
+    __typename: 'emails_var_pop_fields';
+    profile_id?: number | undefined;
+  };
+  /** order by var_pop() on columns of table "emails" */
+  ['emails_var_pop_order_by']: {
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+  };
+  /** aggregate var_samp on columns */
+  ['emails_var_samp_fields']: {
+    __typename: 'emails_var_samp_fields';
+    profile_id?: number | undefined;
+  };
+  /** order by var_samp() on columns of table "emails" */
+  ['emails_var_samp_order_by']: {
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+  };
+  /** aggregate variance on columns */
+  ['emails_variance_fields']: {
+    __typename: 'emails_variance_fields';
+    profile_id?: number | undefined;
+  };
+  /** order by variance() on columns of table "emails" */
+  ['emails_variance_order_by']: {
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+  };
   /** columns and relationships of "epoch_pgive_data" */
   ['epoch_pgive_data']: {
     __typename: 'epoch_pgive_data';
@@ -45370,6 +46327,10 @@ export type GraphQLTypes = {
       | undefined;
     /** delete single row from the table: "distributions" */
     delete_distributions_by_pk?: GraphQLTypes['distributions'] | undefined;
+    /** delete data from the table: "emails" */
+    delete_emails?: GraphQLTypes['emails_mutation_response'] | undefined;
+    /** delete single row from the table: "emails" */
+    delete_emails_by_pk?: GraphQLTypes['emails'] | undefined;
     /** delete data from the table: "epoch_pgive_data" */
     delete_epoch_pgive_data?:
       | GraphQLTypes['epoch_pgive_data_mutation_response']
@@ -45621,6 +46582,10 @@ export type GraphQLTypes = {
       | undefined;
     /** insert a single row into the table: "distributions" */
     insert_distributions_one?: GraphQLTypes['distributions'] | undefined;
+    /** insert data into the table: "emails" */
+    insert_emails?: GraphQLTypes['emails_mutation_response'] | undefined;
+    /** insert a single row into the table: "emails" */
+    insert_emails_one?: GraphQLTypes['emails'] | undefined;
     /** insert data into the table: "epoch_pgive_data" */
     insert_epoch_pgive_data?:
       | GraphQLTypes['epoch_pgive_data_mutation_response']
@@ -45956,6 +46921,14 @@ export type GraphQLTypes = {
     /** update multiples rows of table: "distributions" */
     update_distributions_many?:
       | Array<GraphQLTypes['distributions_mutation_response'] | undefined>
+      | undefined;
+    /** update data of the table: "emails" */
+    update_emails?: GraphQLTypes['emails_mutation_response'] | undefined;
+    /** update single row of the table: "emails" */
+    update_emails_by_pk?: GraphQLTypes['emails'] | undefined;
+    /** update multiples rows of table: "emails" */
+    update_emails_many?:
+      | Array<GraphQLTypes['emails_mutation_response'] | undefined>
       | undefined;
     /** update data of the table: "epoch_pgive_data" */
     update_epoch_pgive_data?:
@@ -48817,6 +49790,10 @@ export type GraphQLTypes = {
     distributions: Array<GraphQLTypes['distributions']>;
     /** An aggregate relationship */
     distributions_aggregate: GraphQLTypes['distributions_aggregate'];
+    /** An array relationship */
+    emails: Array<GraphQLTypes['emails']>;
+    /** An aggregate relationship */
+    emails_aggregate: GraphQLTypes['emails_aggregate'];
     github_username?: string | undefined;
     id: GraphQLTypes['bigint'];
     medium_username?: string | undefined;
@@ -48896,6 +49873,8 @@ export type GraphQLTypes = {
     distributions_aggregate?:
       | GraphQLTypes['distributions_aggregate_bool_exp']
       | undefined;
+    emails?: GraphQLTypes['emails_bool_exp'] | undefined;
+    emails_aggregate?: GraphQLTypes['emails_aggregate_bool_exp'] | undefined;
     github_username?: GraphQLTypes['String_comparison_exp'] | undefined;
     id?: GraphQLTypes['bigint_comparison_exp'] | undefined;
     medium_username?: GraphQLTypes['String_comparison_exp'] | undefined;
@@ -48947,6 +49926,7 @@ export type GraphQLTypes = {
     distributions?:
       | GraphQLTypes['distributions_arr_rel_insert_input']
       | undefined;
+    emails?: GraphQLTypes['emails_arr_rel_insert_input'] | undefined;
     github_username?: string | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
     medium_username?: string | undefined;
@@ -49045,6 +50025,7 @@ export type GraphQLTypes = {
     distributions_aggregate?:
       | GraphQLTypes['distributions_aggregate_order_by']
       | undefined;
+    emails_aggregate?: GraphQLTypes['emails_aggregate_order_by'] | undefined;
     github_username?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
     medium_username?: GraphQLTypes['order_by'] | undefined;
@@ -49274,6 +50255,12 @@ export type GraphQLTypes = {
     distributions_aggregate: GraphQLTypes['distributions_aggregate'];
     /** fetch data from the table: "distributions" using primary key columns */
     distributions_by_pk?: GraphQLTypes['distributions'] | undefined;
+    /** An array relationship */
+    emails: Array<GraphQLTypes['emails']>;
+    /** An aggregate relationship */
+    emails_aggregate: GraphQLTypes['emails_aggregate'];
+    /** fetch data from the table: "emails" using primary key columns */
+    emails_by_pk?: GraphQLTypes['emails'] | undefined;
     /** fetch data from the table: "epoch_pgive_data" */
     epoch_pgive_data: Array<GraphQLTypes['epoch_pgive_data']>;
     /** fetch aggregated fields from the table: "epoch_pgive_data" */
@@ -49898,6 +50885,14 @@ export type GraphQLTypes = {
     distributions_by_pk?: GraphQLTypes['distributions'] | undefined;
     /** fetch data from the table in a streaming manner: "distributions" */
     distributions_stream: Array<GraphQLTypes['distributions']>;
+    /** An array relationship */
+    emails: Array<GraphQLTypes['emails']>;
+    /** An aggregate relationship */
+    emails_aggregate: GraphQLTypes['emails_aggregate'];
+    /** fetch data from the table: "emails" using primary key columns */
+    emails_by_pk?: GraphQLTypes['emails'] | undefined;
+    /** fetch data from the table in a streaming manner: "emails" */
+    emails_stream: Array<GraphQLTypes['emails']>;
     /** fetch data from the table: "epoch_pgive_data" */
     epoch_pgive_data: Array<GraphQLTypes['epoch_pgive_data']>;
     /** fetch aggregated fields from the table: "epoch_pgive_data" */
@@ -53483,6 +54478,34 @@ export const enum distributions_update_column {
   tx_hash = 'tx_hash',
   updated_at = 'updated_at',
   vault_id = 'vault_id',
+}
+/** unique or primary key constraints on table "emails" */
+export const enum emails_constraint {
+  emails_pkey = 'emails_pkey',
+}
+/** select columns of table "emails" */
+export const enum emails_select_column {
+  email = 'email',
+  primary = 'primary',
+  profile_id = 'profile_id',
+  verification_code = 'verification_code',
+  verified_at = 'verified_at',
+}
+/** select "emails_aggregate_bool_exp_bool_and_arguments_columns" columns of table "emails" */
+export const enum emails_select_column_emails_aggregate_bool_exp_bool_and_arguments_columns {
+  primary = 'primary',
+}
+/** select "emails_aggregate_bool_exp_bool_or_arguments_columns" columns of table "emails" */
+export const enum emails_select_column_emails_aggregate_bool_exp_bool_or_arguments_columns {
+  primary = 'primary',
+}
+/** update columns of table "emails" */
+export const enum emails_update_column {
+  email = 'email',
+  primary = 'primary',
+  profile_id = 'profile_id',
+  verification_code = 'verification_code',
+  verified_at = 'verified_at',
 }
 /** unique or primary key constraints on table "epoch_pgive_data" */
 export const enum epoch_pgive_data_constraint {

--- a/api-lib/postmark.ts
+++ b/api-lib/postmark.ts
@@ -7,7 +7,9 @@ const BASE_URL = 'https://api.postmarkapp.com';
 const FROM_EMAIL = 'support@coordinape.com';
 const FROM_NAME = 'Coordinape';
 
-const TEMPLATE_VERIFY = 33123816;
+const TEMPLATE_VERIFY = 'verify_email';
+const TEMPLATE_WELCOME = 'welcome';
+type TemplateAliases = typeof TEMPLATE_VERIFY | typeof TEMPLATE_WELCOME;
 
 const BASE_INPUT = {
   help_url: HELP_URL,
@@ -29,7 +31,7 @@ export async function sendVerifyEmail(params: {
 
 async function sendEmail(
   to: string,
-  templateId: number,
+  templateAlias: TemplateAliases,
   templateModel: Record<string, unknown>
 ) {
   const response = await fetch(`${BASE_URL}/email/withTemplate`, {
@@ -42,7 +44,7 @@ async function sendEmail(
     body: JSON.stringify({
       From: `${FROM_NAME} <${FROM_EMAIL}>`,
       To: to,
-      TemplateId: templateId,
+      TemplateAlias: templateAlias,
       TemplateModel: { ...BASE_INPUT, ...templateModel },
     }),
   });

--- a/api-lib/postmark.ts
+++ b/api-lib/postmark.ts
@@ -1,0 +1,52 @@
+import assert from 'assert';
+
+import fetch from 'node-fetch';
+
+const HELP_URL = 'https://docs.coordinape.com';
+const BASE_URL = 'https://api.postmarkapp.com';
+const FROM_EMAIL = 'support@coordinape.com';
+const FROM_NAME = 'Coordinape';
+
+const TEMPLATE_VERIFY = 33123816;
+
+const BASE_INPUT = {
+  help_url: HELP_URL,
+};
+
+export async function sendVerifyEmail(params: {
+  name: string;
+  email: string;
+  verification_code: string;
+}) {
+  const input = {
+    name: params.name,
+    action_url:
+      'https://coordinape.com/email/verify/' + params.verification_code,
+  };
+  const res = await sendEmail(params.email, TEMPLATE_VERIFY, input);
+  return res;
+}
+
+async function sendEmail(
+  to: string,
+  templateId: number,
+  templateModel: Record<string, unknown>
+) {
+  const response = await fetch(`${BASE_URL}/email/withTemplate`, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'X-Postmark-Server-Token': process.env.POSTMARK_SERVER_TOKEN || '',
+    },
+    body: JSON.stringify({
+      From: `${FROM_NAME} <${FROM_EMAIL}>`,
+      To: to,
+      TemplateId: templateId,
+      TemplateModel: { ...BASE_INPUT, ...templateModel },
+    }),
+  });
+  // TODO: better error handling
+  assert(response.ok);
+  return response;
+}

--- a/api/hasura/actions/_handlers/addEmail.ts
+++ b/api/hasura/actions/_handlers/addEmail.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import assert from 'assert';
 
 import type { VercelRequest, VercelResponse } from '@vercel/node';
@@ -123,7 +122,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     await sendVerifyEmail(verifyData);
     return res.status(200).json({ success: true });
-    // .json({ tos_agreed_at: update_profiles_by_pk.tos_agreed_at });
   } catch (e: any) {
     return errorResponse(res, e);
   }

--- a/api/hasura/actions/_handlers/addEmail.ts
+++ b/api/hasura/actions/_handlers/addEmail.ts
@@ -1,0 +1,130 @@
+/* eslint-disable no-console */
+import assert from 'assert';
+
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { z } from 'zod';
+
+import { adminClient } from '../../../../api-lib/gql/adminClient';
+import { getInput } from '../../../../api-lib/handlerHelpers';
+import {
+  errorResponse,
+  UnprocessableError,
+} from '../../../../api-lib/HttpError';
+import { sendVerifyEmail } from '../../../../api-lib/postmark';
+
+const addEmailInput = z
+  .object({
+    email: z.string().email().toLowerCase(),
+  })
+  .strict();
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  try {
+    const {
+      payload,
+      session: { hasuraProfileId },
+    } = await getInput(req, addEmailInput);
+
+    // make sure this email isn't already verified for another account
+    // it's ok if it exists but is not verified for another user
+    // if it's already associated with the current account, we should just resend the verify email
+    const { other_emails, my_emails } = await adminClient.query(
+      {
+        __alias: {
+          other_emails: {
+            emails: [
+              {
+                where: {
+                  email: { _eq: payload.email },
+                  profile_id: { _neq: hasuraProfileId },
+                  verified_at: { _is_null: false },
+                },
+              },
+              {
+                profile_id: true,
+              },
+            ],
+          },
+          my_emails: {
+            emails: [
+              {
+                where: {
+                  email: { _eq: payload.email },
+                  profile_id: { _eq: hasuraProfileId },
+                },
+              },
+              {
+                profile_id: true,
+                verified_at: true,
+                verification_code: true,
+                profile: {
+                  name: true,
+                },
+              },
+            ],
+          },
+        },
+      },
+      { operationName: 'addEmail_check_existing_emails' }
+    );
+
+    // make sure nobody else has it verified
+    if (other_emails.length > 0) {
+      throw new UnprocessableError(
+        'email is already verified for another account'
+      );
+    }
+
+    const myEmail = my_emails.pop();
+
+    let verifyData: Parameters<typeof sendVerifyEmail>[0] | undefined;
+    if (myEmail) {
+      if (myEmail.verified_at) {
+        throw new UnprocessableError(
+          'email is already verified for this account'
+        );
+      } else {
+        // get the UUID/link and send it again
+        verifyData = {
+          verification_code: myEmail.verification_code,
+          name: myEmail.profile.name,
+          email: payload.email,
+        };
+      }
+    } else {
+      // ok insert it
+      const { insert_emails_one } = await adminClient.mutate(
+        {
+          insert_emails_one: [
+            {
+              object: {
+                email: payload.email,
+                profile_id: hasuraProfileId,
+              },
+            },
+            {
+              verification_code: true,
+              profile: {
+                name: true,
+              },
+            },
+          ],
+        },
+        { operationName: 'addEmail_insert_emails_one' }
+      );
+      assert(insert_emails_one);
+      verifyData = {
+        verification_code: insert_emails_one.verification_code,
+        name: insert_emails_one.profile.name,
+        email: payload.email,
+      };
+    }
+    assert(verifyData);
+
+    await sendVerifyEmail(verifyData);
+    return res.status(200).json({ success: true });
+    // .json({ tos_agreed_at: update_profiles_by_pk.tos_agreed_at });
+  } catch (e: any) {
+    return errorResponse(res, e);
+  }
+}

--- a/api/hasura/actions/actionManager.ts
+++ b/api/hasura/actions/actionManager.ts
@@ -5,6 +5,7 @@ import { ActionPayload } from '../../../api-lib/types';
 import { verifyHasuraRequestMiddleware } from '../../../api-lib/validate';
 
 import acceptTOS from './_handlers/acceptTOS';
+import addEmail from './_handlers/addEmail';
 import adminUpdateUser from './_handlers/adminUpdateUser';
 import allocationCsv from './_handlers/allocationCsv';
 import createCircle from './_handlers/createCircle';
@@ -89,6 +90,7 @@ const HANDLERS: HandlerDict = {
   uploadProfileAvatar,
   uploadProfileBackground,
   vouch,
+  addEmail,
 };
 
 async function actionHandler(req: VercelRequest, res: VercelResponse) {

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -3,6 +3,10 @@ type Mutation {
 }
 
 type Mutation {
+  addEmail(payload: AddEmailInput!): ConfirmationResponse
+}
+
+type Mutation {
   adminUpdateUser(payload: AdminUpdateUserInput!): UserResponse
 }
 
@@ -474,6 +478,10 @@ input UpdateCircleStartingGiveInput {
 
 input AcceptTOSInput {
   profile_id: Int!
+}
+
+input AddEmailInput {
+  email: String!
 }
 
 type CreateCircleResponse {

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -10,6 +10,16 @@ actions:
     permissions:
       - role: user
     comment: Accept Terms of Service action
+  - name: addEmail
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_API_BASE_URL}}/actions/actionManager?action_name=addEmail'
+      headers:
+        - name: verification_key
+          value_from_env: HASURA_EVENT_SECRET
+    permissions:
+      - role: user
+    comment: adds a new (unverified) email address to a users profile
   - name: adminUpdateUser
     definition:
       kind: synchronous
@@ -450,6 +460,7 @@ custom_types:
     - name: SyncCoSoulInput
     - name: UpdateCircleStartingGiveInput
     - name: AcceptTOSInput
+    - name: AddEmailInput
   objects:
     - name: CreateCircleResponse
       relationships:

--- a/hasura/metadata/databases/default/tables/public_emails.yaml
+++ b/hasura/metadata/databases/default/tables/public_emails.yaml
@@ -1,0 +1,7 @@
+table:
+  name: emails
+  schema: public
+object_relationships:
+  - name: profile
+    using:
+      foreign_key_constraint_on: profile_id

--- a/hasura/metadata/databases/default/tables/public_org_members.yaml
+++ b/hasura/metadata/databases/default/tables/public_org_members.yaml
@@ -40,4 +40,4 @@ update_permissions:
         profile_id:
           _eq: X-Hasura-User-Id
       check: null
-    comment: ''
+    comment: ""

--- a/hasura/metadata/databases/default/tables/public_profiles.yaml
+++ b/hasura/metadata/databases/default/tables/public_profiles.yaml
@@ -35,6 +35,13 @@ array_relationships:
         table:
           name: distributions
           schema: public
+  - name: emails
+    using:
+      foreign_key_constraint_on:
+        column: profile_id
+        table:
+          name: emails
+          schema: public
   - name: nominees
     using:
       manual_configuration:

--- a/hasura/metadata/databases/default/tables/tables.yaml
+++ b/hasura/metadata/databases/default/tables/tables.yaml
@@ -15,6 +15,7 @@
 - "!include public_contributions.yaml"
 - "!include public_cosouls.yaml"
 - "!include public_distributions.yaml"
+- "!include public_emails.yaml"
 - "!include public_epoch_pgive_data.yaml"
 - "!include public_epoches.yaml"
 - "!include public_gift_private.yaml"

--- a/hasura/migrations/default/1695076119850_create_table_public_emails/down.sql
+++ b/hasura/migrations/default/1695076119850_create_table_public_emails/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE "public"."emails";

--- a/hasura/migrations/default/1695076119850_create_table_public_emails/up.sql
+++ b/hasura/migrations/default/1695076119850_create_table_public_emails/up.sql
@@ -1,0 +1,14 @@
+
+-- need this extension for gen_random_uuid()
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE "public"."emails" (
+    "email" citext NOT NULL,
+    "profile_id" integer NOT NULL,
+    "verified_at" timestamp null,
+    "primary" boolean NOT NULL DEFAULT true,
+    "verification_code" uuid not null default gen_random_uuid(),
+    PRIMARY KEY ("email","profile_id"),
+    FOREIGN KEY ("profile_id") REFERENCES "public"."profiles"("id") ON UPDATE cascade ON DELETE cascade
+);
+

--- a/hasura/schema/admin/schema.graphql
+++ b/hasura/schema/admin/schema.graphql
@@ -10800,6 +10800,477 @@ input distributions_variance_order_by {
 }
 
 """
+columns and relationships of "emails"
+"""
+type emails {
+  email: citext!
+  primary: Boolean!
+
+  """
+  An object relationship
+  """
+  profile: profiles!
+  profile_id: Int!
+  verification_code: uuid!
+  verified_at: timestamp
+}
+
+"""
+aggregated selection of "emails"
+"""
+type emails_aggregate {
+  aggregate: emails_aggregate_fields
+  nodes: [emails!]!
+}
+
+input emails_aggregate_bool_exp {
+  bool_and: emails_aggregate_bool_exp_bool_and
+  bool_or: emails_aggregate_bool_exp_bool_or
+  count: emails_aggregate_bool_exp_count
+}
+
+input emails_aggregate_bool_exp_bool_and {
+  arguments: emails_select_column_emails_aggregate_bool_exp_bool_and_arguments_columns!
+  distinct: Boolean
+  filter: emails_bool_exp
+  predicate: Boolean_comparison_exp!
+}
+
+input emails_aggregate_bool_exp_bool_or {
+  arguments: emails_select_column_emails_aggregate_bool_exp_bool_or_arguments_columns!
+  distinct: Boolean
+  filter: emails_bool_exp
+  predicate: Boolean_comparison_exp!
+}
+
+input emails_aggregate_bool_exp_count {
+  arguments: [emails_select_column!]
+  distinct: Boolean
+  filter: emails_bool_exp
+  predicate: Int_comparison_exp!
+}
+
+"""
+aggregate fields of "emails"
+"""
+type emails_aggregate_fields {
+  avg: emails_avg_fields
+  count(columns: [emails_select_column!], distinct: Boolean): Int!
+  max: emails_max_fields
+  min: emails_min_fields
+  stddev: emails_stddev_fields
+  stddev_pop: emails_stddev_pop_fields
+  stddev_samp: emails_stddev_samp_fields
+  sum: emails_sum_fields
+  var_pop: emails_var_pop_fields
+  var_samp: emails_var_samp_fields
+  variance: emails_variance_fields
+}
+
+"""
+order by aggregate values of table "emails"
+"""
+input emails_aggregate_order_by {
+  avg: emails_avg_order_by
+  count: order_by
+  max: emails_max_order_by
+  min: emails_min_order_by
+  stddev: emails_stddev_order_by
+  stddev_pop: emails_stddev_pop_order_by
+  stddev_samp: emails_stddev_samp_order_by
+  sum: emails_sum_order_by
+  var_pop: emails_var_pop_order_by
+  var_samp: emails_var_samp_order_by
+  variance: emails_variance_order_by
+}
+
+"""
+input type for inserting array relation for remote table "emails"
+"""
+input emails_arr_rel_insert_input {
+  data: [emails_insert_input!]!
+
+  """
+  upsert condition
+  """
+  on_conflict: emails_on_conflict
+}
+
+"""
+aggregate avg on columns
+"""
+type emails_avg_fields {
+  profile_id: Float
+}
+
+"""
+order by avg() on columns of table "emails"
+"""
+input emails_avg_order_by {
+  profile_id: order_by
+}
+
+"""
+Boolean expression to filter rows from the table "emails". All fields are combined with a logical 'AND'.
+"""
+input emails_bool_exp {
+  _and: [emails_bool_exp!]
+  _not: emails_bool_exp
+  _or: [emails_bool_exp!]
+  email: citext_comparison_exp
+  primary: Boolean_comparison_exp
+  profile: profiles_bool_exp
+  profile_id: Int_comparison_exp
+  verification_code: uuid_comparison_exp
+  verified_at: timestamp_comparison_exp
+}
+
+"""
+unique or primary key constraints on table "emails"
+"""
+enum emails_constraint {
+  """
+  unique or primary key constraint on columns "profile_id", "email"
+  """
+  emails_pkey
+}
+
+"""
+input type for incrementing numeric columns in table "emails"
+"""
+input emails_inc_input {
+  profile_id: Int
+}
+
+"""
+input type for inserting data into table "emails"
+"""
+input emails_insert_input {
+  email: citext
+  primary: Boolean
+  profile: profiles_obj_rel_insert_input
+  profile_id: Int
+  verification_code: uuid
+  verified_at: timestamp
+}
+
+"""
+aggregate max on columns
+"""
+type emails_max_fields {
+  email: citext
+  profile_id: Int
+  verification_code: uuid
+  verified_at: timestamp
+}
+
+"""
+order by max() on columns of table "emails"
+"""
+input emails_max_order_by {
+  email: order_by
+  profile_id: order_by
+  verification_code: order_by
+  verified_at: order_by
+}
+
+"""
+aggregate min on columns
+"""
+type emails_min_fields {
+  email: citext
+  profile_id: Int
+  verification_code: uuid
+  verified_at: timestamp
+}
+
+"""
+order by min() on columns of table "emails"
+"""
+input emails_min_order_by {
+  email: order_by
+  profile_id: order_by
+  verification_code: order_by
+  verified_at: order_by
+}
+
+"""
+response of any mutation on the table "emails"
+"""
+type emails_mutation_response {
+  """
+  number of rows affected by the mutation
+  """
+  affected_rows: Int!
+
+  """
+  data from the rows affected by the mutation
+  """
+  returning: [emails!]!
+}
+
+"""
+on_conflict condition type for table "emails"
+"""
+input emails_on_conflict {
+  constraint: emails_constraint!
+  update_columns: [emails_update_column!]! = []
+  where: emails_bool_exp
+}
+
+"""
+Ordering options when selecting data from "emails".
+"""
+input emails_order_by {
+  email: order_by
+  primary: order_by
+  profile: profiles_order_by
+  profile_id: order_by
+  verification_code: order_by
+  verified_at: order_by
+}
+
+"""
+primary key columns input for table: emails
+"""
+input emails_pk_columns_input {
+  email: citext!
+  profile_id: Int!
+}
+
+"""
+select columns of table "emails"
+"""
+enum emails_select_column {
+  """
+  column name
+  """
+  email
+
+  """
+  column name
+  """
+  primary
+
+  """
+  column name
+  """
+  profile_id
+
+  """
+  column name
+  """
+  verification_code
+
+  """
+  column name
+  """
+  verified_at
+}
+
+"""
+select "emails_aggregate_bool_exp_bool_and_arguments_columns" columns of table "emails"
+"""
+enum emails_select_column_emails_aggregate_bool_exp_bool_and_arguments_columns {
+  """
+  column name
+  """
+  primary
+}
+
+"""
+select "emails_aggregate_bool_exp_bool_or_arguments_columns" columns of table "emails"
+"""
+enum emails_select_column_emails_aggregate_bool_exp_bool_or_arguments_columns {
+  """
+  column name
+  """
+  primary
+}
+
+"""
+input type for updating data in table "emails"
+"""
+input emails_set_input {
+  email: citext
+  primary: Boolean
+  profile_id: Int
+  verification_code: uuid
+  verified_at: timestamp
+}
+
+"""
+aggregate stddev on columns
+"""
+type emails_stddev_fields {
+  profile_id: Float
+}
+
+"""
+order by stddev() on columns of table "emails"
+"""
+input emails_stddev_order_by {
+  profile_id: order_by
+}
+
+"""
+aggregate stddev_pop on columns
+"""
+type emails_stddev_pop_fields {
+  profile_id: Float
+}
+
+"""
+order by stddev_pop() on columns of table "emails"
+"""
+input emails_stddev_pop_order_by {
+  profile_id: order_by
+}
+
+"""
+aggregate stddev_samp on columns
+"""
+type emails_stddev_samp_fields {
+  profile_id: Float
+}
+
+"""
+order by stddev_samp() on columns of table "emails"
+"""
+input emails_stddev_samp_order_by {
+  profile_id: order_by
+}
+
+"""
+Streaming cursor of the table "emails"
+"""
+input emails_stream_cursor_input {
+  """
+  Stream column input with initial value
+  """
+  initial_value: emails_stream_cursor_value_input!
+
+  """
+  cursor ordering
+  """
+  ordering: cursor_ordering
+}
+
+"""
+Initial value of the column from where the streaming should start
+"""
+input emails_stream_cursor_value_input {
+  email: citext
+  primary: Boolean
+  profile_id: Int
+  verification_code: uuid
+  verified_at: timestamp
+}
+
+"""
+aggregate sum on columns
+"""
+type emails_sum_fields {
+  profile_id: Int
+}
+
+"""
+order by sum() on columns of table "emails"
+"""
+input emails_sum_order_by {
+  profile_id: order_by
+}
+
+"""
+update columns of table "emails"
+"""
+enum emails_update_column {
+  """
+  column name
+  """
+  email
+
+  """
+  column name
+  """
+  primary
+
+  """
+  column name
+  """
+  profile_id
+
+  """
+  column name
+  """
+  verification_code
+
+  """
+  column name
+  """
+  verified_at
+}
+
+input emails_updates {
+  """
+  increments the numeric columns with given value of the filtered values
+  """
+  _inc: emails_inc_input
+
+  """
+  sets the columns of the filtered rows to the given values
+  """
+  _set: emails_set_input
+
+  """
+  filter the rows which have to be updated
+  """
+  where: emails_bool_exp!
+}
+
+"""
+aggregate var_pop on columns
+"""
+type emails_var_pop_fields {
+  profile_id: Float
+}
+
+"""
+order by var_pop() on columns of table "emails"
+"""
+input emails_var_pop_order_by {
+  profile_id: order_by
+}
+
+"""
+aggregate var_samp on columns
+"""
+type emails_var_samp_fields {
+  profile_id: Float
+}
+
+"""
+order by var_samp() on columns of table "emails"
+"""
+input emails_var_samp_order_by {
+  profile_id: order_by
+}
+
+"""
+aggregate variance on columns
+"""
+type emails_variance_fields {
+  profile_id: Float
+}
+
+"""
+order by variance() on columns of table "emails"
+"""
+input emails_variance_order_by {
+  profile_id: order_by
+}
+
+"""
 columns and relationships of "epoch_pgive_data"
 """
 type epoch_pgive_data {
@@ -16249,6 +16720,21 @@ type mutation_root {
   delete_distributions_by_pk(id: bigint!): distributions
 
   """
+  delete data from the table: "emails"
+  """
+  delete_emails(
+    """
+    filter the rows which have to be deleted
+    """
+    where: emails_bool_exp!
+  ): emails_mutation_response
+
+  """
+  delete single row from the table: "emails"
+  """
+  delete_emails_by_pk(email: citext!, profile_id: Int!): emails
+
+  """
   delete data from the table: "epoch_pgive_data"
   """
   delete_epoch_pgive_data(
@@ -17099,6 +17585,36 @@ type mutation_root {
     """
     on_conflict: distributions_on_conflict
   ): distributions
+
+  """
+  insert data into the table: "emails"
+  """
+  insert_emails(
+    """
+    the rows to be inserted
+    """
+    objects: [emails_insert_input!]!
+
+    """
+    upsert condition
+    """
+    on_conflict: emails_on_conflict
+  ): emails_mutation_response
+
+  """
+  insert a single row into the table: "emails"
+  """
+  insert_emails_one(
+    """
+    the row to be inserted
+    """
+    object: emails_insert_input!
+
+    """
+    upsert condition
+    """
+    on_conflict: emails_on_conflict
+  ): emails
 
   """
   insert data into the table: "epoch_pgive_data"
@@ -18687,6 +19203,52 @@ type mutation_root {
     """
     updates: [distributions_updates!]!
   ): [distributions_mutation_response]
+
+  """
+  update data of the table: "emails"
+  """
+  update_emails(
+    """
+    increments the numeric columns with given value of the filtered values
+    """
+    _inc: emails_inc_input
+
+    """
+    sets the columns of the filtered rows to the given values
+    """
+    _set: emails_set_input
+
+    """
+    filter the rows which have to be updated
+    """
+    where: emails_bool_exp!
+  ): emails_mutation_response
+
+  """
+  update single row of the table: "emails"
+  """
+  update_emails_by_pk(
+    """
+    increments the numeric columns with given value of the filtered values
+    """
+    _inc: emails_inc_input
+
+    """
+    sets the columns of the filtered rows to the given values
+    """
+    _set: emails_set_input
+    pk_columns: emails_pk_columns_input!
+  ): emails
+
+  """
+  update multiples rows of table: "emails"
+  """
+  update_emails_many(
+    """
+    updates to execute, in order
+    """
+    updates: [emails_updates!]!
+  ): [emails_mutation_response]
 
   """
   update data of the table: "epoch_pgive_data"
@@ -24485,6 +25047,66 @@ type profiles {
     """
     where: distributions_bool_exp
   ): distributions_aggregate!
+
+  """
+  An array relationship
+  """
+  emails(
+    """
+    distinct select on columns
+    """
+    distinct_on: [emails_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [emails_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: emails_bool_exp
+  ): [emails!]!
+
+  """
+  An aggregate relationship
+  """
+  emails_aggregate(
+    """
+    distinct select on columns
+    """
+    distinct_on: [emails_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [emails_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: emails_bool_exp
+  ): emails_aggregate!
   github_username: String
   id: bigint!
   medium_username: String
@@ -24854,6 +25476,8 @@ input profiles_bool_exp {
   discord_username: String_comparison_exp
   distributions: distributions_bool_exp
   distributions_aggregate: distributions_aggregate_bool_exp
+  emails: emails_bool_exp
+  emails_aggregate: emails_aggregate_bool_exp
   github_username: String_comparison_exp
   id: bigint_comparison_exp
   medium_username: String_comparison_exp
@@ -24919,6 +25543,7 @@ input profiles_insert_input {
   created_at: timestamp
   discord_username: String
   distributions: distributions_arr_rel_insert_input
+  emails: emails_arr_rel_insert_input
   github_username: String
   id: bigint
   medium_username: String
@@ -25036,6 +25661,7 @@ input profiles_order_by {
   created_at: order_by
   discord_username: order_by
   distributions_aggregate: distributions_aggregate_order_by
+  emails_aggregate: emails_aggregate_order_by
   github_username: order_by
   id: order_by
   medium_username: order_by
@@ -26475,6 +27101,71 @@ type query_root {
   fetch data from the table: "distributions" using primary key columns
   """
   distributions_by_pk(id: bigint!): distributions
+
+  """
+  An array relationship
+  """
+  emails(
+    """
+    distinct select on columns
+    """
+    distinct_on: [emails_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [emails_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: emails_bool_exp
+  ): [emails!]!
+
+  """
+  An aggregate relationship
+  """
+  emails_aggregate(
+    """
+    distinct select on columns
+    """
+    distinct_on: [emails_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [emails_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: emails_bool_exp
+  ): emails_aggregate!
+
+  """
+  fetch data from the table: "emails" using primary key columns
+  """
+  emails_by_pk(email: citext!, profile_id: Int!): emails
 
   """
   fetch data from the table: "epoch_pgive_data"
@@ -30215,6 +30906,91 @@ type subscription_root {
     """
     where: distributions_bool_exp
   ): [distributions!]!
+
+  """
+  An array relationship
+  """
+  emails(
+    """
+    distinct select on columns
+    """
+    distinct_on: [emails_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [emails_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: emails_bool_exp
+  ): [emails!]!
+
+  """
+  An aggregate relationship
+  """
+  emails_aggregate(
+    """
+    distinct select on columns
+    """
+    distinct_on: [emails_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [emails_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: emails_bool_exp
+  ): emails_aggregate!
+
+  """
+  fetch data from the table: "emails" using primary key columns
+  """
+  emails_by_pk(email: citext!, profile_id: Int!): emails
+
+  """
+  fetch data from the table in a streaming manner: "emails"
+  """
+  emails_stream(
+    """
+    maximum number of rows returned in a single batch
+    """
+    batch_size: Int!
+
+    """
+    cursor to stream the results returned by the query
+    """
+    cursor: [emails_stream_cursor_input]!
+
+    """
+    filter the rows returned
+    """
+    where: emails_bool_exp
+  ): [emails!]!
 
   """
   fetch data from the table: "epoch_pgive_data"


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 35fb5cd</samp>

This pull request adds a feature to allow users to add and verify multiple email addresses to their profiles. It creates a new `emails` table in the database and the Hasura metadata, and exposes it in the GraphQL API. It also adds a new `addEmail` action and a new `sendVerifyEmail` function that use the Postmark API to send email verification links. It updates the `api-lib/gql/__generated__/zeus/const.ts` file to include the new types and properties for the `emails` table and its related queries and mutations. It modifies the `org_members` and `profiles` tables in the Hasura metadata to add comments and relationships. It adds and modifies several files in the `api`, `api-lib`, and `hasura` directories to implement the feature.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 35fb5cd</samp>

> _Sing, O Muse, of the valiant developers who strove_
> _To craft the feature of multiple emails for the users,_
> _Using the mighty Postmark and the wise Hasura,_
> _And the swift node-fetch and the faithful zod._

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 35fb5cd</samp>

*  Add `sendVerifyEmail` function to `api-lib/postmark.ts` to send email verification link using Postmark API ([link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-0ae55db9a83e75892b84b9d54fe9f1d61d500dadab7966eb9b161e8a92bc8954R1-R52))
*  Add `addEmail` action to Hasura metadata and GraphQL schema to allow users to add an email address to their profile ([link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-589f402dbb6eb11ea9c28e067ac01d020e1b8f8f087f45d59435eaae684975c3R6-R9), [link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-589f402dbb6eb11ea9c28e067ac01d020e1b8f8f087f45d59435eaae684975c3R483-R486), [link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-49e7aa4e1112b93bcdbd36419aeb0b64fb23ea532e80c9a0f5ff1c5a585763f9R13-R22), [link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-49e7aa4e1112b93bcdbd36419aeb0b64fb23ea532e80c9a0f5ff1c5a585763f9R463))
*  Add `addEmail` handler to `api/hasura/actions/_handlers/addEmail.ts` to validate input, generate verification code, insert email record, and call `sendVerifyEmail` function ([link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-57b2701e019340c226994ab44ac88b7aca26c3a5d6c8d8514edc18b9a07aaa76R1-R130))
*  Register `addEmail` handler in `api/hasura/actions/actionManager.ts` to dispatch the action based on request parameters ([link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-a6a476461d778e69905cd6d1cab214af3b0f749568bce39067fdde541f73a24eR8), [link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-a6a476461d778e69905cd6d1cab214af3b0f749568bce39067fdde541f73a24eR93))
*  Create `emails` table in database using SQL script in `hasura/migrations/default/1695076119850_create_table_public_emails/up.sql` ([link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-74384d9c24c469f6d380ed06a42c45be8a93c3ebcf1adcb82e97bafa8b8bf795R1-R14))
*  Drop `emails` table in database using SQL script in `hasura/migrations/default/1695076119850_create_table_public_emails/down.sql` ([link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-53d223c5e5c18360963585dd13f87cc99b187fd52bc9697973cbcb69766f5772L1-L-1))
*  Define `emails` table in Hasura metadata and GraphQL schema to expose it in GraphQL API and track its changes ([link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-e3fcc720cfb4d3d9d9f3784aea437911ecc54128562dc0d665da2d734348a11aR1-R7), [link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-4147b15d5a605e64a3d76bd68b59506ec8886da36d27df21dbf794443820377fR18))
*  Define `emails` and `emails_aggregate` queries and mutations in `api-lib/gql/__generated__/zeus/const.ts` to enable the use of `emails` table in GraphQL API ([link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R2808-R2947), [link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R4430-R4435), [link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R4705-R4712), [link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R5171-R5183), [link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R6659-R6668), [link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R6742-R6743), [link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R6775), [link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R6808), [link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R7066-R7078), [link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R7852-R7868), [link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R11655-R11719), [link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R12809-R12810), [link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R12899-R12900), [link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R13020-R13022), [link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R14005-R14006), [link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R14164-R14166), [link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R14406-R14409))
*  Define `emails` array relationship in `hasura/metadata/databases/default/tables/public_profiles.yaml` to link `profiles` and `emails` tables ([link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-8a805eab88da264de96c08096667337e06066993a6aa70395cd913c3c3feffaeR38-R44))
*  Define `profile` object relationship in `hasura/metadata/databases/default/tables/public_emails.yaml` to link `emails` and `profiles` tables ([link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-e3fcc720cfb4d3d9d9f3784aea437911ecc54128562dc0d665da2d734348a11aR1-R7))
*  Format comment value in `hasura/metadata/databases/default/tables/public_org_members.yaml` to use double quotes ([link](https://github.com/coordinape/coordinape/pull/2323/files?diff=unified&w=0#diff-7961e8d6baa6c56b9e32de690b9cc4629d5239228bd2d83caecf74f41ce13840L43-R43))
