### PR TITLE
Bugfix: clicking on toasts closed the modal

### DIFF
--- a/src/ui/Modal.tsx
+++ b/src/ui/Modal.tsx
@@ -21,6 +21,8 @@ const Overlay = styled(Dialog.Overlay, {
   },
 });
 
+const OverlayClose = styled(Dialog.Close);
+
 const Close = styled(Dialog.Close, {
   position: 'absolute',
   right: 'calc($sm + 3px)',
@@ -110,6 +112,7 @@ export const Modal = ({
   drawer,
   loader,
 }: ModalProps) => {
+  const clickToClose = !!(showClose !== false && !loader);
   return (
     <Dialog.Root
       modal
@@ -118,7 +121,13 @@ export const Modal = ({
       onOpenChange={onOpenChange}
     >
       <Dialog.Portal>
-        <Overlay />
+        {clickToClose ? (
+          <OverlayClose>
+            <Overlay />
+          </OverlayClose>
+        ) : (
+          <Overlay />
+        )}
         <Content
           className={
             forceTheme === 'dark' ? dark : forceTheme === 'light' ? light : ''
@@ -126,8 +135,14 @@ export const Modal = ({
           drawer={drawer}
           css={css}
           loader={loader}
+          onPointerDownOutside={event => {
+            event.preventDefault();
+          }}
+          onInteractOutside={event => {
+            event.preventDefault();
+          }}
         >
-          {(showClose || showClose === undefined) && !loader && (
+          {clickToClose && (
             <Close>
               <X size="lg" />
             </Close>


### PR DESCRIPTION
When clicking outside the modal, now when you click on the scrim it closes it.  Previously, when you clicked on ANYTHING that was not the Content of the modal (like a toast) it would close the modal.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f3b4645</samp>

Add click-to-close option and fix close button for modal component. Improve the user experience and functionality of the `Modal` component in `src/ui/Modal.tsx` by allowing users to close it by clicking outside of it, and by resolving some potential bugs with the existing close button and the `@reach/dialog` library.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f3b4645</samp>

*  Add a styled component `OverlayClose` to enable closing the modal by clicking outside of it ([link](https://github.com/coordinape/coordinape/pull/2347/files?diff=unified&w=0#diff-b0c5212c10911c651bc023f686549cbc65a4d545e53069d4a486bded49cf5fa9R24-R25))
*  Introduce a variable `clickToClose` to determine whether the modal can be closed by clicking outside of it or not, based on the props `showClose` and `loader` ([link](https://github.com/coordinape/coordinape/pull/2347/files?diff=unified&w=0#diff-b0c5212c10911c651bc023f686549cbc65a4d545e53069d4a486bded49cf5fa9R115))
*  Wrap the `Overlay` component with `OverlayClose` if `clickToClose` is true, otherwise render it as before ([link](https://github.com/coordinape/coordinape/pull/2347/files?diff=unified&w=0#diff-b0c5212c10911c651bc023f686549cbc65a4d545e53069d4a486bded49cf5fa9L121-R130))
*  Add event handlers to the `Content` component to prevent closing the modal by clicking or interacting outside of it, and modify the condition for rendering the `Close` component inside the modal, based on the `clickToClose` variable ([link](https://github.com/coordinape/coordinape/pull/2347/files?diff=unified&w=0#diff-b0c5212c10911c651bc023f686549cbc65a4d545e53069d4a486bded49cf5fa9L129-R145))
