### PR TITLE
Fix sync keys

### DIFF
--- a/src/features/soulkeys/api/getTradeLogs.ts
+++ b/src/features/soulkeys/api/getTradeLogs.ts
@@ -32,5 +32,6 @@ export async function getTradeLogs() {
 
 function parseEventLog(log: any) {
   const soulKeys = getSoulKeysContract();
-  return soulKeys.interface.decodeEventLog(TRADE_SIG, log.data);
+  const sk = soulKeys.interface.decodeEventLog(TRADE_SIG, log.data);
+  return sk;
 }

--- a/src/features/soulkeys/api/getTradeLogs.ts
+++ b/src/features/soulkeys/api/getTradeLogs.ts
@@ -24,7 +24,10 @@ export async function getTradeLogs() {
     toBlock: currentBlock,
   });
 
-  return rawLogs.map(rl => parseEventLog(rl));
+  return rawLogs.map(rl => ({
+    transactionHash: rl.transactionHash,
+    ...parseEventLog(rl),
+  }));
 }
 
 function parseEventLog(log: any) {

--- a/src/features/soulkeys/api/getTradeLogs.ts
+++ b/src/features/soulkeys/api/getTradeLogs.ts
@@ -26,11 +26,11 @@ export async function getTradeLogs() {
 
   return rawLogs.map(rl => ({
     transactionHash: rl.transactionHash,
-    ...parseEventLog(rl),
+    data: parseEventLog(rl),
   }));
 }
 
-function parseEventLog(log: any) {
+function parseEventLog(log: ethers.providers.Log) {
   const soulKeys = getSoulKeysContract();
   const sk = soulKeys.interface.decodeEventLog(TRADE_SIG, log.data);
   return sk;

--- a/src/features/soulkeys/api/updateHolders.ts
+++ b/src/features/soulkeys/api/updateHolders.ts
@@ -33,7 +33,7 @@ export const updateHolders = async () => {
         insert_key_tx_one: [
           {
             object: {
-              tx_hash: log.transactionHash.toLowerCase(),
+              tx_hash: transactionHash.toLowerCase(),
               trader: trader.toLowerCase(),
               subject: subject.toLowerCase(),
               buy: isBuy,

--- a/src/features/soulkeys/api/updateHolders.ts
+++ b/src/features/soulkeys/api/updateHolders.ts
@@ -23,7 +23,7 @@ export const updateHolders = async () => {
       protocolEthAmount,
       subjectEthAmount,
       supply,
-    } = log;
+    } = log.data;
 
     subjectsToUpdate.add(subject.toLowerCase());
     addressesToUpdate.add(trader.toLowerCase());
@@ -33,7 +33,7 @@ export const updateHolders = async () => {
         insert_key_tx_one: [
           {
             object: {
-              tx_hash: transactionHash.toLowerCase(),
+              tx_hash: log.transactionHash.toLowerCase(),
               trader: trader.toLowerCase(),
               subject: subject.toLowerCase(),
               buy: isBuy,


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 47c733a</samp>

The pull request changes the `getTradeLogs` and `updateHolders` functions in the `soulkeys` feature to improve the data processing and handling of trade logs. It also adds more type safety and clarity to the `parseEventLog` function.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 47c733a</samp>

> _`getTradeLogs` changed_
> _Returns more data for trades_
> _Winter of holders_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 47c733a</samp>

*  Modify `getTradeLogs` function to return more information for each trade log ([link](https://github.com/coordinape/coordinape/pull/2366/files?diff=unified&w=0#diff-0311d9e32d92a465b712c0f593dae39f47538de233a016a8a2a71014769b9d5bL27-R36))
* Update `updateHolders` function to use the new format of trade logs ([link](https://github.com/coordinape/coordinape/pull/2366/files?diff=unified&w=0#diff-753bad8929774e5c531652da3976f3e26e795a45811bb9cedcfafe8603520164L26-R26))
