### PR TITLE
force show magic link ui if no accounts

### DIFF
--- a/src/features/auth/magic.tsx
+++ b/src/features/auth/magic.tsx
@@ -51,11 +51,14 @@ export const getMagic = () => {
 };
 
 export const getMagicProvider = async () => {
-  // FIXME
+  const m = getMagic();
   // @ts-ignore
-  const provider = new Web3Provider(getMagic().rpcProvider);
+  const provider = new Web3Provider(m.rpcProvider);
   const accounts = await provider.listAccounts();
   console.log(accounts[0]); // eslint-disable-line
+  if (!accounts[0]) {
+    m.wallet.connectWithUI();
+  }
   return provider;
 };
 


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d9efb00</samp>

Improved magic wallet integration by checking and prompting for account connection in `getMagicProvider`. Fixed some UI and error handling issues in `src/features/auth/magic.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d9efb00</samp>

> _`getMagicProvider`_
> _Connects account if needed_
> _A winter solstice_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d9efb00</samp>

*  Prompt the user to connect to the magic wallet if no account is detected ([link](https://github.com/coordinape/coordinape/pull/2338/files?diff=unified&w=0#diff-2724f0c8eeff3ea6eda838dfac123faef13e5e109741b234c910407fb389ac9aL54-R61)) in `magic.tsx`
