### PR TITLE
SoulKeys Webhooks

### DIFF
--- a/api-lib/alchemySignature.ts
+++ b/api-lib/alchemySignature.ts
@@ -1,0 +1,12 @@
+import { createHmac } from 'crypto';
+
+export function isValidSignatureForStringBody(
+  body: string, // must be raw string body, not json transformed version of the body
+  signature: string, // your "x-alchemy-signature" from header
+  signingKey: string // taken from dashboard for specific webhook
+): boolean {
+  const hmac = createHmac('sha256', signingKey); // Create a HMAC SHA256 hash using the signing key
+  hmac.update(body, 'utf8'); // Update the token hash with the request body using utf8
+  const digest = hmac.digest('hex');
+  return signature === digest;
+}

--- a/api-lib/config.ts
+++ b/api-lib/config.ts
@@ -130,3 +130,7 @@ export const POSTMARK_SERVER_TOKEN: string = getEnvValue(
   'POSTMARK_SERVER_TOKEN',
   ''
 );
+export const COSOUL_WEBHOOK_ALCHEMY_SIGNING_KEY: string = getEnvValue(
+  'COSOUL_WEBHOOK_ALCHEMY_SIGNING_KEY',
+  ''
+);

--- a/api/hasura/actions/_handlers/syncCoSoul.ts
+++ b/api/hasura/actions/_handlers/syncCoSoul.ts
@@ -100,16 +100,14 @@ export const minted = async (
   }
 };
 
