### PR TITLE
add epochId to sendEmail request

### DIFF
--- a/api-lib/postmark.ts
+++ b/api-lib/postmark.ts
@@ -81,11 +81,13 @@ export async function sendEpochEndedEmail(params: {
   email: string;
   circle_name: string;
   circle_id: number;
+  epoch_id: number;
   num_give_senders: number;
   num_notes_received: number;
 }) {
   const input = {
     circle_name: params.circle_name,
+    epoch_id: params.epoch_id,
     num_give_senders: params.num_give_senders,
     num_notes_received: params.num_notes_received,
     action_url: `${URL_BASE}/circles/${params.circle_id}/epochs`,
@@ -98,9 +100,11 @@ export async function sendEpochEndingSoonEmail(params: {
   email: string;
   circle_name: string;
   circle_id: number;
+  epoch_id: number;
 }) {
   const input = {
     circle_name: params.circle_name,
+    epoch_id: params.epoch_id,
     action_url: `${URL_BASE}/circles/${params.circle_id}/give`,
   };
   const res = await sendEmail(params.email, TEMPLATES.EPOCH_ENDING_SOON, input);
@@ -111,9 +115,11 @@ export async function sendEpochStartedEmail(params: {
   email: string;
   circle_name: string;
   circle_id: number;
+  epoch_id: number;
 }) {
   const input = {
     circle_name: params.circle_name,
+    epoch_id: params.epoch_id,
     action_url: `${URL_BASE}/circles/${params.circle_id}/give`,
   };
   const res = await sendEmail(params.email, TEMPLATES.EPOCH_STARTED, input);

--- a/api-test/hasura/cron/epochs_emails_stubbed.test.ts
+++ b/api-test/hasura/cron/epochs_emails_stubbed.test.ts
@@ -47,17 +47,26 @@ jest.mock('../../../api-lib/postmark', () => ({
       email: string;
       circle_name: string;
       circle_id: number;
+      epoch_id: number;
       num_give_senders: number;
       num_notes_received: number;
     }) => Promise.resolve({ params })
   ),
   sendEpochStartedEmail: jest.fn(
-    (params: { email: string; circle_name: string; circle_id: number }) =>
-      Promise.resolve({ params })
+    (params: {
+      email: string;
+      circle_name: string;
+      circle_id: number;
+      epoch_id: number;
+    }) => Promise.resolve({ params })
   ),
   sendEpochEndingSoonEmail: jest.fn(
-    (params: { email: string; circle_name: string; circle_id: number }) =>
-      Promise.resolve({ params })
+    (params: {
+      email: string;
+      circle_name: string;
+      circle_id: number;
+      epoch_id: number;
+    }) => Promise.resolve({ params })
   ),
 }));
 
@@ -125,7 +134,7 @@ const mockEpoch = {
     circle: mockCircle.notifyStartEpochs,
   },
   notifyEndEpochs: {
-    id: 9,
+    id: 5,
     circle_id: 1,
     number: 3,
     end_date: DateTime.now().plus({ days: 1 }),
@@ -133,7 +142,7 @@ const mockEpoch = {
     token_gifts: [{ tokens: 50 }, { tokens: 100 }],
   },
   endEpoch: {
-    id: 9,
+    id: 6,
     start_date: DateTime.now().minus({ days: 1 }).toISO(),
     end_date: DateTime.now().plus({ days: 1 }).toISO(),
     repeat_data: { type: 'monthly', week: 0, time_zone: 'UTC' },
@@ -200,6 +209,7 @@ describe('send email notifications to circle members with verified emails', () =
       circle_id: 1,
       circle_name: 'circle with epoch that has ended',
       email: 'person0@test.com',
+      epoch_id: 6,
       num_give_senders: 1,
       num_notes_received: 1,
     });
@@ -217,11 +227,13 @@ describe('send email notifications to circle members with verified emails', () =
       circle_id: 5,
       circle_name: 'circle with starting epoch',
       email: 'bob@test.com',
+      epoch_id: 9,
     });
     expect(sendEpochStartedEmail).nthCalledWith(2, {
       circle_id: 5,
       circle_name: 'circle with starting epoch',
       email: 'alice@test.com',
+      epoch_id: 9,
     });
   });
 
