### PR TITLE
add indices to contributions

### DIFF
--- a/hasura/migrations/default/1697943622991_create_index_idx_created_at/down.sql
+++ b/hasura/migrations/default/1697943622991_create_index_idx_created_at/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS "public"."idx_created_at";

--- a/hasura/migrations/default/1697943622991_create_index_idx_created_at/up.sql
+++ b/hasura/migrations/default/1697943622991_create_index_idx_created_at/up.sql
@@ -1,0 +1,2 @@
+CREATE  INDEX "idx_created_at" on
+  "public"."contributions" using brin ("created_at");

--- a/hasura/migrations/default/1697943636652_create_index_idx_circle_id/down.sql
+++ b/hasura/migrations/default/1697943636652_create_index_idx_circle_id/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS "public"."idx_circle_id";

--- a/hasura/migrations/default/1697943636652_create_index_idx_circle_id/up.sql
+++ b/hasura/migrations/default/1697943636652_create_index_idx_circle_id/up.sql
@@ -1,0 +1,2 @@
+CREATE  INDEX "idx_circle_id" on
+  "public"."contributions" using btree ("circle_id");


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bc0933e</samp>

This pull request adds two indexes on the `contributions` table to speed up queries by `created_at` and `circle_id`. It also includes the corresponding migration scripts to create and drop the indexes.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bc0933e</samp>

> _`contributions` table_
> _adding and dropping indexes_
> _migration in spring_

