### PR TITLE
refactor soulkeys update holders and change how soulkeys contract optionality works

### DIFF
--- a/api/hasura/actions/_handlers/syncKeys.ts
+++ b/api/hasura/actions/_handlers/syncKeys.ts
@@ -2,12 +2,12 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 
 import { getInput } from '../../../../api-lib/handlerHelpers';
 import { errorResponse } from '../../../../api-lib/HttpError';
-import { updateHolders } from '../../../../src/features/soulkeys/api/updateHolders';
+import { updateHoldersFromRecentBlocks } from '../../../../src/features/soulkeys/api/updateHolders';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   try {
     await getInput(req);
-    await updateHolders();
+    await updateHoldersFromRecentBlocks();
     return res.status(200).json({ success: true });
   } catch (e: any) {
     return errorResponse(res, e);

--- a/src/features/cosoul/contracts.ts
+++ b/src/features/cosoul/contracts.ts
@@ -8,8 +8,6 @@ import { SoulKeys } from '@coordinape/hardhat/dist/typechain/SoulKeys';
 import type { Signer } from '@ethersproject/abstract-signer';
 import type { JsonRpcProvider } from '@ethersproject/providers';
 
-import { isFeatureEnabled } from '../../config/features';
-
 const requiredContracts = ['CoSoul'];
 
 export const supportedChainIds: string[] = Object.entries(deploymentInfo)
@@ -41,7 +39,7 @@ export class Contracts {
       info.CoSoul.address,
       this.signerOrProvider
     );
-    if (isFeatureEnabled('soulkeys')) {
+    if (info.SoulKeys?.address) {
       this.soulKeys = SoulKeys__factory.connect(
         info.SoulKeys.address,
         this.signerOrProvider


### PR DESCRIPTION
## What
* This prepares the update holders code for handling webhook event logs.
* Change soulkey backend code to not use feature flag

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d0a17a1</samp>

This pull request updates the code to integrate with the SoulKeys contract and handle its trade events. It removes the feature flag for the contract, adds a new type and function for parsing trade logs, refactors the existing function for updating key holders, and renames some functions for clarity. It also modifies the `Contracts` class and the `syncKeys` action handler to work with the new logic.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d0a17a1</samp>

> _`updateHolders` splits_
> _SoulKeys trades join the party_
> _Autumn of contracts_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d0a17a1</samp>

*  Rename `updateHolders` function to `updateHoldersFromRecentBlocks` for clarity ([link](https://github.com/coordinape/coordinape/pull/2372/files?diff=unified&w=0#diff-0eb92345899bdcb82868ad7ed09d43c78c75a832429c714563295a8d0db369a8L5-R10))
*  Remove unused `isFeatureEnabled` import from `contracts.ts` ([link](https://github.com/coordinape/coordinape/pull/2372/files?diff=unified&w=0#diff-58c8466731549d7e5e65fb3cdf432608c2f167b1347db1cbb1a26f9c6cfc1d7aL11-L12))
*  Replace `isFeatureEnabled` check with nullish check for `info.SoulKeys` in `Contracts` constructor ([link](https://github.com/coordinape/coordinape/pull/2372/files?diff=unified&w=0#diff-58c8466731549d7e5e65fb3cdf432608c2f167b1347db1cbb1a26f9c6cfc1d7aL44-R42))
*  Add `BigNumber` import and `TradeEvent` type to `getTradeLogs.ts` ([link](https://github.com/coordinape/coordinape/pull/2372/files?diff=unified&w=0#diff-0311d9e32d92a465b712c0f593dae39f47538de233a016a8a2a71014769b9d5bL4-R4), [link](https://github.com/coordinape/coordinape/pull/2372/files?diff=unified&w=0#diff-0311d9e32d92a465b712c0f593dae39f47538de233a016a8a2a71014769b9d5bR15-R24))
*  Modify `parseEventLog` function to cast decoded log to `TradeEvent` type and export it ([link](https://github.com/coordinape/coordinape/pull/2372/files?diff=unified&w=0#diff-0311d9e32d92a465b712c0f593dae39f47538de233a016a8a2a71014769b9d5bL31-R54))
*  Modify `getTradeLogs` function to return parsed data and transaction hash for each log ([link](https://github.com/coordinape/coordinape/pull/2372/files?diff=unified&w=0#diff-0311d9e32d92a465b712c0f593dae39f47538de233a016a8a2a71014769b9d5bL31-R54))
*  Add `assert` and `ethers` imports to `updateHolders.ts` ([link](https://github.com/coordinape/coordinape/pull/2372/files?diff=unified&w=0#diff-753bad8929774e5c531652da3976f3e26e795a45811bb9cedcfafe8603520164R1-R4))
*  Add `getSoulKeysContract`, `parseEventLog`, and `TradeEvent` imports to `updateHolders.ts` ([link](https://github.com/coordinape/coordinape/pull/2372/files?diff=unified&w=0#diff-753bad8929774e5c531652da3976f3e26e795a45811bb9cedcfafe8603520164L9-R30))
*  Add `updateHoldersFromOneLog` function to handle a single trade event log and update key holders table ([link](https://github.com/coordinape/coordinape/pull/2372/files?diff=unified&w=0#diff-753bad8929774e5c531652da3976f3e26e795a45811bb9cedcfafe8603520164L9-R30))
*  Simplify `updateHolders` function to loop through trade logs and call `insertTradeEvent` function for each log ([link](https://github.com/coordinape/coordinape/pull/2372/files?diff=unified&w=0#diff-753bad8929774e5c531652da3976f3e26e795a45811bb9cedcfafe8603520164L17-R40))
*  Extract `insertTradeEvent` function to handle insertion logic and conflicts for key tx table ([link](https://github.com/coordinape/coordinape/pull/2372/files?diff=unified&w=0#diff-753bad8929774e5c531652da3976f3e26e795a45811bb9cedcfafe8603520164R140-R210))
*  Simplify `updateHolders` function to call `updateKeyHoldersTable` function after collecting holders to update ([link](https://github.com/coordinape/coordinape/pull/2372/files?diff=unified&w=0#diff-753bad8929774e5c531652da3976f3e26e795a45811bb9cedcfafe8603520164L71-R52))
*  Extract `updateKeyHoldersTable` function to handle insertion or update logic and duplicates for key holders table ([link](https://github.com/coordinape/coordinape/pull/2372/files?diff=unified&w=0#diff-753bad8929774e5c531652da3976f3e26e795a45811bb9cedcfafe8603520164R140-R210))
