### PR TITLE
Create set primary email handler

### DIFF
--- a/api-lib/gql/__generated__/zeus/const.ts
+++ b/api-lib/gql/__generated__/zeus/const.ts
@@ -56,6 +56,7 @@ export const AllTypesProps: Record<string, any> = {
   LinkDiscordUserInput: {},
   LogVaultTxInput: {},
   MarkClaimedInput: {},
+  SetPrimaryEmailInput: {},
   String_comparison_exp: {},
   SyncCoSoulInput: {},
   UpdateCircleInput: {},
@@ -4925,6 +4926,9 @@ export const AllTypesProps: Record<string, any> = {
     },
     restoreCoordinape: {
       payload: 'CoordinapeInput',
+    },
+    setPrimaryEmail: {
+      payload: 'SetPrimaryEmailInput',
     },
     syncCoSoul: {
       payload: 'SyncCoSoulInput',
@@ -12967,6 +12971,7 @@ export const ReturnTypes: Record<string, any> = {
     logoutUser: 'LogoutResponse',
     markClaimed: 'MarkClaimedOutput',
     restoreCoordinape: 'ConfirmationResponse',
+    setPrimaryEmail: 'ConfirmationResponse',
     syncCoSoul: 'SyncCoSoulOutput',
     updateAllocations: 'AllocationsResponse',
     updateCircle: 'UpdateCircleOutput',

--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -928,6 +928,9 @@ export type ValueTypes = {
     new?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
+  ['SetPrimaryEmailInput']: {
+    email: string;
+  };
   /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
   ['String_comparison_exp']: {
     _eq?: string | undefined | null;
@@ -13032,6 +13035,10 @@ export type ValueTypes = {
     ];
     restoreCoordinape?: [
       { payload: ValueTypes['CoordinapeInput'] },
+      ValueTypes['ConfirmationResponse']
+    ];
+    setPrimaryEmail?: [
+      { payload: ValueTypes['SetPrimaryEmailInput'] },
       ValueTypes['ConfirmationResponse']
     ];
     syncCoSoul?: [
@@ -27340,6 +27347,7 @@ export type ModelTypes = {
     id: string;
     new: boolean;
   };
+  ['SetPrimaryEmailInput']: GraphQLTypes['SetPrimaryEmailInput'];
   /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
   ['String_comparison_exp']: GraphQLTypes['String_comparison_exp'];
   ['SyncCoSoulInput']: GraphQLTypes['SyncCoSoulInput'];
@@ -32510,6 +32518,8 @@ export type ModelTypes = {
     logoutUser?: GraphQLTypes['LogoutResponse'] | undefined;
     markClaimed?: GraphQLTypes['MarkClaimedOutput'] | undefined;
     restoreCoordinape?: GraphQLTypes['ConfirmationResponse'] | undefined;
+    /** sets a given email as the primary email for user */
+    setPrimaryEmail?: GraphQLTypes['ConfirmationResponse'] | undefined;
     syncCoSoul?: GraphQLTypes['SyncCoSoulOutput'] | undefined;
     updateAllocations?: GraphQLTypes['AllocationsResponse'] | undefined;
     updateCircle?: GraphQLTypes['UpdateCircleOutput'] | undefined;
@@ -37018,6 +37028,9 @@ export type GraphQLTypes = {
     OrgMemberResponse?: GraphQLTypes['org_members'] | undefined;
     id: string;
     new: boolean;
+  };
+  ['SetPrimaryEmailInput']: {
+    email: string;
   };
   /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
   ['String_comparison_exp']: {
@@ -46773,6 +46786,8 @@ export type GraphQLTypes = {
     logoutUser?: GraphQLTypes['LogoutResponse'] | undefined;
     markClaimed?: GraphQLTypes['MarkClaimedOutput'] | undefined;
     restoreCoordinape?: GraphQLTypes['ConfirmationResponse'] | undefined;
+    /** sets a given email as the primary email for user */
+    setPrimaryEmail?: GraphQLTypes['ConfirmationResponse'] | undefined;
     syncCoSoul?: GraphQLTypes['SyncCoSoulOutput'] | undefined;
     updateAllocations?: GraphQLTypes['AllocationsResponse'] | undefined;
     updateCircle?: GraphQLTypes['UpdateCircleOutput'] | undefined;

--- a/api/hasura/actions/_handlers/setPrimaryEmail.ts
+++ b/api/hasura/actions/_handlers/setPrimaryEmail.ts
@@ -1,0 +1,72 @@
+import assert from 'assert';
+
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { z } from 'zod';
+
+import { adminClient } from '../../../../api-lib/gql/adminClient';
+import { getInput } from '../../../../api-lib/handlerHelpers';
+import {
+  errorResponse,
+  UnprocessableError,
+} from '../../../../api-lib/HttpError';
+
+const setPrimaryEmailInput = z
+  .object({
+    email: z.string().email().toLowerCase(),
+  })
+  .strict();
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  try {
+    const {
+      payload,
+      session: { hasuraProfileId },
+    } = await getInput(req, setPrimaryEmailInput);
+
+    // set given email as primary for user, make all other users' email not primary
+    const { primaryEmail } = await adminClient.mutate(
+      {
+        __alias: {
+          primaryEmail: {
+            update_emails: [
+              {
+                where: {
+                  profile_id: { _eq: hasuraProfileId },
+                  email: { _eq: payload.email },
+                },
+                _set: {
+                  primary: true,
+                },
+              },
+              { affected_rows: true },
+            ],
+          },
+          otherEmails: {
+            update_emails: [
+              {
+                where: {
+                  profile_id: { _eq: hasuraProfileId },
+                  email: { _neq: payload.email },
+                },
+                _set: {
+                  primary: false,
+                },
+              },
+              { affected_rows: true },
+            ],
+          },
+        },
+      },
+      { operationName: 'setPrimaryEmail__update_emails' }
+    );
+
+    assert(primaryEmail);
+    if (primaryEmail.affected_rows == 0) {
+      throw new UnprocessableError('error setting email as primary');
+    }
+
+    return res.status(200).json({ success: true });
+  } catch (e: any) {
+    return errorResponse(res, e);
+  }
+}

--- a/api/hasura/actions/actionManager.ts
+++ b/api/hasura/actions/actionManager.ts
@@ -33,6 +33,7 @@ import linkDiscordUser from './_handlers/linkDiscordUser';
 import logoutUser from './_handlers/logoutUser';
 import markClaimed from './_handlers/markClaimed';
 import restoreCoordinape from './_handlers/restoreCoordinape';
+import setPrimaryEmail from './_handlers/setPrimaryEmail';
 import syncCoSoul from './_handlers/syncCoSoul';
 import updateAllocations from './_handlers/updateAllocations';
 import updateCircle from './_handlers/updateCircle';
@@ -79,6 +80,7 @@ const HANDLERS: HandlerDict = {
   logoutUser,
   markClaimed,
   restoreCoordinape,
+  setPrimaryEmail,
   syncCoSoul,
   updateAllocations,
   updateCircle,

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -119,6 +119,10 @@ type Mutation {
 }
 
 type Mutation {
+  setPrimaryEmail(payload: SetPrimaryEmailInput!): ConfirmationResponse
+}
+
+type Mutation {
   syncCoSoul(payload: SyncCoSoulInput!): SyncCoSoulOutput
 }
 
@@ -489,6 +493,10 @@ input AddEmailInput {
 }
 
 input DeleteEmailInput {
+  email: String!
+}
+
+input SetPrimaryEmailInput {
   email: String!
 }
 

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -219,7 +219,7 @@ actions:
     comment: Generates an API key for a circle
   - name: getGuildInfo
     definition:
-      kind: ""
+      kind: ''
       handler: '{{HASURA_API_BASE_URL}}/actions/actionManager?action_name=getGuildInfo'
       headers:
         - name: verification_key
@@ -482,7 +482,6 @@ custom_types:
     - name: AcceptTOSInput
     - name: AddEmailInput
     - name: DeleteEmailInput
-    - name: setPrimaryEmailInput
     - name: SetPrimaryEmailInput
   objects:
     - name: CreateCircleResponse

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -283,6 +283,16 @@ actions:
           value_from_env: HASURA_EVENT_SECRET
     permissions:
       - role: user
+  - name: setPrimaryEmail
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_API_BASE_URL}}/actions/actionManager?action_name=setPrimaryEmail'
+      headers:
+        - name: verification_key
+          value_from_env: HASURA_EVENT_SECRET
+    permissions:
+      - role: user
+    comment: sets a given email as the primary email for user
   - name: syncCoSoul
     definition:
       kind: synchronous
@@ -472,6 +482,8 @@ custom_types:
     - name: AcceptTOSInput
     - name: AddEmailInput
     - name: DeleteEmailInput
+    - name: setPrimaryEmailInput
+    - name: SetPrimaryEmailInput
   objects:
     - name: CreateCircleResponse
       relationships:

--- a/hasura/schema/admin/schema.graphql
+++ b/hasura/schema/admin/schema.graphql
@@ -406,6 +406,10 @@ type OrgMemberResponse {
   new: Boolean!
 }
 
+input SetPrimaryEmailInput {
+  email: String!
+}
+
 """
 Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'.
 """
@@ -18376,6 +18380,11 @@ type mutation_root {
   logoutUser: LogoutResponse
   markClaimed(payload: MarkClaimedInput!): MarkClaimedOutput
   restoreCoordinape(payload: CoordinapeInput!): ConfirmationResponse
+
+  """
+  sets a given email as the primary email for user
+  """
+  setPrimaryEmail(payload: SetPrimaryEmailInput!): ConfirmationResponse
   syncCoSoul(payload: SyncCoSoulInput!): SyncCoSoulOutput
   updateAllocations(payload: Allocations!): AllocationsResponse
   updateCircle(payload: UpdateCircleInput!): UpdateCircleOutput

--- a/hasura/schema/user/schema.graphql
+++ b/hasura/schema/user/schema.graphql
@@ -372,6 +372,10 @@ type OrgMemberResponse {
   new: Boolean!
 }
 
+input SetPrimaryEmailInput {
+  email: String!
+}
+
 """
 Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'.
 """
@@ -8480,6 +8484,11 @@ type mutation_root {
   logoutUser: LogoutResponse
   markClaimed(payload: MarkClaimedInput!): MarkClaimedOutput
   restoreCoordinape(payload: CoordinapeInput!): ConfirmationResponse
+
+  """
+  sets a given email as the primary email for user
+  """
+  setPrimaryEmail(payload: SetPrimaryEmailInput!): ConfirmationResponse
   syncCoSoul(payload: SyncCoSoulInput!): SyncCoSoulOutput
   updateAllocations(payload: Allocations!): AllocationsResponse
   updateCircle(payload: UpdateCircleInput!): UpdateCircleOutput

--- a/src/lib/gql/__generated__/zeus/const.ts
+++ b/src/lib/gql/__generated__/zeus/const.ts
@@ -50,6 +50,7 @@ export const AllTypesProps: Record<string, any> = {
   LinkDiscordUserInput: {},
   LogVaultTxInput: {},
   MarkClaimedInput: {},
+  SetPrimaryEmailInput: {},
   String_comparison_exp: {},
   SyncCoSoulInput: {},
   UpdateCircleInput: {},
@@ -2789,6 +2790,9 @@ export const AllTypesProps: Record<string, any> = {
     },
     restoreCoordinape: {
       payload: 'CoordinapeInput',
+    },
+    setPrimaryEmail: {
+      payload: 'SetPrimaryEmailInput',
     },
     syncCoSoul: {
       payload: 'SyncCoSoulInput',
@@ -6847,6 +6851,7 @@ export const ReturnTypes: Record<string, any> = {
     logoutUser: 'LogoutResponse',
     markClaimed: 'MarkClaimedOutput',
     restoreCoordinape: 'ConfirmationResponse',
+    setPrimaryEmail: 'ConfirmationResponse',
     syncCoSoul: 'SyncCoSoulOutput',
     updateAllocations: 'AllocationsResponse',
     updateCircle: 'UpdateCircleOutput',

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -900,6 +900,9 @@ export type ValueTypes = {
     new?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
+  ['SetPrimaryEmailInput']: {
+    email: string;
+  };
   /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
   ['String_comparison_exp']: {
     _eq?: string | undefined | null;
@@ -6545,6 +6548,10 @@ export type ValueTypes = {
     ];
     restoreCoordinape?: [
       { payload: ValueTypes['CoordinapeInput'] },
+      ValueTypes['ConfirmationResponse']
+    ];
+    setPrimaryEmail?: [
+      { payload: ValueTypes['SetPrimaryEmailInput'] },
       ValueTypes['ConfirmationResponse']
     ];
     syncCoSoul?: [
@@ -13849,6 +13856,7 @@ export type ModelTypes = {
     id: string;
     new: boolean;
   };
+  ['SetPrimaryEmailInput']: GraphQLTypes['SetPrimaryEmailInput'];
   /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
   ['String_comparison_exp']: GraphQLTypes['String_comparison_exp'];
   ['SyncCoSoulInput']: GraphQLTypes['SyncCoSoulInput'];
@@ -15782,6 +15790,8 @@ export type ModelTypes = {
     logoutUser?: GraphQLTypes['LogoutResponse'] | undefined;
     markClaimed?: GraphQLTypes['MarkClaimedOutput'] | undefined;
     restoreCoordinape?: GraphQLTypes['ConfirmationResponse'] | undefined;
+    /** sets a given email as the primary email for user */
+    setPrimaryEmail?: GraphQLTypes['ConfirmationResponse'] | undefined;
     syncCoSoul?: GraphQLTypes['SyncCoSoulOutput'] | undefined;
     updateAllocations?: GraphQLTypes['AllocationsResponse'] | undefined;
     updateCircle?: GraphQLTypes['UpdateCircleOutput'] | undefined;
@@ -17893,6 +17903,9 @@ export type GraphQLTypes = {
     OrgMemberResponse?: GraphQLTypes['org_members'] | undefined;
     id: string;
     new: boolean;
+  };
+  ['SetPrimaryEmailInput']: {
+    email: string;
   };
   /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
   ['String_comparison_exp']: {
@@ -22391,6 +22404,8 @@ export type GraphQLTypes = {
     logoutUser?: GraphQLTypes['LogoutResponse'] | undefined;
     markClaimed?: GraphQLTypes['MarkClaimedOutput'] | undefined;
     restoreCoordinape?: GraphQLTypes['ConfirmationResponse'] | undefined;
+    /** sets a given email as the primary email for user */
+    setPrimaryEmail?: GraphQLTypes['ConfirmationResponse'] | undefined;
     syncCoSoul?: GraphQLTypes['SyncCoSoulOutput'] | undefined;
     updateAllocations?: GraphQLTypes['AllocationsResponse'] | undefined;
     updateCircle?: GraphQLTypes['UpdateCircleOutput'] | undefined;


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ed5d122</samp>

This pull request adds a new feature that allows users to change their primary email address. It introduces a new custom action `setPrimaryEmail` to the Hasura metadata and GraphQL schemas, and a new handler function `setPrimaryEmail.ts` to the Vercel serverless function. It also updates the TypeScript types and constants for the GraphQL queries and mutations in the `api-lib` and `src/lib` folders.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ed5d122</samp>

> _Oh we're the coders of the Hasura sea_
> _And we write the actions for the GraphQL API_
> _We've added a new one for `setPrimaryEmail`_
> _So heave away, me hearties, heave away_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ed5d122</samp>

*  Add a new mutation `setPrimaryEmail` to the GraphQL schema and the Hasura metadata that allows users to change their primary email address ([link](https://github.com/coordinape/coordinape/pull/2326/files?diff=unified&w=0#diff-589f402dbb6eb11ea9c28e067ac01d020e1b8f8f087f45d59435eaae684975c3R122-R125), [link](https://github.com/coordinape/coordinape/pull/2326/files?diff=unified&w=0#diff-589f402dbb6eb11ea9c28e067ac01d020e1b8f8f087f45d59435eaae684975c3R499-R502), [link](https://github.com/coordinape/coordinape/pull/2326/files?diff=unified&w=0#diff-49e7aa4e1112b93bcdbd36419aeb0b64fb23ea532e80c9a0f5ff1c5a585763f9R286-R295), [link](https://github.com/coordinape/coordinape/pull/2326/files?diff=unified&w=0#diff-49e7aa4e1112b93bcdbd36419aeb0b64fb23ea532e80c9a0f5ff1c5a585763f9R485-R486), [link](https://github.com/coordinape/coordinape/pull/2326/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R409-R412), [link](https://github.com/coordinape/coordinape/pull/2326/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R18383-R18387), [link](https://github.com/coordinape/coordinape/pull/2326/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebR375-R378), [link](https://github.com/coordinape/coordinape/pull/2326/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebR8487-R8491))
* Generate the TypeScript types and constants for the `setPrimaryEmail` mutation and its input and return types using the Zeus library in the `api-lib/gql/__generated__/zeus/const.ts` and `src/lib/gql/__generated__/zeus/const.ts` files ([link](https://github.com/coordinape/coordinape/pull/2326/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R59), [link](https://github.com/coordinape/coordinape/pull/2326/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R4930-R4932), [link](https://github.com/coordinape/coordinape/pull/2326/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R12974), [link](https://github.com/coordinape/coordinape/pull/2326/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060R53), [link](https://github.com/coordinape/coordinape/pull/2326/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060R2794-R2796), [link](https://github.com/coordinape/coordinape/pull/2326/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060R6854))
* Implement the handler function for the `setPrimaryEmail` action in the `api/hasura/actions/_handlers/setPrimaryEmail.ts` file that validates the input, updates the database, and returns a confirmation response ([link](https://github.com/coordinape/coordinape/pull/2326/files?diff=unified&w=0#diff-b5b6bfa0ba84b713f190b46c15010c931e35a84d7c4e58bf6d34bc25cea6cab2R1-R72))
* Register the handler function for the `setPrimaryEmail` action in the action manager in the `api/hasura/actions/actionManager.ts` file ([link](https://github.com/coordinape/coordinape/pull/2326/files?diff=unified&w=0#diff-a6a476461d778e69905cd6d1cab214af3b0f749568bce39067fdde541f73a24eR36), [link](https://github.com/coordinape/coordinape/pull/2326/files?diff=unified&w=0#diff-a6a476461d778e69905cd6d1cab214af3b0f749568bce39067fdde541f73a24eR83))
