### PR TITLE
Bugfix: Click to close modal drawer

### DIFF
--- a/src/ui/Modal.tsx
+++ b/src/ui/Modal.tsx
@@ -112,7 +112,6 @@ export const Modal = ({
   drawer,
   loader,
 }: ModalProps) => {
-  const clickToClose = !!(showClose !== false && !loader);
   return (
     <Dialog.Root
       modal
@@ -121,13 +120,9 @@ export const Modal = ({
       onOpenChange={onOpenChange}
     >
       <Dialog.Portal>
-        {clickToClose ? (
-          <OverlayClose>
-            <Overlay />
-          </OverlayClose>
-        ) : (
+        <OverlayClose>
           <Overlay />
-        )}
+        </OverlayClose>
         <Content
           className={
             forceTheme === 'dark' ? dark : forceTheme === 'light' ? light : ''
@@ -142,7 +137,7 @@ export const Modal = ({
             event.preventDefault();
           }}
         >
-          {clickToClose && (
+          {showClose !== false && !loader && (
             <Close>
               <X size="lg" />
             </Close>


### PR DESCRIPTION
Modal scrim should always be clickable

## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 53f71fb</samp>

Refactor and fix `Modal.tsx` component. Remove unnecessary variable, simplify overlay logic, and ensure close button works as expected.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 53f71fb</samp>

> _No more redundancy, no more overlay_
> _We refactored the modal, we made it our way_
> _We fixed the bug that kept us in the dark_
> _We smashed the close button, we left our mark_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 53f71fb</samp>

*  Remove redundant `clickToClose` variable and simplify overlay rendering logic in `Modal` component ([link](https://github.com/coordinape/coordinape/pull/2350/files?diff=unified&w=0#diff-b0c5212c10911c651bc023f686549cbc65a4d545e53069d4a486bded49cf5fa9L115), [link](https://github.com/coordinape/coordinape/pull/2350/files?diff=unified&w=0#diff-b0c5212c10911c651bc023f686549cbc65a4d545e53069d4a486bded49cf5fa9L124-R125), [link](https://github.com/coordinape/coordinape/pull/2350/files?diff=unified&w=0#diff-b0c5212c10911c651bc023f686549cbc65a4d545e53069d4a486bded49cf5fa9L145-R140))
