### PR TITLE
switch magic link to polygon

### DIFF
--- a/src/features/auth/magic.tsx
+++ b/src/features/auth/magic.tsx
@@ -38,7 +38,7 @@ export const getMagic = () => {
     const override = localStorage.getItem('magic:network') || '';
     const network =
       networks[override] ||
-      (IN_PRODUCTION ? networks.mainnet : networks.goerli);
+      (IN_PRODUCTION ? networks.polygon : networks.goerli);
 
     magic = new Magic(API_KEY, {
       network,


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d98aac1</samp>

Updated the `getMagic` function to connect to the Polygon network instead of Ethereum in production mode. 

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d98aac1</samp>

> _`getMagic` changes_
> _Polygon network in prod_
> _Winter gas is low_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d98aac1</samp>

* Migrate the app from Ethereum to Polygon network to reduce gas fees and improve performance
  * Switch the `getMagic` function to use the Polygon network instead of the mainnet network when the app is in production mode ([link](https://github.com/coordinape/coordinape/pull/2329/files?diff=unified&w=0#diff-2724f0c8eeff3ea6eda838dfac123faef13e5e109741b234c910407fb389ac9aL41-R41))
