### PR TITLE
add primary email to allocation csv

### DIFF
--- a/api/hasura/actions/_handlers/allocationCsv.test.ts
+++ b/api/hasura/actions/_handlers/allocationCsv.test.ts
@@ -136,14 +136,24 @@ function getMockCircleDistribution(
       {
         id: 1,
         fixed_payment_amount: 100,
-        profile: { id: 1, name: 'User 1', address: '0x1' },
+        profile: {
+          id: 1,
+          name: 'User 1',
+          address: '0x1',
+          emails: [{ email: 'test1@test.com' }],
+        },
         received_gifts: [{ tokens: 100 }],
         sent_gifts: [{ tokens: 50 }],
       },
       {
         id: 2,
         fixed_payment_amount: 101,
-        profile: { id: 2, name: 'User 2', address: '0x2' },
+        profile: {
+          id: 2,
+          name: 'User 2',
+          address: '0x2',
+          emails: [{ email: 'test2@test.com' }],
+        },
         received_gifts: [{ tokens: 50 }],
         sent_gifts: [{ tokens: 100 }],
       },
@@ -197,6 +207,8 @@ describe('Allocation CSV Calculation', () => {
     expect(results[0][9]).toEqual('100.00');
     //fixed payment token
     expect(results[0][10]).toEqual('DAI');
+    // user verified primary email
+    expect(results[0][11]).toEqual('test1@test.com');
   });
 
   test('Fixed Distribution Only', async () => {

--- a/api/hasura/actions/_handlers/allocationCsv.ts
+++ b/api/hasura/actions/_handlers/allocationCsv.ts
@@ -83,6 +83,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     headers.push('fixed_payment_token_symbol');
   }
   if (grant) headers.push('Grant_amt');
+  headers.push('email');
   let csvText = `${headers.join(',')}\r\n`;
   userValues.forEach(rowValues => {
     csvText += `${rowValues.join(',')}\r\n`;
@@ -182,6 +183,7 @@ export function generateCsvValues(
             ? Math.floor(((received * grant) / totalTokensSent) * 100) / 100
             : 0
         );
+      rowValues.push(u.profile.emails?.[0]?.email || '');
 
       return rowValues;
     }) || []
@@ -244,7 +246,21 @@ export async function getCircleDetails(
               id: true,
               deleted_at: true,
               fixed_payment_amount: true,
-              profile: { id: true, name: true, address: true },
+              profile: {
+                id: true,
+                name: true,
+                address: true,
+                emails: [
+                  {
+                    where: {
+                      primary: { _eq: true },
+                      verified_at: { _is_null: false },
+                    },
+                    limit: 1,
+                  },
+                  { email: true },
+                ],
+              },
               received_gifts: [
                 { where: { epoch_id: { _eq: epochId } } },
                 { tokens: true },

--- a/api/hasura/actions/_handlers/giveCsv.test.ts
+++ b/api/hasura/actions/_handlers/giveCsv.test.ts
@@ -136,14 +136,24 @@ function getMockCircleDistribution(
       {
         id: 1,
         fixed_payment_amount: 100,
-        profile: { id: 1, name: 'User 1', address: '0x1' },
+        profile: {
+          id: 1,
+          name: 'User 1',
+          address: '0x1',
+          emails: [{ email: 'test1@test.com' }],
+        },
         received_gifts: [{ tokens: 100 }],
         sent_gifts: [{ tokens: 50 }],
       },
       {
         id: 2,
         fixed_payment_amount: 101,
-        profile: { id: 2, name: 'User 2', address: '0x2' },
+        profile: {
+          id: 2,
+          name: 'User 2',
+          address: '0x2',
+          emails: [{ email: 'test2@test.com' }],
+        },
         received_gifts: [{ tokens: 50 }],
         sent_gifts: [{ tokens: 100 }],
       },


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8a0c578</samp>

This pull request adds the verified primary email of each user to the CSV outputs of the circle distribution actions `allocationCsv` and `giveCsv`. This is done to provide more information for the circle admins. The corresponding test files are also updated to reflect the changes.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8a0c578</samp>

> _Sing, O Muse, of the skillful coder who updated the CSV files_
> _To include the emails of the users, verified and true,_
> _As a boon for the circle admins, who oversee the gifts and trials_
> _Of the generous and the needy, who share their resources through._

## Why

add primary verified email to allocation csv

## Test and Deployment Plan
allocation.test.csv is update to test the changes

## Screenshots (if appropriate):

![image](https://github.com/coordinape/coordinape/assets/34943689/c1045620-3946-43fe-a9d4-8365225a989f)



## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8a0c578</samp>

*  Add verified primary email of each user to the CSV output of the `allocationCsv` and `giveCsv` handlers ([link](https://github.com/coordinape/coordinape/pull/2391/files?diff=unified&w=0#diff-dfe15f85a70920c7deb2b9f6e12daf50da2ac351bc998fb611e63d68686f96f6R86), [link](https://github.com/coordinape/coordinape/pull/2391/files?diff=unified&w=0#diff-dfe15f85a70920c7deb2b9f6e12daf50da2ac351bc998fb611e63d68686f96f6R186), [link](https://github.com/coordinape/coordinape/pull/2391/files?diff=unified&w=0#diff-dfe15f85a70920c7deb2b9f6e12daf50da2ac351bc998fb611e63d68686f96f6L247-R263), [link](https://github.com/coordinape/coordinape/pull/2391/files?diff=unified&w=0#diff-99dc739502d6b6400dcfbbb513dddf6760ece2e6152aefb335a79680e78e888fL139-R144), [link](https://github.com/coordinape/coordinape/pull/2391/files?diff=unified&w=0#diff-99dc739502d6b6400dcfbbb513dddf6760ece2e6152aefb335a79680e78e888fL146-R156))
  - Modify the query for the circle distribution in `allocationCsv.ts` and `giveCsv.ts` to include the `emails` field of the profile and filter by primary and verified email ([link](https://github.com/coordinape/coordinape/pull/2391/files?diff=unified&w=0#diff-dfe15f85a70920c7deb2b9f6e12daf50da2ac351bc998fb611e63d68686f96f6L247-R263))
  - Add the `email` header to the CSV output in `allocationCsv.ts` ([link](https://github.com/coordinape/coordinape/pull/2391/files?diff=unified&w=0#diff-dfe15f85a70920c7deb2b9f6e12daf50da2ac351bc998fb611e63d68686f96f6R86))
  - Add the email value to the row values of the CSV output in `allocationCsv.ts`, using the first element of the `emails` array or an empty string ([link](https://github.com/coordinape/coordinape/pull/2391/files?diff=unified&w=0#diff-dfe15f85a70920c7deb2b9f6e12daf50da2ac351bc998fb611e63d68686f96f6R186))
  - Add the `emails` field to the mock profiles of user 1 and user 2 in `allocationCsv.test.ts` and `giveCsv.test.ts` to match the updated query ([link](https://github.com/coordinape/coordinape/pull/2391/files?diff=unified&w=0#diff-b5487ccc5e72c19e0091442696390c1c13334f8ff9298d53f84c5617226749e5L139-R144), [link](https://github.com/coordinape/coordinape/pull/2391/files?diff=unified&w=0#diff-b5487ccc5e72c19e0091442696390c1c13334f8ff9298d53f84c5617226749e5L146-R156), [link](https://github.com/coordinape/coordinape/pull/2391/files?diff=unified&w=0#diff-99dc739502d6b6400dcfbbb513dddf6760ece2e6152aefb335a79680e78e888fL139-R144), [link](https://github.com/coordinape/coordinape/pull/2391/files?diff=unified&w=0#diff-99dc739502d6b6400dcfbbb513dddf6760ece2e6152aefb335a79680e78e888fL146-R156))
* Add assertions to the test case for the `allocationCsv` handler in `allocationCsv.test.ts` to check that the email of user 1 is correctly retrieved and formatted in the CSV output ([link](https://github.com/coordinape/coordinape/pull/2391/files?diff=unified&w=0#diff-b5487ccc5e72c19e0091442696390c1c13334f8ff9298d53f84c5617226749e5R210-R211))
