### PR TITLE
bugfix: give page allocation breakpoint fix

### DIFF
--- a/src/pages/GivePage/GiveRow.tsx
+++ b/src/pages/GivePage/GiveRow.tsx
@@ -177,7 +177,7 @@ const GiveRowComponent = ({
             background: 'transparent',
             alignItems: 'center',
             display: 'grid',
-            gridTemplateColumns: gridView ? '1fr' : '1fr 1.5fr',
+            gridTemplateColumns: gridView ? '1fr' : '1fr 1fr',
             justifyContent: 'space-between',
             gap: gridView ? '$md' : '$lg',
             minHeight: 'calc($2xl + $xs)',


### PR DESCRIPTION
fixing this:
<img width="720" alt="Screen_Shot_2023-10-25_at_4 15 59_PM" src="https://github.com/coordinape/coordinape/assets/100873710/a1e6ba7c-aead-47e5-9173-96129496319b">


now looks like this:
![Screenshot 2023-10-25 at 4 42 31 PM](https://github.com/coordinape/coordinape/assets/100873710/9eeb1a7c-303f-452f-9a38-e0394a394cc9)
