### PR TITLE
Fix/sync poap

### DIFF
--- a/api-lib/poap/poap-api.ts
+++ b/api-lib/poap/poap-api.ts
@@ -108,6 +108,18 @@ export const syncPoapDataForAddress = async (address: string) => {
   const eventsMap: Record<number, ValueTypes['poap_events_insert_input']> = {};
   const holders: ValueTypes['poap_holders_insert_input'][] = [];
 
+  // eslint-disable-next-line no-console
+  console.log(
+    'received data for address',
+    address,
+    ' with length: ',
+    data.length
+  );
+
+  if (data.length === 0) {
+    return;
+  }
+
   // collect events key from data and rename id key to poap_id
   data.map(d => {
     const { id, ...eventData } = d.event;

--- a/api-lib/poap/poap-api.ts
+++ b/api-lib/poap/poap-api.ts
@@ -57,7 +57,7 @@ export const getEventsForAddress = async (address: string): Promise<Data[]> => {
   try {
     const url = baseUrl + '/actions/scan/' + address;
     const res = await fetch(url, options);
-    const data: Data[] = await res.json();
+    const data: Data[] = (await res.json()) ?? [];
     return data;
   } catch (e) {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c461962</samp>

Improve error handling and logging of `poap-api.ts` function. Use `??` operator and check for empty data when fetching POAP events.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c461962</samp>

> _No events for your address, you face the void of doom_
> _The API fetches nothing, you hear the silent gloom_
> _But we won't let it crash, we use the `??` operator_
> _We log the error and return, we are the null terminator_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c461962</samp>

*  Add nullish coalescing operator to API response to prevent errors ([link](https://github.com/coordinape/coordinape/pull/2392/files?diff=unified&w=0#diff-1c94cb78d152557eb07f7b63c6a870a6358304fd2f3d0255335c2781f7804761L60-R60))
*  Log received data and return early if empty for debugging and optimization ([link](https://github.com/coordinape/coordinape/pull/2392/files?diff=unified&w=0#diff-1c94cb78d152557eb07f7b63c6a870a6358304fd2f3d0255335c2781f7804761R111-R122))