@@ -237,11 +249,13 @@ describe('send email notifications to circle members with verified emails', () =
       circle_id: 5,
       circle_name: 'circle with ending epoch',
       email: 'bob@test.com',
+      epoch_id: 5,
     });
     expect(sendEpochEndingSoonEmail).nthCalledWith(2, {
       circle_id: 5,
       circle_name: 'circle with ending epoch',
       email: 'alice@test.com',
+      epoch_id: 5,
     });
   });
 });

--- a/api/hasura/cron/epochs.ts
+++ b/api/hasura/cron/epochs.ts
@@ -342,6 +342,7 @@ export async function notifyEpochStart({
         status: 'started',
         circleId: epoch.circle_id,
         circleName: circle.name,
+        epochId: epoch.id,
         membersData,
       });
     }
@@ -403,6 +404,7 @@ export async function notifyEpochEnd({
         status: 'endingSoon',
         circleId: epoch.circle_id,
         circleName: circle.name,
+        epochId: epoch.id,
         membersData,
       });
     }
@@ -591,6 +593,7 @@ export async function endEpochHandler(
       status: 'ended',
       circleId: epoch.circle_id,
       circleName: circle.name,
+      epochId: epoch.id,
       membersData,
     });
   }
@@ -846,11 +849,13 @@ async function emailEpochStatus({
   status,
   circleId,
   circleName,
+  epochId,
   membersData,
 }: {
   status: 'started' | 'endingSoon' | 'ended';
   circleId: number;
   circleName: string;
+  epochId: number;
   membersData: Array<{
     email: string;
     tokenNumReceived?: number;
@@ -865,6 +870,7 @@ async function emailEpochStatus({
               email: memberData.email,
               circle_id: circleId,
               circle_name: circleName,
+              epoch_id: epochId,
               num_give_senders: memberData.tokenNumReceived ?? 0,
               num_notes_received: memberData.notesNumReceived ?? 0,
             });
@@ -875,6 +881,7 @@ async function emailEpochStatus({
               email: memberData.email,
               circle_id: circleId,
               circle_name: circleName,
+              epoch_id: epochId,
             });
           })
         : status === 'started'
@@ -883,6 +890,7 @@ async function emailEpochStatus({
               email: memberData.email,
               circle_id: circleId,
               circle_name: circleName,
+              epoch_id: epochId,
             });
           })
         : []