-const burned = async (address: string, profileId: number) => {
+export const burned = async (address: string, profileId?: number) => {
   const { delete_cosouls } = await adminClient.mutate(
     {
       delete_cosouls: [
         {
           where: {
-            profile: {
-              address: {
-                _eq: address,
-              },
+            address: {
+              _eq: address,
             },
           },
         },

--- a/api/webhooks/alchemy_cosoul.test.ts
+++ b/api/webhooks/alchemy_cosoul.test.ts
@@ -1,0 +1,153 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import faker from 'faker';
+
+import { isValidSignatureForStringBody } from '../../api-lib/alchemySignature';
+import { adminClient } from '../../api-lib/gql/adminClient';
+import { createProfile } from '../../api-test/helpers';
+
+import handler from './alchemy_cosoul';
+
+const address = faker.unique(faker.finance.ethereumAddress);
+
+const minted_req = {
+  headers: {
+    'x-alchemy-signature': 'bad-sig',
+  },
+
+  body: {
+    webhookId: 'wh_ow5nupt9gmbrux9g',
+    id: 'whevt_09xyz8ryar37i4la',
+    createdAt: '2023-10-19T00:15:35.584894990Z',
+    type: 'GRAPHQL',
+    event: {
+      data: {
+        block: {
+          hash: '0x702d89f5060838bdf7a1670504929ccf84e189abe1598612d58ef82fc19e4850',
+          logs: [
+            {
+              topics: [
+                '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+                '0x0000000000000000000000000000000000000000000000000000000000000000',
+                `0x000000000000000000000000${address.slice(2)}`,
+                '0x0000000000000000000000000000000000000000000000000000000000006498',
+              ],
+              data: '0x',
+              transaction: {
+                hash: '0x063a99174eec785345413a611ce3f62a8bfbda4680220398b8ba53e8ae4321a8',
+                index: 6,
+                to: { address: '0x47c2a56176335fb2b1ded8e7b5acb136d307dc2d' },
+                from: { address: '0x1186835ce1fc896c50f6cc7490388fbc556617dc' },
+                status: 1,
+              },
+            },
+          ],
+        },
+      },
+      sequenceNumber: '10000000000578619000',
+    },
+  },
+} as unknown as VercelRequest;
+
+const res = {
+  status: jest.fn(() => res),
+  json: jest.fn(),
+  send: jest.fn(),
+} as unknown as VercelResponse;
+
+beforeEach(() => {
+  process.env.COSOUL_WEBHOOK_ALCHEMY_SIGNING_KEY = 'test-key';
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+jest.mock('../../api-lib/alchemySignature.ts');
+
+let profile;
+
+describe('CoSoul Alchemy Webhook', () => {
+  describe('with invalid signature', () => {
+    it('errors without valid signatures', async () => {
+      (isValidSignatureForStringBody as jest.Mock).mockReturnValue(false);
+      await handler(minted_req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+  });
+
+  describe('mint webhook with valid signature', () => {
+    beforeEach(async () => {
+      (isValidSignatureForStringBody as jest.Mock).mockReturnValue(true);
+    });
+
+    afterEach(async () => {
+      await deleteCosouls();
+    });
+
+    describe('unknown address without profile ', () => {
+      it('creates cosoul without profile', async () => {
+        expect(await getCosouls()).toHaveLength(0);
+        await handler(minted_req, res);
+        expect(res.status).toHaveBeenCalledWith(200);
+
+        const cosouls = await getCosouls();
+
+        expect(cosouls).toHaveLength(1);
+        expect(cosouls[0].profile).toEqual(null);
+      });
+    });
+    describe('address with existing profile', () => {
+      it('creates cosoul with profile', async () => {
+        expect(await getCosouls()).toHaveLength(0);
+        profile = await createProfile(adminClient, {
+          address: address,
+        });
+
+        await handler(minted_req, res);
+
+        expect(res.status).toHaveBeenCalledWith(200);
+
+        const cosouls = await getCosouls();
+        expect(cosouls).toHaveLength(1);
+        expect(cosouls[0]?.profile?.id).toEqual(profile?.id);
+      });
+    });
+  });
+});
+
+const deleteCosouls = async () => {
+  await adminClient.mutate(
+    {
+      delete_cosouls: [
+        {
+          where: {},
+        },
+        // something needs to be returned in the mutation
+        { __typename: true, affected_rows: true },
+      ],
+    },
+    { operationName: 'test__DeleteCosouls' }
+  );
+};
+
+const getCosouls = async () => {
+  const { cosouls } = await adminClient.query(
+    {
+      cosouls: [
+        {
+          where: {},
+        },
+        {
+          __typename: true,
+          id: true,
+          token_id: true,
+          address: true,
+          profile: { id: true, address: true },
+        },
+      ],
+    },
+    { operationName: 'test__GetCosouls' }
+  );
+
+  return cosouls;
+};

--- a/api/webhooks/alchemy_cosoul.ts
+++ b/api/webhooks/alchemy_cosoul.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import assert from 'assert';
 
 import type { VercelRequest, VercelResponse } from '@vercel/node';
@@ -25,7 +24,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
 
     const payload = req.body;
-    console.log('payload', JSON.stringify(payload));
 
     const {
       event: {
@@ -47,12 +45,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 }
 
 const handleLog = async (log: any) => {
-  const { topics, transaction } = log;
-  console.log({ topics, transaction });
+  const { transaction } = log;
 
   const mintInfo = await getMintInfofromLogs(log);
-
-  console.log({ mintInfo });
 
   assert(transaction.hash);
   assert(mintInfo);
@@ -65,6 +60,7 @@ const handleLog = async (log: any) => {
     // duplicate burned ehre if they do through the UI??? and don't have profileId
     await burned(mintInfo.from, profileId);
   } else {
+    // eslint-disable-next-line no-console
     console.log('WTF: cosoul transferred... txHash: ', transaction.hash);
   }
 };

--- a/api/webhooks/alchemy_cosoul.ts
+++ b/api/webhooks/alchemy_cosoul.ts
@@ -1,0 +1,89 @@
+/* eslint-disable no-console */
+import assert from 'assert';
+
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { ethers } from 'ethers';
+
+import { isValidSignatureForStringBody } from '../../api-lib/alchemySignature';
+import { adminClient } from '../../api-lib/gql/adminClient';
+import { errorResponse } from '../../api-lib/HttpError';
+import { getMintInfofromLogs } from '../../src/features/cosoul/api/cosoul';
+import { minted, burned } from '../hasura/actions/_handlers/syncCoSoul';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  try {
+    const signature = req.headers['x-alchemy-signature'] as string;
+    assert(signature, 'Missing signature');
+
+    // uncomment to test webhook
+    const signingKey = process.env.COSOUL_WEBHOOK_ALCHEMY_SIGNING_KEY as string;
+    assert(signingKey, 'Missing alchemy signing key');
+
+    if (!isValidSignatureForStringBody(signature, req.body, signingKey)) {
+      res.status(400).send('Webhook signature not valid');
+      return;
+    }
+
+    const payload = req.body;
+    console.log('payload', JSON.stringify(payload));
+
+    const {
+      event: {
+        data: {
+          block: { logs },
+        },
+      },
+    } = payload;
+
+    // iterate over logs
+    for (const log of logs) {
+      await handleLog(log);
+    }
+
+    return res.status(200).send({ success: true });
+  } catch (error: any) {
+    return errorResponse(res, error);
+  }
+}
+
+const handleLog = async (log: any) => {
+  const { topics, transaction } = log;
+  console.log({ topics, transaction });
+
+  const mintInfo = await getMintInfofromLogs(log);
+
+  console.log({ mintInfo });
+
+  assert(transaction.hash);
+  assert(mintInfo);
+
+  const profileId = await getProfileIdFromAddress(mintInfo.to);
+
+  if (mintInfo.from == ethers.constants.AddressZero) {
+    await minted(mintInfo.to, transaction.hash, mintInfo.tokenId, profileId);
+  } else if (mintInfo.to == ethers.constants.AddressZero) {
+    // duplicate burned ehre if they do through the UI??? and don't have profileId
+    await burned(mintInfo.from, profileId);
+  } else {
+    console.log('WTF: cosoul transferred... txHash: ', transaction.hash);
+  }
+};
+
+const getProfileIdFromAddress = async (address: string) => {
+  const data = await adminClient.query(
+    {
+      profiles: [
+        {
+          where: { address: { _ilike: address } },
+          limit: 1,
+        },
+        { id: true },
+      ],
+    },
+    { operationName: 'coSoulVerify__getProfileIdFromAddress' }
+  );
+
+  const profileId: number | undefined = data?.profiles[0]?.id;
+
+  return profileId;
+};

--- a/api/webhooks/alchemy_key_trade.test.ts
+++ b/api/webhooks/alchemy_key_trade.test.ts
@@ -1,0 +1,82 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import faker from 'faker';
+
+import { isValidSignatureForStringBody } from '../../api-lib/alchemySignature';
+
+import handler from './alchemy_key_trade';
+
+const address = faker.unique(faker.finance.ethereumAddress);
+
+const trade_req = {
+  headers: {
+    'x-alchemy-signature': 'bad-sig',
+  },
+  body: {
+    webhookId: 'wh_2ems5leedljza922',
+    id: 'whevt_1mlcd4fozo3zbh6z',
+    createdAt: '2023-10-19T04:20:17.135886570Z',
+    type: 'GRAPHQL',
+    event: {
+      data: {
+        block: {
+          hash: '0x3f9cdea4b7594e126fbe1e9267a8bf6d8455d6857b8957c8d2231517c5217e93',
+          logs: [
+            {
+              topics: [
+                '0x2c76e7a47fd53e2854856ac3f0a5f3ee40d15cfaa82266357ea9779c486ab9c3',
+              ],
+              data: '0x000000000000000000000000065f56506474db0384583867f01ceeaf5ed2ad1c000000000000000000000000065f56506474db0384583867f01ceeaf5ed2ad1c00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000038d7ea4c6800000000000000000000000000000000000000000000000000000002d79883d200000000000000000000000000000000000000000000000000000002d79883d2000000000000000000000000000000000000000000000000000000000000000002',
+              transaction: {
+                hash: '0x7a0f2f5eac21fec3d0a9fe6bc9723e70363068b1aa032ebcece920d98be394c6',
+                index: 1,
+                to: { address: '0xbb57fe325e769dedb1236525a91cded842143fa7' },
+                from: { address: '0x065f56506474db0384583867f01ceeaf5ed2ad1c' },
+                status: 1,
+              },
+            },
+          ],
+        },
+      },
+      sequenceNumber: '10000000000578619000',
+    },
+  },
+} as unknown as VercelRequest;
+
+const res = {
+  status: jest.fn(() => res),
+  json: jest.fn(),
+  send: jest.fn(),
+} as unknown as VercelResponse;
+
+beforeEach(() => {
+  process.env.COSOUL_WEBHOOK_ALCHEMY_SIGNING_KEY = 'test-key';
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+jest.mock('../../api-lib/alchemySignature.ts');
+
+describe('SoulKey Alchemy Webhook', () => {
+  describe('with invalid signature', () => {
+    it('errors without valid signatures', async () => {
+      (isValidSignatureForStringBody as jest.Mock).mockReturnValue(false);
+      await handler(trade_req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+  });
+
+  describe('with valid signature', () => {
+    beforeEach(async () => {
+      (isValidSignatureForStringBody as jest.Mock).mockReturnValue(true);
+    });
+    it('parses the trade event', async () => {
+      await handler(trade_req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+
+      // some assertions?
+    });
+  });
+});

--- a/api/webhooks/alchemy_key_trade.ts
+++ b/api/webhooks/alchemy_key_trade.ts
@@ -1,0 +1,60 @@
+import assert from 'assert';
+
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+import { adminClient } from '../../api-lib/gql/adminClient';
+import { errorResponse } from '../../api-lib/HttpError';
+import { isValidSignature } from '../../api-lib/tenderlySignature';
+import { getMintInfofromLogs } from '../../src/features/cosoul/api/cosoul';
+import { minted } from '../hasura/actions/_handlers/syncCoSoul';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  try {
+    const signature = req.headers['x-tenderly-signature'] as string;
+    const timestamp = req.headers['date'] as string;
+
+    assert(signature, 'Missing signature');
+    assert(timestamp, 'Missing timestamp');
+    if (!isValidSignature(signature, JSON.stringify(req.body), timestamp)) {
+      res.status(400).send('Webhook signature not valid');
+      return;
+    }
+
+    const payload = req.body;
+    const { transaction } = payload;
+
+    const { block_hash } = transaction;
+
+    const mintInfo = await getMintInfofromLogs(transaction.logs[0]);
+
+    assert(block_hash);
+    assert(mintInfo);
+
+    const profileId = await getProfileIdFromAddress(mintInfo.to);
+
+    await minted(mintInfo.to, block_hash, mintInfo.tokenId, profileId);
+
+    return res.status(200).send({ success: true });
+  } catch (error: any) {
+    return errorResponse(res, error);
+  }
+}
+
+const getProfileIdFromAddress = async (address: string) => {
+  const data = await adminClient.query(
+    {
+      profiles: [
+        {
+          where: { address: { _ilike: address } },
+          limit: 1,
+        },
+        { id: true },
+      ],
+    },
+    { operationName: 'coSoulVerify__getProfileIdFromAddress' }
+  );
+
+  const profileId = data?.profiles[0]?.id;
+
+  return profileId;
+};

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "cy:run": "./scripts/ci/manager.sh test --cypress",
     "start": "./scripts/serve.sh",
     "build": "craco build",
+    "webhooks:setup": "./scripts/env.sh ts-node scripts/alchemy/setup_webhooks.ts",
     "hardhat:dev": "yarn --cwd hardhat dev",
     "hardhat:ganache": "./scripts/env.sh ./hardhat/scripts/start-ganache.sh",
     "hardhat:test": "yarn --cwd hardhat test",

--- a/scripts/alchemy/setup_webhooks.ts
+++ b/scripts/alchemy/setup_webhooks.ts
@@ -29,18 +29,51 @@ const createWebhook = (name: string, options: any, body: any) => {
     .catch(err => console.error(err));
 };
 
-createWebhook('CoSoul Transfer events', options, {
-  network: 'OPT_MAINNET',
+// createWebhook('CoSoul Transfer events', options, {
+//   network: 'OPT_MAINNET',
+//   webhook_type: 'GRAPHQL',
+//   webhook_url: 'https://app.coordinape.com/api/webhooks/alchemy_cosoul',
+//   graphql_query: {
+//     skip_empty_messages: true,
+//     query: `
+// # Get all Transfer event logs for the CoSoul contract
+// {
+//   block {
+//     hash
+//     logs(filter: {addresses: ["0x47c2a56176335fb2b1ded8e7b5acb136d307dc2d"], topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"]}) {
+//       topics
+//       data
+//       transaction{
+//         hash
+//         index
+//         to{
+//           address
+//         }
+//         from {
+//           address
+//         }
+//         status
+//       }
+//     }
+//   }
+// }
+// `.trim(),
+//   },
+// });
+
+createWebhook('SoulKey Trade events', options, {
+  network: 'OPT_GOERLI',
   webhook_type: 'GRAPHQL',
-  webhook_url: 'https://app.coordinape.com/api/webhooks/alchemy_cosoul',
+  webhook_url:
+    'https://4fe0-146-70-133-131.ngrok-free.app/api/webhooks/alchemy_key_trade',
   graphql_query: {
     skip_empty_messages: true,
     query: `
-# Get all Transfer event logs for the CoSoul contract 
+# Get all Trade event logs for the SoulKey contract 
 {
-  block {
+  block("0x3f9cdea4b7594e126fbe1e9267a8bf6d8455d6857b8957c8d2231517c5217e93") {
     hash
-    logs(filter: {addresses: ["0x47c2a56176335fb2b1ded8e7b5acb136d307dc2d"], topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"]}) {
+    logs(filter: {addresses: ["0xbB57FE325e769DEDB1236525a91cDEd842143fA7"], topics: ["0x2c76e7a47fd53e2854856ac3f0a5f3ee40d15cfaa82266357ea9779c486ab9c3"]}) {
       topics
       data
       transaction{

--- a/scripts/alchemy/setup_webhooks.ts
+++ b/scripts/alchemy/setup_webhooks.ts
@@ -1,0 +1,62 @@
+/* eslint-disable no-console */
+// Script to idempotently (delete then create) webhooks with Alchemy
+
+import assert from 'assert';
+
+import fetch from 'node-fetch';
+
+const api_token = process.env.ALCHEMY_API_TOKEN;
+assert(api_token, 'Missing ALCHEMY_API_TOKEN');
+
+const options = {
+  method: 'POST',
+  headers: {
+    accept: 'application/json',
+    'X-Alchemy-Token': api_token,
+    'content-type': 'application/json',
+  },
+};
+
+const createWebhook = (name: string, options: any, body: any) => {
+  console.log('Creating webhook for', name);
+  const opts = {
+    ...options,
+    body: JSON.stringify(body),
+  };
+  fetch('https://dashboard.alchemy.com/api/create-webhook', opts)
+    .then(response => response.json())
+    .then(response => console.log(response))
+    .catch(err => console.error(err));
+};
+
+createWebhook('CoSoul Transfer events', options, {
+  network: 'OPT_MAINNET',
+  webhook_type: 'GRAPHQL',
+  webhook_url: 'https://app.coordinape.com/api/webhooks/alchemy_cosoul',
+  graphql_query: {
+    skip_empty_messages: true,
+    query: `
+# Get all Transfer event logs for the CoSoul contract 
+{
+  block {
+    hash
+    logs(filter: {addresses: ["0x47c2a56176335fb2b1ded8e7b5acb136d307dc2d"], topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"]}) {
+      topics
+      data
+      transaction{
+        hash
+        index
+        to{
+          address
+        }
+        from {
+          address
+        }
+        status
+      }
+    }
+  }
+}
+`.trim(),
+  },
+});

--- a/scripts/serve_dev.ts
+++ b/scripts/serve_dev.ts
@@ -27,6 +27,7 @@ import log from '../api/log';
 import login from '../api/login';
 import mpTrack from '../api/mp/track';
 import time from '../api/time';
+import alchemy_cosoul from '../api/webhooks/alchemy_cosoul';
 
 const app = express();
 app.use(express.json({ limit: '10mb' })); // for parsing application/json
@@ -78,6 +79,7 @@ app.get('/api/join/:token', (req, res) => {
 
 // TODO: probably rename these to match prod, but this overlaps with :address route
 app.post('/api/_cosoul/verify', tf(verify));
+app.post('/api/webhooks/alchemy_cosoul', tf(alchemy_cosoul));
 app.get('/api/_cosoul/verify', tf(verify));
 app.get('/api/cosoul/:address', (req, res) => {
   return tf(address)({ ...req, query: req.params }, res);

--- a/scripts/serve_dev.ts
+++ b/scripts/serve_dev.ts
@@ -28,6 +28,7 @@ import login from '../api/login';
 import mpTrack from '../api/mp/track';
 import time from '../api/time';
 import alchemy_cosoul from '../api/webhooks/alchemy_cosoul';
+import alchemy_key_trade from '../api/webhooks/alchemy_key_trade';
 
 const app = express();
 app.use(express.json({ limit: '10mb' })); // for parsing application/json
@@ -80,6 +81,7 @@ app.get('/api/join/:token', (req, res) => {
 // TODO: probably rename these to match prod, but this overlaps with :address route
 app.post('/api/_cosoul/verify', tf(verify));
 app.post('/api/webhooks/alchemy_cosoul', tf(alchemy_cosoul));
+app.post('/api/webhooks/alchemy_key_trade', tf(alchemy_key_trade));
 app.get('/api/_cosoul/verify', tf(verify));
 app.get('/api/cosoul/:address', (req, res) => {
   return tf(address)({ ...req, query: req.params }, res);

--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -10,7 +10,9 @@ export type FeatureName =
 // this is a very simple implementation of build-time feature flags that you can
 // hardcode or set with environment variables
 
-const staticFeatureFlags: Partial<Record<FeatureName, boolean>> = {};
+const staticFeatureFlags: Partial<Record<FeatureName, boolean>> = {
+  soulkeys: true,
+};
 
 // this code is safe to use in a non-browser environment because of the typeof
 // check, but our setup in tsconfig-backend.json still flags the use of `window`

--- a/src/features/cosoul/art/screenshot.ts
+++ b/src/features/cosoul/art/screenshot.ts
@@ -44,8 +44,9 @@ export async function screenshotCoSoul(tokenId: number): Promise<Buffer> {
 }
 
 export async function storeCoSoulImage(tokenId: number) {
-  // no-op in CI
+  // no-op in CI and if local flag set
   if (process.env.CI) return;
+  if (process.env.NO_COSOUL_SCREENSHOTS) return;
 
   const buffer = await screenshotCoSoul(tokenId);
   return await uploadImage(`cosoul/screenshots/${tokenId}.png`, buffer);

--- a/src/features/soulkeys/api/getTradeLogs.ts
+++ b/src/features/soulkeys/api/getTradeLogs.ts
@@ -34,7 +34,7 @@ export async function getTradeLogs() {
   }));
 }
 
-function parseEventLog(soulKeys: SoulKeys, log: ethers.providers.Log) {
+export function parseEventLog(soulKeys: SoulKeys, log: ethers.providers.Log) {
   const sk = soulKeys.interface.decodeEventLog(TRADE_SIG, log.data);
   return sk;
 }


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0792e85</samp>

This pull request updates the code to support the new SoulKey contract and event for swapping alchemy keys between coordinape nodes. It modifies the alchemy_key_trade webhook handler, the serve_dev script, and the setup_webhooks script to match the new alchemy service and contract. It also adds a test file for the webhook handler and enables the soulkeys feature flag.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0792e85</samp>

> _We're swapping keys on the blockchain, me hearties_
> _With `alchemy_key_trade` webhooks so smarties_
> _We'll test and refactor all our code, yo ho_
> _And on the count of three we'll pull and go_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0792e85</samp>

* Enable the soulkeys feature flag to allow users to trade SoulKeys for CoSoul tokens ([link](https://github.com/coordinape/coordinape/pull/2371/files?diff=unified&w=0#diff-5c118d9192f4171e7f6592b2205521832975d0666a8673815188b73c9644088aL13-R15))
* Modify the alchemy_key_trade webhook handler to validate, parse, and handle the SoulKey trade events from the alchemy webhook service ([link](https://github.com/coordinape/coordinape/pull/2371/files?diff=unified&w=0#diff-60ccf3a4562a1039073ac5bef93ad5e09271f2d0243bc8e196d49bb73813971aL1-R21), [link](https://github.com/coordinape/coordinape/pull/2371/files?diff=unified&w=0#diff-60ccf3a4562a1039073ac5bef93ad5e09271f2d0243bc8e196d49bb73813971aL24-R40), [link](https://github.com/coordinape/coordinape/pull/2371/files?diff=unified&w=0#diff-60ccf3a4562a1039073ac5bef93ad5e09271f2d0243bc8e196d49bb73813971aL43-R55), [link](https://github.com/coordinape/coordinape/pull/2371/files?diff=unified&w=0#diff-0311d9e32d92a465b712c0f593dae39f47538de233a016a8a2a71014769b9d5bL37-R37))
* Add a new test file for the alchemy_key_trade webhook handler with some mock data and test cases ([link](https://github.com/coordinape/coordinape/pull/2371/files?diff=unified&w=0#diff-e2bfb4b7f63c8675df528fc134ca7c5a4f8f1e358b30f8b44435c3aa94098608R1-R82))
* Add a new route for the alchemy_key_trade webhook handler in the serve_dev script for local testing ([link](https://github.com/coordinape/coordinape/pull/2371/files?diff=unified&w=0#diff-dd65c0157396f6335fc1f86164d9ffeb75c19d3c2e7fb5ebcd684e9f1a41f5b7R31), [link](https://github.com/coordinape/coordinape/pull/2371/files?diff=unified&w=0#diff-dd65c0157396f6335fc1f86164d9ffeb75c19d3c2e7fb5ebcd684e9f1a41f5b7R84))
* Add a new script for creating the SoulKey trade webhook on the alchemy dashboard using the `scripts/alchemy/setup_webhooks.ts` file ([link](https://github.com/coordinape/coordinape/pull/2371/files?diff=unified&w=0#diff-d0de69c13cddd665665ff60dbe92c7a356ffa199b5b322643f289232a0c3fc6dL32-R76))
