### PR TITLE
Add email subscription-settings to Edit Email form

### DIFF
--- a/src/pages/ProfilePage/EmailSettings/EditEmailForm.tsx
+++ b/src/pages/ProfilePage/EmailSettings/EditEmailForm.tsx
@@ -185,19 +185,17 @@ export const EditEmailForm = () => {
           Add Email
         </Button>
       </Flex>
-      <Panel>
+      <Flex column css={{ my: '$lg' }}>
         <Text bold h2>
           Subscription settings
         </Text>
         <HR />
         {!!email_settings && (
-          <Panel>
+          <Flex column>
             <Flex row>
-              <Text css={{ mr: '$md' }}>
-                Receive transactional email notifications
-              </Text>
               <CheckBox
                 value={email_settings?.app_emails}
+                label="Receive transactional email notifications"
                 onChange={e => {
                   updateEmailSettings(profileId, {
                     ...email_settings,
@@ -211,9 +209,9 @@ export const EditEmailForm = () => {
               ></CheckBox>
             </Flex>
             <Flex row>
-              <Text css={{ mr: '$md' }}> Receive product update emails</Text>
               <CheckBox
                 value={email_settings?.product_emails}
+                label="Receive product update emails"
                 onChange={e => {
                   updateEmailSettings(profileId, {
                     ...email_settings,
@@ -226,17 +224,17 @@ export const EditEmailForm = () => {
                 }}
               ></CheckBox>
             </Flex>
+          </Flex>
+        )}
+        {showSuccessEmail && (
+          <Panel neutral css={{ mt: '$lg' }}>
+            <Text>
+              Check your email for {showSuccessEmail} and click the Verify Email
+              button.
+            </Text>
           </Panel>
         )}
-      </Panel>
-      {showSuccessEmail && (
-        <Panel neutral css={{ mt: '$lg' }}>
-          <Text>
-            Check your email for {showSuccessEmail} and click the Verify Email
-            button.
-          </Text>
-        </Panel>
-      )}
+      </Flex>
     </>
   );
 };


### PR DESCRIPTION
## What

Add options for app_emails and product_emails to Edit Email form

TODO: some more stylingz

<img width="638" alt="Screenshot 2023-10-04 at 10 41 59 AM" src="https://github.com/coordinape/coordinape/assets/83605543/4cdb8518-122d-4b53-b235-a9a4ac2b1ffc">


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 949ac7b</samp>

Added a form to edit email settings on the profile page. The form allows the user to change their email address and subscription preferences for different types of notifications. The form uses existing components from `HR` and `CheckBox`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 949ac7b</samp>

> _In the shadows of the profile, you hide your secrets well_
> _But we can query and update your email settings from hell_
> _With the `HR` and `CheckBox` components, we control your fate_
> _You can't escape the subscription, you can only validate_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 949ac7b</samp>

* Import `assert` module and `useAuthStore` hook to get and check profileId ([link](https://github.com/coordinape/coordinape/pull/2346/files?diff=unified&w=0#diff-7ec456d91c2ea445c54a26ace526b4da9ee2bd8789f6a7de252565995feca557L1-R4))
* Import `HR` and `CheckBox` components from `ui` module to render email settings ([link](https://github.com/coordinape/coordinape/pull/2346/files?diff=unified&w=0#diff-7ec456d91c2ea445c54a26ace526b4da9ee2bd8789f6a7de252565995feca557L10-R12))
* Add `updateEmailSettings` and `getEmailSettings` functions to send mutation and query requests to GraphQL client ([link](https://github.com/coordinape/coordinape/pull/2346/files?diff=unified&w=0#diff-7ec456d91c2ea445c54a26ace526b4da9ee2bd8789f6a7de252565995feca557R45-R84))
* Declare `profileId` and `email_settings` variables and use `useQuery` hook to fetch email settings from server ([link](https://github.com/coordinape/coordinape/pull/2346/files?diff=unified&w=0#diff-7ec456d91c2ea445c54a26ace526b4da9ee2bd8789f6a7de252565995feca557L51-R106))
* Add subscription settings section to `EditEmailForm` component with checkboxes for app_emails and product_emails settings ([link](https://github.com/coordinape/coordinape/pull/2346/files?diff=unified&w=0#diff-7ec456d91c2ea445c54a26ace526b4da9ee2bd8789f6a7de252565995feca557L135-R237))
* Move success panel inside flex container to align with other elements ([link](https://github.com/coordinape/coordinape/pull/2346/files?diff=unified&w=0#diff-7ec456d91c2ea445c54a26ace526b4da9ee2bd8789f6a7de252565995feca557L135-R237))