--- a/src/pages/HistoryPage/CurrentEpochPanel.tsx
+++ b/src/pages/HistoryPage/CurrentEpochPanel.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { ACTIVITIES_QUERY_KEY } from 'features/activities/ActivityList';
@@ -38,6 +38,7 @@ type Props = {
   isAdmin: boolean;
   css?: CSS;
   children?: React.ReactNode;
+  targetEpoch: boolean;
 };
 export const CurrentEpochPanel = ({
   epoch,
@@ -50,7 +51,9 @@ export const CurrentEpochPanel = ({
   isAdmin,
   children,
   css = {},
+  targetEpoch,
 }: Props) => {
+  const targetEpochRef = useRef<null | HTMLLabelElement>(null);
   const startDate = DateTime.fromISO(epoch.start_date);
   const endDate = DateTime.fromISO(epoch.end_date);
 
@@ -62,6 +65,12 @@ export const CurrentEpochPanel = ({
   const [epochDescriptionText, setEpochDescriptionText] = useState<string>(
     epoch.description ?? 'Epoch ' + (epoch.number ?? '')
   );
+
+  useEffect(() => {
+    if (targetEpochRef.current && targetEpoch) {
+      targetEpochRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [targetEpoch, targetEpochRef]);
 
   return (
     <Panel
@@ -166,7 +175,12 @@ export const CurrentEpochPanel = ({
             </Minicard>
           </Flex>
           {(showGives || isAdmin) && (
-            <NotesSection sent={[]} received={gifts} tokenName={tokenName} />
+            <NotesSection
+              sent={[]}
+              received={gifts}
+              tokenName={tokenName}
+              targetEpoch={targetEpoch}
+            />
           )}
         </Flex>
       </Flex>

--- a/src/pages/HistoryPage/CurrentEpochPanel.tsx
+++ b/src/pages/HistoryPage/CurrentEpochPanel.tsx
@@ -38,7 +38,7 @@ type Props = {
   isAdmin: boolean;
   css?: CSS;
   children?: React.ReactNode;
-  targetEpoch: boolean;
+  expanded: boolean;
 };
 export const CurrentEpochPanel = ({
   epoch,
@@ -51,9 +51,9 @@ export const CurrentEpochPanel = ({
   isAdmin,
   children,
   css = {},
-  targetEpoch,
+  expanded,
 }: Props) => {
-  const targetEpochRef = useRef<null | HTMLLabelElement>(null);
+  const notesSectionRef = useRef<null | HTMLLabelElement>(null);
   const startDate = DateTime.fromISO(epoch.start_date);
   const endDate = DateTime.fromISO(epoch.end_date);
 
@@ -67,10 +67,10 @@ export const CurrentEpochPanel = ({
   );
 
   useEffect(() => {
-    if (targetEpochRef.current && targetEpoch) {
-      targetEpochRef.current.scrollIntoView({ behavior: 'smooth' });
+    if (notesSectionRef.current && expanded) {
+      notesSectionRef.current.scrollIntoView({ behavior: 'smooth' });
     }
-  }, [targetEpoch, targetEpochRef]);
+  }, [expanded, notesSectionRef]);
 
   return (
     <Panel
@@ -176,10 +176,11 @@ export const CurrentEpochPanel = ({
           </Flex>
           {(showGives || isAdmin) && (
             <NotesSection
+              ref={notesSectionRef}
               sent={[]}
               received={gifts}
               tokenName={tokenName}
-              targetEpoch={targetEpoch}
+              expanded={expanded}
             />
           )}
         </Flex>

--- a/src/pages/HistoryPage/EpochPanel.tsx
+++ b/src/pages/HistoryPage/EpochPanel.tsx
@@ -18,17 +18,17 @@ type EpochPanelProps = {
   tokenName: string;
   css?: CSS;
   isAdmin: boolean;
-  targetEpoch: boolean;
+  expanded: boolean;
 };
 export const EpochPanel = ({
   circleId,
   epoch,
   tokenName,
   isAdmin,
-  targetEpoch,
+  expanded,
   css = {},
 }: EpochPanelProps) => {
-  const targetEpochRef = useRef<null | HTMLLabelElement>(null);
+  const notesSectionRef = useRef<null | HTMLLabelElement>(null);
   const startDate = DateTime.fromISO(epoch.start_date);
   const endDate = DateTime.fromISO(epoch.end_date);
   const endDateFormat = endDate.month === startDate.month ? 'd' : 'MMM d';
@@ -41,10 +41,10 @@ export const EpochPanel = ({
   const totalReceived = received.map(g => g.tokens).reduce((a, b) => a + b, 0);
 
   useEffect(() => {
-    if (targetEpochRef.current && targetEpoch) {
-      targetEpochRef.current.scrollIntoView({ behavior: 'smooth' });
+    if (notesSectionRef.current && expanded) {
+      notesSectionRef.current.scrollIntoView({ behavior: 'smooth' });
     }
-  }, [targetEpoch, targetEpochRef]);
+  }, [expanded, notesSectionRef]);
 
   return (
     <Panel
@@ -138,12 +138,12 @@ export const EpochPanel = ({
           </Flex>
         </Flex>
         <NotesSection
-          ref={targetEpochRef}
+          ref={notesSectionRef}
           sent={sent}
           received={received}
           tokenName={tokenName}
           epochStatements={epochStatements}
-          targetEpoch={targetEpoch}
+          expanded={expanded}
         />
       </Flex>
     </Panel>

--- a/src/pages/HistoryPage/EpochPanel.tsx
+++ b/src/pages/HistoryPage/EpochPanel.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from 'react';
+
 import fp from 'lodash/fp';
 import round from 'lodash/round';
 import { DateTime } from 'luxon';
@@ -16,14 +18,17 @@ type EpochPanelProps = {
   tokenName: string;
   css?: CSS;
   isAdmin: boolean;
+  targetEpoch: boolean;
 };
 export const EpochPanel = ({
   circleId,
   epoch,
   tokenName,
   isAdmin,
+  targetEpoch,
   css = {},
 }: EpochPanelProps) => {
+  const targetEpochRef = useRef<null | HTMLLabelElement>(null);
   const startDate = DateTime.fromISO(epoch.start_date);
   const endDate = DateTime.fromISO(epoch.end_date);
   const endDateFormat = endDate.month === startDate.month ? 'd' : 'MMM d';
@@ -34,6 +39,12 @@ export const EpochPanel = ({
   const totalAllocated =
     epoch.token_gifts_aggregate.aggregate?.sum?.tokens || 0;
   const totalReceived = received.map(g => g.tokens).reduce((a, b) => a + b, 0);
+
+  useEffect(() => {
+    if (targetEpochRef.current && targetEpoch) {
+      targetEpochRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [targetEpoch, targetEpochRef]);
 
   return (
     <Panel
@@ -127,10 +138,12 @@ export const EpochPanel = ({
           </Flex>
         </Flex>
         <NotesSection
+          ref={targetEpochRef}
           sent={sent}
           received={received}
           tokenName={tokenName}
           epochStatements={epochStatements}
+          targetEpoch={targetEpoch}
         />
       </Flex>
     </Panel>

--- a/src/pages/HistoryPage/HistoryPage.tsx
+++ b/src/pages/HistoryPage/HistoryPage.tsx
@@ -372,7 +372,7 @@ export const HistoryPage = () => {
             circleId={circleId}
             userId={userId}
             epoch={currentEpoch}
-            targetEpoch={currentEpoch.id === epochId}
+            expanded={currentEpoch.id === epochId}
             unallocated={unallocated}
             tokenName={circle?.token_name}
             isAdmin={isAdmin}
@@ -407,7 +407,7 @@ export const HistoryPage = () => {
           {shownPastEpochs.map((epoch: QueryPastEpoch) => (
             <EpochPanel
               key={epoch.id}
-              targetEpoch={epoch.id === epochId}
+              expanded={epoch.id === epochId}
               circleId={circleId}
               epoch={epoch}
               tokenName={circle?.token_name || 'GIVE'}

--- a/src/pages/HistoryPage/HistoryPage.tsx
+++ b/src/pages/HistoryPage/HistoryPage.tsx
@@ -5,6 +5,7 @@ import { useMyUser } from 'features/auth/useLoginData';
 import { isUserAdmin } from 'lib/users';
 import { DateTime } from 'luxon';
 import { useQuery } from 'react-query';
+import { useParams } from 'react-router-dom';
 
 import { LoadingModal } from '../../components';
 import HintBanner from '../../components/HintBanner';
@@ -48,6 +49,8 @@ const pageSize = 3;
 
 export const HistoryPage = () => {
   const circleId = useCircleIdParam();
+  const params = useParams();
+  const epochId = Number(params.epochId);
   const userId = useMyUser(circleId)?.id;
 
   const query = useQuery(
@@ -87,6 +90,16 @@ export const HistoryPage = () => {
   );
   const totalPages = Math.ceil(pastEpochs.length / pageSize);
 
+  const targetEpochPage = useMemo(() => {
+    if (pastEpochs && epochId) {
+      const pageIndex = pastEpochs.findIndex(epoch => epoch.id === epochId);
+      if (pageIndex >= 0) {
+        return Math.floor(pageIndex / pageSize);
+      }
+    }
+    return 0;
+  }, [pastEpochs, epochId]);
+
   const unallocated = (!me?.non_giver && me?.give_token_remaining) || 0;
 
   const { showDefault, showSuccess } = useToast();
@@ -114,6 +127,10 @@ export const HistoryPage = () => {
     setEditEpoch(undefined);
     setNewEpoch(false);
   }, [circleId]);
+
+  useEffect(() => {
+    if (targetEpochPage !== page) setPage(targetEpochPage);
+  }, [targetEpochPage]);
 
   const deleteEpochHandler = async (
     epochToDelete: QueryFutureEpoch | undefined,
@@ -355,6 +372,7 @@ export const HistoryPage = () => {
             circleId={circleId}
             userId={userId}
             epoch={currentEpoch}
+            targetEpoch={currentEpoch.id === epochId}
             unallocated={unallocated}
             tokenName={circle?.token_name}
             isAdmin={isAdmin}
@@ -389,6 +407,7 @@ export const HistoryPage = () => {
           {shownPastEpochs.map((epoch: QueryPastEpoch) => (
             <EpochPanel
               key={epoch.id}
+              targetEpoch={epoch.id === epochId}
               circleId={circleId}
               epoch={epoch}
               tokenName={circle?.token_name || 'GIVE'}

--- a/src/pages/HistoryPage/HistoryPage.tsx
+++ b/src/pages/HistoryPage/HistoryPage.tsx
@@ -92,9 +92,9 @@ export const HistoryPage = () => {
 
   const targetEpochPage = useMemo(() => {
     if (pastEpochs && epochId) {
-      const pageIndex = pastEpochs.findIndex(epoch => epoch.id === epochId);
-      if (pageIndex >= 0) {
-        return Math.floor(pageIndex / pageSize);
+      const epochIndex = pastEpochs.findIndex(epoch => epoch.id === epochId);
+      if (epochIndex >= 0) {
+        return Math.floor(epochIndex / pageSize);
       }
     }
     return 0;

--- a/src/pages/HistoryPage/Notes.tsx
+++ b/src/pages/HistoryPage/Notes.tsx
@@ -17,13 +17,13 @@ export const NotesSection = forwardRef(function NotesSection(
     sent,
     epochStatements,
     tokenName,
-    targetEpoch,
+    expanded,
   }: {
     received: QueryPastEpoch['receivedGifts'];
     sent?: QueryPastEpoch['sentGifts'];
     epochStatements?: QueryPastEpoch['epochStatements'];
     tokenName: string;
-    targetEpoch: boolean;
+    expanded: boolean;
   },
   ref
 ) {
@@ -35,7 +35,7 @@ export const NotesSection = forwardRef(function NotesSection(
   const epochStatementsLength = filteredEpochStatements?.length;
   const [tab, setTab] = useState<
     'sent' | 'received' | 'epochStatements' | null
-  >(targetEpoch ? 'received' : null);
+  >(expanded ? 'received' : null);
 
   return (
     <Flex column>

--- a/src/pages/HistoryPage/Notes.tsx
+++ b/src/pages/HistoryPage/Notes.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { useState } from 'react';
+import { forwardRef, useState } from 'react';
 
 import sortBy from 'lodash/sortBy';
 
@@ -11,17 +11,22 @@ type QueryReceivedGift = QueryPastEpoch['receivedGifts'][0];
 type QuerySentGift = QueryPastEpoch['sentGifts'][0];
 type QueryGift = QueryReceivedGift | QuerySentGift;
 
-export const NotesSection = ({
-  received,
-  sent,
-  epochStatements,
-  tokenName,
-}: {
-  received: QueryPastEpoch['receivedGifts'];
-  sent?: QueryPastEpoch['sentGifts'];
-  epochStatements?: QueryPastEpoch['epochStatements'];
-  tokenName: string;
-}) => {
+export const NotesSection = forwardRef(function NotesSection(
+  {
+    received,
+    sent,
+    epochStatements,
+    tokenName,
+    targetEpoch,
+  }: {
+    received: QueryPastEpoch['receivedGifts'];
+    sent?: QueryPastEpoch['sentGifts'];
+    epochStatements?: QueryPastEpoch['epochStatements'];
+    tokenName: string;
+    targetEpoch: boolean;
+  },
+  ref
+) {
   const receivedLength = received.filter(g => g.gift_private?.note).length;
   const sentLength = sent?.filter(g => g.gift_private?.note).length;
   const filteredEpochStatements = epochStatements?.filter(
@@ -30,7 +35,7 @@ export const NotesSection = ({
   const epochStatementsLength = filteredEpochStatements?.length;
   const [tab, setTab] = useState<
     'sent' | 'received' | 'epochStatements' | null
-  >(null);
+  >(targetEpoch ? 'received' : null);
 
   return (
     <Flex column>
@@ -43,7 +48,11 @@ export const NotesSection = ({
         }}
       >
         <Flex column css={{ gap: '$sm' }}>
-          <Text variant="label" as="label">
+          <Text
+            variant="label"
+            as="label"
+            ref={ref as React.RefObject<HTMLLabelElement>}
+          >
             Your Notes
           </Text>
           <Box css={{ display: 'flex', gap: '$sm', mb: '$xs' }}>
@@ -132,7 +141,7 @@ export const NotesSection = ({
       )}
     </Flex>
   );
-};
+});
 
 type NotesProps = {
   tokenName: string;

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -89,6 +89,7 @@ const LoggedInRoutes = () => {
       {/* circle routes that are only for circle members */}
       <Route path="circles/:circleId" element={<CircleRouteHandler />}>
         <Route path="epochs" element={<HistoryPage />} />
+        <Route path="epochs/:epochId" element={<HistoryPage />} />
         <Route path="give" element={<GivePage />} />
         <Route path="contributions" element={<ContributionsPage />} />
         <Route path="members/add" element={<CircleAdminRouteHandler />}>


### PR DESCRIPTION
## What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a68f476</samp>

This pull request adds the ability to scroll to a specific epoch in the history page by using the URL parameter `epochId`. It also adds the `epoch_id` parameter to various email functions and templates to display the relevant epoch information to the recipients. It modifies the files `api-lib/postmark.ts`, `api-test/hasura/cron/epochs_emails_stubbed.test.ts`, `api/hasura/cron/epochs.ts`, `src/pages/HistoryPage/CurrentEpochPanel.tsx`, `src/pages/HistoryPage/EpochPanel.tsx`, `src/pages/HistoryPage/HistoryPage.tsx`, `src/pages/HistoryPage/Notes.tsx`, and `src/routes/routes.tsx` to implement these features.

## Why
We want to be able to add a link to the epoch notes in the email notification
if the epoch link is used app.coordinape.com/circles/[circleId]/epochs/[epochId] it will switch to the epoch page and scroll to the epoch then expand the notes

## How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a68f476</samp>

*  Add `epoch_id` parameter to email sending functions and pass it to Postmark API to populate email templates with epoch information ([link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-0ae55db9a83e75892b84b9d54fe9f1d61d500dadab7966eb9b161e8a92bc8954R84),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-0ae55db9a83e75892b84b9d54fe9f1d61d500dadab7966eb9b161e8a92bc8954R90),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-0ae55db9a83e75892b84b9d54fe9f1d61d500dadab7966eb9b161e8a92bc8954L101-R107),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-0ae55db9a83e75892b84b9d54fe9f1d61d500dadab7966eb9b161e8a92bc8954L114-R122),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-ac1f75a435bbaedbc21a6db941465f7d22fd4da453de64217474857c2be131a5R345),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-ac1f75a435bbaedbc21a6db941465f7d22fd4da453de64217474857c2be131a5R407),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-ac1f75a435bbaedbc21a6db941465f7d22fd4da453de64217474857c2be131a5R596),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-ac1f75a435bbaedbc21a6db941465f7d22fd4da453de64217474857c2be131a5R852),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-ac1f75a435bbaedbc21a6db941465f7d22fd4da453de64217474857c2be131a5R858),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-ac1f75a435bbaedbc21a6db941465f7d22fd4da453de64217474857c2be131a5R873),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-ac1f75a435bbaedbc21a6db941465f7d22fd4da453de64217474857c2be131a5R884),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-ac1f75a435bbaedbc21a6db941465f7d22fd4da453de64217474857c2be131a5R893))
*  Modify mock epoch ids and add `epoch_id` parameter to mock email sending functions and expected results in `api-test/hasura/cron/epochs_emails_stubbed.test.ts` to match actual functions and test email sending logic ([link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-e5a13fa0ec57b6e4622a89fdea5b914d5b18a0eb540c60318a3ababd4b31425bR50),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-e5a13fa0ec57b6e4622a89fdea5b914d5b18a0eb540c60318a3ababd4b31425bL55-R69),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-e5a13fa0ec57b6e4622a89fdea5b914d5b18a0eb540c60318a3ababd4b31425bL128-R137),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-e5a13fa0ec57b6e4622a89fdea5b914d5b18a0eb540c60318a3ababd4b31425bL136-R145),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-e5a13fa0ec57b6e4622a89fdea5b914d5b18a0eb540c60318a3ababd4b31425bR212),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-e5a13fa0ec57b6e4622a89fdea5b914d5b18a0eb540c60318a3ababd4b31425bR230),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-e5a13fa0ec57b6e4622a89fdea5b914d5b18a0eb540c60318a3ababd4b31425bR236),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-e5a13fa0ec57b6e4622a89fdea5b914d5b18a0eb540c60318a3ababd4b31425bR252),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-e5a13fa0ec57b6e4622a89fdea5b914d5b18a0eb540c60318a3ababd4b31425bR258))
*  Add `targetEpoch` prop and `targetEpochRef` variable to `CurrentEpochPanel` and `EpochPanel` components and use `useEffect` hook to scroll the target epoch panel into view if the prop is true ([link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-97df18eacb52adcf725974367a4b1007c27644225338253660b03fa66f0b15a4L1-R1),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-97df18eacb52adcf725974367a4b1007c27644225338253660b03fa66f0b15a4R41),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-97df18eacb52adcf725974367a4b1007c27644225338253660b03fa66f0b15a4L53-R56),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-97df18eacb52adcf725974367a4b1007c27644225338253660b03fa66f0b15a4R69-R74),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-e3d27b7ad7e6b16d694fc88c0523663c141c03f322914062c6db5cab9e160096R1-R2),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-e3d27b7ad7e6b16d694fc88c0523663c141c03f322914062c6db5cab9e160096R21),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-e3d27b7ad7e6b16d694fc88c0523663c141c03f322914062c6db5cab9e160096L25-R31),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-e3d27b7ad7e6b16d694fc88c0523663c141c03f322914062c6db5cab9e160096R43-R48))
*  Use `useParams` hook to get `epochId` parameter from URL and use `useMemo` hook to calculate `targetEpochPage` based on `pastEpochs` data and `epochId` in `HistoryPage` component ([link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-2cf00674fa58cba2a035c641f5f18d43d2e823d79c558fefbe79f01e1043478fR8),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-2cf00674fa58cba2a035c641f5f18d43d2e823d79c558fefbe79f01e1043478fR52-R53),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-2cf00674fa58cba2a035c641f5f18d43d2e823d79c558fefbe79f01e1043478fR93-R102))
*  Use `useEffect` hook to set `page` state to `targetEpochPage` value in `HistoryPage` component to show the correct page that contains the target epoch ([link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-2cf00674fa58cba2a035c641f5f18d43d2e823d79c558fefbe79f01e1043478fR131-R134))
*  Pass `targetEpoch` prop to `CurrentEpochPanel` and `EpochPanel` components in `HistoryPage` component and set it to true if the epoch id matches the `epochId` variable ([link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-2cf00674fa58cba2a035c641f5f18d43d2e823d79c558fefbe79f01e1043478fR375),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-2cf00674fa58cba2a035c641f5f18d43d2e823d79c558fefbe79f01e1043478fR410))
*  Wrap `NotesSection` component with `forwardRef` function and add `targetEpoch` prop and `ref` parameter to receive them from parent component and use them to set the default tab and the ref for the scrolling logic ([link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-ff5c26b2ff0ffb35226ecc2bc40296132c8d7af40ea9881945382d154e9e722dL2-R2),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-ff5c26b2ff0ffb35226ecc2bc40296132c8d7af40ea9881945382d154e9e722dL14-R29),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-ff5c26b2ff0ffb35226ecc2bc40296132c8d7af40ea9881945382d154e9e722dL33-R38),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-ff5c26b2ff0ffb35226ecc2bc40296132c8d7af40ea9881945382d154e9e722dL46-R55),[link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-ff5c26b2ff0ffb35226ecc2bc40296132c8d7af40ea9881945382d154e9e722dL135-R144))
*  Add a new route to `LoggedInRoutes` component to enable the user to access the history page with a specific epoch id in the URL ([link](https://github.com/coordinape/coordinape/pull/2353/files?diff=unified&w=0#diff-0005a5feea8701ddb5aef0d57e1a5a03c36dae6cd62fc3ecf35fd15a88bb5c03R87))