### PR TITLE
remove epoch timing settings changes banner

### DIFF
--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -2,7 +2,6 @@
 
 export type FeatureName =
   | 'cosoul'
-  | 'epoch_timing_banner'
   | 'debug'
   | 'email'
   // dnt = Do Not Track. enable this feature to debug Mixpanel
@@ -13,7 +12,6 @@ export type FeatureName =
 
 const staticFeatureFlags: Partial<Record<FeatureName, boolean>> = {
   cosoul: true,
-  epoch_timing_banner: !!process.env.REACT_APP_FEATURE_FLAG_EPOCH_TIMING_BANNER,
 };
 
 // this code is safe to use in a non-browser environment because of the typeof

--- a/src/pages/HistoryPage/HistoryPage.tsx
+++ b/src/pages/HistoryPage/HistoryPage.tsx
@@ -15,7 +15,6 @@ import {
   paths,
 } from '../../routes/paths';
 import { Paginator } from 'components/Paginator';
-import isFeatureEnabled from 'config/features';
 import { useToast, useApiAdminCircle } from 'hooks';
 import { EmailPromo } from 'pages/ProfilePage/EmailSettings/EmailPromo';
 import { useCircleIdParam } from 'routes/hooks';
@@ -192,24 +191,6 @@ export const HistoryPage = () => {
           </Button>
         )}
       </ContentHeader>
-      {isFeatureEnabled('epoch_timing_banner') && (
-        <HintBanner title={'Epoch Timing Settings'}>
-          <Text p as="p" css={{ color: 'inherit' }}>
-            Heads up, we&apos;ve released updated settings for epoch timing.
-          </Text>
-          <Button
-            as="a"
-            href={
-              'https://docs.coordinape.com/get-started/epochs/create-an-epoch'
-            }
-            target="_blank"
-            rel="noreferrer"
-            color="secondary"
-          >
-            Read the docs to learn more.
-          </Button>
-        </HintBanner>
-      )}
       {/* show some help for admins who don't have an epoch yet */}
       {isAdmin &&
         circle &&


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b60c292</samp>

Removed obsolete code related to epoch timing banner feature. This feature was used to show epoch start and end dates, but is no longer needed.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b60c292</samp>

> _No more `epoch_timing_banner` in the code_
> _We don't need to see the clock of doom_
> _We erased the feature flag and the hint_
> _We are free from the tyranny of time_

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b60c292</samp>

*  Remove the `epoch_timing_banner` feature flag and its usage from the codebase ([link](https://github.com/coordinape/coordinape/pull/2356/files?diff=unified&w=0#diff-5c118d9192f4171e7f6592b2205521832975d0666a8673815188b73c9644088aL5), [link](https://github.com/coordinape/coordinape/pull/2356/files?diff=unified&w=0#diff-5c118d9192f4171e7f6592b2205521832975d0666a8673815188b73c9644088aL16), [link](https://github.com/coordinape/coordinape/pull/2356/files?diff=unified&w=0#diff-2cf00674fa58cba2a035c641f5f18d43d2e823d79c558fefbe79f01e1043478fL18), [link](https://github.com/coordinape/coordinape/pull/2356/files?diff=unified&w=0#diff-2cf00674fa58cba2a035c641f5f18d43d2e823d79c558fefbe79f01e1043478fL195-L212))
