### PR TITLE
allow api user to set profile_id on contributions

### DIFF
--- a/hasura/metadata/databases/default/tables/public_contributions.yaml
+++ b/hasura/metadata/databases/default/tables/public_contributions.yaml
@@ -55,6 +55,7 @@ insert_permissions:
         created_with_api_key_hash: x-hasura-Api-Key-Hash
       columns:
         - description
+        - profile_id
         - user_id
   - role: user
     permission:
@@ -93,6 +94,7 @@ select_permissions:
         - created_at
         - description
         - id
+        - profile_id
         - updated_at
         - user_id
       filter:

--- a/hasura/metadata/databases/default/tables/public_poap_events.yaml
+++ b/hasura/metadata/databases/default/tables/public_poap_events.yaml
@@ -25,7 +25,7 @@ select_permissions:
         - embedding
       filter: {}
       allow_aggregations: true
-    comment: ''
+    comment: ""
   - role: user
     permission:
       columns:
@@ -49,4 +49,4 @@ select_permissions:
         - year
       filter: {}
       allow_aggregations: true
-    comment: ''
+    comment: ""


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 38c7c12</samp>

This pull request updates the Hasura metadata for the `public.contributions` and `public.poap_events` tables. It adds a new column and permission to link contributions with user profiles, and fixes the formatting of the comment properties for the roles.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 38c7c12</samp>

> _`contributions` link_
> _profiles with donations_
> _autumn harvest time_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 38c7c12</samp>

*  Add `profile_id` column as a foreign key to `public.contributions` table referencing `public.profiles.id` ([link](https://github.com/coordinape/coordinape/pull/2399/files?diff=unified&w=0#diff-bacfab372512e82ec75f7dee295fc59f40cf4f14afef1c55021ca775a6e457c0R58))
*  Allow `user` role to select `profile_id` column from `public.contributions` table ([link](https://github.com/coordinape/coordinape/pull/2399/files?diff=unified&w=0#diff-bacfab372512e82ec75f7dee295fc59f40cf4f14afef1c55021ca775a6e457c0R97))
*  Fix quote formatting for `comment` property of `admin` and `user` roles on `public.poap_events` table ([link](https://github.com/coordinape/coordinape/pull/2399/files?diff=unified&w=0#diff-7ac72d6974707cb6d954b321eb3eb41f5ab477530aaeaf2205a58b10dbca25a2L28-R28), [link](https://github.com/coordinape/coordinape/pull/2399/files?diff=unified&w=0#diff-7ac72d6974707cb6d954b321eb3eb41f5ab477530aaeaf2205a58b10dbca25a2L52-R52))
