### PR TITLE
Cosoul explore

### DIFF
--- a/api-lib/gql/__generated__/zeus/const.ts
+++ b/api-lib/gql/__generated__/zeus/const.ts
@@ -2063,6 +2063,7 @@ export const AllTypesProps: Record<string, any> = {
     id: 'Int_comparison_exp',
     pgive: 'Int_comparison_exp',
     profile: 'profiles_bool_exp',
+    profile_public: 'profiles_public_bool_exp',
     synced_at: 'timestamptz_comparison_exp',
     token_id: 'Int_comparison_exp',
     updated_at: 'timestamptz_comparison_exp',
@@ -2074,6 +2075,7 @@ export const AllTypesProps: Record<string, any> = {
     checked_at: 'timestamptz',
     created_at: 'timestamptz',
     profile: 'profiles_obj_rel_insert_input',
+    profile_public: 'profiles_public_obj_rel_insert_input',
     synced_at: 'timestamptz',
     updated_at: 'timestamptz',
   },
@@ -2094,6 +2096,7 @@ export const AllTypesProps: Record<string, any> = {
     id: 'order_by',
     pgive: 'order_by',
     profile: 'profiles_order_by',
+    profile_public: 'profiles_public_order_by',
     synced_at: 'order_by',
     token_id: 'order_by',
     updated_at: 'order_by',
@@ -4530,6 +4533,9 @@ export const AllTypesProps: Record<string, any> = {
     delete_profiles_by_pk: {
       id: 'bigint',
     },
+    delete_profiles_public: {
+      where: 'profiles_public_bool_exp',
+    },
     delete_reactions: {
       where: 'reactions_bool_exp',
     },
@@ -4850,6 +4856,12 @@ export const AllTypesProps: Record<string, any> = {
     insert_profiles_one: {
       object: 'profiles_insert_input',
       on_conflict: 'profiles_on_conflict',
+    },
+    insert_profiles_public: {
+      objects: 'profiles_public_insert_input',
+    },
+    insert_profiles_public_one: {
+      object: 'profiles_public_insert_input',
     },
     insert_reactions: {
       objects: 'reactions_insert_input',
@@ -5423,6 +5435,14 @@ export const AllTypesProps: Record<string, any> = {
     },
     update_profiles_many: {
       updates: 'profiles_updates',
+    },
+    update_profiles_public: {
+      _inc: 'profiles_public_inc_input',
+      _set: 'profiles_public_set_input',
+      where: 'profiles_public_bool_exp',
+    },
+    update_profiles_public_many: {
+      updates: 'profiles_public_updates',
     },
     update_reactions: {
       _inc: 'reactions_inc_input',
@@ -6842,6 +6862,54 @@ export const AllTypesProps: Record<string, any> = {
   profiles_pk_columns_input: {
     id: 'bigint',
   },
+  profiles_public_aggregate_fields: {
+    count: {
+      columns: 'profiles_public_select_column',
+    },
+  },
+  profiles_public_bool_exp: {
+    _and: 'profiles_public_bool_exp',
+    _not: 'profiles_public_bool_exp',
+    _or: 'profiles_public_bool_exp',
+    address: 'String_comparison_exp',
+    avatar: 'String_comparison_exp',
+    id: 'bigint_comparison_exp',
+    name: 'citext_comparison_exp',
+  },
+  profiles_public_inc_input: {
+    id: 'bigint',
+  },
+  profiles_public_insert_input: {
+    id: 'bigint',
+    name: 'citext',
+  },
+  profiles_public_obj_rel_insert_input: {
+    data: 'profiles_public_insert_input',
+  },
+  profiles_public_order_by: {
+    address: 'order_by',
+    avatar: 'order_by',
+    id: 'order_by',
+    name: 'order_by',
+  },
+  profiles_public_select_column: true,
+  profiles_public_set_input: {
+    id: 'bigint',
+    name: 'citext',
+  },
+  profiles_public_stream_cursor_input: {
+    initial_value: 'profiles_public_stream_cursor_value_input',
+    ordering: 'cursor_ordering',
+  },
+  profiles_public_stream_cursor_value_input: {
+    id: 'bigint',
+    name: 'citext',
+  },
+  profiles_public_updates: {
+    _inc: 'profiles_public_inc_input',
+    _set: 'profiles_public_set_input',
+    where: 'profiles_public_bool_exp',
+  },
   profiles_select_column: true,
   profiles_set_input: {
     created_at: 'timestamp',
@@ -7322,6 +7390,16 @@ export const AllTypesProps: Record<string, any> = {
     },
     profiles_by_pk: {
       id: 'bigint',
+    },
+    profiles_public: {
+      distinct_on: 'profiles_public_select_column',
+      order_by: 'profiles_public_order_by',
+      where: 'profiles_public_bool_exp',
+    },
+    profiles_public_aggregate: {
+      distinct_on: 'profiles_public_select_column',
+      order_by: 'profiles_public_order_by',
+      where: 'profiles_public_bool_exp',
     },
     reactions: {
       distinct_on: 'reactions_select_column',
@@ -8180,6 +8258,20 @@ export const AllTypesProps: Record<string, any> = {
     },
     profiles_by_pk: {
       id: 'bigint',
+    },
+    profiles_public: {
+      distinct_on: 'profiles_public_select_column',
+      order_by: 'profiles_public_order_by',
+      where: 'profiles_public_bool_exp',
+    },
+    profiles_public_aggregate: {
+      distinct_on: 'profiles_public_select_column',
+      order_by: 'profiles_public_order_by',
+      where: 'profiles_public_bool_exp',
+    },
+    profiles_public_stream: {
+      cursor: 'profiles_public_stream_cursor_input',
+      where: 'profiles_public_bool_exp',
     },
     profiles_stream: {
       cursor: 'profiles_stream_cursor_input',
@@ -11115,6 +11207,7 @@ export const ReturnTypes: Record<string, any> = {
     id: 'Int',
     pgive: 'Int',
     profile: 'profiles',
+    profile_public: 'profiles_public',
     synced_at: 'timestamptz',
     token_id: 'Int',
     updated_at: 'timestamptz',
@@ -12874,6 +12967,7 @@ export const ReturnTypes: Record<string, any> = {
     delete_personal_access_tokens_by_pk: 'personal_access_tokens',
     delete_profiles: 'profiles_mutation_response',
     delete_profiles_by_pk: 'profiles',
+    delete_profiles_public: 'profiles_public_mutation_response',
     delete_reactions: 'reactions_mutation_response',
     delete_reactions_by_pk: 'reactions',
     delete_teammates: 'teammates_mutation_response',
@@ -12966,6 +13060,8 @@ export const ReturnTypes: Record<string, any> = {
     insert_personal_access_tokens_one: 'personal_access_tokens',
     insert_profiles: 'profiles_mutation_response',
     insert_profiles_one: 'profiles',
+    insert_profiles_public: 'profiles_public_mutation_response',
+    insert_profiles_public_one: 'profiles_public',
     insert_reactions: 'reactions_mutation_response',
     insert_reactions_one: 'reactions',
     insert_teammates: 'teammates_mutation_response',
@@ -13108,6 +13204,8 @@ export const ReturnTypes: Record<string, any> = {
     update_profiles: 'profiles_mutation_response',
     update_profiles_by_pk: 'profiles',
     update_profiles_many: 'profiles_mutation_response',
+    update_profiles_public: 'profiles_public_mutation_response',
+    update_profiles_public_many: 'profiles_public_mutation_response',
     update_reactions: 'reactions_mutation_response',
     update_reactions_by_pk: 'reactions',
     update_reactions_many: 'reactions_mutation_response',
@@ -14123,6 +14221,69 @@ export const ReturnTypes: Record<string, any> = {
     affected_rows: 'Int',
     returning: 'profiles',
   },
+  profiles_public: {
+    address: 'String',
+    avatar: 'String',
+    id: 'bigint',
+    name: 'citext',
+  },
+  profiles_public_aggregate: {
+    aggregate: 'profiles_public_aggregate_fields',
+    nodes: 'profiles_public',
+  },
+  profiles_public_aggregate_fields: {
+    avg: 'profiles_public_avg_fields',
+    count: 'Int',
+    max: 'profiles_public_max_fields',
+    min: 'profiles_public_min_fields',
+    stddev: 'profiles_public_stddev_fields',
+    stddev_pop: 'profiles_public_stddev_pop_fields',
+    stddev_samp: 'profiles_public_stddev_samp_fields',
+    sum: 'profiles_public_sum_fields',
+    var_pop: 'profiles_public_var_pop_fields',
+    var_samp: 'profiles_public_var_samp_fields',
+    variance: 'profiles_public_variance_fields',
+  },
+  profiles_public_avg_fields: {
+    id: 'Float',
+  },
+  profiles_public_max_fields: {
+    address: 'String',
+    avatar: 'String',
+    id: 'bigint',
+    name: 'citext',
+  },
+  profiles_public_min_fields: {
+    address: 'String',
+    avatar: 'String',
+    id: 'bigint',
+    name: 'citext',
+  },
+  profiles_public_mutation_response: {
+    affected_rows: 'Int',
+    returning: 'profiles_public',
+  },
+  profiles_public_stddev_fields: {
+    id: 'Float',
+  },
+  profiles_public_stddev_pop_fields: {
+    id: 'Float',
+  },
+  profiles_public_stddev_samp_fields: {
+    id: 'Float',
+  },
+  profiles_public_sum_fields: {
+    id: 'bigint',
+  },
+  profiles_public_var_pop_fields: {
+    id: 'Float',
+  },
+  profiles_public_var_samp_fields: {
+    id: 'Float',
+  },
+  profiles_public_variance_fields: {
+    id: 'Float',
+  },
   profiles_stddev_fields: {
     id: 'Float',
   },
@@ -14255,6 +14416,8 @@ export const ReturnTypes: Record<string, any> = {
     profiles: 'profiles',
     profiles_aggregate: 'profiles_aggregate',
     profiles_by_pk: 'profiles',
+    profiles_public: 'profiles_public',
+    profiles_public_aggregate: 'profiles_public_aggregate',
     reactions: 'reactions',
     reactions_aggregate: 'reactions_aggregate',
     reactions_by_pk: 'reactions',
@@ -14514,6 +14677,9 @@ export const ReturnTypes: Record<string, any> = {
     profiles: 'profiles',
     profiles_aggregate: 'profiles_aggregate',
     profiles_by_pk: 'profiles',
+    profiles_public: 'profiles_public',
+    profiles_public_aggregate: 'profiles_public_aggregate',
+    profiles_public_stream: 'profiles_public',
     profiles_stream: 'profiles',
     reactions: 'reactions',
     reactions_aggregate: 'reactions_aggregate',

--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -5797,6 +5797,8 @@ export type ValueTypes = {
     pgive?: boolean | `@${string}`;
     /** An object relationship */
     profile?: ValueTypes['profiles'];
+    /** An object relationship */
+    profile_public?: ValueTypes['profiles_public'];
     synced_at?: boolean | `@${string}`;
     token_id?: boolean | `@${string}`;
     updated_at?: boolean | `@${string}`;
@@ -5848,6 +5850,7 @@ export type ValueTypes = {
     id?: ValueTypes['Int_comparison_exp'] | undefined | null;
     pgive?: ValueTypes['Int_comparison_exp'] | undefined | null;
     profile?: ValueTypes['profiles_bool_exp'] | undefined | null;
+    profile_public?: ValueTypes['profiles_public_bool_exp'] | undefined | null;
     synced_at?: ValueTypes['timestamptz_comparison_exp'] | undefined | null;
     token_id?: ValueTypes['Int_comparison_exp'] | undefined | null;
     updated_at?: ValueTypes['timestamptz_comparison_exp'] | undefined | null;
@@ -5869,6 +5872,10 @@ export type ValueTypes = {
     id?: number | undefined | null;
     pgive?: number | undefined | null;
     profile?: ValueTypes['profiles_obj_rel_insert_input'] | undefined | null;
+    profile_public?:
+      | ValueTypes['profiles_public_obj_rel_insert_input']
+      | undefined
+      | null;
     synced_at?: ValueTypes['timestamptz'] | undefined | null;
     token_id?: number | undefined | null;
     updated_at?: ValueTypes['timestamptz'] | undefined | null;
@@ -5928,6 +5935,7 @@ export type ValueTypes = {
     id?: ValueTypes['order_by'] | undefined | null;
     pgive?: ValueTypes['order_by'] | undefined | null;
     profile?: ValueTypes['profiles_order_by'] | undefined | null;
+    profile_public?: ValueTypes['profiles_public_order_by'] | undefined | null;
     synced_at?: ValueTypes['order_by'] | undefined | null;
     token_id?: ValueTypes['order_by'] | undefined | null;
     updated_at?: ValueTypes['order_by'] | undefined | null;
@@ -12049,6 +12057,13 @@ export type ValueTypes = {
       { id: ValueTypes['bigint'] },
       ValueTypes['profiles']
     ];
+    delete_profiles_public?: [
+      {
+        /** filter the rows which have to be deleted */
+        where: ValueTypes['profiles_public_bool_exp'];
+      },
+      ValueTypes['profiles_public_mutation_response']
+    ];
     delete_reactions?: [
       {
         /** filter the rows which have to be deleted */
@@ -12862,6 +12877,20 @@ export type ValueTypes = {
         on_conflict?: ValueTypes['profiles_on_conflict'] | undefined | null;
       },
       ValueTypes['profiles']
+    ];
+    insert_profiles_public?: [
+      {
+        /** the rows to be inserted */
+        objects: Array<ValueTypes['profiles_public_insert_input']>;
+      },
+      ValueTypes['profiles_public_mutation_response']
+    ];
+    insert_profiles_public_one?: [
+      {
+        /** the row to be inserted */
+        object: ValueTypes['profiles_public_insert_input'];
+      },
+      ValueTypes['profiles_public']
     ];
     insert_reactions?: [
       {
@@ -14373,6 +14402,28 @@ export type ValueTypes = {
         updates: Array<ValueTypes['profiles_updates']>;
       },
       ValueTypes['profiles_mutation_response']
+    ];
+    update_profiles_public?: [
+      {
+        /** increments the numeric columns with given value of the filtered values */
+        _inc?:
+          | ValueTypes['profiles_public_inc_input']
+          | undefined
+          | null /** sets the columns of the filtered rows to the given values */;
+        _set?:
+          | ValueTypes['profiles_public_set_input']
+          | undefined
+          | null /** filter the rows which have to be updated */;
+        where: ValueTypes['profiles_public_bool_exp'];
+      },
+      ValueTypes['profiles_public_mutation_response']
+    ];
+    update_profiles_public_many?: [
+      {
+        /** updates to execute, in order */
+        updates: Array<ValueTypes['profiles_public_updates']>;
+      },
+      ValueTypes['profiles_public_mutation_response']
     ];
     update_reactions?: [
       {
@@ -18198,6 +18249,171 @@ export type ValueTypes = {
   ['profiles_pk_columns_input']: {
     id: ValueTypes['bigint'];
   };
+  /** columns and relationships of "profiles_public" */
+  ['profiles_public']: AliasType<{
+    address?: boolean | `@${string}`;
+    avatar?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    name?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregated selection of "profiles_public" */
+  ['profiles_public_aggregate']: AliasType<{
+    aggregate?: ValueTypes['profiles_public_aggregate_fields'];
+    nodes?: ValueTypes['profiles_public'];
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate fields of "profiles_public" */
+  ['profiles_public_aggregate_fields']: AliasType<{
+    avg?: ValueTypes['profiles_public_avg_fields'];
+    count?: [
+      {
+        columns?:
+          | Array<ValueTypes['profiles_public_select_column']>
+          | undefined
+          | null;
+        distinct?: boolean | undefined | null;
+      },
+      boolean | `@${string}`
+    ];
+    max?: ValueTypes['profiles_public_max_fields'];
+    min?: ValueTypes['profiles_public_min_fields'];
+    stddev?: ValueTypes['profiles_public_stddev_fields'];
+    stddev_pop?: ValueTypes['profiles_public_stddev_pop_fields'];
+    stddev_samp?: ValueTypes['profiles_public_stddev_samp_fields'];
+    sum?: ValueTypes['profiles_public_sum_fields'];
+    var_pop?: ValueTypes['profiles_public_var_pop_fields'];
+    var_samp?: ValueTypes['profiles_public_var_samp_fields'];
+    variance?: ValueTypes['profiles_public_variance_fields'];
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate avg on columns */
+  ['profiles_public_avg_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** Boolean expression to filter rows from the table "profiles_public". All fields are combined with a logical 'AND'. */
+  ['profiles_public_bool_exp']: {
+    _and?: Array<ValueTypes['profiles_public_bool_exp']> | undefined | null;
+    _not?: ValueTypes['profiles_public_bool_exp'] | undefined | null;
+    _or?: Array<ValueTypes['profiles_public_bool_exp']> | undefined | null;
+    address?: ValueTypes['String_comparison_exp'] | undefined | null;
+    avatar?: ValueTypes['String_comparison_exp'] | undefined | null;
+    id?: ValueTypes['bigint_comparison_exp'] | undefined | null;
+    name?: ValueTypes['citext_comparison_exp'] | undefined | null;
+  };
+  /** input type for incrementing numeric columns in table "profiles_public" */
+  ['profiles_public_inc_input']: {
+    id?: ValueTypes['bigint'] | undefined | null;
+  };
+  /** input type for inserting data into table "profiles_public" */
+  ['profiles_public_insert_input']: {
+    address?: string | undefined | null;
+    avatar?: string | undefined | null;
+    id?: ValueTypes['bigint'] | undefined | null;
+    name?: ValueTypes['citext'] | undefined | null;
+  };
+  /** aggregate max on columns */
+  ['profiles_public_max_fields']: AliasType<{
+    address?: boolean | `@${string}`;
+    avatar?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    name?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate min on columns */
+  ['profiles_public_min_fields']: AliasType<{
+    address?: boolean | `@${string}`;
+    avatar?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    name?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** response of any mutation on the table "profiles_public" */
+  ['profiles_public_mutation_response']: AliasType<{
+    /** number of rows affected by the mutation */
+    affected_rows?: boolean | `@${string}`;
+    /** data from the rows affected by the mutation */
+    returning?: ValueTypes['profiles_public'];
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** input type for inserting object relation for remote table "profiles_public" */
+  ['profiles_public_obj_rel_insert_input']: {
+    data: ValueTypes['profiles_public_insert_input'];
+  };
+  /** Ordering options when selecting data from "profiles_public". */
+  ['profiles_public_order_by']: {
+    address?: ValueTypes['order_by'] | undefined | null;
+    avatar?: ValueTypes['order_by'] | undefined | null;
+    id?: ValueTypes['order_by'] | undefined | null;
+    name?: ValueTypes['order_by'] | undefined | null;
+  };
+  /** select columns of table "profiles_public" */
+  ['profiles_public_select_column']: profiles_public_select_column;
+  /** input type for updating data in table "profiles_public" */
+  ['profiles_public_set_input']: {
+    address?: string | undefined | null;
+    avatar?: string | undefined | null;
+    id?: ValueTypes['bigint'] | undefined | null;
+    name?: ValueTypes['citext'] | undefined | null;
+  };
+  /** aggregate stddev on columns */
+  ['profiles_public_stddev_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate stddev_pop on columns */
+  ['profiles_public_stddev_pop_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate stddev_samp on columns */
+  ['profiles_public_stddev_samp_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** Streaming cursor of the table "profiles_public" */
+  ['profiles_public_stream_cursor_input']: {
+    /** Stream column input with initial value */
+    initial_value: ValueTypes['profiles_public_stream_cursor_value_input'];
+    /** cursor ordering */
+    ordering?: ValueTypes['cursor_ordering'] | undefined | null;
+  };
+  /** Initial value of the column from where the streaming should start */
+  ['profiles_public_stream_cursor_value_input']: {
+    address?: string | undefined | null;
+    avatar?: string | undefined | null;
+    id?: ValueTypes['bigint'] | undefined | null;
+    name?: ValueTypes['citext'] | undefined | null;
+  };
+  /** aggregate sum on columns */
+  ['profiles_public_sum_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  ['profiles_public_updates']: {
+    /** increments the numeric columns with given value of the filtered values */
+    _inc?: ValueTypes['profiles_public_inc_input'] | undefined | null;
+    /** sets the columns of the filtered rows to the given values */
+    _set?: ValueTypes['profiles_public_set_input'] | undefined | null;
+    /** filter the rows which have to be updated */
+    where: ValueTypes['profiles_public_bool_exp'];
+  };
+  /** aggregate var_pop on columns */
+  ['profiles_public_var_pop_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate var_samp on columns */
+  ['profiles_public_var_samp_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate variance on columns */
+  ['profiles_public_variance_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
   /** select columns of table "profiles" */
   ['profiles_select_column']: profiles_select_column;
   /** input type for updating data in table "profiles" */
@@ -20136,6 +20352,52 @@ export type ValueTypes = {
       ValueTypes['profiles_aggregate']
     ];
     profiles_by_pk?: [{ id: ValueTypes['bigint'] }, ValueTypes['profiles']];
+    profiles_public?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['profiles_public_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['profiles_public_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ValueTypes['profiles_public_bool_exp'] | undefined | null;
+      },
+      ValueTypes['profiles_public']
+    ];
+    profiles_public_aggregate?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['profiles_public_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['profiles_public_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ValueTypes['profiles_public_bool_exp'] | undefined | null;
+      },
+      ValueTypes['profiles_public_aggregate']
+    ];
     reactions?: [
       {
         /** distinct select on columns */
@@ -23157,6 +23419,63 @@ export type ValueTypes = {
       ValueTypes['profiles_aggregate']
     ];
     profiles_by_pk?: [{ id: ValueTypes['bigint'] }, ValueTypes['profiles']];
+    profiles_public?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['profiles_public_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['profiles_public_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ValueTypes['profiles_public_bool_exp'] | undefined | null;
+      },
+      ValueTypes['profiles_public']
+    ];
+    profiles_public_aggregate?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['profiles_public_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['profiles_public_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ValueTypes['profiles_public_bool_exp'] | undefined | null;
+      },
+      ValueTypes['profiles_public_aggregate']
+    ];
+    profiles_public_stream?: [
+      {
+        /** maximum number of rows returned in a single batch */
+        batch_size: number /** cursor to stream the results returned by the query */;
+        cursor: Array<
+          ValueTypes['profiles_public_stream_cursor_input'] | undefined | null
+        > /** filter the rows returned */;
+        where?: ValueTypes['profiles_public_bool_exp'] | undefined | null;
+      },
+      ValueTypes['profiles_public']
+    ];
     profiles_stream?: [
       {
         /** maximum number of rows returned in a single batch */
@@ -29308,6 +29627,8 @@ export type ModelTypes = {
     pgive?: number | undefined;
     /** An object relationship */
     profile?: GraphQLTypes['profiles'] | undefined;
+    /** An object relationship */
+    profile_public?: GraphQLTypes['profiles_public'] | undefined;
     synced_at?: GraphQLTypes['timestamptz'] | undefined;
     token_id: number;
     updated_at: GraphQLTypes['timestamptz'];
@@ -32242,6 +32563,10 @@ export type ModelTypes = {
     delete_profiles?: GraphQLTypes['profiles_mutation_response'] | undefined;
     /** delete single row from the table: "profiles" */
     delete_profiles_by_pk?: GraphQLTypes['profiles'] | undefined;
+    /** delete data from the table: "profiles_public" */
+    delete_profiles_public?:
+      | GraphQLTypes['profiles_public_mutation_response']
+      | undefined;
     /** delete data from the table: "reactions" */
     delete_reactions?: GraphQLTypes['reactions_mutation_response'] | undefined;
     /** delete single row from the table: "reactions" */
@@ -32499,6 +32824,12 @@ export type ModelTypes = {
     insert_profiles?: GraphQLTypes['profiles_mutation_response'] | undefined;
     /** insert a single row into the table: "profiles" */
     insert_profiles_one?: GraphQLTypes['profiles'] | undefined;
+    /** insert data into the table: "profiles_public" */
+    insert_profiles_public?:
+      | GraphQLTypes['profiles_public_mutation_response']
+      | undefined;
+    /** insert a single row into the table: "profiles_public" */
+    insert_profiles_public_one?: GraphQLTypes['profiles_public'] | undefined;
     /** insert data into the table: "reactions" */
     insert_reactions?: GraphQLTypes['reactions_mutation_response'] | undefined;
     /** insert a single row into the table: "reactions" */
@@ -32923,6 +33254,14 @@ export type ModelTypes = {
     /** update multiples rows of table: "profiles" */
     update_profiles_many?:
       | Array<GraphQLTypes['profiles_mutation_response'] | undefined>
+      | undefined;
+    /** update data of the table: "profiles_public" */
+    update_profiles_public?:
+      | GraphQLTypes['profiles_public_mutation_response']
+      | undefined;
+    /** update multiples rows of table: "profiles_public" */
+    update_profiles_public_many?:
+      | Array<GraphQLTypes['profiles_public_mutation_response'] | undefined>
       | undefined;
     /** update data of the table: "reactions" */
     update_reactions?: GraphQLTypes['reactions_mutation_response'] | undefined;
@@ -34541,6 +34880,106 @@ export type ModelTypes = {
   ['profiles_order_by']: GraphQLTypes['profiles_order_by'];
   /** primary key columns input for table: profiles */
   ['profiles_pk_columns_input']: GraphQLTypes['profiles_pk_columns_input'];
+  /** columns and relationships of "profiles_public" */
+  ['profiles_public']: {
+    address?: string | undefined;
+    avatar?: string | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    name?: GraphQLTypes['citext'] | undefined;
+  };
+  /** aggregated selection of "profiles_public" */
+  ['profiles_public_aggregate']: {
+    aggregate?: GraphQLTypes['profiles_public_aggregate_fields'] | undefined;
+    nodes: Array<GraphQLTypes['profiles_public']>;
+  };
+  /** aggregate fields of "profiles_public" */
+  ['profiles_public_aggregate_fields']: {
+    avg?: GraphQLTypes['profiles_public_avg_fields'] | undefined;
+    count: number;
+    max?: GraphQLTypes['profiles_public_max_fields'] | undefined;
+    min?: GraphQLTypes['profiles_public_min_fields'] | undefined;
+    stddev?: GraphQLTypes['profiles_public_stddev_fields'] | undefined;
+    stddev_pop?: GraphQLTypes['profiles_public_stddev_pop_fields'] | undefined;
+    stddev_samp?:
+      | GraphQLTypes['profiles_public_stddev_samp_fields']
+      | undefined;
+    sum?: GraphQLTypes['profiles_public_sum_fields'] | undefined;
+    var_pop?: GraphQLTypes['profiles_public_var_pop_fields'] | undefined;
+    var_samp?: GraphQLTypes['profiles_public_var_samp_fields'] | undefined;
+    variance?: GraphQLTypes['profiles_public_variance_fields'] | undefined;
+  };
+  /** aggregate avg on columns */
+  ['profiles_public_avg_fields']: {
+    id?: number | undefined;
+  };
+  /** Boolean expression to filter rows from the table "profiles_public". All fields are combined with a logical 'AND'. */
+  ['profiles_public_bool_exp']: GraphQLTypes['profiles_public_bool_exp'];
+  /** input type for incrementing numeric columns in table "profiles_public" */
+  ['profiles_public_inc_input']: GraphQLTypes['profiles_public_inc_input'];
+  /** input type for inserting data into table "profiles_public" */
+  ['profiles_public_insert_input']: GraphQLTypes['profiles_public_insert_input'];
+  /** aggregate max on columns */
+  ['profiles_public_max_fields']: {
+    address?: string | undefined;
+    avatar?: string | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    name?: GraphQLTypes['citext'] | undefined;
+  };
+  /** aggregate min on columns */
+  ['profiles_public_min_fields']: {
+    address?: string | undefined;
+    avatar?: string | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    name?: GraphQLTypes['citext'] | undefined;
+  };
+  /** response of any mutation on the table "profiles_public" */
+  ['profiles_public_mutation_response']: {
+    /** number of rows affected by the mutation */
+    affected_rows: number;
+    /** data from the rows affected by the mutation */
+    returning: Array<GraphQLTypes['profiles_public']>;
+  };
+  /** input type for inserting object relation for remote table "profiles_public" */
+  ['profiles_public_obj_rel_insert_input']: GraphQLTypes['profiles_public_obj_rel_insert_input'];
+  /** Ordering options when selecting data from "profiles_public". */
+  ['profiles_public_order_by']: GraphQLTypes['profiles_public_order_by'];
+  /** select columns of table "profiles_public" */
+  ['profiles_public_select_column']: GraphQLTypes['profiles_public_select_column'];
+  /** input type for updating data in table "profiles_public" */
+  ['profiles_public_set_input']: GraphQLTypes['profiles_public_set_input'];
+  /** aggregate stddev on columns */
+  ['profiles_public_stddev_fields']: {
+    id?: number | undefined;
+  };
+  /** aggregate stddev_pop on columns */
+  ['profiles_public_stddev_pop_fields']: {
+    id?: number | undefined;
+  };
+  /** aggregate stddev_samp on columns */
+  ['profiles_public_stddev_samp_fields']: {
+    id?: number | undefined;
+  };
+  /** Streaming cursor of the table "profiles_public" */
+  ['profiles_public_stream_cursor_input']: GraphQLTypes['profiles_public_stream_cursor_input'];
+  /** Initial value of the column from where the streaming should start */
+  ['profiles_public_stream_cursor_value_input']: GraphQLTypes['profiles_public_stream_cursor_value_input'];
+  /** aggregate sum on columns */
+  ['profiles_public_sum_fields']: {
+    id?: GraphQLTypes['bigint'] | undefined;
+  };
+  ['profiles_public_updates']: GraphQLTypes['profiles_public_updates'];
+  /** aggregate var_pop on columns */
+  ['profiles_public_var_pop_fields']: {
+    id?: number | undefined;
+  };
+  /** aggregate var_samp on columns */
+  ['profiles_public_var_samp_fields']: {
+    id?: number | undefined;
+  };
+  /** aggregate variance on columns */
+  ['profiles_public_variance_fields']: {
+    id?: number | undefined;
+  };
   /** select columns of table "profiles" */
   ['profiles_select_column']: GraphQLTypes['profiles_select_column'];
   /** input type for updating data in table "profiles" */
@@ -34813,6 +35252,10 @@ export type ModelTypes = {
     profiles_aggregate: GraphQLTypes['profiles_aggregate'];
     /** fetch data from the table: "profiles" using primary key columns */
     profiles_by_pk?: GraphQLTypes['profiles'] | undefined;
+    /** fetch data from the table: "profiles_public" */
+    profiles_public: Array<GraphQLTypes['profiles_public']>;
+    /** fetch aggregated fields from the table: "profiles_public" */
+    profiles_public_aggregate: GraphQLTypes['profiles_public_aggregate'];
     /** An array relationship */
     reactions: Array<GraphQLTypes['reactions']>;
     /** An aggregate relationship */
@@ -35337,6 +35780,12 @@ export type ModelTypes = {
     profiles_aggregate: GraphQLTypes['profiles_aggregate'];
     /** fetch data from the table: "profiles" using primary key columns */
     profiles_by_pk?: GraphQLTypes['profiles'] | undefined;
+    /** fetch data from the table: "profiles_public" */
+    profiles_public: Array<GraphQLTypes['profiles_public']>;
+    /** fetch aggregated fields from the table: "profiles_public" */
+    profiles_public_aggregate: GraphQLTypes['profiles_public_aggregate'];
+    /** fetch data from the table in a streaming manner: "profiles_public" */
+    profiles_public_stream: Array<GraphQLTypes['profiles_public']>;
     /** fetch data from the table in a streaming manner: "profiles" */
     profiles_stream: Array<GraphQLTypes['profiles']>;
     /** An array relationship */
@@ -41151,6 +41600,8 @@ export type GraphQLTypes = {
     pgive?: number | undefined;
     /** An object relationship */
     profile?: GraphQLTypes['profiles'] | undefined;
+    /** An object relationship */
+    profile_public?: GraphQLTypes['profiles_public'] | undefined;
     synced_at?: GraphQLTypes['timestamptz'] | undefined;
     token_id: number;
     updated_at: GraphQLTypes['timestamptz'];
@@ -41195,6 +41646,7 @@ export type GraphQLTypes = {
     id?: GraphQLTypes['Int_comparison_exp'] | undefined;
     pgive?: GraphQLTypes['Int_comparison_exp'] | undefined;
     profile?: GraphQLTypes['profiles_bool_exp'] | undefined;
+    profile_public?: GraphQLTypes['profiles_public_bool_exp'] | undefined;
     synced_at?: GraphQLTypes['timestamptz_comparison_exp'] | undefined;
     token_id?: GraphQLTypes['Int_comparison_exp'] | undefined;
     updated_at?: GraphQLTypes['timestamptz_comparison_exp'] | undefined;
@@ -41216,6 +41668,9 @@ export type GraphQLTypes = {
     id?: number | undefined;
     pgive?: number | undefined;
     profile?: GraphQLTypes['profiles_obj_rel_insert_input'] | undefined;
+    profile_public?:
+      | GraphQLTypes['profiles_public_obj_rel_insert_input']
+      | undefined;
     synced_at?: GraphQLTypes['timestamptz'] | undefined;
     token_id?: number | undefined;
     updated_at?: GraphQLTypes['timestamptz'] | undefined;
@@ -41275,6 +41730,7 @@ export type GraphQLTypes = {
     id?: GraphQLTypes['order_by'] | undefined;
     pgive?: GraphQLTypes['order_by'] | undefined;
     profile?: GraphQLTypes['profiles_order_by'] | undefined;
+    profile_public?: GraphQLTypes['profiles_public_order_by'] | undefined;
     synced_at?: GraphQLTypes['order_by'] | undefined;
     token_id?: GraphQLTypes['order_by'] | undefined;
     updated_at?: GraphQLTypes['order_by'] | undefined;
@@ -46519,6 +46975,10 @@ export type GraphQLTypes = {
     delete_profiles?: GraphQLTypes['profiles_mutation_response'] | undefined;
     /** delete single row from the table: "profiles" */
     delete_profiles_by_pk?: GraphQLTypes['profiles'] | undefined;
+    /** delete data from the table: "profiles_public" */
+    delete_profiles_public?:
+      | GraphQLTypes['profiles_public_mutation_response']
+      | undefined;
     /** delete data from the table: "reactions" */
     delete_reactions?: GraphQLTypes['reactions_mutation_response'] | undefined;
     /** delete single row from the table: "reactions" */
@@ -46776,6 +47236,12 @@ export type GraphQLTypes = {
     insert_profiles?: GraphQLTypes['profiles_mutation_response'] | undefined;
     /** insert a single row into the table: "profiles" */
     insert_profiles_one?: GraphQLTypes['profiles'] | undefined;
+    /** insert data into the table: "profiles_public" */
+    insert_profiles_public?:
+      | GraphQLTypes['profiles_public_mutation_response']
+      | undefined;
+    /** insert a single row into the table: "profiles_public" */
+    insert_profiles_public_one?: GraphQLTypes['profiles_public'] | undefined;
     /** insert data into the table: "reactions" */
     insert_reactions?: GraphQLTypes['reactions_mutation_response'] | undefined;
     /** insert a single row into the table: "reactions" */
@@ -47200,6 +47666,14 @@ export type GraphQLTypes = {
     /** update multiples rows of table: "profiles" */
     update_profiles_many?:
       | Array<GraphQLTypes['profiles_mutation_response'] | undefined>
+      | undefined;
+    /** update data of the table: "profiles_public" */
+    update_profiles_public?:
+      | GraphQLTypes['profiles_public_mutation_response']
+      | undefined;
+    /** update multiples rows of table: "profiles_public" */
+    update_profiles_public_many?:
+      | Array<GraphQLTypes['profiles_public_mutation_response'] | undefined>
       | undefined;
     /** update data of the table: "reactions" */
     update_reactions?: GraphQLTypes['reactions_mutation_response'] | undefined;
@@ -50143,6 +50617,164 @@ export type GraphQLTypes = {
   ['profiles_pk_columns_input']: {
     id: GraphQLTypes['bigint'];
   };
+  /** columns and relationships of "profiles_public" */
+  ['profiles_public']: {
+    __typename: 'profiles_public';
+    address?: string | undefined;
+    avatar?: string | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    name?: GraphQLTypes['citext'] | undefined;
+  };
+  /** aggregated selection of "profiles_public" */
+  ['profiles_public_aggregate']: {
+    __typename: 'profiles_public_aggregate';
+    aggregate?: GraphQLTypes['profiles_public_aggregate_fields'] | undefined;
+    nodes: Array<GraphQLTypes['profiles_public']>;
+  };
+  /** aggregate fields of "profiles_public" */
+  ['profiles_public_aggregate_fields']: {
+    __typename: 'profiles_public_aggregate_fields';
+    avg?: GraphQLTypes['profiles_public_avg_fields'] | undefined;
+    count: number;
+    max?: GraphQLTypes['profiles_public_max_fields'] | undefined;
+    min?: GraphQLTypes['profiles_public_min_fields'] | undefined;
+    stddev?: GraphQLTypes['profiles_public_stddev_fields'] | undefined;
+    stddev_pop?: GraphQLTypes['profiles_public_stddev_pop_fields'] | undefined;
+    stddev_samp?:
+      | GraphQLTypes['profiles_public_stddev_samp_fields']
+      | undefined;
+    sum?: GraphQLTypes['profiles_public_sum_fields'] | undefined;
+    var_pop?: GraphQLTypes['profiles_public_var_pop_fields'] | undefined;
+    var_samp?: GraphQLTypes['profiles_public_var_samp_fields'] | undefined;
+    variance?: GraphQLTypes['profiles_public_variance_fields'] | undefined;
+  };
+  /** aggregate avg on columns */
+  ['profiles_public_avg_fields']: {
+    __typename: 'profiles_public_avg_fields';
+    id?: number | undefined;
+  };
+  /** Boolean expression to filter rows from the table "profiles_public". All fields are combined with a logical 'AND'. */
+  ['profiles_public_bool_exp']: {
+    _and?: Array<GraphQLTypes['profiles_public_bool_exp']> | undefined;
+    _not?: GraphQLTypes['profiles_public_bool_exp'] | undefined;
+    _or?: Array<GraphQLTypes['profiles_public_bool_exp']> | undefined;
+    address?: GraphQLTypes['String_comparison_exp'] | undefined;
+    avatar?: GraphQLTypes['String_comparison_exp'] | undefined;
+    id?: GraphQLTypes['bigint_comparison_exp'] | undefined;
+    name?: GraphQLTypes['citext_comparison_exp'] | undefined;
+  };
+  /** input type for incrementing numeric columns in table "profiles_public" */
+  ['profiles_public_inc_input']: {
+    id?: GraphQLTypes['bigint'] | undefined;
+  };
+  /** input type for inserting data into table "profiles_public" */
+  ['profiles_public_insert_input']: {
+    address?: string | undefined;
+    avatar?: string | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    name?: GraphQLTypes['citext'] | undefined;
+  };
+  /** aggregate max on columns */
+  ['profiles_public_max_fields']: {
+    __typename: 'profiles_public_max_fields';
+    address?: string | undefined;
+    avatar?: string | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    name?: GraphQLTypes['citext'] | undefined;
+  };
+  /** aggregate min on columns */
+  ['profiles_public_min_fields']: {
+    __typename: 'profiles_public_min_fields';
+    address?: string | undefined;
+    avatar?: string | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    name?: GraphQLTypes['citext'] | undefined;
+  };
+  /** response of any mutation on the table "profiles_public" */
+  ['profiles_public_mutation_response']: {
+    __typename: 'profiles_public_mutation_response';
+    /** number of rows affected by the mutation */
+    affected_rows: number;
+    /** data from the rows affected by the mutation */
+    returning: Array<GraphQLTypes['profiles_public']>;
+  };
+  /** input type for inserting object relation for remote table "profiles_public" */
+  ['profiles_public_obj_rel_insert_input']: {
+    data: GraphQLTypes['profiles_public_insert_input'];
+  };
+  /** Ordering options when selecting data from "profiles_public". */
+  ['profiles_public_order_by']: {
+    address?: GraphQLTypes['order_by'] | undefined;
+    avatar?: GraphQLTypes['order_by'] | undefined;
+    id?: GraphQLTypes['order_by'] | undefined;
+    name?: GraphQLTypes['order_by'] | undefined;
+  };
+  /** select columns of table "profiles_public" */
+  ['profiles_public_select_column']: profiles_public_select_column;
+  /** input type for updating data in table "profiles_public" */
+  ['profiles_public_set_input']: {
+    address?: string | undefined;
+    avatar?: string | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    name?: GraphQLTypes['citext'] | undefined;
+  };
+  /** aggregate stddev on columns */
+  ['profiles_public_stddev_fields']: {
+    __typename: 'profiles_public_stddev_fields';
+    id?: number | undefined;
+  };
+  /** aggregate stddev_pop on columns */
+  ['profiles_public_stddev_pop_fields']: {
+    __typename: 'profiles_public_stddev_pop_fields';
+    id?: number | undefined;
+  };
+  /** aggregate stddev_samp on columns */
+  ['profiles_public_stddev_samp_fields']: {
+    __typename: 'profiles_public_stddev_samp_fields';
+    id?: number | undefined;
+  };
+  /** Streaming cursor of the table "profiles_public" */
+  ['profiles_public_stream_cursor_input']: {
+    /** Stream column input with initial value */
+    initial_value: GraphQLTypes['profiles_public_stream_cursor_value_input'];
+    /** cursor ordering */
+    ordering?: GraphQLTypes['cursor_ordering'] | undefined;
+  };
+  /** Initial value of the column from where the streaming should start */
+  ['profiles_public_stream_cursor_value_input']: {
+    address?: string | undefined;
+    avatar?: string | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    name?: GraphQLTypes['citext'] | undefined;
+  };
+  /** aggregate sum on columns */
+  ['profiles_public_sum_fields']: {
+    __typename: 'profiles_public_sum_fields';
+    id?: GraphQLTypes['bigint'] | undefined;
+  };
+  ['profiles_public_updates']: {
+    /** increments the numeric columns with given value of the filtered values */
+    _inc?: GraphQLTypes['profiles_public_inc_input'] | undefined;
+    /** sets the columns of the filtered rows to the given values */
+    _set?: GraphQLTypes['profiles_public_set_input'] | undefined;
+    /** filter the rows which have to be updated */
+    where: GraphQLTypes['profiles_public_bool_exp'];
+  };
+  /** aggregate var_pop on columns */
+  ['profiles_public_var_pop_fields']: {
+    __typename: 'profiles_public_var_pop_fields';
+    id?: number | undefined;
+  };
+  /** aggregate var_samp on columns */
+  ['profiles_public_var_samp_fields']: {
+    __typename: 'profiles_public_var_samp_fields';
+    id?: number | undefined;
+  };
+  /** aggregate variance on columns */
+  ['profiles_public_variance_fields']: {
+    __typename: 'profiles_public_variance_fields';
+    id?: number | undefined;
+  };
   /** select columns of table "profiles" */
   ['profiles_select_column']: profiles_select_column;
   /** input type for updating data in table "profiles" */
@@ -50477,6 +51109,10 @@ export type GraphQLTypes = {
     profiles_aggregate: GraphQLTypes['profiles_aggregate'];
     /** fetch data from the table: "profiles" using primary key columns */
     profiles_by_pk?: GraphQLTypes['profiles'] | undefined;
+    /** fetch data from the table: "profiles_public" */
+    profiles_public: Array<GraphQLTypes['profiles_public']>;
+    /** fetch aggregated fields from the table: "profiles_public" */
+    profiles_public_aggregate: GraphQLTypes['profiles_public_aggregate'];
     /** An array relationship */
     reactions: Array<GraphQLTypes['reactions']>;
     /** An aggregate relationship */
@@ -51151,6 +51787,12 @@ export type GraphQLTypes = {
     profiles_aggregate: GraphQLTypes['profiles_aggregate'];
     /** fetch data from the table: "profiles" using primary key columns */
     profiles_by_pk?: GraphQLTypes['profiles'] | undefined;
+    /** fetch data from the table: "profiles_public" */
+    profiles_public: Array<GraphQLTypes['profiles_public']>;
+    /** fetch aggregated fields from the table: "profiles_public" */
+    profiles_public_aggregate: GraphQLTypes['profiles_public_aggregate'];
+    /** fetch data from the table in a streaming manner: "profiles_public" */
+    profiles_public_stream: Array<GraphQLTypes['profiles_public']>;
     /** fetch data from the table in a streaming manner: "profiles" */
     profiles_stream: Array<GraphQLTypes['profiles']>;
     /** An array relationship */
@@ -55092,6 +55734,13 @@ export const enum profiles_constraint {
   profiles_address_key = 'profiles_address_key',
   profiles_name_key = 'profiles_name_key',
   profiles_pkey = 'profiles_pkey',
+}
+/** select columns of table "profiles_public" */
+export const enum profiles_public_select_column {
+  address = 'address',
+  avatar = 'avatar',
+  id = 'id',
+  name = 'name',
 }
 /** select columns of table "profiles" */
 export const enum profiles_select_column {

--- a/api/hasura/auth.ts
+++ b/api/hasura/auth.ts
@@ -45,6 +45,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       return;
     }
 
+    if (!req.headers?.authorization) {
+      return res.status(200).json({
+        'X-Hasura-Role': 'anon-user',
+      });
+    }
     assert(req.headers?.authorization, 'No token was provided');
     const { prefix, tokenHash } = parseAuthHeader(req.headers.authorization);
 
@@ -72,6 +77,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     // handle personal access tokens
     const profile = await getProfileFromAuthToken(prefix, tokenHash);
+    if (!profile) {
+      return res.status(200).json({
+        'X-Hasura-Role': 'anon-user',
+      });
+    }
     assert(profile, 'The token provided was not recognized');
 
     res.status(200).json({

--- a/hasura/metadata/databases/default/tables/public_cosouls.yaml
+++ b/hasura/metadata/databases/default/tables/public_cosouls.yaml
@@ -11,7 +11,25 @@ object_relationships:
         remote_table:
           name: profiles
           schema: public
+  - name: profile_public
+    using:
+      manual_configuration:
+        column_mapping:
+          address: address
+        insertion_order: null
+        remote_table:
+          name: profiles_public
+          schema: public
 select_permissions:
+  - role: anon-user
+    permission:
+      columns:
+        - address
+        - id
+        - pgive
+        - token_id
+      filter: {}
+    comment: ""
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/public_profiles_public.yaml
+++ b/hasura/metadata/databases/default/tables/public_profiles_public.yaml
@@ -1,0 +1,22 @@
+table:
+  name: profiles_public
+  schema: public
+select_permissions:
+  - role: anon-user
+    permission:
+      columns:
+        - id
+        - address
+        - name
+        - avatar
+      filter: {}
+    comment: ""
+  - role: user
+    permission:
+      columns:
+        - id
+        - address
+        - avatar
+        - name
+      filter: {}
+    comment: ""

--- a/hasura/metadata/databases/default/tables/tables.yaml
+++ b/hasura/metadata/databases/default/tables/tables.yaml
@@ -35,6 +35,7 @@
 - "!include public_pending_vault_transactions.yaml"
 - "!include public_personal_access_tokens.yaml"
 - "!include public_profiles.yaml"
+- "!include public_profiles_public.yaml"
 - "!include public_reactions.yaml"
 - "!include public_teammates.yaml"
 - "!include public_token_gifts.yaml"

--- a/hasura/migrations/default/1696915436967_create_view_profiles_public/down.sql
+++ b/hasura/migrations/default/1696915436967_create_view_profiles_public/down.sql
@@ -1,0 +1,2 @@
+-- Could not auto-generate a down migration.
+DROP VIEW IF EXISTS "public"."profiles_public";

--- a/hasura/migrations/default/1696915436967_create_view_profiles_public/up.sql
+++ b/hasura/migrations/default/1696915436967_create_view_profiles_public/up.sql
@@ -1,0 +1,8 @@
+CREATE
+OR REPLACE VIEW "public"."profiles_public" AS
+SELECT
+  p.id AS id,
+  p.address AS address,
+  p.name AS name,
+  p.avatar AS avatar
+FROM    profiles p;

--- a/hasura/schema/admin/schema.graphql
+++ b/hasura/schema/admin/schema.graphql
@@ -7771,6 +7771,11 @@ type cosouls {
   An object relationship
   """
   profile: profiles
+
+  """
+  An object relationship
+  """
+  profile_public: profiles_public
   synced_at: timestamptz
   token_id: Int!
   updated_at: timestamptz!
@@ -7824,6 +7829,7 @@ input cosouls_bool_exp {
   id: Int_comparison_exp
   pgive: Int_comparison_exp
   profile: profiles_bool_exp
+  profile_public: profiles_public_bool_exp
   synced_at: timestamptz_comparison_exp
   token_id: Int_comparison_exp
   updated_at: timestamptz_comparison_exp
@@ -7864,6 +7870,7 @@ input cosouls_insert_input {
   id: Int
   pgive: Int
   profile: profiles_obj_rel_insert_input
+  profile_public: profiles_public_obj_rel_insert_input
   synced_at: timestamptz
   token_id: Int
   updated_at: timestamptz
@@ -7946,6 +7953,7 @@ input cosouls_order_by {
   id: order_by
   pgive: order_by
   profile: profiles_order_by
+  profile_public: profiles_public_order_by
   synced_at: order_by
   token_id: order_by
   updated_at: order_by
@@ -17007,6 +17015,16 @@ type mutation_root {
   delete_profiles_by_pk(id: bigint!): profiles
 
   """
+  delete data from the table: "profiles_public"
+  """
+  delete_profiles_public(
+    """
+    filter the rows which have to be deleted
+    """
+    where: profiles_public_bool_exp!
+  ): profiles_public_mutation_response
+
+  """
   delete data from the table: "reactions"
   """
   delete_reactions(
@@ -18126,6 +18144,26 @@ type mutation_root {
     """
     on_conflict: profiles_on_conflict
   ): profiles
+
+  """
+  insert data into the table: "profiles_public"
+  """
+  insert_profiles_public(
+    """
+    the rows to be inserted
+    """
+    objects: [profiles_public_insert_input!]!
+  ): profiles_public_mutation_response
+
+  """
+  insert a single row into the table: "profiles_public"
+  """
+  insert_profiles_public_one(
+    """
+    the row to be inserted
+    """
+    object: profiles_public_insert_input!
+  ): profiles_public
 
   """
   insert data into the table: "reactions"
@@ -20125,6 +20163,36 @@ type mutation_root {
     """
     updates: [profiles_updates!]!
   ): [profiles_mutation_response]
+
+  """
+  update data of the table: "profiles_public"
+  """
+  update_profiles_public(
+    """
+    increments the numeric columns with given value of the filtered values
+    """
+    _inc: profiles_public_inc_input
+
+    """
+    sets the columns of the filtered rows to the given values
+    """
+    _set: profiles_public_set_input
+
+    """
+    filter the rows which have to be updated
+    """
+    where: profiles_public_bool_exp!
+  ): profiles_public_mutation_response
+
+  """
+  update multiples rows of table: "profiles_public"
+  """
+  update_profiles_public_many(
+    """
+    updates to execute, in order
+    """
+    updates: [profiles_public_updates!]!
+  ): [profiles_public_mutation_response]
 
   """
   update data of the table: "reactions"
@@ -25722,6 +25790,256 @@ input profiles_pk_columns_input {
 }
 
 """
+columns and relationships of "profiles_public"
+"""
+type profiles_public {
+  address: String
+  avatar: String
+  id: bigint
+  name: citext
+}
+
+"""
+aggregated selection of "profiles_public"
+"""
+type profiles_public_aggregate {
+  aggregate: profiles_public_aggregate_fields
+  nodes: [profiles_public!]!
+}
+
+"""
+aggregate fields of "profiles_public"
+"""
+type profiles_public_aggregate_fields {
+  avg: profiles_public_avg_fields
+  count(columns: [profiles_public_select_column!], distinct: Boolean): Int!
+  max: profiles_public_max_fields
+  min: profiles_public_min_fields
+  stddev: profiles_public_stddev_fields
+  stddev_pop: profiles_public_stddev_pop_fields
+  stddev_samp: profiles_public_stddev_samp_fields
+  sum: profiles_public_sum_fields
+  var_pop: profiles_public_var_pop_fields
+  var_samp: profiles_public_var_samp_fields
+  variance: profiles_public_variance_fields
+}
+
+"""
+aggregate avg on columns
+"""
+type profiles_public_avg_fields {
+  id: Float
+}
+
+"""
+Boolean expression to filter rows from the table "profiles_public". All fields are combined with a logical 'AND'.
+"""
+input profiles_public_bool_exp {
+  _and: [profiles_public_bool_exp!]
+  _not: profiles_public_bool_exp
+  _or: [profiles_public_bool_exp!]
+  address: String_comparison_exp
+  avatar: String_comparison_exp
+  id: bigint_comparison_exp
+  name: citext_comparison_exp
+}
+
+"""
+input type for incrementing numeric columns in table "profiles_public"
+"""
+input profiles_public_inc_input {
+  id: bigint
+}
+
+"""
+input type for inserting data into table "profiles_public"
+"""
+input profiles_public_insert_input {
+  address: String
+  avatar: String
+  id: bigint
+  name: citext
+}
+
+"""
+aggregate max on columns
+"""
+type profiles_public_max_fields {
+  address: String
+  avatar: String
+  id: bigint
+  name: citext
+}
+
+"""
+aggregate min on columns
+"""
+type profiles_public_min_fields {
+  address: String
+  avatar: String
+  id: bigint
+  name: citext
+}
+
+"""
+response of any mutation on the table "profiles_public"
+"""
+type profiles_public_mutation_response {
+  """
+  number of rows affected by the mutation
+  """
+  affected_rows: Int!
+
+  """
+  data from the rows affected by the mutation
+  """
+  returning: [profiles_public!]!
+}
+
+"""
+input type for inserting object relation for remote table "profiles_public"
+"""
+input profiles_public_obj_rel_insert_input {
+  data: profiles_public_insert_input!
+}
+
+"""
+Ordering options when selecting data from "profiles_public".
+"""
+input profiles_public_order_by {
+  address: order_by
+  avatar: order_by
+  id: order_by
+  name: order_by
+}
+
+"""
+select columns of table "profiles_public"
+"""
+enum profiles_public_select_column {
+  """
+  column name
+  """
+  address
+
+  """
+  column name
+  """
+  avatar
+
+  """
+  column name
+  """
+  id
+
+  """
+  column name
+  """
+  name
+}
+
+"""
+input type for updating data in table "profiles_public"
+"""
+input profiles_public_set_input {
+  address: String
+  avatar: String
+  id: bigint
+  name: citext
+}
+
+"""
+aggregate stddev on columns
+"""
+type profiles_public_stddev_fields {
+  id: Float
+}
+
+"""
+aggregate stddev_pop on columns
+"""
+type profiles_public_stddev_pop_fields {
+  id: Float
+}
+
+"""
+aggregate stddev_samp on columns
+"""
+type profiles_public_stddev_samp_fields {
+  id: Float
+}
+
+"""
+Streaming cursor of the table "profiles_public"
+"""
+input profiles_public_stream_cursor_input {
+  """
+  Stream column input with initial value
+  """
+  initial_value: profiles_public_stream_cursor_value_input!
+
+  """
+  cursor ordering
+  """
+  ordering: cursor_ordering
+}
+
+"""
+Initial value of the column from where the streaming should start
+"""
+input profiles_public_stream_cursor_value_input {
+  address: String
+  avatar: String
+  id: bigint
+  name: citext
+}
+
+"""
+aggregate sum on columns
+"""
+type profiles_public_sum_fields {
+  id: bigint
+}
+
+input profiles_public_updates {
+  """
+  increments the numeric columns with given value of the filtered values
+  """
+  _inc: profiles_public_inc_input
+
+  """
+  sets the columns of the filtered rows to the given values
+  """
+  _set: profiles_public_set_input
+
+  """
+  filter the rows which have to be updated
+  """
+  where: profiles_public_bool_exp!
+}
+
+"""
+aggregate var_pop on columns
+"""
+type profiles_public_var_pop_fields {
+  id: Float
+}
+
+"""
+aggregate var_samp on columns
+"""
+type profiles_public_var_samp_fields {
+  id: Float
+}
+
+"""
+aggregate variance on columns
+"""
+type profiles_public_variance_fields {
+  id: Float
+}
+
+"""
 select columns of table "profiles"
 """
 enum profiles_select_column {
@@ -28443,6 +28761,66 @@ type query_root {
   fetch data from the table: "profiles" using primary key columns
   """
   profiles_by_pk(id: bigint!): profiles
+
+  """
+  fetch data from the table: "profiles_public"
+  """
+  profiles_public(
+    """
+    distinct select on columns
+    """
+    distinct_on: [profiles_public_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [profiles_public_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: profiles_public_bool_exp
+  ): [profiles_public!]!
+
+  """
+  fetch aggregated fields from the table: "profiles_public"
+  """
+  profiles_public_aggregate(
+    """
+    distinct select on columns
+    """
+    distinct_on: [profiles_public_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [profiles_public_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: profiles_public_bool_exp
+  ): profiles_public_aggregate!
 
   """
   An array relationship
@@ -32626,6 +33004,86 @@ type subscription_root {
   fetch data from the table: "profiles" using primary key columns
   """
   profiles_by_pk(id: bigint!): profiles
+
+  """
+  fetch data from the table: "profiles_public"
+  """
+  profiles_public(
+    """
+    distinct select on columns
+    """
+    distinct_on: [profiles_public_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [profiles_public_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: profiles_public_bool_exp
+  ): [profiles_public!]!
+
+  """
+  fetch aggregated fields from the table: "profiles_public"
+  """
+  profiles_public_aggregate(
+    """
+    distinct select on columns
+    """
+    distinct_on: [profiles_public_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [profiles_public_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: profiles_public_bool_exp
+  ): profiles_public_aggregate!
+
+  """
+  fetch data from the table in a streaming manner: "profiles_public"
+  """
+  profiles_public_stream(
+    """
+    maximum number of rows returned in a single batch
+    """
+    batch_size: Int!
+
+    """
+    cursor to stream the results returned by the query
+    """
+    cursor: [profiles_public_stream_cursor_input]!
+
+    """
+    filter the rows returned
+    """
+    where: profiles_public_bool_exp
+  ): [profiles_public!]!
 
   """
   fetch data from the table in a streaming manner: "profiles"

--- a/hasura/schema/anon-user/schema.graphql
+++ b/hasura/schema/anon-user/schema.graphql
@@ -1,0 +1,581 @@
+schema {
+  query: query_root
+  subscription: subscription_root
+}
+
+"""
+whether this query should be cached (Hasura Cloud only)
+"""
+directive @cached(
+  """
+  measured in seconds
+  """
+  ttl: Int! = 60
+
+  """
+  refresh the cache entry
+  """
+  refresh: Boolean! = false
+) on QUERY
+
+"""
+Boolean expression to compare columns of type "Int". All fields are combined with logical 'AND'.
+"""
+input Int_comparison_exp {
+  _eq: Int
+  _gt: Int
+  _gte: Int
+  _in: [Int!]
+  _is_null: Boolean
+  _lt: Int
+  _lte: Int
+  _neq: Int
+  _nin: [Int!]
+}
+
+"""
+Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'.
+"""
+input String_comparison_exp {
+  _eq: String
+  _gt: String
+  _gte: String
+
+  """
+  does the column match the given case-insensitive pattern
+  """
+  _ilike: String
+  _in: [String!]
+
+  """
+  does the column match the given POSIX regular expression, case insensitive
+  """
+  _iregex: String
+  _is_null: Boolean
+
+  """
+  does the column match the given pattern
+  """
+  _like: String
+  _lt: String
+  _lte: String
+  _neq: String
+
+  """
+  does the column NOT match the given case-insensitive pattern
+  """
+  _nilike: String
+  _nin: [String!]
+
+  """
+  does the column NOT match the given POSIX regular expression, case insensitive
+  """
+  _niregex: String
+
+  """
+  does the column NOT match the given pattern
+  """
+  _nlike: String
+
+  """
+  does the column NOT match the given POSIX regular expression, case sensitive
+  """
+  _nregex: String
+
+  """
+  does the column NOT match the given SQL regular expression
+  """
+  _nsimilar: String
+
+  """
+  does the column match the given POSIX regular expression, case sensitive
+  """
+  _regex: String
+
+  """
+  does the column match the given SQL regular expression
+  """
+  _similar: String
+}
+
+scalar bigint
+
+"""
+Boolean expression to compare columns of type "bigint". All fields are combined with logical 'AND'.
+"""
+input bigint_comparison_exp {
+  _eq: bigint
+  _gt: bigint
+  _gte: bigint
+  _in: [bigint!]
+  _is_null: Boolean
+  _lt: bigint
+  _lte: bigint
+  _neq: bigint
+  _nin: [bigint!]
+}
+
+scalar citext
+
+"""
+Boolean expression to compare columns of type "citext". All fields are combined with logical 'AND'.
+"""
+input citext_comparison_exp {
+  _eq: citext
+  _gt: citext
+  _gte: citext
+
+  """
+  does the column match the given case-insensitive pattern
+  """
+  _ilike: citext
+  _in: [citext!]
+
+  """
+  does the column match the given POSIX regular expression, case insensitive
+  """
+  _iregex: citext
+  _is_null: Boolean
+
+  """
+  does the column match the given pattern
+  """
+  _like: citext
+  _lt: citext
+  _lte: citext
+  _neq: citext
+
+  """
+  does the column NOT match the given case-insensitive pattern
+  """
+  _nilike: citext
+  _nin: [citext!]
+
+  """
+  does the column NOT match the given POSIX regular expression, case insensitive
+  """
+  _niregex: citext
+
+  """
+  does the column NOT match the given pattern
+  """
+  _nlike: citext
+
+  """
+  does the column NOT match the given POSIX regular expression, case sensitive
+  """
+  _nregex: citext
+
+  """
+  does the column NOT match the given SQL regular expression
+  """
+  _nsimilar: citext
+
+  """
+  does the column match the given POSIX regular expression, case sensitive
+  """
+  _regex: citext
+
+  """
+  does the column match the given SQL regular expression
+  """
+  _similar: citext
+}
+
+"""
+local db copy of last synced on-chain cosoul data
+"""
+type cosouls {
+  address: citext!
+  id: Int!
+  pgive: Int
+
+  """
+  An object relationship
+  """
+  profile_public: profiles_public
+  token_id: Int!
+}
+
+"""
+Boolean expression to filter rows from the table "cosouls". All fields are combined with a logical 'AND'.
+"""
+input cosouls_bool_exp {
+  _and: [cosouls_bool_exp!]
+  _not: cosouls_bool_exp
+  _or: [cosouls_bool_exp!]
+  address: citext_comparison_exp
+  id: Int_comparison_exp
+  pgive: Int_comparison_exp
+  profile_public: profiles_public_bool_exp
+  token_id: Int_comparison_exp
+}
+
+"""
+Ordering options when selecting data from "cosouls".
+"""
+input cosouls_order_by {
+  address: order_by
+  id: order_by
+  pgive: order_by
+  profile_public: profiles_public_order_by
+  token_id: order_by
+}
+
+"""
+select columns of table "cosouls"
+"""
+enum cosouls_select_column {
+  """
+  column name
+  """
+  address
+
+  """
+  column name
+  """
+  id
+
+  """
+  column name
+  """
+  pgive
+
+  """
+  column name
+  """
+  token_id
+}
+
+"""
+Streaming cursor of the table "cosouls"
+"""
+input cosouls_stream_cursor_input {
+  """
+  Stream column input with initial value
+  """
+  initial_value: cosouls_stream_cursor_value_input!
+
+  """
+  cursor ordering
+  """
+  ordering: cursor_ordering
+}
+
+"""
+Initial value of the column from where the streaming should start
+"""
+input cosouls_stream_cursor_value_input {
+  address: citext
+  id: Int
+  pgive: Int
+  token_id: Int
+}
+
+"""
+ordering argument of a cursor
+"""
+enum cursor_ordering {
+  """
+  ascending ordering of the cursor
+  """
+  ASC
+
+  """
+  descending ordering of the cursor
+  """
+  DESC
+}
+
+"""
+column ordering options
+"""
+enum order_by {
+  """
+  in ascending order, nulls last
+  """
+  asc
+
+  """
+  in ascending order, nulls first
+  """
+  asc_nulls_first
+
+  """
+  in ascending order, nulls last
+  """
+  asc_nulls_last
+
+  """
+  in descending order, nulls first
+  """
+  desc
+
+  """
+  in descending order, nulls first
+  """
+  desc_nulls_first
+
+  """
+  in descending order, nulls last
+  """
+  desc_nulls_last
+}
+
+"""
+columns and relationships of "profiles_public"
+"""
+type profiles_public {
+  address: String
+  avatar: String
+  id: bigint
+  name: citext
+}
+
+"""
+Boolean expression to filter rows from the table "profiles_public". All fields are combined with a logical 'AND'.
+"""
+input profiles_public_bool_exp {
+  _and: [profiles_public_bool_exp!]
+  _not: profiles_public_bool_exp
+  _or: [profiles_public_bool_exp!]
+  address: String_comparison_exp
+  avatar: String_comparison_exp
+  id: bigint_comparison_exp
+  name: citext_comparison_exp
+}
+
+"""
+Ordering options when selecting data from "profiles_public".
+"""
+input profiles_public_order_by {
+  address: order_by
+  avatar: order_by
+  id: order_by
+  name: order_by
+}
+
+"""
+select columns of table "profiles_public"
+"""
+enum profiles_public_select_column {
+  """
+  column name
+  """
+  address
+
+  """
+  column name
+  """
+  avatar
+
+  """
+  column name
+  """
+  id
+
+  """
+  column name
+  """
+  name
+}
+
+"""
+Streaming cursor of the table "profiles_public"
+"""
+input profiles_public_stream_cursor_input {
+  """
+  Stream column input with initial value
+  """
+  initial_value: profiles_public_stream_cursor_value_input!
+
+  """
+  cursor ordering
+  """
+  ordering: cursor_ordering
+}
+
+"""
+Initial value of the column from where the streaming should start
+"""
+input profiles_public_stream_cursor_value_input {
+  address: String
+  avatar: String
+  id: bigint
+  name: citext
+}
+
+type query_root {
+  """
+  fetch data from the table: "cosouls"
+  """
+  cosouls(
+    """
+    distinct select on columns
+    """
+    distinct_on: [cosouls_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [cosouls_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: cosouls_bool_exp
+  ): [cosouls!]!
+
+  """
+  fetch data from the table: "cosouls" using primary key columns
+  """
+  cosouls_by_pk(id: Int!): cosouls
+  price_per_share(chain_id: Int!, token_address: String): Float!
+
+  """
+  fetch data from the table: "profiles_public"
+  """
+  profiles_public(
+    """
+    distinct select on columns
+    """
+    distinct_on: [profiles_public_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [profiles_public_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: profiles_public_bool_exp
+  ): [profiles_public!]!
+}
+
+type subscription_root {
+  """
+  fetch data from the table: "cosouls"
+  """
+  cosouls(
+    """
+    distinct select on columns
+    """
+    distinct_on: [cosouls_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [cosouls_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: cosouls_bool_exp
+  ): [cosouls!]!
+
+  """
+  fetch data from the table: "cosouls" using primary key columns
+  """
+  cosouls_by_pk(id: Int!): cosouls
+
+  """
+  fetch data from the table in a streaming manner: "cosouls"
+  """
+  cosouls_stream(
+    """
+    maximum number of rows returned in a single batch
+    """
+    batch_size: Int!
+
+    """
+    cursor to stream the results returned by the query
+    """
+    cursor: [cosouls_stream_cursor_input]!
+
+    """
+    filter the rows returned
+    """
+    where: cosouls_bool_exp
+  ): [cosouls!]!
+
+  """
+  fetch data from the table: "profiles_public"
+  """
+  profiles_public(
+    """
+    distinct select on columns
+    """
+    distinct_on: [profiles_public_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [profiles_public_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: profiles_public_bool_exp
+  ): [profiles_public!]!
+
+  """
+  fetch data from the table in a streaming manner: "profiles_public"
+  """
+  profiles_public_stream(
+    """
+    maximum number of rows returned in a single batch
+    """
+    batch_size: Int!
+
+    """
+    cursor to stream the results returned by the query
+    """
+    cursor: [profiles_public_stream_cursor_input]!
+
+    """
+    filter the rows returned
+    """
+    where: profiles_public_bool_exp
+  ): [profiles_public!]!
+}

--- a/hasura/schema/user/schema.graphql
+++ b/hasura/schema/user/schema.graphql
@@ -4349,6 +4349,11 @@ type cosouls {
   An object relationship
   """
   profile: profiles
+
+  """
+  An object relationship
+  """
+  profile_public: profiles_public
   synced_at: timestamptz
   token_id: Int!
   updated_at: timestamptz!
@@ -4367,6 +4372,7 @@ input cosouls_bool_exp {
   id: Int_comparison_exp
   pgive: Int_comparison_exp
   profile: profiles_bool_exp
+  profile_public: profiles_public_bool_exp
   synced_at: timestamptz_comparison_exp
   token_id: Int_comparison_exp
   updated_at: timestamptz_comparison_exp
@@ -4382,6 +4388,7 @@ input cosouls_order_by {
   id: order_by
   pgive: order_by
   profile: profiles_order_by
+  profile_public: profiles_public_order_by
   synced_at: order_by
   token_id: order_by
   updated_at: order_by
@@ -11508,6 +11515,89 @@ input profiles_pk_columns_input {
 }
 
 """
+columns and relationships of "profiles_public"
+"""
+type profiles_public {
+  address: String
+  avatar: String
+  id: bigint
+  name: citext
+}
+
+"""
+Boolean expression to filter rows from the table "profiles_public". All fields are combined with a logical 'AND'.
+"""
+input profiles_public_bool_exp {
+  _and: [profiles_public_bool_exp!]
+  _not: profiles_public_bool_exp
+  _or: [profiles_public_bool_exp!]
+  address: String_comparison_exp
+  avatar: String_comparison_exp
+  id: bigint_comparison_exp
+  name: citext_comparison_exp
+}
+
+"""
+Ordering options when selecting data from "profiles_public".
+"""
+input profiles_public_order_by {
+  address: order_by
+  avatar: order_by
+  id: order_by
+  name: order_by
+}
+
+"""
+select columns of table "profiles_public"
+"""
+enum profiles_public_select_column {
+  """
+  column name
+  """
+  address
+
+  """
+  column name
+  """
+  avatar
+
+  """
+  column name
+  """
+  id
+
+  """
+  column name
+  """
+  name
+}
+
+"""
+Streaming cursor of the table "profiles_public"
+"""
+input profiles_public_stream_cursor_input {
+  """
+  Stream column input with initial value
+  """
+  initial_value: profiles_public_stream_cursor_value_input!
+
+  """
+  cursor ordering
+  """
+  ordering: cursor_ordering
+}
+
+"""
+Initial value of the column from where the streaming should start
+"""
+input profiles_public_stream_cursor_value_input {
+  address: String
+  avatar: String
+  id: bigint
+  name: citext
+}
+
+"""
 select columns of table "profiles"
 """
 enum profiles_select_column {
@@ -12940,6 +13030,36 @@ type query_root {
   fetch data from the table: "profiles" using primary key columns
   """
   profiles_by_pk(id: bigint!): profiles
+
+  """
+  fetch data from the table: "profiles_public"
+  """
+  profiles_public(
+    """
+    distinct select on columns
+    """
+    distinct_on: [profiles_public_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [profiles_public_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: profiles_public_bool_exp
+  ): [profiles_public!]!
 
   """
   An array relationship
@@ -15645,6 +15765,56 @@ type subscription_root {
   fetch data from the table: "profiles" using primary key columns
   """
   profiles_by_pk(id: bigint!): profiles
+
+  """
+  fetch data from the table: "profiles_public"
+  """
+  profiles_public(
+    """
+    distinct select on columns
+    """
+    distinct_on: [profiles_public_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [profiles_public_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: profiles_public_bool_exp
+  ): [profiles_public!]!
+
+  """
+  fetch data from the table in a streaming manner: "profiles_public"
+  """
+  profiles_public_stream(
+    """
+    maximum number of rows returned in a single batch
+    """
+    batch_size: Int!
+
+    """
+    cursor to stream the results returned by the query
+    """
+    cursor: [profiles_public_stream_cursor_input]!
+
+    """
+    filter the rows returned
+    """
+    where: profiles_public_bool_exp
+  ): [profiles_public!]!
 
   """
   fetch data from the table in a streaming manner: "profiles"

--- a/scripts/generate_zeus.sh
+++ b/scripts/generate_zeus.sh
@@ -7,6 +7,7 @@ set +o allexport
 
 ADMIN_PATH=./api-lib/gql/__generated__
 USER_PATH=./src/lib/gql/__generated__
+ANON_PATH=./src/lib/anongql/__generated__
 
 function generate() {
   # use the first argument as the path to move files to
@@ -67,6 +68,8 @@ const logger = new DebugLogger('zeus')\\
 generate admin $ADMIN_PATH --node -h x-hasura-admin-secret:$HASURA_GRAPHQL_ADMIN_SECRET --graphql hasura/schema/admin
 sleep 12
 generate user $USER_PATH -h x-hasura-role:user -h "authorization:generate" --graphql hasura/schema/user
+sleep 12
+generate user $ANON_PATH -h x-hasura-role:anon-user -h "authorization:generate" --graphql hasura/schema/anon-user
 
 # fix formatting of generated files
-node_modules/.bin/prettier --write {$ADMIN_PATH,$USER_PATH,hasura/schema}
+node_modules/.bin/prettier --write {$ADMIN_PATH,$USER_PATH,$ANON_PATH,hasura/schema}

--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -1,7 +1,6 @@
 // add your own feature names here
 
 export type FeatureName =
-  | 'cosoul'
   | 'debug'
   | 'email'
   // dnt = Do Not Track. enable this feature to debug Mixpanel
@@ -10,9 +9,7 @@ export type FeatureName =
 // this is a very simple implementation of build-time feature flags that you can
 // hardcode or set with environment variables
 
-const staticFeatureFlags: Partial<Record<FeatureName, boolean>> = {
-  cosoul: true,
-};
+const staticFeatureFlags: Partial<Record<FeatureName, boolean>> = {};
 
 // this code is safe to use in a non-browser environment because of the typeof
 // check, but our setup in tsconfig-backend.json still flags the use of `window`

--- a/src/features/cosoul/DebugCoSoulGalleryPage.tsx
+++ b/src/features/cosoul/DebugCoSoulGalleryPage.tsx
@@ -1,4 +1,3 @@
-import isFeatureEnabled from 'config/features';
 import { Flex, Text } from 'ui';
 import Iframe from 'ui/Iframe/Iframe';
 import { shortenAddressWithFrontLength } from 'utils';
@@ -26,10 +25,7 @@ const canvasStyles = {
   },
 };
 
-export const CoSoulGalleryPage = () => {
-  if (!isFeatureEnabled('cosoul')) {
-    return <></>;
-  }
+export const DebugCoSoulGalleryPage = () => {
   return (
     <>
       <Flex column>

--- a/src/features/cosoul/MintPage.tsx
+++ b/src/features/cosoul/MintPage.tsx
@@ -3,7 +3,6 @@ import { useState } from 'react';
 import { useLoginData } from 'features/auth';
 import { useQuery } from 'react-query';
 
-import isFeatureEnabled from 'config/features';
 // import { Button } from 'ui';
 import { SingleColumnLayout } from 'ui/layouts';
 
@@ -36,9 +35,6 @@ export const MintPage = () => {
   const [minted, setMinted] = useState(false);
   const coSoulMinted = !!cosoul_data?.mintInfo;
 
-  if (!isFeatureEnabled('cosoul')) {
-    return <></>;
-  }
   return (
     <>
       {cosoul_data && (

--- a/src/features/cosoul/SplashPage.tsx
+++ b/src/features/cosoul/SplashPage.tsx
@@ -4,7 +4,6 @@ import { useQuery } from 'react-query';
 import { NavLink } from 'react-router-dom';
 
 import { CosoulData } from '../../../api/cosoul/[address]';
-import isFeatureEnabled from 'config/features';
 import useConnectedAddress from 'hooks/useConnectedAddress';
 import { paths } from 'routes/paths';
 import { Box, Button, Flex, Text } from 'ui';
@@ -34,9 +33,6 @@ export const SplashPage = () => {
     }
   );
 
-  if (!isFeatureEnabled('cosoul')) {
-    return <></>;
-  }
   return (
     <Box css={{ position: 'relative' }}>
       <Box

--- a/src/features/cosoul/ViewPage.tsx
+++ b/src/features/cosoul/ViewPage.tsx
@@ -4,7 +4,6 @@ import { useParams } from 'react-router-dom';
 
 import { CosoulData } from '../../../api/cosoul/[address]';
 import { LoadingModal } from 'components';
-import isFeatureEnabled from 'config/features';
 import { Box, Flex, Text } from 'ui';
 import { SingleColumnLayout } from 'ui/layouts';
 
@@ -42,10 +41,6 @@ export const ViewPage = () => {
     }
   );
   coSoulMinted = !!data?.mintInfo;
-
-  if (!isFeatureEnabled('cosoul')) {
-    return <></>;
-  }
 
   // Waiting to validate the token
   if (isLoading) {

--- a/src/features/nav/SideNav.tsx
+++ b/src/features/nav/SideNav.tsx
@@ -10,7 +10,6 @@ import { useQuery } from 'react-query';
 import { NavLink, useLocation } from 'react-router-dom';
 
 import { getCircleFromPath, getOrgFromPath, paths } from '../../routes/paths';
-import isFeatureEnabled from 'config/features';
 import { Menu, X } from 'icons/__generated';
 import { EmailCTA } from 'pages/ProfilePage/EmailSettings/EmailCTA';
 import { Button, Flex, IconButton } from 'ui';
@@ -218,44 +217,38 @@ export const SideNav = () => {
             <>
               <Flex column css={{ gap: '$sm' }}>
                 <EmailCTA />
-                {isFeatureEnabled('cosoul') && (
-                  <>
-                    <Button
-                      color="cta"
-                      size="xs"
-                      as={NavLink}
-                      onClick={() => cosoulCtaClick()}
-                      css={{
-                        zIndex: 3,
-                        position: 'relative',
-                        '&:before': {
-                          ...pulseStyles,
-                          animationDelay: '3s',
-                          display: suppressCosoulCtaAnimation
-                            ? 'none'
-                            : 'block',
-                        },
-                        '&:after': {
-                          ...pulseStyles,
-                          animationDelay: '1.5s',
-                          zIndex: -1,
-                          display: suppressCosoulCtaAnimation
-                            ? 'none'
-                            : 'block',
-                        },
-                      }}
-                      to={
-                        cosoul_data?.mintInfo
-                          ? paths.cosoulView(`${data?.profile.address}`)
-                          : paths.cosoul
-                      }
-                    >
-                      {cosoul_data?.mintInfo ? 'View ' : 'Mint '}
-                      Your CoSoul NFT
-                    </Button>
-                    <CoSoulPromoModal minted={!!cosoul_data?.mintInfo} />
-                  </>
-                )}
+                <>
+                  <Button
+                    color="cta"
+                    size="xs"
+                    as={NavLink}
+                    onClick={() => cosoulCtaClick()}
+                    css={{
+                      zIndex: 3,
+                      position: 'relative',
+                      '&:before': {
+                        ...pulseStyles,
+                        animationDelay: '3s',
+                        display: suppressCosoulCtaAnimation ? 'none' : 'block',
+                      },
+                      '&:after': {
+                        ...pulseStyles,
+                        animationDelay: '1.5s',
+                        zIndex: -1,
+                        display: suppressCosoulCtaAnimation ? 'none' : 'block',
+                      },
+                    }}
+                    to={
+                      cosoul_data?.mintInfo
+                        ? paths.cosoulView(`${data?.profile.address}`)
+                        : paths.cosoul
+                    }
+                  >
+                    {cosoul_data?.mintInfo ? 'View ' : 'Mint '}
+                    Your CoSoul NFT
+                  </Button>
+                  <CoSoulPromoModal minted={!!cosoul_data?.mintInfo} />
+                </>
                 {showClaimsButton && <NavClaimsButton />}
               </Flex>
               <Suspense fallback={null}>

--- a/src/lib/anongql/__generated__/zeus/const.ts
+++ b/src/lib/anongql/__generated__/zeus/const.ts
@@ -1,0 +1,162 @@
+/* eslint-disable */
+
+export const AllTypesProps: Record<string, any> = {
+  Int_comparison_exp: {},
+  String_comparison_exp: {},
+  bigint: 'String',
+  bigint_comparison_exp: {
+    _eq: 'bigint',
+    _gt: 'bigint',
+    _gte: 'bigint',
+    _in: 'bigint',
+    _lt: 'bigint',
+    _lte: 'bigint',
+    _neq: 'bigint',
+    _nin: 'bigint',
+  },
+  citext: 'String',
+  citext_comparison_exp: {
+    _eq: 'citext',
+    _gt: 'citext',
+    _gte: 'citext',
+    _ilike: 'citext',
+    _in: 'citext',
+    _iregex: 'citext',
+    _like: 'citext',
+    _lt: 'citext',
+    _lte: 'citext',
+    _neq: 'citext',
+    _nilike: 'citext',
+    _nin: 'citext',
+    _niregex: 'citext',
+    _nlike: 'citext',
+    _nregex: 'citext',
+    _nsimilar: 'citext',
+    _regex: 'citext',
+    _similar: 'citext',
+  },
+  cosouls_bool_exp: {
+    _and: 'cosouls_bool_exp',
+    _not: 'cosouls_bool_exp',
+    _or: 'cosouls_bool_exp',
+    address: 'citext_comparison_exp',
+    id: 'Int_comparison_exp',
+    pgive: 'Int_comparison_exp',
+    profile_public: 'profiles_public_bool_exp',
+    token_id: 'Int_comparison_exp',
+  },
+  cosouls_order_by: {
+    address: 'order_by',
+    id: 'order_by',
+    pgive: 'order_by',
+    profile_public: 'profiles_public_order_by',
+    token_id: 'order_by',
+  },
+  cosouls_select_column: true,
+  cosouls_stream_cursor_input: {
+    initial_value: 'cosouls_stream_cursor_value_input',
+    ordering: 'cursor_ordering',
+  },
+  cosouls_stream_cursor_value_input: {
+    address: 'citext',
+  },
+  cursor_ordering: true,
+  order_by: true,
+  profiles_public_bool_exp: {
+    _and: 'profiles_public_bool_exp',
+    _not: 'profiles_public_bool_exp',
+    _or: 'profiles_public_bool_exp',
+    address: 'String_comparison_exp',
+    avatar: 'String_comparison_exp',
+    id: 'bigint_comparison_exp',
+    name: 'citext_comparison_exp',
+  },
+  profiles_public_order_by: {
+    address: 'order_by',
+    avatar: 'order_by',
+    id: 'order_by',
+    name: 'order_by',
+  },
+  profiles_public_select_column: true,
+  profiles_public_stream_cursor_input: {
+    initial_value: 'profiles_public_stream_cursor_value_input',
+    ordering: 'cursor_ordering',
+  },
+  profiles_public_stream_cursor_value_input: {
+    id: 'bigint',
+    name: 'citext',
+  },
+  query_root: {
+    cosouls: {
+      distinct_on: 'cosouls_select_column',
+      order_by: 'cosouls_order_by',
+      where: 'cosouls_bool_exp',
+    },
+    cosouls_by_pk: {},
+    price_per_share: {},
+    profiles_public: {
+      distinct_on: 'profiles_public_select_column',
+      order_by: 'profiles_public_order_by',
+      where: 'profiles_public_bool_exp',
+    },
+  },
+  subscription_root: {
+    cosouls: {
+      distinct_on: 'cosouls_select_column',
+      order_by: 'cosouls_order_by',
+      where: 'cosouls_bool_exp',
+    },
+    cosouls_by_pk: {},
+    cosouls_stream: {
+      cursor: 'cosouls_stream_cursor_input',
+      where: 'cosouls_bool_exp',
+    },
+    profiles_public: {
+      distinct_on: 'profiles_public_select_column',
+      order_by: 'profiles_public_order_by',
+      where: 'profiles_public_bool_exp',
+    },
+    profiles_public_stream: {
+      cursor: 'profiles_public_stream_cursor_input',
+      where: 'profiles_public_bool_exp',
+    },
+  },
+};
+
+export const ReturnTypes: Record<string, any> = {
+  cached: {
+    ttl: 'Int',
+    refresh: 'Boolean',
+  },
+  cosouls: {
+    address: 'citext',
+    id: 'Int',
+    pgive: 'Int',
+    profile_public: 'profiles_public',
+    token_id: 'Int',
+  },
+  profiles_public: {
+    address: 'String',
+    avatar: 'String',
+    id: 'bigint',
+    name: 'citext',
+  },
+  query_root: {
+    cosouls: 'cosouls',
+    cosouls_by_pk: 'cosouls',
+    price_per_share: 'Float',
+    profiles_public: 'profiles_public',
+  },
+  subscription_root: {
+    cosouls: 'cosouls',
+    cosouls_by_pk: 'cosouls',
+    cosouls_stream: 'cosouls',
+    profiles_public: 'profiles_public',
+    profiles_public_stream: 'profiles_public',
+  },
+};
+
+export const Ops = {
+  query: 'query_root' as const,
+  subscription: 'subscription_root' as const,
+};

--- a/src/lib/anongql/__generated__/zeus/index.ts
+++ b/src/lib/anongql/__generated__/zeus/index.ts
@@ -1,0 +1,1206 @@
+/* eslint-disable */
+import { DebugLogger } from 'common-lib/log';
+const logger = new DebugLogger('zeus');
+
+import { AllTypesProps, ReturnTypes, Ops } from './const';
+export const HOST = 'http://localhost:8080/v1/graphql';
+
+const handleFetchResponse = (response: Response): Promise<GraphQLResponse> => {
+  if (!response.ok) {
+    return new Promise((_, reject) => {
+      response
+        .text()
+        .then(text => {
+          try {
+            reject(JSON.parse(text));
+          } catch (err) {
+            reject(text);
+          }
+        })
+        .catch(reject);
+    });
+  }
+  return response.json();
+};
+
+export const apiFetch =
+  (options: fetchOptions) =>
+  (query: string, variables: Record<string, unknown> = {}) => {
+    const fetchOptions = options[1] || {};
+    if (fetchOptions.method && fetchOptions.method === 'GET') {
+      return fetch(
+        `${options[0]}?query=${encodeURIComponent(query)}`,
+        fetchOptions
+      )
+        .then(handleFetchResponse)
+        .then((response: GraphQLResponse) => {
+          if (response.errors) {
+            throw new GraphQLError(response);
+          }
+          return response.data;
+        });
+    }
+    return fetch(`${options[0]}`, {
+      body: JSON.stringify({ query, variables }),
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      ...fetchOptions,
+    })
+      .then(handleFetchResponse)
+      .then((response: GraphQLResponse) => {
+        if (response.errors) {
+          throw new GraphQLError(response);
+        }
+        return response.data;
+      });
+  };
+
+export const apiSubscription = (options: chainOptions) => (query: string) => {
+  try {
+    const queryString = options[0] + '?query=' + encodeURIComponent(query);
+    const wsString = queryString.replace('http', 'ws');
+    const host = (options.length > 1 && options[1]?.websocket?.[0]) || wsString;
+    const webSocketOptions = options[1]?.websocket || [host];
+    const ws = new WebSocket(...webSocketOptions);
+    return {
+      ws,
+      on: (e: (args: any) => void) => {
+        ws.onmessage = (event: any) => {
+          if (event.data) {
+            const parsed = JSON.parse(event.data);
+            const data = parsed.data;
+            return e(data);
+          }
+        };
+      },
+      off: (e: (args: any) => void) => {
+        ws.onclose = e;
+      },
+      error: (e: (args: any) => void) => {
+        ws.onerror = e;
+      },
+      open: (e: () => void) => {
+        ws.onopen = e;
+      },
+    };
+  } catch {
+    throw new Error('No websockets implemented');
+  }
+};
+
+export const InternalsBuildQuery = (
+  props: AllTypesPropsType,
+  returns: ReturnTypesType,
+  ops: Operations,
+  options?: OperationOptions
+) => {
+  const ibb = (
+    k: string,
+    o: InputValueType | VType,
+    p = '',
+    root = true
+  ): string => {
+    const keyForPath = purifyGraphQLKey(k);
+    const newPath = [p, keyForPath].join(SEPARATOR);
+    if (!o) {
+      return '';
+    }
+    if (typeof o === 'boolean' || typeof o === 'number') {
+      return k;
+    }
+    if (typeof o === 'string') {
+      return `${k} ${o}`;
+    }
+    if (Array.isArray(o)) {
+      const args = InternalArgsBuilt(
+        props,
+        returns,
+        ops,
+        options?.variables?.values
+      )(o[0], newPath);
+      return `${ibb(args ? `${k}(${args})` : k, o[1], p, false)}`;
+    }
+    if (k === '__alias') {
+      return Object.entries(o)
+        .map(([alias, objectUnderAlias]) => {
+          if (
+            typeof objectUnderAlias !== 'object' ||
+            Array.isArray(objectUnderAlias)
+          ) {
+            throw new Error(
+              'Invalid alias it should be __alias:{ YOUR_ALIAS_NAME: { OPERATION_NAME: { ...selectors }}}'
+            );
+          }
+          const operationName = Object.keys(objectUnderAlias)[0];
+          const operation = objectUnderAlias[operationName];
+          return ibb(`${alias}:${operationName}`, operation, p, false);
+        })
+        .join('\n');
+    }
+    const hasOperationName =
+      root && options?.operationName ? ' ' + options.operationName : '';
+    const hasVariables =
+      root && options?.variables?.$params
+        ? `(${options.variables?.$params})`
+        : '';
+    const keyForDirectives = o.__directives ?? '';
+    return `${k} ${keyForDirectives}${hasOperationName}${hasVariables}{${Object.entries(
+      o
+    )
+      .filter(([k]) => k !== '__directives')
+      .map(e => ibb(...e, [p, `field<>${keyForPath}`].join(SEPARATOR), false))
+      .join('\n')}}`;
+  };
+  return ibb;
+};
+
+export const Thunder =
+  (fn: FetchFunction) =>
+  <
+    O extends keyof typeof Ops,
+    R extends keyof ValueTypes = GenericOperation<O>
+  >(
+    operation: O
+  ) =>
+  <Z extends ValueTypes[R]>(o: Z | ValueTypes[R], ops?: OperationOptions) =>
+    fullChainConstruct(fn)(operation)(o as any, ops) as Promise<
+      InputType<GraphQLTypes[R], Z>
+    >;
+
+export const Chain = (...options: chainOptions) => Thunder(apiFetch(options));
+
+export const SubscriptionThunder =
+  (fn: SubscriptionFunction) =>
+  <
+    O extends keyof typeof Ops,
+    R extends keyof ValueTypes = GenericOperation<O>
+  >(
+    operation: O
+  ) =>
+  <Z extends ValueTypes[R]>(o: Z | ValueTypes[R], ops?: OperationOptions) =>
+    fullSubscriptionConstruct(fn)(operation)(
+      o as any,
+      ops
+    ) as SubscriptionToGraphQL<Z, GraphQLTypes[R]>;
+
+export const Subscription = (...options: chainOptions) =>
+  SubscriptionThunder(apiSubscription(options));
+export const Zeus = <
+  Z extends ValueTypes[R],
+  O extends keyof typeof Ops,
+  R extends keyof ValueTypes = GenericOperation<O>
+>(
+  operation: O,
+  o: Z | ValueTypes[R],
+  ops?: OperationOptions
+) =>
+  InternalsBuildQuery(
+    AllTypesProps,
+    ReturnTypes,
+    Ops,
+    ops
+  )(operation, o as any);
+export const Selector = <T extends keyof ValueTypes>(key: T) =>
+  ZeusSelect<ValueTypes[T]>();
+
+export const Gql = Chain(HOST);
+
+export const fullChainConstruct =
+  (fn: FetchFunction) =>
+  (t: 'query' | 'mutation' | 'subscription') =>
+  (o: Record<any, any>, options?: OperationOptions) => {
+    const builder = InternalsBuildQuery(
+      AllTypesProps,
+      ReturnTypes,
+      Ops,
+      options
+    );
+    return fn(builder(t, o), options?.variables?.values);
+  };
+
+export const fullSubscriptionConstruct =
+  (fn: SubscriptionFunction) =>
+  (t: 'query' | 'mutation' | 'subscription') =>
+  (o: Record<any, any>, options?: OperationOptions) => {
+    const builder = InternalsBuildQuery(
+      AllTypesProps,
+      ReturnTypes,
+      Ops,
+      options
+    );
+    return fn(builder(t, o));
+  };
+
+export type AllTypesPropsType = {
+  [x: string]:
+    | undefined
+    | boolean
+    | {
+        [x: string]:
+          | undefined
+          | string
+          | {
+              [x: string]: string | undefined;
+            };
+      };
+};
+
+export type ReturnTypesType = {
+  [x: string]:
+    | {
+        [x: string]: string | undefined;
+      }
+    | undefined;
+};
+export type InputValueType = {
+  [x: string]:
+    | undefined
+    | boolean
+    | string
+    | number
+    | [any, undefined | boolean | InputValueType]
+    | InputValueType;
+};
+export type VType =
+  | undefined
+  | boolean
+  | string
+  | number
+  | [any, undefined | boolean | InputValueType]
+  | InputValueType;
+
+export type PlainType = boolean | number | string | null | undefined;
+export type ZeusArgsType =
+  | PlainType
+  | {
+      [x: string]: ZeusArgsType;
+    }
+  | Array<ZeusArgsType>;
+
+export type Operations = Record<string, string | undefined>;
+
+export type VariableDefinition = {
+  [x: string]: unknown;
+};
+
+export const SEPARATOR = '|';
+
+export type fetchOptions = Parameters<typeof fetch>;
+type websocketOptions = typeof WebSocket extends new (
+  ...args: infer R
+) => WebSocket
+  ? R
+  : never;
+export type chainOptions =
+  | [fetchOptions[0], fetchOptions[1] & { websocket?: websocketOptions }]
+  | [fetchOptions[0]];
+export type FetchFunction = (
+  query: string,
+  variables?: Record<string, any>
+) => Promise<any>;
+export type SubscriptionFunction = (query: string) => any;
+type NotUndefined<T> = T extends undefined ? never : T;
+export type ResolverType<F> = NotUndefined<
+  F extends [infer ARGS, any] ? ARGS : undefined
+>;
+
+export type OperationOptions<
+  Z extends Record<string, unknown> = Record<string, unknown>
+> = {
+  variables?: VariableInput<Z>;
+  operationName?: string;
+};
+
+export interface GraphQLResponse {
+  data?: Record<string, any>;
+  errors?: Array<{
+    message: string;
+  }>;
+}
+export class GraphQLError extends Error {
+  constructor(public response: GraphQLResponse) {
+    super(response.errors?.map(e => e.message).join('. '));
+    logger.log(JSON.stringify(response, null, 2));
+  }
+  toString() {
+    return 'GraphQL Response Error';
+  }
+}
+export type GenericOperation<O> = O extends keyof typeof Ops
+  ? typeof Ops[O]
+  : never;
+
+export const purifyGraphQLKey = (k: string) =>
+  k.replace(/\([^)]*\)/g, '').replace(/^[^:]*\:/g, '');
+
+const mapPart = (p: string) => {
+  const [isArg, isField] = p.split('<>');
+  if (isField) {
+    return {
+      v: isField,
+      __type: 'field',
+    } as const;
+  }
+  return {
+    v: isArg,
+    __type: 'arg',
+  } as const;
+};
+
+type Part = ReturnType<typeof mapPart>;
+
+export const ResolveFromPath = (
+  props: AllTypesPropsType,
+  returns: ReturnTypesType,
+  ops: Operations
+) => {
+  const ResolvePropsType = (mappedParts: Part[]) => {
+    const oKey = ops[mappedParts[0].v];
+    const propsP1 = oKey ? props[oKey] : props[mappedParts[0].v];
+    if (typeof propsP1 === 'boolean' && mappedParts.length === 1) {
+      return 'enum';
+    }
+    if (typeof propsP1 === 'object') {
+      const propsP2 = propsP1[mappedParts[1].v];
+      if (typeof propsP2 === 'string') {
+        return rpp(
+          `${propsP2}${SEPARATOR}${mappedParts
+            .slice(2)
+            .map(mp => mp.v)
+            .join(SEPARATOR)}`
+        );
+      }
+      if (typeof propsP2 === 'object') {
+        const propsP3 = propsP2[mappedParts[2].v];
+        if (propsP3 && mappedParts[2].__type === 'arg') {
+          return rpp(
+            `${propsP3}${SEPARATOR}${mappedParts
+              .slice(3)
+              .map(mp => mp.v)
+              .join(SEPARATOR)}`
+          );
+        }
+      }
+    }
+  };
+  const ResolveReturnType = (mappedParts: Part[]) => {
+    const oKey = ops[mappedParts[0].v];
+    const returnP1 = oKey ? returns[oKey] : returns[mappedParts[0].v];
+    if (typeof returnP1 === 'object') {
+      const returnP2 = returnP1[mappedParts[1].v];
+      if (returnP2) {
+        return rpp(
+          `${returnP2}${SEPARATOR}${mappedParts
+            .slice(2)
+            .map(mp => mp.v)
+            .join(SEPARATOR)}`
+        );
+      }
+    }
+  };
+  const rpp = (path: string): 'enum' | 'not' => {
+    const parts = path.split(SEPARATOR).filter(l => l.length > 0);
+    const mappedParts = parts.map(mapPart);
+    const propsP1 = ResolvePropsType(mappedParts);
+    if (propsP1) {
+      return propsP1;
+    }
+    const returnP1 = ResolveReturnType(mappedParts);
+    if (returnP1) {
+      return returnP1;
+    }
+    return 'not';
+  };
+  return rpp;
+};
+
+export const InternalArgsBuilt = (
+  props: AllTypesPropsType,
+  returns: ReturnTypesType,
+  ops: Operations,
+  variables?: Record<string, unknown>
+) => {
+  const arb = (a: ZeusArgsType, p = '', root = true): string => {
+    if (Array.isArray(a)) {
+      return `[${a.map(arr => arb(arr, p, false)).join(', ')}]`;
+    }
+    if (typeof a === 'string') {
+      if (a.startsWith('$') && variables?.[a.slice(1)]) {
+        return a;
+      }
+      const checkType = ResolveFromPath(props, returns, ops)(p);
+      if (checkType === 'enum') {
+        return a;
+      }
+      return `${JSON.stringify(a)}`;
+    }
+    if (typeof a === 'object') {
+      if (a === null) {
+        return `null`;
+      }
+      const returnedObjectString = Object.entries(a)
+        .filter(([, v]) => typeof v !== 'undefined')
+        .map(([k, v]) => `${k}: ${arb(v, [p, k].join(SEPARATOR), false)}`)
+        .join(',\n');
+      if (!root) {
+        return `{${returnedObjectString}}`;
+      }
+      return returnedObjectString;
+    }
+    return `${a}`;
+  };
+  return arb;
+};
+
+export const resolverFor = <
+  X,
+  T extends keyof ValueTypes,
+  Z extends keyof ValueTypes[T]
+>(
+  type: T,
+  field: Z,
+  fn: (
+    args: Required<ValueTypes[T]>[Z] extends [infer Input, any] ? Input : any,
+    source: any
+  ) => Z extends keyof ModelTypes[T]
+    ? ModelTypes[T][Z] | Promise<ModelTypes[T][Z]> | X
+    : any
+) => fn as (args?: any, source?: any) => any;
+
+export type SelectionFunction<V> = <T>(t: T | V) => T;
+export const ZeusSelect = <T>() => ((t: unknown) => t) as SelectionFunction<T>;
+
+export type UnwrapPromise<T> = T extends Promise<infer R> ? R : T;
+export type ZeusState<T extends (...args: any[]) => Promise<any>> = NonNullable<
+  UnwrapPromise<ReturnType<T>>
+>;
+export type ZeusHook<
+  T extends (
+    ...args: any[]
+  ) => Record<string, (...args: any[]) => Promise<any>>,
+  N extends keyof ReturnType<T>
+> = ZeusState<ReturnType<T>[N]>;
+
+export type WithTypeNameValue<T> = T & {
+  __typename?: boolean;
+  __directives?: string;
+};
+export type AliasType<T> = WithTypeNameValue<T> & {
+  __alias?: Record<string, WithTypeNameValue<T>>;
+};
+type DeepAnify<T> = {
+  [P in keyof T]?: any;
+};
+type IsPayLoad<T> = T extends [any, infer PayLoad] ? PayLoad : T;
+type IsArray<T, U> = T extends Array<infer R>
+  ? InputType<R, U>[]
+  : InputType<T, U>;
+type FlattenArray<T> = T extends Array<infer R> ? R : T;
+type BaseZeusResolver = boolean | 1 | string;
+
+type IsInterfaced<SRC extends DeepAnify<DST>, DST> = FlattenArray<SRC> extends
+  | ZEUS_INTERFACES
+  | ZEUS_UNIONS
+  ? {
+      [P in keyof SRC]: SRC[P] extends '__union' & infer R
+        ? P extends keyof DST
+          ? IsArray<
+              R,
+              '__typename' extends keyof DST
+                ? DST[P] & { __typename: true }
+                : DST[P]
+            >
+          : Record<string, unknown>
+        : never;
+    }[keyof DST] & {
+      [P in keyof Omit<
+        Pick<
+          SRC,
+          {
+            [P in keyof DST]: SRC[P] extends '__union' & infer R ? never : P;
+          }[keyof DST]
+        >,
+        '__typename'
+      >]: IsPayLoad<DST[P]> extends BaseZeusResolver
+        ? SRC[P]
+        : IsArray<SRC[P], DST[P]>;
+    }
+  : {
+      [P in keyof Pick<SRC, keyof DST>]: IsPayLoad<
+        DST[P]
+      > extends BaseZeusResolver
+        ? SRC[P]
+        : IsArray<SRC[P], DST[P]>;
+    };
+
+export type MapType<SRC, DST> = SRC extends DeepAnify<DST>
+  ? IsInterfaced<SRC, DST>
+  : never;
+export type InputType<SRC, DST> = IsPayLoad<DST> extends { __alias: infer R }
+  ? {
+      [P in keyof R]: MapType<SRC, R[P]>[keyof MapType<SRC, R[P]>];
+    } & MapType<SRC, Omit<IsPayLoad<DST>, '__alias'>>
+  : MapType<SRC, IsPayLoad<DST>>;
+export type SubscriptionToGraphQL<Z, T> = {
+  ws: WebSocket;
+  on: (fn: (args: InputType<T, Z>) => void) => void;
+  off: (
+    fn: (e: {
+      data?: InputType<T, Z>;
+      code?: number;
+      reason?: string;
+      message?: string;
+    }) => void
+  ) => void;
+  error: (
+    fn: (e: { data?: InputType<T, Z>; errors?: string[] }) => void
+  ) => void;
+  open: () => void;
+};
+
+export const useZeusVariables =
+  <T>(variables: T) =>
+  <
+    Z extends {
+      [P in keyof T]: unknown;
+    }
+  >(
+    values: Z
+  ) => {
+    return {
+      $params: Object.keys(variables)
+        .map(k => `$${k}: ${variables[k as keyof T]}`)
+        .join(', '),
+      $: <U extends keyof Z>(variable: U) => {
+        return `$${variable}` as unknown as Z[U];
+      },
+      values,
+    };
+  };
+
+export type VariableInput<Z extends Record<string, unknown>> = {
+  $params: ReturnType<ReturnType<typeof useZeusVariables>>['$params'];
+  values: Z;
+};
+
+type ZEUS_INTERFACES = never;
+type ZEUS_UNIONS = never;
+
+export type ValueTypes = {
+  /** Boolean expression to compare columns of type "Int". All fields are combined with logical 'AND'. */
+  ['Int_comparison_exp']: {
+    _eq?: number | undefined | null;
+    _gt?: number | undefined | null;
+    _gte?: number | undefined | null;
+    _in?: Array<number> | undefined | null;
+    _is_null?: boolean | undefined | null;
+    _lt?: number | undefined | null;
+    _lte?: number | undefined | null;
+    _neq?: number | undefined | null;
+    _nin?: Array<number> | undefined | null;
+  };
+  /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
+  ['String_comparison_exp']: {
+    _eq?: string | undefined | null;
+    _gt?: string | undefined | null;
+    _gte?: string | undefined | null;
+    /** does the column match the given case-insensitive pattern */
+    _ilike?: string | undefined | null;
+    _in?: Array<string> | undefined | null;
+    /** does the column match the given POSIX regular expression, case insensitive */
+    _iregex?: string | undefined | null;
+    _is_null?: boolean | undefined | null;
+    /** does the column match the given pattern */
+    _like?: string | undefined | null;
+    _lt?: string | undefined | null;
+    _lte?: string | undefined | null;
+    _neq?: string | undefined | null;
+    /** does the column NOT match the given case-insensitive pattern */
+    _nilike?: string | undefined | null;
+    _nin?: Array<string> | undefined | null;
+    /** does the column NOT match the given POSIX regular expression, case insensitive */
+    _niregex?: string | undefined | null;
+    /** does the column NOT match the given pattern */
+    _nlike?: string | undefined | null;
+    /** does the column NOT match the given POSIX regular expression, case sensitive */
+    _nregex?: string | undefined | null;
+    /** does the column NOT match the given SQL regular expression */
+    _nsimilar?: string | undefined | null;
+    /** does the column match the given POSIX regular expression, case sensitive */
+    _regex?: string | undefined | null;
+    /** does the column match the given SQL regular expression */
+    _similar?: string | undefined | null;
+  };
+  ['bigint']: number;
+  /** Boolean expression to compare columns of type "bigint". All fields are combined with logical 'AND'. */
+  ['bigint_comparison_exp']: {
+    _eq?: ValueTypes['bigint'] | undefined | null;
+    _gt?: ValueTypes['bigint'] | undefined | null;
+    _gte?: ValueTypes['bigint'] | undefined | null;
+    _in?: Array<ValueTypes['bigint']> | undefined | null;
+    _is_null?: boolean | undefined | null;
+    _lt?: ValueTypes['bigint'] | undefined | null;
+    _lte?: ValueTypes['bigint'] | undefined | null;
+    _neq?: ValueTypes['bigint'] | undefined | null;
+    _nin?: Array<ValueTypes['bigint']> | undefined | null;
+  };
+  ['citext']: unknown;
+  /** Boolean expression to compare columns of type "citext". All fields are combined with logical 'AND'. */
+  ['citext_comparison_exp']: {
+    _eq?: ValueTypes['citext'] | undefined | null;
+    _gt?: ValueTypes['citext'] | undefined | null;
+    _gte?: ValueTypes['citext'] | undefined | null;
+    /** does the column match the given case-insensitive pattern */
+    _ilike?: ValueTypes['citext'] | undefined | null;
+    _in?: Array<ValueTypes['citext']> | undefined | null;
+    /** does the column match the given POSIX regular expression, case insensitive */
+    _iregex?: ValueTypes['citext'] | undefined | null;
+    _is_null?: boolean | undefined | null;
+    /** does the column match the given pattern */
+    _like?: ValueTypes['citext'] | undefined | null;
+    _lt?: ValueTypes['citext'] | undefined | null;
+    _lte?: ValueTypes['citext'] | undefined | null;
+    _neq?: ValueTypes['citext'] | undefined | null;
+    /** does the column NOT match the given case-insensitive pattern */
+    _nilike?: ValueTypes['citext'] | undefined | null;
+    _nin?: Array<ValueTypes['citext']> | undefined | null;
+    /** does the column NOT match the given POSIX regular expression, case insensitive */
+    _niregex?: ValueTypes['citext'] | undefined | null;
+    /** does the column NOT match the given pattern */
+    _nlike?: ValueTypes['citext'] | undefined | null;
+    /** does the column NOT match the given POSIX regular expression, case sensitive */
+    _nregex?: ValueTypes['citext'] | undefined | null;
+    /** does the column NOT match the given SQL regular expression */
+    _nsimilar?: ValueTypes['citext'] | undefined | null;
+    /** does the column match the given POSIX regular expression, case sensitive */
+    _regex?: ValueTypes['citext'] | undefined | null;
+    /** does the column match the given SQL regular expression */
+    _similar?: ValueTypes['citext'] | undefined | null;
+  };
+  /** local db copy of last synced on-chain cosoul data */
+  ['cosouls']: AliasType<{
+    address?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    pgive?: boolean | `@${string}`;
+    /** An object relationship */
+    profile_public?: ValueTypes['profiles_public'];
+    token_id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** Boolean expression to filter rows from the table "cosouls". All fields are combined with a logical 'AND'. */
+  ['cosouls_bool_exp']: {
+    _and?: Array<ValueTypes['cosouls_bool_exp']> | undefined | null;
+    _not?: ValueTypes['cosouls_bool_exp'] | undefined | null;
+    _or?: Array<ValueTypes['cosouls_bool_exp']> | undefined | null;
+    address?: ValueTypes['citext_comparison_exp'] | undefined | null;
+    id?: ValueTypes['Int_comparison_exp'] | undefined | null;
+    pgive?: ValueTypes['Int_comparison_exp'] | undefined | null;
+    profile_public?: ValueTypes['profiles_public_bool_exp'] | undefined | null;
+    token_id?: ValueTypes['Int_comparison_exp'] | undefined | null;
+  };
+  /** Ordering options when selecting data from "cosouls". */
+  ['cosouls_order_by']: {
+    address?: ValueTypes['order_by'] | undefined | null;
+    id?: ValueTypes['order_by'] | undefined | null;
+    pgive?: ValueTypes['order_by'] | undefined | null;
+    profile_public?: ValueTypes['profiles_public_order_by'] | undefined | null;
+    token_id?: ValueTypes['order_by'] | undefined | null;
+  };
+  /** select columns of table "cosouls" */
+  ['cosouls_select_column']: cosouls_select_column;
+  /** Streaming cursor of the table "cosouls" */
+  ['cosouls_stream_cursor_input']: {
+    /** Stream column input with initial value */
+    initial_value: ValueTypes['cosouls_stream_cursor_value_input'];
+    /** cursor ordering */
+    ordering?: ValueTypes['cursor_ordering'] | undefined | null;
+  };
+  /** Initial value of the column from where the streaming should start */
+  ['cosouls_stream_cursor_value_input']: {
+    address?: ValueTypes['citext'] | undefined | null;
+    id?: number | undefined | null;
+    pgive?: number | undefined | null;
+    token_id?: number | undefined | null;
+  };
+  /** ordering argument of a cursor */
+  ['cursor_ordering']: cursor_ordering;
+  /** column ordering options */
+  ['order_by']: order_by;
+  /** columns and relationships of "profiles_public" */
+  ['profiles_public']: AliasType<{
+    address?: boolean | `@${string}`;
+    avatar?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    name?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** Boolean expression to filter rows from the table "profiles_public". All fields are combined with a logical 'AND'. */
+  ['profiles_public_bool_exp']: {
+    _and?: Array<ValueTypes['profiles_public_bool_exp']> | undefined | null;
+    _not?: ValueTypes['profiles_public_bool_exp'] | undefined | null;
+    _or?: Array<ValueTypes['profiles_public_bool_exp']> | undefined | null;
+    address?: ValueTypes['String_comparison_exp'] | undefined | null;
+    avatar?: ValueTypes['String_comparison_exp'] | undefined | null;
+    id?: ValueTypes['bigint_comparison_exp'] | undefined | null;
+    name?: ValueTypes['citext_comparison_exp'] | undefined | null;
+  };
+  /** Ordering options when selecting data from "profiles_public". */
+  ['profiles_public_order_by']: {
+    address?: ValueTypes['order_by'] | undefined | null;
+    avatar?: ValueTypes['order_by'] | undefined | null;
+    id?: ValueTypes['order_by'] | undefined | null;
+    name?: ValueTypes['order_by'] | undefined | null;
+  };
+  /** select columns of table "profiles_public" */
+  ['profiles_public_select_column']: profiles_public_select_column;
+  /** Streaming cursor of the table "profiles_public" */
+  ['profiles_public_stream_cursor_input']: {
+    /** Stream column input with initial value */
+    initial_value: ValueTypes['profiles_public_stream_cursor_value_input'];
+    /** cursor ordering */
+    ordering?: ValueTypes['cursor_ordering'] | undefined | null;
+  };
+  /** Initial value of the column from where the streaming should start */
+  ['profiles_public_stream_cursor_value_input']: {
+    address?: string | undefined | null;
+    avatar?: string | undefined | null;
+    id?: ValueTypes['bigint'] | undefined | null;
+    name?: ValueTypes['citext'] | undefined | null;
+  };
+  ['query_root']: AliasType<{
+    cosouls?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['cosouls_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['cosouls_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ValueTypes['cosouls_bool_exp'] | undefined | null;
+      },
+      ValueTypes['cosouls']
+    ];
+    cosouls_by_pk?: [{ id: number }, ValueTypes['cosouls']];
+    price_per_share?: [
+      { chain_id: number; token_address?: string | undefined | null },
+      boolean | `@${string}`
+    ];
+    profiles_public?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['profiles_public_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['profiles_public_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ValueTypes['profiles_public_bool_exp'] | undefined | null;
+      },
+      ValueTypes['profiles_public']
+    ];
+    __typename?: boolean | `@${string}`;
+  }>;
+  ['subscription_root']: AliasType<{
+    cosouls?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['cosouls_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['cosouls_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ValueTypes['cosouls_bool_exp'] | undefined | null;
+      },
+      ValueTypes['cosouls']
+    ];
+    cosouls_by_pk?: [{ id: number }, ValueTypes['cosouls']];
+    cosouls_stream?: [
+      {
+        /** maximum number of rows returned in a single batch */
+        batch_size: number /** cursor to stream the results returned by the query */;
+        cursor: Array<
+          ValueTypes['cosouls_stream_cursor_input'] | undefined | null
+        > /** filter the rows returned */;
+        where?: ValueTypes['cosouls_bool_exp'] | undefined | null;
+      },
+      ValueTypes['cosouls']
+    ];
+    profiles_public?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['profiles_public_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['profiles_public_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ValueTypes['profiles_public_bool_exp'] | undefined | null;
+      },
+      ValueTypes['profiles_public']
+    ];
+    profiles_public_stream?: [
+      {
+        /** maximum number of rows returned in a single batch */
+        batch_size: number /** cursor to stream the results returned by the query */;
+        cursor: Array<
+          ValueTypes['profiles_public_stream_cursor_input'] | undefined | null
+        > /** filter the rows returned */;
+        where?: ValueTypes['profiles_public_bool_exp'] | undefined | null;
+      },
+      ValueTypes['profiles_public']
+    ];
+    __typename?: boolean | `@${string}`;
+  }>;
+};
+
+export type ModelTypes = {
+  /** Boolean expression to compare columns of type "Int". All fields are combined with logical 'AND'. */
+  ['Int_comparison_exp']: GraphQLTypes['Int_comparison_exp'];
+  /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
+  ['String_comparison_exp']: GraphQLTypes['String_comparison_exp'];
+  ['bigint']: number;
+  /** Boolean expression to compare columns of type "bigint". All fields are combined with logical 'AND'. */
+  ['bigint_comparison_exp']: GraphQLTypes['bigint_comparison_exp'];
+  ['citext']: any;
+  /** Boolean expression to compare columns of type "citext". All fields are combined with logical 'AND'. */
+  ['citext_comparison_exp']: GraphQLTypes['citext_comparison_exp'];
+  /** local db copy of last synced on-chain cosoul data */
+  ['cosouls']: {
+    address: GraphQLTypes['citext'];
+    id: number;
+    pgive?: number | undefined;
+    /** An object relationship */
+    profile_public?: GraphQLTypes['profiles_public'] | undefined;
+    token_id: number;
+  };
+  /** Boolean expression to filter rows from the table "cosouls". All fields are combined with a logical 'AND'. */
+  ['cosouls_bool_exp']: GraphQLTypes['cosouls_bool_exp'];
+  /** Ordering options when selecting data from "cosouls". */
+  ['cosouls_order_by']: GraphQLTypes['cosouls_order_by'];
+  /** select columns of table "cosouls" */
+  ['cosouls_select_column']: GraphQLTypes['cosouls_select_column'];
+  /** Streaming cursor of the table "cosouls" */
+  ['cosouls_stream_cursor_input']: GraphQLTypes['cosouls_stream_cursor_input'];
+  /** Initial value of the column from where the streaming should start */
+  ['cosouls_stream_cursor_value_input']: GraphQLTypes['cosouls_stream_cursor_value_input'];
+  /** ordering argument of a cursor */
+  ['cursor_ordering']: GraphQLTypes['cursor_ordering'];
+  /** column ordering options */
+  ['order_by']: GraphQLTypes['order_by'];
+  /** columns and relationships of "profiles_public" */
+  ['profiles_public']: {
+    address?: string | undefined;
+    avatar?: string | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    name?: GraphQLTypes['citext'] | undefined;
+  };
+  /** Boolean expression to filter rows from the table "profiles_public". All fields are combined with a logical 'AND'. */
+  ['profiles_public_bool_exp']: GraphQLTypes['profiles_public_bool_exp'];
+  /** Ordering options when selecting data from "profiles_public". */
+  ['profiles_public_order_by']: GraphQLTypes['profiles_public_order_by'];
+  /** select columns of table "profiles_public" */
+  ['profiles_public_select_column']: GraphQLTypes['profiles_public_select_column'];
+  /** Streaming cursor of the table "profiles_public" */
+  ['profiles_public_stream_cursor_input']: GraphQLTypes['profiles_public_stream_cursor_input'];
+  /** Initial value of the column from where the streaming should start */
+  ['profiles_public_stream_cursor_value_input']: GraphQLTypes['profiles_public_stream_cursor_value_input'];
+  ['query_root']: {
+    /** fetch data from the table: "cosouls" */
+    cosouls: Array<GraphQLTypes['cosouls']>;
+    /** fetch data from the table: "cosouls" using primary key columns */
+    cosouls_by_pk?: GraphQLTypes['cosouls'] | undefined;
+    price_per_share: number;
+    /** fetch data from the table: "profiles_public" */
+    profiles_public: Array<GraphQLTypes['profiles_public']>;
+  };
+  ['subscription_root']: {
+    /** fetch data from the table: "cosouls" */
+    cosouls: Array<GraphQLTypes['cosouls']>;
+    /** fetch data from the table: "cosouls" using primary key columns */
+    cosouls_by_pk?: GraphQLTypes['cosouls'] | undefined;
+    /** fetch data from the table in a streaming manner: "cosouls" */
+    cosouls_stream: Array<GraphQLTypes['cosouls']>;
+    /** fetch data from the table: "profiles_public" */
+    profiles_public: Array<GraphQLTypes['profiles_public']>;
+    /** fetch data from the table in a streaming manner: "profiles_public" */
+    profiles_public_stream: Array<GraphQLTypes['profiles_public']>;
+  };
+};
+
+export type GraphQLTypes = {
+  /** Boolean expression to compare columns of type "Int". All fields are combined with logical 'AND'. */
+  ['Int_comparison_exp']: {
+    _eq?: number | undefined;
+    _gt?: number | undefined;
+    _gte?: number | undefined;
+    _in?: Array<number> | undefined;
+    _is_null?: boolean | undefined;
+    _lt?: number | undefined;
+    _lte?: number | undefined;
+    _neq?: number | undefined;
+    _nin?: Array<number> | undefined;
+  };
+  /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
+  ['String_comparison_exp']: {
+    _eq?: string | undefined;
+    _gt?: string | undefined;
+    _gte?: string | undefined;
+    /** does the column match the given case-insensitive pattern */
+    _ilike?: string | undefined;
+    _in?: Array<string> | undefined;
+    /** does the column match the given POSIX regular expression, case insensitive */
+    _iregex?: string | undefined;
+    _is_null?: boolean | undefined;
+    /** does the column match the given pattern */
+    _like?: string | undefined;
+    _lt?: string | undefined;
+    _lte?: string | undefined;
+    _neq?: string | undefined;
+    /** does the column NOT match the given case-insensitive pattern */
+    _nilike?: string | undefined;
+    _nin?: Array<string> | undefined;
+    /** does the column NOT match the given POSIX regular expression, case insensitive */
+    _niregex?: string | undefined;
+    /** does the column NOT match the given pattern */
+    _nlike?: string | undefined;
+    /** does the column NOT match the given POSIX regular expression, case sensitive */
+    _nregex?: string | undefined;
+    /** does the column NOT match the given SQL regular expression */
+    _nsimilar?: string | undefined;
+    /** does the column match the given POSIX regular expression, case sensitive */
+    _regex?: string | undefined;
+    /** does the column match the given SQL regular expression */
+    _similar?: string | undefined;
+  };
+  ['bigint']: any;
+  /** Boolean expression to compare columns of type "bigint". All fields are combined with logical 'AND'. */
+  ['bigint_comparison_exp']: {
+    _eq?: GraphQLTypes['bigint'] | undefined;
+    _gt?: GraphQLTypes['bigint'] | undefined;
+    _gte?: GraphQLTypes['bigint'] | undefined;
+    _in?: Array<GraphQLTypes['bigint']> | undefined;
+    _is_null?: boolean | undefined;
+    _lt?: GraphQLTypes['bigint'] | undefined;
+    _lte?: GraphQLTypes['bigint'] | undefined;
+    _neq?: GraphQLTypes['bigint'] | undefined;
+    _nin?: Array<GraphQLTypes['bigint']> | undefined;
+  };
+  ['citext']: any;
+  /** Boolean expression to compare columns of type "citext". All fields are combined with logical 'AND'. */
+  ['citext_comparison_exp']: {
+    _eq?: GraphQLTypes['citext'] | undefined;
+    _gt?: GraphQLTypes['citext'] | undefined;
+    _gte?: GraphQLTypes['citext'] | undefined;
+    /** does the column match the given case-insensitive pattern */
+    _ilike?: GraphQLTypes['citext'] | undefined;
+    _in?: Array<GraphQLTypes['citext']> | undefined;
+    /** does the column match the given POSIX regular expression, case insensitive */
+    _iregex?: GraphQLTypes['citext'] | undefined;
+    _is_null?: boolean | undefined;
+    /** does the column match the given pattern */
+    _like?: GraphQLTypes['citext'] | undefined;
+    _lt?: GraphQLTypes['citext'] | undefined;
+    _lte?: GraphQLTypes['citext'] | undefined;
+    _neq?: GraphQLTypes['citext'] | undefined;
+    /** does the column NOT match the given case-insensitive pattern */
+    _nilike?: GraphQLTypes['citext'] | undefined;
+    _nin?: Array<GraphQLTypes['citext']> | undefined;
+    /** does the column NOT match the given POSIX regular expression, case insensitive */
+    _niregex?: GraphQLTypes['citext'] | undefined;
+    /** does the column NOT match the given pattern */
+    _nlike?: GraphQLTypes['citext'] | undefined;
+    /** does the column NOT match the given POSIX regular expression, case sensitive */
+    _nregex?: GraphQLTypes['citext'] | undefined;
+    /** does the column NOT match the given SQL regular expression */
+    _nsimilar?: GraphQLTypes['citext'] | undefined;
+    /** does the column match the given POSIX regular expression, case sensitive */
+    _regex?: GraphQLTypes['citext'] | undefined;
+    /** does the column match the given SQL regular expression */
+    _similar?: GraphQLTypes['citext'] | undefined;
+  };
+  /** local db copy of last synced on-chain cosoul data */
+  ['cosouls']: {
+    __typename: 'cosouls';
+    address: GraphQLTypes['citext'];
+    id: number;
+    pgive?: number | undefined;
+    /** An object relationship */
+    profile_public?: GraphQLTypes['profiles_public'] | undefined;
+    token_id: number;
+  };
+  /** Boolean expression to filter rows from the table "cosouls". All fields are combined with a logical 'AND'. */
+  ['cosouls_bool_exp']: {
+    _and?: Array<GraphQLTypes['cosouls_bool_exp']> | undefined;
+    _not?: GraphQLTypes['cosouls_bool_exp'] | undefined;
+    _or?: Array<GraphQLTypes['cosouls_bool_exp']> | undefined;
+    address?: GraphQLTypes['citext_comparison_exp'] | undefined;
+    id?: GraphQLTypes['Int_comparison_exp'] | undefined;
+    pgive?: GraphQLTypes['Int_comparison_exp'] | undefined;
+    profile_public?: GraphQLTypes['profiles_public_bool_exp'] | undefined;
+    token_id?: GraphQLTypes['Int_comparison_exp'] | undefined;
+  };
+  /** Ordering options when selecting data from "cosouls". */
+  ['cosouls_order_by']: {
+    address?: GraphQLTypes['order_by'] | undefined;
+    id?: GraphQLTypes['order_by'] | undefined;
+    pgive?: GraphQLTypes['order_by'] | undefined;
+    profile_public?: GraphQLTypes['profiles_public_order_by'] | undefined;
+    token_id?: GraphQLTypes['order_by'] | undefined;
+  };
+  /** select columns of table "cosouls" */
+  ['cosouls_select_column']: cosouls_select_column;
+  /** Streaming cursor of the table "cosouls" */
+  ['cosouls_stream_cursor_input']: {
+    /** Stream column input with initial value */
+    initial_value: GraphQLTypes['cosouls_stream_cursor_value_input'];
+    /** cursor ordering */
+    ordering?: GraphQLTypes['cursor_ordering'] | undefined;
+  };
+  /** Initial value of the column from where the streaming should start */
+  ['cosouls_stream_cursor_value_input']: {
+    address?: GraphQLTypes['citext'] | undefined;
+    id?: number | undefined;
+    pgive?: number | undefined;
+    token_id?: number | undefined;
+  };
+  /** ordering argument of a cursor */
+  ['cursor_ordering']: cursor_ordering;
+  /** column ordering options */
+  ['order_by']: order_by;
+  /** columns and relationships of "profiles_public" */
+  ['profiles_public']: {
+    __typename: 'profiles_public';
+    address?: string | undefined;
+    avatar?: string | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    name?: GraphQLTypes['citext'] | undefined;
+  };
+  /** Boolean expression to filter rows from the table "profiles_public". All fields are combined with a logical 'AND'. */
+  ['profiles_public_bool_exp']: {
+    _and?: Array<GraphQLTypes['profiles_public_bool_exp']> | undefined;
+    _not?: GraphQLTypes['profiles_public_bool_exp'] | undefined;
+    _or?: Array<GraphQLTypes['profiles_public_bool_exp']> | undefined;
+    address?: GraphQLTypes['String_comparison_exp'] | undefined;
+    avatar?: GraphQLTypes['String_comparison_exp'] | undefined;
+    id?: GraphQLTypes['bigint_comparison_exp'] | undefined;
+    name?: GraphQLTypes['citext_comparison_exp'] | undefined;
+  };
+  /** Ordering options when selecting data from "profiles_public". */
+  ['profiles_public_order_by']: {
+    address?: GraphQLTypes['order_by'] | undefined;
+    avatar?: GraphQLTypes['order_by'] | undefined;
+    id?: GraphQLTypes['order_by'] | undefined;
+    name?: GraphQLTypes['order_by'] | undefined;
+  };
+  /** select columns of table "profiles_public" */
+  ['profiles_public_select_column']: profiles_public_select_column;
+  /** Streaming cursor of the table "profiles_public" */
+  ['profiles_public_stream_cursor_input']: {
+    /** Stream column input with initial value */
+    initial_value: GraphQLTypes['profiles_public_stream_cursor_value_input'];
+    /** cursor ordering */
+    ordering?: GraphQLTypes['cursor_ordering'] | undefined;
+  };
+  /** Initial value of the column from where the streaming should start */
+  ['profiles_public_stream_cursor_value_input']: {
+    address?: string | undefined;
+    avatar?: string | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    name?: GraphQLTypes['citext'] | undefined;
+  };
+  ['query_root']: {
+    __typename: 'query_root';
+    /** fetch data from the table: "cosouls" */
+    cosouls: Array<GraphQLTypes['cosouls']>;
+    /** fetch data from the table: "cosouls" using primary key columns */
+    cosouls_by_pk?: GraphQLTypes['cosouls'] | undefined;
+    price_per_share: number;
+    /** fetch data from the table: "profiles_public" */
+    profiles_public: Array<GraphQLTypes['profiles_public']>;
+  };
+  ['subscription_root']: {
+    __typename: 'subscription_root';
+    /** fetch data from the table: "cosouls" */
+    cosouls: Array<GraphQLTypes['cosouls']>;
+    /** fetch data from the table: "cosouls" using primary key columns */
+    cosouls_by_pk?: GraphQLTypes['cosouls'] | undefined;
+    /** fetch data from the table in a streaming manner: "cosouls" */
+    cosouls_stream: Array<GraphQLTypes['cosouls']>;
+    /** fetch data from the table: "profiles_public" */
+    profiles_public: Array<GraphQLTypes['profiles_public']>;
+    /** fetch data from the table in a streaming manner: "profiles_public" */
+    profiles_public_stream: Array<GraphQLTypes['profiles_public']>;
+  };
+};
+/** select columns of table "cosouls" */
+export const enum cosouls_select_column {
+  address = 'address',
+  id = 'id',
+  pgive = 'pgive',
+  token_id = 'token_id',
+}
+/** ordering argument of a cursor */
+export const enum cursor_ordering {
+  ASC = 'ASC',
+  DESC = 'DESC',
+}
+/** column ordering options */
+export const enum order_by {
+  asc = 'asc',
+  asc_nulls_first = 'asc_nulls_first',
+  asc_nulls_last = 'asc_nulls_last',
+  desc = 'desc',
+  desc_nulls_first = 'desc_nulls_first',
+  desc_nulls_last = 'desc_nulls_last',
+}
+/** select columns of table "profiles_public" */
+export const enum profiles_public_select_column {
+  address = 'address',
+  avatar = 'avatar',
+  id = 'id',
+  name = 'name',
+}

--- a/src/lib/anongql/anonClient.ts
+++ b/src/lib/anongql/anonClient.ts
@@ -1,0 +1,79 @@
+import type { SubscriptionHookOptions } from '@apollo/client';
+import { gql, useSubscription } from '@apollo/client';
+
+import { REACT_APP_HASURA_URL } from '../../config/env';
+import {
+  apiFetch,
+  FetchFunction,
+  fullChainConstruct,
+  GenericOperation,
+  GraphQLTypes,
+  InputType,
+  OperationOptions,
+  ValueTypes,
+  Zeus,
+} from '../gql/__generated__/zeus/index';
+
+import { Ops } from './__generated__/zeus/const';
+
+let mockHeaders: Record<string, string> = {};
+
+export const setMockHeaders = (h: Record<string, string>) => {
+  mockHeaders = h;
+};
+
+/* A bit verbose TS, but this allows us to enforce OperationName as a required */
+export const ThunderRequireOperationName =
+  (fn: FetchFunction) =>
+  <
+    O extends keyof typeof Ops,
+    R extends keyof ValueTypes = GenericOperation<O>
+  >(
+    operation: O
+  ) =>
+  <Z extends ValueTypes[R]>(
+    o: Z | ValueTypes[R],
+    ops: Omit<OperationOptions, 'operationName'> & { operationName: string }
+  ) =>
+    fullChainConstruct(fn)(operation)(o as any, ops) as Promise<
+      InputType<GraphQLTypes[R], Z>
+    >;
+
+const makeThunder = (headers = {}) =>
+  ThunderRequireOperationName(async (...params) =>
+    apiFetch([
+      REACT_APP_HASURA_URL,
+      {
+        method: 'POST',
+        headers: {
+          'Hasura-Client-Name': 'web',
+          ...mockHeaders,
+          ...headers,
+        },
+      },
+    ])(...params)
+  );
+
+const thunder = makeThunder();
+
+export const anonClient = {
+  query: thunder('query'),
+  subscribe: thunder('subscription'),
+};
+
+export function useTypedSubscription<
+  Z extends ValueTypes[O],
+  O extends 'subscription_root'
+>(
+  subscription: Z | ValueTypes[O],
+  options?: SubscriptionHookOptions<InputType<GraphQLTypes[O], Z>>,
+  operationOptions?: OperationOptions
+) {
+  // @ts-ignore
+  return useSubscription<InputType<GraphQLTypes[O], Z>>(
+    // @ts-ignore
+    gql(Zeus('subscription', subscription, operationOptions)),
+    // @ts-ignore
+    options
+  );
+}

--- a/src/lib/gql/__generated__/zeus/const.ts
+++ b/src/lib/gql/__generated__/zeus/const.ts
@@ -1381,6 +1381,7 @@ export const AllTypesProps: Record<string, any> = {
     id: 'Int_comparison_exp',
     pgive: 'Int_comparison_exp',
     profile: 'profiles_bool_exp',
+    profile_public: 'profiles_public_bool_exp',
     synced_at: 'timestamptz_comparison_exp',
     token_id: 'Int_comparison_exp',
     updated_at: 'timestamptz_comparison_exp',
@@ -1392,6 +1393,7 @@ export const AllTypesProps: Record<string, any> = {
     id: 'order_by',
     pgive: 'order_by',
     profile: 'profiles_order_by',
+    profile_public: 'profiles_public_order_by',
     synced_at: 'order_by',
     token_id: 'order_by',
     updated_at: 'order_by',
@@ -3811,6 +3813,30 @@ export const AllTypesProps: Record<string, any> = {
   profiles_pk_columns_input: {
     id: 'bigint',
   },
+  profiles_public_bool_exp: {
+    _and: 'profiles_public_bool_exp',
+    _not: 'profiles_public_bool_exp',
+    _or: 'profiles_public_bool_exp',
+    address: 'String_comparison_exp',
+    avatar: 'String_comparison_exp',
+    id: 'bigint_comparison_exp',
+    name: 'citext_comparison_exp',
+  },
+  profiles_public_order_by: {
+    address: 'order_by',
+    avatar: 'order_by',
+    id: 'order_by',
+    name: 'order_by',
+  },
+  profiles_public_select_column: true,
+  profiles_public_stream_cursor_input: {
+    initial_value: 'profiles_public_stream_cursor_value_input',
+    ordering: 'cursor_ordering',
+  },
+  profiles_public_stream_cursor_value_input: {
+    id: 'bigint',
+    name: 'citext',
+  },
   profiles_select_column: true,
   profiles_set_input: {},
   profiles_stream_cursor_input: {
@@ -4087,6 +4113,11 @@ export const AllTypesProps: Record<string, any> = {
     },
     profiles_by_pk: {
       id: 'bigint',
+    },
+    profiles_public: {
+      distinct_on: 'profiles_public_select_column',
+      order_by: 'profiles_public_order_by',
+      where: 'profiles_public_bool_exp',
     },
     reactions: {
       distinct_on: 'reactions_select_column',
@@ -4673,6 +4704,15 @@ export const AllTypesProps: Record<string, any> = {
     },
     profiles_by_pk: {
       id: 'bigint',
+    },
+    profiles_public: {
+      distinct_on: 'profiles_public_select_column',
+      order_by: 'profiles_public_order_by',
+      where: 'profiles_public_bool_exp',
+    },
+    profiles_public_stream: {
+      cursor: 'profiles_public_stream_cursor_input',
+      where: 'profiles_public_bool_exp',
     },
     profiles_stream: {
       cursor: 'profiles_stream_cursor_input',
@@ -6428,6 +6468,7 @@ export const ReturnTypes: Record<string, any> = {
     id: 'Int',
     pgive: 'Int',
     profile: 'profiles',
+    profile_public: 'profiles_public',
     synced_at: 'timestamptz',
     token_id: 'Int',
     updated_at: 'timestamptz',
@@ -7227,6 +7268,12 @@ export const ReturnTypes: Record<string, any> = {
     affected_rows: 'Int',
     returning: 'profiles',
   },
+  profiles_public: {
+    address: 'String',
+    avatar: 'String',
+    id: 'bigint',
+    name: 'citext',
+  },
   query_root: {
     activities: 'activities',
     activities_aggregate: 'activities_aggregate',
@@ -7293,6 +7340,7 @@ export const ReturnTypes: Record<string, any> = {
     price_per_share: 'Float',
     profiles: 'profiles',
     profiles_by_pk: 'profiles',
+    profiles_public: 'profiles_public',
     reactions: 'reactions',
     reactions_aggregate: 'reactions_aggregate',
     reactions_by_pk: 'reactions',
@@ -7496,6 +7544,8 @@ export const ReturnTypes: Record<string, any> = {
     pending_vault_transactions_stream: 'pending_vault_transactions',
     profiles: 'profiles',
     profiles_by_pk: 'profiles',
+    profiles_public: 'profiles_public',
+    profiles_public_stream: 'profiles_public',
     profiles_stream: 'profiles',
     reactions: 'reactions',
     reactions_aggregate: 'reactions_aggregate',

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -3638,6 +3638,8 @@ export type ValueTypes = {
     pgive?: boolean | `@${string}`;
     /** An object relationship */
     profile?: ValueTypes['profiles'];
+    /** An object relationship */
+    profile_public?: ValueTypes['profiles_public'];
     synced_at?: boolean | `@${string}`;
     token_id?: boolean | `@${string}`;
     updated_at?: boolean | `@${string}`;
@@ -3654,6 +3656,7 @@ export type ValueTypes = {
     id?: ValueTypes['Int_comparison_exp'] | undefined | null;
     pgive?: ValueTypes['Int_comparison_exp'] | undefined | null;
     profile?: ValueTypes['profiles_bool_exp'] | undefined | null;
+    profile_public?: ValueTypes['profiles_public_bool_exp'] | undefined | null;
     synced_at?: ValueTypes['timestamptz_comparison_exp'] | undefined | null;
     token_id?: ValueTypes['Int_comparison_exp'] | undefined | null;
     updated_at?: ValueTypes['timestamptz_comparison_exp'] | undefined | null;
@@ -3666,6 +3669,7 @@ export type ValueTypes = {
     id?: ValueTypes['order_by'] | undefined | null;
     pgive?: ValueTypes['order_by'] | undefined | null;
     profile?: ValueTypes['profiles_order_by'] | undefined | null;
+    profile_public?: ValueTypes['profiles_public_order_by'] | undefined | null;
     synced_at?: ValueTypes['order_by'] | undefined | null;
     token_id?: ValueTypes['order_by'] | undefined | null;
     updated_at?: ValueTypes['order_by'] | undefined | null;
@@ -8610,6 +8614,47 @@ export type ValueTypes = {
   ['profiles_pk_columns_input']: {
     id: ValueTypes['bigint'];
   };
+  /** columns and relationships of "profiles_public" */
+  ['profiles_public']: AliasType<{
+    address?: boolean | `@${string}`;
+    avatar?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    name?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** Boolean expression to filter rows from the table "profiles_public". All fields are combined with a logical 'AND'. */
+  ['profiles_public_bool_exp']: {
+    _and?: Array<ValueTypes['profiles_public_bool_exp']> | undefined | null;
+    _not?: ValueTypes['profiles_public_bool_exp'] | undefined | null;
+    _or?: Array<ValueTypes['profiles_public_bool_exp']> | undefined | null;
+    address?: ValueTypes['String_comparison_exp'] | undefined | null;
+    avatar?: ValueTypes['String_comparison_exp'] | undefined | null;
+    id?: ValueTypes['bigint_comparison_exp'] | undefined | null;
+    name?: ValueTypes['citext_comparison_exp'] | undefined | null;
+  };
+  /** Ordering options when selecting data from "profiles_public". */
+  ['profiles_public_order_by']: {
+    address?: ValueTypes['order_by'] | undefined | null;
+    avatar?: ValueTypes['order_by'] | undefined | null;
+    id?: ValueTypes['order_by'] | undefined | null;
+    name?: ValueTypes['order_by'] | undefined | null;
+  };
+  /** select columns of table "profiles_public" */
+  ['profiles_public_select_column']: profiles_public_select_column;
+  /** Streaming cursor of the table "profiles_public" */
+  ['profiles_public_stream_cursor_input']: {
+    /** Stream column input with initial value */
+    initial_value: ValueTypes['profiles_public_stream_cursor_value_input'];
+    /** cursor ordering */
+    ordering?: ValueTypes['cursor_ordering'] | undefined | null;
+  };
+  /** Initial value of the column from where the streaming should start */
+  ['profiles_public_stream_cursor_value_input']: {
+    address?: string | undefined | null;
+    avatar?: string | undefined | null;
+    id?: ValueTypes['bigint'] | undefined | null;
+    name?: ValueTypes['citext'] | undefined | null;
+  };
   /** select columns of table "profiles" */
   ['profiles_select_column']: profiles_select_column;
   /** input type for updating data in table "profiles" */
@@ -9620,6 +9665,29 @@ export type ValueTypes = {
       ValueTypes['profiles']
     ];
     profiles_by_pk?: [{ id: ValueTypes['bigint'] }, ValueTypes['profiles']];
+    profiles_public?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['profiles_public_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['profiles_public_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ValueTypes['profiles_public_bool_exp'] | undefined | null;
+      },
+      ValueTypes['profiles_public']
+    ];
     reactions?: [
       {
         /** distinct select on columns */
@@ -11513,6 +11581,40 @@ export type ValueTypes = {
       ValueTypes['profiles']
     ];
     profiles_by_pk?: [{ id: ValueTypes['bigint'] }, ValueTypes['profiles']];
+    profiles_public?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['profiles_public_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['profiles_public_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ValueTypes['profiles_public_bool_exp'] | undefined | null;
+      },
+      ValueTypes['profiles_public']
+    ];
+    profiles_public_stream?: [
+      {
+        /** maximum number of rows returned in a single batch */
+        batch_size: number /** cursor to stream the results returned by the query */;
+        cursor: Array<
+          ValueTypes['profiles_public_stream_cursor_input'] | undefined | null
+        > /** filter the rows returned */;
+        where?: ValueTypes['profiles_public_bool_exp'] | undefined | null;
+      },
+      ValueTypes['profiles_public']
+    ];
     profiles_stream?: [
       {
         /** maximum number of rows returned in a single batch */
@@ -14954,6 +15056,8 @@ export type ModelTypes = {
     pgive?: number | undefined;
     /** An object relationship */
     profile?: GraphQLTypes['profiles'] | undefined;
+    /** An object relationship */
+    profile_public?: GraphQLTypes['profiles_public'] | undefined;
     synced_at?: GraphQLTypes['timestamptz'] | undefined;
     token_id: number;
     updated_at: GraphQLTypes['timestamptz'];
@@ -16614,6 +16718,23 @@ export type ModelTypes = {
   ['profiles_order_by']: GraphQLTypes['profiles_order_by'];
   /** primary key columns input for table: profiles */
   ['profiles_pk_columns_input']: GraphQLTypes['profiles_pk_columns_input'];
+  /** columns and relationships of "profiles_public" */
+  ['profiles_public']: {
+    address?: string | undefined;
+    avatar?: string | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    name?: GraphQLTypes['citext'] | undefined;
+  };
+  /** Boolean expression to filter rows from the table "profiles_public". All fields are combined with a logical 'AND'. */
+  ['profiles_public_bool_exp']: GraphQLTypes['profiles_public_bool_exp'];
+  /** Ordering options when selecting data from "profiles_public". */
+  ['profiles_public_order_by']: GraphQLTypes['profiles_public_order_by'];
+  /** select columns of table "profiles_public" */
+  ['profiles_public_select_column']: GraphQLTypes['profiles_public_select_column'];
+  /** Streaming cursor of the table "profiles_public" */
+  ['profiles_public_stream_cursor_input']: GraphQLTypes['profiles_public_stream_cursor_input'];
+  /** Initial value of the column from where the streaming should start */
+  ['profiles_public_stream_cursor_value_input']: GraphQLTypes['profiles_public_stream_cursor_value_input'];
   /** select columns of table "profiles" */
   ['profiles_select_column']: GraphQLTypes['profiles_select_column'];
   /** input type for updating data in table "profiles" */
@@ -16766,6 +16887,8 @@ export type ModelTypes = {
     profiles: Array<GraphQLTypes['profiles']>;
     /** fetch data from the table: "profiles" using primary key columns */
     profiles_by_pk?: GraphQLTypes['profiles'] | undefined;
+    /** fetch data from the table: "profiles_public" */
+    profiles_public: Array<GraphQLTypes['profiles_public']>;
     /** An array relationship */
     reactions: Array<GraphQLTypes['reactions']>;
     /** An aggregate relationship */
@@ -17163,6 +17286,10 @@ export type ModelTypes = {
     profiles: Array<GraphQLTypes['profiles']>;
     /** fetch data from the table: "profiles" using primary key columns */
     profiles_by_pk?: GraphQLTypes['profiles'] | undefined;
+    /** fetch data from the table: "profiles_public" */
+    profiles_public: Array<GraphQLTypes['profiles_public']>;
+    /** fetch data from the table in a streaming manner: "profiles_public" */
+    profiles_public_stream: Array<GraphQLTypes['profiles_public']>;
     /** fetch data from the table in a streaming manner: "profiles" */
     profiles_stream: Array<GraphQLTypes['profiles']>;
     /** An array relationship */
@@ -20399,6 +20526,8 @@ export type GraphQLTypes = {
     pgive?: number | undefined;
     /** An object relationship */
     profile?: GraphQLTypes['profiles'] | undefined;
+    /** An object relationship */
+    profile_public?: GraphQLTypes['profiles_public'] | undefined;
     synced_at?: GraphQLTypes['timestamptz'] | undefined;
     token_id: number;
     updated_at: GraphQLTypes['timestamptz'];
@@ -20414,6 +20543,7 @@ export type GraphQLTypes = {
     id?: GraphQLTypes['Int_comparison_exp'] | undefined;
     pgive?: GraphQLTypes['Int_comparison_exp'] | undefined;
     profile?: GraphQLTypes['profiles_bool_exp'] | undefined;
+    profile_public?: GraphQLTypes['profiles_public_bool_exp'] | undefined;
     synced_at?: GraphQLTypes['timestamptz_comparison_exp'] | undefined;
     token_id?: GraphQLTypes['Int_comparison_exp'] | undefined;
     updated_at?: GraphQLTypes['timestamptz_comparison_exp'] | undefined;
@@ -20426,6 +20556,7 @@ export type GraphQLTypes = {
     id?: GraphQLTypes['order_by'] | undefined;
     pgive?: GraphQLTypes['order_by'] | undefined;
     profile?: GraphQLTypes['profiles_order_by'] | undefined;
+    profile_public?: GraphQLTypes['profiles_public_order_by'] | undefined;
     synced_at?: GraphQLTypes['order_by'] | undefined;
     token_id?: GraphQLTypes['order_by'] | undefined;
     updated_at?: GraphQLTypes['order_by'] | undefined;
@@ -24050,6 +24181,47 @@ export type GraphQLTypes = {
   ['profiles_pk_columns_input']: {
     id: GraphQLTypes['bigint'];
   };
+  /** columns and relationships of "profiles_public" */
+  ['profiles_public']: {
+    __typename: 'profiles_public';
+    address?: string | undefined;
+    avatar?: string | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    name?: GraphQLTypes['citext'] | undefined;
+  };
+  /** Boolean expression to filter rows from the table "profiles_public". All fields are combined with a logical 'AND'. */
+  ['profiles_public_bool_exp']: {
+    _and?: Array<GraphQLTypes['profiles_public_bool_exp']> | undefined;
+    _not?: GraphQLTypes['profiles_public_bool_exp'] | undefined;
+    _or?: Array<GraphQLTypes['profiles_public_bool_exp']> | undefined;
+    address?: GraphQLTypes['String_comparison_exp'] | undefined;
+    avatar?: GraphQLTypes['String_comparison_exp'] | undefined;
+    id?: GraphQLTypes['bigint_comparison_exp'] | undefined;
+    name?: GraphQLTypes['citext_comparison_exp'] | undefined;
+  };
+  /** Ordering options when selecting data from "profiles_public". */
+  ['profiles_public_order_by']: {
+    address?: GraphQLTypes['order_by'] | undefined;
+    avatar?: GraphQLTypes['order_by'] | undefined;
+    id?: GraphQLTypes['order_by'] | undefined;
+    name?: GraphQLTypes['order_by'] | undefined;
+  };
+  /** select columns of table "profiles_public" */
+  ['profiles_public_select_column']: profiles_public_select_column;
+  /** Streaming cursor of the table "profiles_public" */
+  ['profiles_public_stream_cursor_input']: {
+    /** Stream column input with initial value */
+    initial_value: GraphQLTypes['profiles_public_stream_cursor_value_input'];
+    /** cursor ordering */
+    ordering?: GraphQLTypes['cursor_ordering'] | undefined;
+  };
+  /** Initial value of the column from where the streaming should start */
+  ['profiles_public_stream_cursor_value_input']: {
+    address?: string | undefined;
+    avatar?: string | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    name?: GraphQLTypes['citext'] | undefined;
+  };
   /** select columns of table "profiles" */
   ['profiles_select_column']: profiles_select_column;
   /** input type for updating data in table "profiles" */
@@ -24245,6 +24417,8 @@ export type GraphQLTypes = {
     profiles: Array<GraphQLTypes['profiles']>;
     /** fetch data from the table: "profiles" using primary key columns */
     profiles_by_pk?: GraphQLTypes['profiles'] | undefined;
+    /** fetch data from the table: "profiles_public" */
+    profiles_public: Array<GraphQLTypes['profiles_public']>;
     /** An array relationship */
     reactions: Array<GraphQLTypes['reactions']>;
     /** An aggregate relationship */
@@ -24762,6 +24936,10 @@ export type GraphQLTypes = {
     profiles: Array<GraphQLTypes['profiles']>;
     /** fetch data from the table: "profiles" using primary key columns */
     profiles_by_pk?: GraphQLTypes['profiles'] | undefined;
+    /** fetch data from the table: "profiles_public" */
+    profiles_public: Array<GraphQLTypes['profiles_public']>;
+    /** fetch data from the table in a streaming manner: "profiles_public" */
+    profiles_public_stream: Array<GraphQLTypes['profiles_public']>;
     /** fetch data from the table in a streaming manner: "profiles" */
     profiles_stream: Array<GraphQLTypes['profiles']>;
     /** An array relationship */
@@ -26781,6 +26959,13 @@ export const enum pending_vault_transactions_select_column {
 /** placeholder for update columns of table "pending_vault_transactions" (current role has no relevant permissions) */
 export const enum pending_vault_transactions_update_column {
   _PLACEHOLDER = '_PLACEHOLDER',
+}
+/** select columns of table "profiles_public" */
+export const enum profiles_public_select_column {
+  address = 'address',
+  avatar = 'avatar',
+  id = 'id',
+  name = 'name',
 }
 /** select columns of table "profiles" */
 export const enum profiles_select_column {

--- a/src/pages/CoSoulExplorePage/CoSoulExplorePage.tsx
+++ b/src/pages/CoSoulExplorePage/CoSoulExplorePage.tsx
@@ -1,0 +1,57 @@
+import { ChangeEvent, useCallback, useState } from 'react';
+
+import debounce from 'lodash/debounce';
+
+import { Box, Flex, Select, Text, TextField } from '../../ui';
+
+import { CoSoulItemList } from './CoSoulItemList';
+import { getOrderBy, Order, orderOptions } from './Order';
+import { Where } from './useInfiniteCoSouls';
+
+const CoSoulExplorePage = () => {
+  const [orderBy, setOrderBy] = useState<Order>(orderOptions[0]);
+  const [where, setWhere] = useState<Where | null>(null);
+  const [queryField, setQueryField] = useState('');
+
+  const handleQueryChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setQueryField(e.target.value);
+    updateWhere(e.target.value);
+  };
+
+  const updateWhere = useCallback(
+    debounce((q: string) => {
+      setWhere(prev => ({
+        ...prev,
+        profile_public: {
+          name: { _ilike: `%${q}%` },
+        },
+      }));
+    }, 1000),
+    []
+  );
+
+  return (
+    <Box>
+      <Flex css={{ gap: '$xl', ml: '$xl' }}>
+        <Text h1>Explore CoSouls</Text>
+        <Flex css={{ m: '$lg', gap: '$lg' }}>
+          <TextField
+            value={queryField}
+            onChange={handleQueryChange}
+            placeholder={'Search by name'}
+          />
+
+          <Select
+            css={{ flexGrow: 0 }}
+            value={orderBy.value}
+            options={orderOptions}
+            onValueChange={value => setOrderBy(getOrderBy(value))}
+          />
+        </Flex>
+      </Flex>
+      <CoSoulItemList where={where} orderBy={orderBy.orderBy} />
+    </Box>
+  );
+};
+
+export default CoSoulExplorePage;

--- a/src/pages/CoSoulExplorePage/CoSoulItem.tsx
+++ b/src/pages/CoSoulExplorePage/CoSoulItem.tsx
@@ -1,0 +1,88 @@
+import { AppLink, Avatar, Box, Flex, Image, Text } from '../../ui';
+
+import { CoSoul } from './useInfiniteCoSouls';
+
+const s3bucket = process.env.REACT_APP_S3_BASE_URL;
+
+export const CoSoulItem = ({ cosoul }: { cosoul: CoSoul }) => {
+  return (
+    <AppLink to={`/cosoul/${cosoul.address}`}>
+      <Box
+        key={cosoul.id}
+        css={{
+          overflow: 'hidden',
+          borderRadius: '$4',
+          position: 'relative',
+          '&:hover': {
+            cursor: 'pointer',
+            transition: 'all 0.2s ease-in-out',
+            transform: 'scale(1.05)',
+          },
+        }}
+      >
+        <Box
+          css={{
+            width: '100%',
+            aspectRatio: '1 / 1',
+          }}
+        >
+          <Image
+            css={{
+              width: '100%',
+              aspectRatio: '1 / 1',
+            }}
+            src={`${s3bucket}/cosoul/screenshots/${cosoul.token_id}.png`}
+            alt="CoSoul Screenshot"
+          />
+        </Box>
+        <Flex
+          css={{
+            p: '$sm',
+            width: '100%',
+            justifyContent: 'space-between',
+            alignItems: 'flex-start',
+          }}
+        >
+          <Flex
+            css={{
+              gap: '$sm',
+              alignItems: 'center',
+              flexGrow: 0,
+              flexShrink: 1,
+            }}
+          >
+            <Avatar
+              path={cosoul.profile_public?.avatar}
+              size="small"
+              name={cosoul.profile_public?.name ?? 'New'}
+            />
+            {/*TODO: if the name is long here this doesn't properly shrink */}
+            <Text
+              ellipsis
+              size="small"
+              semibold
+              css={{ flexGrow: 0, flexShrink: 1 }}
+            >
+              {abbreviateString(cosoul.profile_public?.name ?? 'Anon', 14)}
+            </Text>
+          </Flex>
+          <Flex column css={{ alignItems: 'flex-end', flexShrink: 0 }}>
+            <Text semibold color="cta">
+              {cosoul.pgive ?? 0}
+            </Text>
+            <Text size={'xs'} color="cta" css={{ opacity: 0.8 }}>
+              pGIVE
+            </Text>
+          </Flex>
+        </Flex>
+      </Box>
+    </AppLink>
+  );
+};
+
+function abbreviateString(str: string, maxLength: number): string {
+  if (str.length <= maxLength) {
+    return str;
+  }
+  return str.substring(0, maxLength - 3) + '...';
+}

--- a/src/pages/CoSoulExplorePage/CoSoulItemList.tsx
+++ b/src/pages/CoSoulExplorePage/CoSoulItemList.tsx
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+import { LoadingIndicator } from '../../components/LoadingIndicator';
+import { Box, Flex } from '../../ui';
+
+import { CoSoulItem } from './CoSoulItem';
+import { OrderBy, useInfiniteCoSouls, Where } from './useInfiniteCoSouls';
+
+export const COSOULS_QUERY_KEY = 'cosouls';
+
+export const CoSoulItemList = ({
+  where,
+  orderBy,
+  onSettled,
+}: {
+  where: Where | null;
+  orderBy: OrderBy[];
+  onSettled?: () => void;
+}) => {
+  const observerRef = useRef<HTMLDivElement>(null);
+  const { data, hasNextPage, fetchNextPage, isFetchingNextPage } =
+    useInfiniteCoSouls(
+      [COSOULS_QUERY_KEY, JSON.stringify(where), JSON.stringify(orderBy)],
+      where,
+      orderBy,
+      onSettled
+    );
+
+  const handleObserver = useCallback(
+    entries => {
+      const [target] = entries;
+      if (target.isIntersecting) {
+        fetchNextPage();
+      }
+    },
+    [fetchNextPage, hasNextPage]
+  );
+
+  useEffect(() => {
+    const element = observerRef.current;
+    if (element) {
+      const option = { threshold: 0 };
+
+      const observer = new IntersectionObserver(handleObserver, option);
+      observer.observe(element);
+      return () => observer.unobserve(element);
+    }
+  }, [fetchNextPage, hasNextPage, handleObserver]);
+
+  if (!data) {
+    return <LoadingIndicator />;
+  }
+
+  return (
+    <Flex
+      column
+      css={{
+        gap: '$md',
+        position: 'relative',
+      }}
+    >
+      {data && data.pages && (
+        <Box
+          css={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
+            gap: '$md',
+            m: '$xl ',
+          }}
+        >
+          {data.pages.map(page =>
+            page.map(cosoul => <CoSoulItem cosoul={cosoul} key={cosoul.id} />)
+          )}
+        </Box>
+      )}
+      <Flex ref={observerRef} css={{ justifyContent: 'center' }}>
+        {isFetchingNextPage ? <LoadingIndicator /> : <Box>&nbsp;</Box>}
+      </Flex>
+    </Flex>
+  );
+};

--- a/src/pages/CoSoulExplorePage/Order.ts
+++ b/src/pages/CoSoulExplorePage/Order.ts
@@ -1,0 +1,46 @@
+import { order_by } from '../../lib/gql/__generated__/zeus';
+
+export const getOrderBy = (val: typeof orderOptions[number]['value']) => {
+  return orderOptions.find(o => o.value === val) ?? orderOptions[0];
+};
+
+export type Order = typeof orderOptions[number];
+
+export const orderOptions = [
+  {
+    label: 'Most PGIVE',
+    value: 'mostPgive',
+    orderBy: [
+      {
+        pgive: order_by.desc_nulls_last,
+      },
+    ],
+  },
+  {
+    label: 'Least PGIVE',
+    value: 'leastPgive',
+    orderBy: [
+      {
+        pgive: order_by.asc_nulls_last,
+      },
+    ],
+  },
+  {
+    label: 'Newest',
+    value: 'newest',
+    orderBy: [
+      {
+        id: order_by.desc_nulls_last,
+      },
+    ],
+  },
+  {
+    label: 'Oldest',
+    value: 'oldest',
+    orderBy: [
+      {
+        id: order_by.asc_nulls_last,
+      },
+    ],
+  },
+];

--- a/src/pages/CoSoulExplorePage/useInfiniteCoSouls.ts
+++ b/src/pages/CoSoulExplorePage/useInfiniteCoSouls.ts
@@ -1,0 +1,65 @@
+import { QueryKey, useInfiniteQuery } from 'react-query';
+
+import { anonClient } from '../../lib/anongql/anonClient';
+import { ValueTypes } from '../../lib/gql/__generated__/zeus';
+import { Awaited } from '../../types/shim';
+
+const PAGE_SIZE = 100;
+
+export type Where = ValueTypes['cosouls_bool_exp'];
+export type OrderBy = ValueTypes['cosouls_order_by'];
+
+export const useInfiniteCoSouls = (
+  queryKey: QueryKey,
+  where: Where | null,
+  orderBy: OrderBy[],
+  onSettled?: () => void
+) => {
+  return useInfiniteQuery(
+    queryKey,
+    ({ pageParam = 0 }) => fetchCoSouls(where, orderBy, pageParam),
+    {
+      getNextPageParam: (lastPage, allPages) => {
+        return lastPage.length == 0 ? undefined : allPages.length;
+      },
+      refetchOnWindowFocus: true,
+      refetchInterval: 10000,
+      onSettled: () => onSettled && onSettled(),
+    }
+  );
+};
+
+const fetchCoSouls = async (
+  where: Where | null,
+  orderBy: OrderBy[],
+  page: number
+) => {
+  const { cosouls } = await anonClient.query(
+    {
+      cosouls: [
+        {
+          where,
+          order_by: orderBy,
+          offset: page * PAGE_SIZE,
+          limit: PAGE_SIZE,
+        },
+        {
+          address: true,
+          id: true,
+          token_id: true,
+          pgive: true,
+          profile_public: {
+            name: true,
+            avatar: true,
+          },
+        },
+      ],
+    },
+    {
+      operationName: 'cosoul_explore',
+    }
+  );
+  return cosouls;
+};
+
+export type CoSoul = Awaited<ReturnType<typeof fetchCoSouls>>[number];

--- a/src/pages/ProfilePage/ProfilePage.tsx
+++ b/src/pages/ProfilePage/ProfilePage.tsx
@@ -16,7 +16,6 @@ import {
   ProfileSocialIcons,
 } from 'components';
 import { EditProfileModal } from 'components/EditProfileModal';
-import isFeatureEnabled from 'config/features';
 import { useImageUploader, useToast } from 'hooks';
 import { useFetchManifest } from 'hooks/legacyApi';
 import { Edit3, ExternalLink } from 'icons/__generated';
@@ -262,7 +261,7 @@ const ProfilePageContent = ({
                   </Flex>
                 )}
               </Flex>
-              {isFeatureEnabled('cosoul') && coSoul?.mintInfo && (
+              {coSoul?.mintInfo && (
                 <Flex
                   column
                   css={{

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -79,6 +79,7 @@ export const paths = {
   cosoulArt: (tokenId: string) => `/cosoul/art/${tokenId}`,
   cosoulImage: (tokenId: string) => `/cosoul/image/${tokenId}`,
   cosoulGallery: '/cosoul/gallery',
+  cosoulExplore: '/cosoul/explore',
 
   profile: (address: string) => `/profile/${address}`,
   organization: (orgId: string) => `/organizations/${orgId}`,

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -8,8 +8,8 @@ import {
 } from 'features/cosoul';
 import { CoSoulArtPublic } from 'features/cosoul/art/CoSoulArtPublic';
 import CoSoulArtOnlyLayout from 'features/cosoul/CoSoulArtOnlyLayout';
-import { CoSoulGalleryPage } from 'features/cosoul/CoSoulGalleryPage';
 import CoSoulLayout from 'features/cosoul/CoSoulLayout';
+import { DebugCoSoulGalleryPage } from 'features/cosoul/DebugCoSoulGalleryPage';
 import { OrgPage, OrgSettingsPage } from 'features/orgs';
 import { isUserAdmin, isUserMember } from 'lib/users';
 import {
@@ -24,11 +24,11 @@ import {
 import { DebugLogger } from '../common-lib/log';
 import AddMembersPage from '../pages/AddMembersPage/AddMembersPage';
 import CircleActivityPage from '../pages/CircleActivityPage';
+import CoSoulExplorePage from '../pages/CoSoulExplorePage/CoSoulExplorePage';
 import GivePage from '../pages/GivePage';
 import JoinPage from '../pages/JoinPage';
 import VerifyEmailPage from '../pages/VerifyEmailPage';
 import { MainLayout } from 'components';
-import isFeatureEnabled from 'config/features';
 import AccountPage from 'pages/AccountPage/AccountPage';
 import CircleAdminPage from 'pages/CircleAdminPage';
 import CirclesPage from 'pages/CirclesPage';
@@ -48,12 +48,12 @@ import VaultsPage from 'pages/VaultsPage';
 import { VaultTransactions } from 'pages/VaultsPage/VaultTransactions';
 
 import {
+  NotReady,
   useCanVouch,
-  useRoleInCircle,
   useCircleIdParam,
   useOrgIdParam,
-  NotReady,
   useRecordPageView,
+  useRoleInCircle,
 } from './hooks';
 import { paths } from './paths';
 
@@ -142,56 +142,56 @@ export const AppRoutes = () => {
   return (
     <Routes>
       {/* CoSoul Pages */}
-      {isFeatureEnabled('cosoul') && (
+      <Route
+        element={
+          <CoSoulArtOnlyLayout>
+            <Outlet />
+          </CoSoulArtOnlyLayout>
+        }
+      >
         <Route
-          element={
-            <CoSoulArtOnlyLayout>
-              <Outlet />
-            </CoSoulArtOnlyLayout>
-          }
-        >
-          <Route
-            path={paths.cosoulArt(':tokenId')}
-            element={<CoSoulArtPublic />}
-          />
-          <Route
-            path={paths.cosoulImage(':tokenId')}
-            element={<CoSoulArtPublic animate={false} />}
-          />
-          <Route path={paths.cosoulGallery} element={<CoSoulGalleryPage />} />
-        </Route>
-      )}
-      {isFeatureEnabled('cosoul') && (
+          path={paths.cosoulArt(':tokenId')}
+          element={<CoSoulArtPublic />}
+        />
         <Route
+          path={paths.cosoulImage(':tokenId')}
+          element={<CoSoulArtPublic animate={false} />}
+        />
+        <Route
+          path={paths.cosoulGallery}
+          element={<DebugCoSoulGalleryPage />}
+        />
+      </Route>
+      <Route
+        element={
+          <CoSoulLayout>
+            <Outlet />
+          </CoSoulLayout>
+        }
+      >
+        <Route
+          path="login"
           element={
-            <CoSoulLayout>
-              <Outlet />
-            </CoSoulLayout>
+            <RequireAuth>
+              <RedirectAfterLogin />
+            </RequireAuth>
           }
-        >
-          <Route
-            path="login"
-            element={
-              <RequireAuth>
-                <RedirectAfterLogin />
-              </RequireAuth>
-            }
-          />
-          <Route path={paths.cosoul} element={<SplashPage />} />
-          <Route
-            path={paths.cosoulView(':address')}
-            element={<CoSoulViewPage />}
-          />
-          <Route
-            path={paths.mint}
-            element={
-              <RequireAuth>
-                <MintPage />
-              </RequireAuth>
-            }
-          />
-        </Route>
-      )}
+        />
+        <Route path={paths.cosoul} element={<SplashPage />} />
+        <Route
+          path={paths.cosoulView(':address')}
+          element={<CoSoulViewPage />}
+        />
+        <Route path={paths.cosoulExplore} element={<CoSoulExplorePage />} />
+        <Route
+          path={paths.mint}
+          element={
+            <RequireAuth>
+              <MintPage />
+            </RequireAuth>
+          }
+        />
+      </Route>
 
       {/* Main App Pages */}
       <Route

--- a/src/stitches.config.ts
+++ b/src/stitches.config.ts
@@ -284,6 +284,7 @@ export const {
       display: 'Denim, apple-system, sans-serif',
     },
     fontSizes: {
+      xs: '12px',
       small: '14px',
       medium: '16px',
       large: '24px',

--- a/src/ui/Text/Text.tsx
+++ b/src/ui/Text/Text.tsx
@@ -53,6 +53,7 @@ export const Text = styled('span', {
     },
 
     size: {
+      xs: { fontSize: '$xs !important', lineHeight: '$shorter' },
       small: { fontSize: '$small !important', lineHeight: '$shorter' },
       medium: { fontSize: '$medium !important', lineHeight: '$shorter' },
       large: { fontSize: '$large !important', lineHeight: '$shorter' },


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1ee27a6</samp>

This pull request adds a new `profiles_public` view to the database and the GraphQL schema, which exposes public profile information of users. It also removes the `cosoul` feature flag and the related code from the frontend and backend, which disables the CoSoul feature. It also adds a new CoSoul explore page to the frontend, which allows the user to browse the CoSoul items with different orderings.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1ee27a6</samp>

> _We added a view `profiles_public`_
> _To query the users with GraphQL logic_
> _We also removed_
> _The `cosoul` feature we loved_
> _And made the CoSoul explore page more dynamic_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1ee27a6</samp>

*  Add a new `profiles_public` view to the database and the Hasura GraphQL engine, and expose it as a GraphQL type with select permissions for anonymous and authenticated users ([link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-412dbd6aa74a0169e4120157039da14d29381e4a3e1cc6551f78afc1616b8e65R1-R20), [link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-db7a5522001579de7a816ecd82e2a3547b48414c9ae1e552fc0dd24ccac28290R1-R9), [link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-ca82769adfb1c46558b7227a28ad5929194c8be675ff8867c1a4d7bbf98b67cfR1-R7), [link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-4147b15d5a605e64a3d76bd68b59506ec8886da36d27df21dbf794443820377fR38), [link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebR11518-R11591), [link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebR13026-R13055), [link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebR15761-R15810), [link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060R3816-R3837), [link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060R4706-R4714), [link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060R7269-R7273), [link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060R7340), [link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060R7544-R7545))
* Add a new object relationship `profile_public` to the `cosouls` table and the `cosouls` GraphQL type, linking the `address` column of the `cosouls` table to the `address` column of the `profiles_public` view, and allow querying, filtering, and ordering the `profile_public` field of the `cosouls` type ([link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-3837acf731f554c94063419d1b6e3b165007c982ac40c9d93b10416b78fd9532L14-R32), [link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebR4352-R4356), [link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebR4375), [link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebR4391), [link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060R1384), [link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060R1396), [link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060R6469))
* Modify the `auth` middleware function for the Hasura GraphQL engine to allow anonymous users to access the GraphQL endpoint with the role `anon-user`, and to check if the user profile exists in the database before granting the role `user` ([link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-597723888c5385bc188e3ba62a1b6032fda30b4c4bfdb964a2c4364deff98ae0L48-R56), [link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-597723888c5385bc188e3ba62a1b6032fda30b4c4bfdb964a2c4364deff98ae0R83-R87))
* Remove the `cosoul` feature flag from the `config/features` module and the frontend code, and disable the CoSoul feature in the frontend application ([link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-5c118d9192f4171e7f6592b2205521832975d0666a8673815188b73c9644088aL4), [link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-5c118d9192f4171e7f6592b2205521832975d0666a8673815188b73c9644088aL15), [link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-d1cac1e147670959ee5e559069bfc06a6d275b0d913887dd995cd97ba7c360fcL1), [link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-d1cac1e147670959ee5e559069bfc06a6d275b0d913887dd995cd97ba7c360fcL29-R28), [link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-a9d33a03447e2b96e70bddf1ebde47791709f7845cfffb8c05a3ee3dacf0348fL6), [link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-a9d33a03447e2b96e70bddf1ebde47791709f7845cfffb8c05a3ee3dacf0348fL39-L41), [link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-b43ef01230c6952eb46ff957b2ed7655a981448947dfe5db28cd2e373a648e35L7), [link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-b43ef01230c6952eb46ff957b2ed7655a981448947dfe5db28cd2e373a648e35L37-L39), [link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-07a5e546156e72d3af4da968af148298858d1943242859c44c28aea5e4b3c5b5L7), [link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-07a5e546156e72d3af4da968af148298858d1943242859c44c28aea5e4b3c5b5L46-L49), [link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-14c17f2206802b962d016d8a767ac1e68950e89f32310c7371d04c790ed7138cL13), [link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-14c17f2206802b962d016d8a767ac1e68950e89f32310c7371d04c790ed7138cL219-R249))
* Add a new `CoSoulExplorePage` component and a new page to the frontend application that allows the user to explore the CoSoul items with different orderings ([link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-ced0aa6673e9e0b4da48550955daaf19521135613c041dc97534a87f514635e9R1-R52))
* Rename the `CoSoulGalleryPage` component to `DebugCoSoulGalleryPage`, and simplify the code by always rendering the button and the animation ([link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-d1cac1e147670959ee5e559069bfc06a6d275b0d913887dd995cd97ba7c360fcL29-R28), [link](https://github.com/coordinape/coordinape/pull/2355/files?diff=unified&w=0#diff-14c17f2206802b962d016d8a767ac1e68950e89f32310c7371d04c790ed7138cL219-R249))
