### PR TITLE
2nd: very basic reputation score page

### DIFF
--- a/api-lib/gql/__generated__/zeus/const.ts
+++ b/api-lib/gql/__generated__/zeus/const.ts
@@ -8091,7 +8091,7 @@ export const AllTypesProps: Record<string, any> = {
     cosoul: 'cosouls_bool_exp',
     id: 'bigint_comparison_exp',
     name: 'citext_comparison_exp',
-    relationship_score: 'reputation_scores_bool_exp',
+    reputation_score: 'reputation_scores_bool_exp',
   },
   profiles_public_inc_input: {
     id: 'bigint',
@@ -8100,7 +8100,7 @@ export const AllTypesProps: Record<string, any> = {
     cosoul: 'cosouls_obj_rel_insert_input',
     id: 'bigint',
     name: 'citext',
-    relationship_score: 'reputation_scores_obj_rel_insert_input',
+    reputation_score: 'reputation_scores_obj_rel_insert_input',
   },
   profiles_public_obj_rel_insert_input: {
     data: 'profiles_public_insert_input',
@@ -8111,7 +8111,7 @@ export const AllTypesProps: Record<string, any> = {
     cosoul: 'cosouls_order_by',
     id: 'order_by',
     name: 'order_by',
-    relationship_score: 'reputation_scores_order_by',
+    reputation_score: 'reputation_scores_order_by',
   },
   profiles_public_select_column: true,
   profiles_public_set_input: {
@@ -16859,7 +16859,7 @@ export const ReturnTypes: Record<string, any> = {
     cosoul: 'cosouls',
     id: 'bigint',
     name: 'citext',
-    relationship_score: 'reputation_scores',
+    reputation_score: 'reputation_scores',
   },
   profiles_public_aggregate: {
     aggregate: 'profiles_public_aggregate_fields',

--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -21440,7 +21440,7 @@ export type ValueTypes = {
     id?: boolean | `@${string}`;
     name?: boolean | `@${string}`;
     /** An object relationship */
-    relationship_score?: ValueTypes['reputation_scores'];
+    reputation_score?: ValueTypes['reputation_scores'];
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregated selection of "profiles_public" */
@@ -21488,7 +21488,7 @@ export type ValueTypes = {
     cosoul?: ValueTypes['cosouls_bool_exp'] | undefined | null;
     id?: ValueTypes['bigint_comparison_exp'] | undefined | null;
     name?: ValueTypes['citext_comparison_exp'] | undefined | null;
-    relationship_score?:
+    reputation_score?:
       | ValueTypes['reputation_scores_bool_exp']
       | undefined
       | null;
@@ -21504,7 +21504,7 @@ export type ValueTypes = {
     cosoul?: ValueTypes['cosouls_obj_rel_insert_input'] | undefined | null;
     id?: ValueTypes['bigint'] | undefined | null;
     name?: ValueTypes['citext'] | undefined | null;
-    relationship_score?:
+    reputation_score?:
       | ValueTypes['reputation_scores_obj_rel_insert_input']
       | undefined
       | null;
@@ -21544,7 +21544,7 @@ export type ValueTypes = {
     cosoul?: ValueTypes['cosouls_order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
     name?: ValueTypes['order_by'] | undefined | null;
-    relationship_score?:
+    reputation_score?:
       | ValueTypes['reputation_scores_order_by']
       | undefined
       | null;
@@ -41683,7 +41683,7 @@ export type ModelTypes = {
     id?: GraphQLTypes['bigint'] | undefined;
     name?: GraphQLTypes['citext'] | undefined;
     /** An object relationship */
-    relationship_score?: GraphQLTypes['reputation_scores'] | undefined;
+    reputation_score?: GraphQLTypes['reputation_scores'] | undefined;
   };
   /** aggregated selection of "profiles_public" */
   ['profiles_public_aggregate']: {
@@ -60436,7 +60436,7 @@ export type GraphQLTypes = {
     id?: GraphQLTypes['bigint'] | undefined;
     name?: GraphQLTypes['citext'] | undefined;
     /** An object relationship */
-    relationship_score?: GraphQLTypes['reputation_scores'] | undefined;
+    reputation_score?: GraphQLTypes['reputation_scores'] | undefined;
   };
   /** aggregated selection of "profiles_public" */
   ['profiles_public_aggregate']: {
@@ -60476,7 +60476,7 @@ export type GraphQLTypes = {
     cosoul?: GraphQLTypes['cosouls_bool_exp'] | undefined;
     id?: GraphQLTypes['bigint_comparison_exp'] | undefined;
     name?: GraphQLTypes['citext_comparison_exp'] | undefined;
-    relationship_score?: GraphQLTypes['reputation_scores_bool_exp'] | undefined;
+    reputation_score?: GraphQLTypes['reputation_scores_bool_exp'] | undefined;
   };
   /** input type for incrementing numeric columns in table "profiles_public" */
   ['profiles_public_inc_input']: {
@@ -60489,7 +60489,7 @@ export type GraphQLTypes = {
     cosoul?: GraphQLTypes['cosouls_obj_rel_insert_input'] | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
     name?: GraphQLTypes['citext'] | undefined;
-    relationship_score?:
+    reputation_score?:
       | GraphQLTypes['reputation_scores_obj_rel_insert_input']
       | undefined;
   };
@@ -60528,7 +60528,7 @@ export type GraphQLTypes = {
     cosoul?: GraphQLTypes['cosouls_order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
     name?: GraphQLTypes['order_by'] | undefined;
-    relationship_score?: GraphQLTypes['reputation_scores_order_by'] | undefined;
+    reputation_score?: GraphQLTypes['reputation_scores_order_by'] | undefined;
   };
   /** select columns of table "profiles_public" */
   ['profiles_public_select_column']: profiles_public_select_column;

--- a/hasura/metadata/databases/default/tables/public_profiles_public.yaml
+++ b/hasura/metadata/databases/default/tables/public_profiles_public.yaml
@@ -11,7 +11,7 @@ object_relationships:
         remote_table:
           name: cosouls
           schema: public
-  - name: relationship_score
+  - name: reputation_score
     using:
       manual_configuration:
         column_mapping:

--- a/hasura/metadata/databases/default/tables/public_reputation_scores.yaml
+++ b/hasura/metadata/databases/default/tables/public_reputation_scores.yaml
@@ -5,11 +5,12 @@ select_permissions:
   - role: user
     permission:
       columns:
+        - profile_id
         - email_score
+        - github_score
         - keys_score
         - pgive_score
         - poap_score
-        - profile_id
         - total_score
         - twitter_score
       filter: {}

--- a/hasura/migrations/default/1699057603796_create_table_public_github_account/down.sql
+++ b/hasura/migrations/default/1699057603796_create_table_public_github_account/down.sql
@@ -1,2 +1,3 @@
 alter table "public"."reputation_scores" drop column "github_score";
+
 DROP TABLE "public"."github_account";

--- a/hasura/schema/admin/schema.graphql
+++ b/hasura/schema/admin/schema.graphql
@@ -30553,7 +30553,7 @@ type profiles_public {
   """
   An object relationship
   """
-  relationship_score: reputation_scores
+  reputation_score: reputation_scores
 }
 
 """
@@ -30600,7 +30600,7 @@ input profiles_public_bool_exp {
   cosoul: cosouls_bool_exp
   id: bigint_comparison_exp
   name: citext_comparison_exp
-  relationship_score: reputation_scores_bool_exp
+  reputation_score: reputation_scores_bool_exp
 }
 
 """
@@ -30619,7 +30619,7 @@ input profiles_public_insert_input {
   cosoul: cosouls_obj_rel_insert_input
   id: bigint
   name: citext
-  relationship_score: reputation_scores_obj_rel_insert_input
+  reputation_score: reputation_scores_obj_rel_insert_input
 }
 
 """
@@ -30673,7 +30673,7 @@ input profiles_public_order_by {
   cosoul: cosouls_order_by
   id: order_by
   name: order_by
-  relationship_score: reputation_scores_order_by
+  reputation_score: reputation_scores_order_by
 }
 
 """

--- a/hasura/schema/user/schema.graphql
+++ b/hasura/schema/user/schema.graphql
@@ -13367,7 +13367,7 @@ type profiles_public {
   """
   An object relationship
   """
-  relationship_score: reputation_scores
+  reputation_score: reputation_scores
 }
 
 """
@@ -13382,7 +13382,7 @@ input profiles_public_bool_exp {
   cosoul: cosouls_bool_exp
   id: bigint_comparison_exp
   name: citext_comparison_exp
-  relationship_score: reputation_scores_bool_exp
+  reputation_score: reputation_scores_bool_exp
 }
 
 """
@@ -13394,7 +13394,7 @@ input profiles_public_order_by {
   cosoul: cosouls_order_by
   id: order_by
   name: order_by
-  relationship_score: reputation_scores_order_by
+  reputation_score: reputation_scores_order_by
 }
 
 """
@@ -16752,6 +16752,7 @@ columns and relationships of "reputation_scores"
 """
 type reputation_scores {
   email_score: Int!
+  github_score: Int!
   keys_score: Int!
   pgive_score: Int!
   poap_score: Int!
@@ -16768,6 +16769,7 @@ input reputation_scores_bool_exp {
   _not: reputation_scores_bool_exp
   _or: [reputation_scores_bool_exp!]
   email_score: Int_comparison_exp
+  github_score: Int_comparison_exp
   keys_score: Int_comparison_exp
   pgive_score: Int_comparison_exp
   poap_score: Int_comparison_exp
@@ -16781,6 +16783,7 @@ Ordering options when selecting data from "reputation_scores".
 """
 input reputation_scores_order_by {
   email_score: order_by
+  github_score: order_by
   keys_score: order_by
   pgive_score: order_by
   poap_score: order_by
@@ -16797,6 +16800,11 @@ enum reputation_scores_select_column {
   column name
   """
   email_score
+
+  """
+  column name
+  """
+  github_score
 
   """
   column name
@@ -16849,6 +16857,7 @@ Initial value of the column from where the streaming should start
 """
 input reputation_scores_stream_cursor_value_input {
   email_score: Int
+  github_score: Int
   keys_score: Int
   pgive_score: Int
   poap_score: Int

--- a/scripts/serve_dev.ts
+++ b/scripts/serve_dev.ts
@@ -10,7 +10,7 @@ import screenshot from '../api/cosoul/screenshot/[tokenId]';
 import verify from '../api/cosoul/verify';
 import discord from '../api/discord/oauth';
 import verifyEmail from '../api/email/verify/[uuid]';
-import githubCallback from '../api/github/callback';
+import github_callback from '../api/github/callback';
 import github_login from '../api/github/login';
 import actionManager from '../api/hasura/actions/actionManager';
 import auth from '../api/hasura/auth';
@@ -106,8 +106,6 @@ app.get('/api/email/verify/:uuid', (req, res) => {
   return tf(verifyEmail)({ ...req, query: req.params }, res);
 });
 
-app.get('/api/github/callback', tf(githubCallback));
-
 app.post('/api/log', tf(log));
 app.post('/api/login', tf(login));
 app.post('/api/mp/track', tf(mpTrack));
@@ -115,6 +113,7 @@ app.get('/api/time', tf(time));
 app.get('/api/twitter/login', tf(twitter_login));
 app.get('/api/twitter/callback', tf(twitter_callback));
 app.get('/api/github/login', tf(github_login));
+app.get('/api/github/callback', tf(github_callback));
 
 // return empty analytics code
 app.get('/stats/js/script.js', (req, res) => {

--- a/src/features/soulkeys/CoLinksLayout.tsx
+++ b/src/features/soulkeys/CoLinksLayout.tsx
@@ -6,7 +6,7 @@ import { Box, Flex } from 'ui';
 
 import { SoulKeyNav } from './SoulKeyNav';
 
-export const SoulKeyLayout = ({ children }: { children: React.ReactNode }) => {
+export const CoLinksLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <Box
       css={{

--- a/src/features/soulkeys/SoulKeyWizard.tsx
+++ b/src/features/soulkeys/SoulKeyWizard.tsx
@@ -58,7 +58,7 @@ export const SoulKeyWizard = () => {
               id: true,
               name: true,
               avatar: true,
-              relationship_score: {
+              reputation_score: {
                 total_score: true,
               },
             },
@@ -72,7 +72,7 @@ export const SoulKeyWizard = () => {
     }
   );
 
-  const hasRep = !!myProfile?.relationship_score?.total_score;
+  const hasRep = !!myProfile?.reputation_score?.total_score;
   const { data: keyData } = useQuery(
     [QUERY_KEY_SOULKEYS, address, 'wizardKeys'],
     async () => {
@@ -357,7 +357,7 @@ export const SoulKeyWizard = () => {
                   Rep Score
                 </Text>
                 <Text h2>
-                  {myProfile?.relationship_score?.total_score ?? '0'}
+                  {myProfile?.reputation_score?.total_score ?? '0'}
                 </Text>
               </Flex>
               <Flex>

--- a/src/lib/gql/__generated__/zeus/const.ts
+++ b/src/lib/gql/__generated__/zeus/const.ts
@@ -4323,7 +4323,7 @@ export const AllTypesProps: Record<string, any> = {
     cosoul: 'cosouls_bool_exp',
     id: 'bigint_comparison_exp',
     name: 'citext_comparison_exp',
-    relationship_score: 'reputation_scores_bool_exp',
+    reputation_score: 'reputation_scores_bool_exp',
   },
   profiles_public_order_by: {
     address: 'order_by',
@@ -4331,7 +4331,7 @@ export const AllTypesProps: Record<string, any> = {
     cosoul: 'cosouls_order_by',
     id: 'order_by',
     name: 'order_by',
-    relationship_score: 'reputation_scores_order_by',
+    reputation_score: 'reputation_scores_order_by',
   },
   profiles_public_select_column: true,
   profiles_public_stream_cursor_input: {
@@ -5090,6 +5090,7 @@ export const AllTypesProps: Record<string, any> = {
     _not: 'reputation_scores_bool_exp',
     _or: 'reputation_scores_bool_exp',
     email_score: 'Int_comparison_exp',
+    github_score: 'Int_comparison_exp',
     keys_score: 'Int_comparison_exp',
     pgive_score: 'Int_comparison_exp',
     poap_score: 'Int_comparison_exp',
@@ -5099,6 +5100,7 @@ export const AllTypesProps: Record<string, any> = {
   },
   reputation_scores_order_by: {
     email_score: 'order_by',
+    github_score: 'order_by',
     keys_score: 'order_by',
     pgive_score: 'order_by',
     poap_score: 'order_by',
@@ -8602,7 +8604,7 @@ export const ReturnTypes: Record<string, any> = {
     cosoul: 'cosouls',
     id: 'bigint',
     name: 'citext',
-    relationship_score: 'reputation_scores',
+    reputation_score: 'reputation_scores',
   },
   query_root: {
     activities: 'activities',
@@ -8905,6 +8907,7 @@ export const ReturnTypes: Record<string, any> = {
   },
   reputation_scores: {
     email_score: 'Int',
+    github_score: 'Int',
     keys_score: 'Int',
     pgive_score: 'Int',
     poap_score: 'Int',

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -9905,7 +9905,7 @@ export type ValueTypes = {
     id?: boolean | `@${string}`;
     name?: boolean | `@${string}`;
     /** An object relationship */
-    relationship_score?: ValueTypes['reputation_scores'];
+    reputation_score?: ValueTypes['reputation_scores'];
     __typename?: boolean | `@${string}`;
   }>;
   /** Boolean expression to filter rows from the table "profiles_public". All fields are combined with a logical 'AND'. */
@@ -9918,7 +9918,7 @@ export type ValueTypes = {
     cosoul?: ValueTypes['cosouls_bool_exp'] | undefined | null;
     id?: ValueTypes['bigint_comparison_exp'] | undefined | null;
     name?: ValueTypes['citext_comparison_exp'] | undefined | null;
-    relationship_score?:
+    reputation_score?:
       | ValueTypes['reputation_scores_bool_exp']
       | undefined
       | null;
@@ -9930,7 +9930,7 @@ export type ValueTypes = {
     cosoul?: ValueTypes['cosouls_order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
     name?: ValueTypes['order_by'] | undefined | null;
-    relationship_score?:
+    reputation_score?:
       | ValueTypes['reputation_scores_order_by']
       | undefined
       | null;
@@ -12274,6 +12274,7 @@ export type ValueTypes = {
   /** columns and relationships of "reputation_scores" */
   ['reputation_scores']: AliasType<{
     email_score?: boolean | `@${string}`;
+    github_score?: boolean | `@${string}`;
     keys_score?: boolean | `@${string}`;
     pgive_score?: boolean | `@${string}`;
     poap_score?: boolean | `@${string}`;
@@ -12288,6 +12289,7 @@ export type ValueTypes = {
     _not?: ValueTypes['reputation_scores_bool_exp'] | undefined | null;
     _or?: Array<ValueTypes['reputation_scores_bool_exp']> | undefined | null;
     email_score?: ValueTypes['Int_comparison_exp'] | undefined | null;
+    github_score?: ValueTypes['Int_comparison_exp'] | undefined | null;
     keys_score?: ValueTypes['Int_comparison_exp'] | undefined | null;
     pgive_score?: ValueTypes['Int_comparison_exp'] | undefined | null;
     poap_score?: ValueTypes['Int_comparison_exp'] | undefined | null;
@@ -12298,6 +12300,7 @@ export type ValueTypes = {
   /** Ordering options when selecting data from "reputation_scores". */
   ['reputation_scores_order_by']: {
     email_score?: ValueTypes['order_by'] | undefined | null;
+    github_score?: ValueTypes['order_by'] | undefined | null;
     keys_score?: ValueTypes['order_by'] | undefined | null;
     pgive_score?: ValueTypes['order_by'] | undefined | null;
     poap_score?: ValueTypes['order_by'] | undefined | null;
@@ -12317,6 +12320,7 @@ export type ValueTypes = {
   /** Initial value of the column from where the streaming should start */
   ['reputation_scores_stream_cursor_value_input']: {
     email_score?: number | undefined | null;
+    github_score?: number | undefined | null;
     keys_score?: number | undefined | null;
     pgive_score?: number | undefined | null;
     poap_score?: number | undefined | null;
@@ -19928,7 +19932,7 @@ export type ModelTypes = {
     id?: GraphQLTypes['bigint'] | undefined;
     name?: GraphQLTypes['citext'] | undefined;
     /** An object relationship */
-    relationship_score?: GraphQLTypes['reputation_scores'] | undefined;
+    reputation_score?: GraphQLTypes['reputation_scores'] | undefined;
   };
   /** Boolean expression to filter rows from the table "profiles_public". All fields are combined with a logical 'AND'. */
   ['profiles_public_bool_exp']: GraphQLTypes['profiles_public_bool_exp'];
@@ -20500,6 +20504,7 @@ export type ModelTypes = {
   /** columns and relationships of "reputation_scores" */
   ['reputation_scores']: {
     email_score: number;
+    github_score: number;
     keys_score: number;
     pgive_score: number;
     poap_score: number;
@@ -28714,7 +28719,7 @@ export type GraphQLTypes = {
     id?: GraphQLTypes['bigint'] | undefined;
     name?: GraphQLTypes['citext'] | undefined;
     /** An object relationship */
-    relationship_score?: GraphQLTypes['reputation_scores'] | undefined;
+    reputation_score?: GraphQLTypes['reputation_scores'] | undefined;
   };
   /** Boolean expression to filter rows from the table "profiles_public". All fields are combined with a logical 'AND'. */
   ['profiles_public_bool_exp']: {
@@ -28726,7 +28731,7 @@ export type GraphQLTypes = {
     cosoul?: GraphQLTypes['cosouls_bool_exp'] | undefined;
     id?: GraphQLTypes['bigint_comparison_exp'] | undefined;
     name?: GraphQLTypes['citext_comparison_exp'] | undefined;
-    relationship_score?: GraphQLTypes['reputation_scores_bool_exp'] | undefined;
+    reputation_score?: GraphQLTypes['reputation_scores_bool_exp'] | undefined;
   };
   /** Ordering options when selecting data from "profiles_public". */
   ['profiles_public_order_by']: {
@@ -28735,7 +28740,7 @@ export type GraphQLTypes = {
     cosoul?: GraphQLTypes['cosouls_order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
     name?: GraphQLTypes['order_by'] | undefined;
-    relationship_score?: GraphQLTypes['reputation_scores_order_by'] | undefined;
+    reputation_score?: GraphQLTypes['reputation_scores_order_by'] | undefined;
   };
   /** select columns of table "profiles_public" */
   ['profiles_public_select_column']: profiles_public_select_column;
@@ -29620,6 +29625,7 @@ export type GraphQLTypes = {
   ['reputation_scores']: {
     __typename: 'reputation_scores';
     email_score: number;
+    github_score: number;
     keys_score: number;
     pgive_score: number;
     poap_score: number;
@@ -29633,6 +29639,7 @@ export type GraphQLTypes = {
     _not?: GraphQLTypes['reputation_scores_bool_exp'] | undefined;
     _or?: Array<GraphQLTypes['reputation_scores_bool_exp']> | undefined;
     email_score?: GraphQLTypes['Int_comparison_exp'] | undefined;
+    github_score?: GraphQLTypes['Int_comparison_exp'] | undefined;
     keys_score?: GraphQLTypes['Int_comparison_exp'] | undefined;
     pgive_score?: GraphQLTypes['Int_comparison_exp'] | undefined;
     poap_score?: GraphQLTypes['Int_comparison_exp'] | undefined;
@@ -29643,6 +29650,7 @@ export type GraphQLTypes = {
   /** Ordering options when selecting data from "reputation_scores". */
   ['reputation_scores_order_by']: {
     email_score?: GraphQLTypes['order_by'] | undefined;
+    github_score?: GraphQLTypes['order_by'] | undefined;
     keys_score?: GraphQLTypes['order_by'] | undefined;
     pgive_score?: GraphQLTypes['order_by'] | undefined;
     poap_score?: GraphQLTypes['order_by'] | undefined;
@@ -29662,6 +29670,7 @@ export type GraphQLTypes = {
   /** Initial value of the column from where the streaming should start */
   ['reputation_scores_stream_cursor_value_input']: {
     email_score?: number | undefined;
+    github_score?: number | undefined;
     keys_score?: number | undefined;
     pgive_score?: number | undefined;
     poap_score?: number | undefined;
@@ -32223,6 +32232,7 @@ export const enum replies_update_column {
 /** select columns of table "reputation_scores" */
 export const enum reputation_scores_select_column {
   email_score = 'email_score',
+  github_score = 'github_score',
   keys_score = 'keys_score',
   pgive_score = 'pgive_score',
   poap_score = 'poap_score',

--- a/src/pages/RepScorePage.tsx
+++ b/src/pages/RepScorePage.tsx
@@ -111,6 +111,7 @@ const ScoreItem = ({
     <Flex css={{ gap: '$md' }}>
       <Text
         size={big ? 'large' : 'medium'}
+        semibold={big ? true : false}
         css={{ width: '100px', justifyContent: 'flex-end' }}
       >
         {score}

--- a/src/pages/RepScorePage.tsx
+++ b/src/pages/RepScorePage.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+
+import { useQuery } from 'react-query';
+import { useParams } from 'react-router-dom';
+
+import { LoadingIndicator } from '../components/LoadingIndicator';
+import { client } from '../lib/gql/client';
+import { Avatar, ContentHeader, Flex, Panel, Text } from '../ui';
+import { SingleColumnLayout } from '../ui/layouts';
+
+export const RepScorePage = () => {
+  const { address } = useParams();
+  const { data, isLoading } = useQuery(
+    ['repscore', address, 'details'],
+    async () => {
+      const { profiles_public } = await client.query(
+        {
+          profiles_public: [
+            {
+              where: {
+                address: {
+                  _eq: address,
+                },
+              },
+            },
+            {
+              name: true,
+              avatar: true,
+              reputation_score: {
+                total_score: true,
+                github_score: true,
+                twitter_score: true,
+                poap_score: true,
+                email_score: true,
+                keys_score: true,
+                pgive_score: true,
+              },
+            },
+          ],
+        },
+        {
+          operationName: 'repscore_details',
+        }
+      );
+      return profiles_public.pop();
+    }
+  );
+
+  if (isLoading && data === undefined) {
+    return <LoadingIndicator />;
+  }
+  if (data === undefined) {
+    return <Panel>User not found</Panel>;
+  }
+  return (
+    <SingleColumnLayout>
+      <ContentHeader>
+        <Flex alignItems="center" css={{ gap: '$sm' }}>
+          <Avatar
+            size="large"
+            name={data.name}
+            path={data.avatar}
+            margin="none"
+            css={{ mr: '$sm' }}
+          />
+          <Flex column>
+            <Text h2 display css={{ color: '$secondaryButtonText' }}>
+              {data.name}
+            </Text>
+            <Text>Reputation Score</Text>
+          </Flex>
+        </Flex>
+      </ContentHeader>
+      {!data.reputation_score ? (
+        <Panel>No score yet.</Panel>
+      ) : (
+        <Flex column css={{ maxWidth: '$readable', gap: '$sm' }}>
+          <ScoreItem
+            big={true}
+            title="Total"
+            score={data.reputation_score.total_score}
+          />
+          <ScoreItem
+            title="GitHub"
+            score={data.reputation_score.github_score}
+          />
+          <ScoreItem
+            title="Twitter"
+            score={data.reputation_score.twitter_score}
+          />
+          <ScoreItem title="POAP" score={data.reputation_score.poap_score} />
+          <ScoreItem title="Email" score={data.reputation_score.email_score} />
+          <ScoreItem title="Links" score={data.reputation_score.keys_score} />
+          <ScoreItem title="PGIVE" score={data.reputation_score.pgive_score} />
+        </Flex>
+      )}
+    </SingleColumnLayout>
+  );
+};
+
+const ScoreItem = ({
+  title,
+  score,
+  big,
+}: {
+  title: string;
+  score: number;
+  big?: boolean;
+}) => {
+  return (
+    <Flex css={{ gap: '$md' }}>
+      <Text
+        size={big ? 'large' : 'medium'}
+        css={{ width: '100px', justifyContent: 'flex-end' }}
+      >
+        {score}
+      </Text>
+      <Text size={big ? 'large' : 'medium'} semibold>
+        {title}
+      </Text>
+    </Flex>
+  );
+};

--- a/src/pages/ViewSoulKeyPage/ViewSoulKeyPageContents.tsx
+++ b/src/pages/ViewSoulKeyPage/ViewSoulKeyPageContents.tsx
@@ -18,6 +18,7 @@ import { useSoulKeys } from '../../features/soulkeys/useSoulKeys';
 import { useToast } from '../../hooks';
 import { Clock } from '../../icons/__generated';
 import { client } from '../../lib/gql/client';
+import { paths } from '../../routes/paths';
 import {
   Avatar,
   Button,
@@ -122,7 +123,7 @@ const PageContents = ({
               id: true,
               name: true,
               avatar: true,
-              relationship_score: {
+              reputation_score: {
                 total_score: true,
               },
             },
@@ -179,9 +180,11 @@ const PageContents = ({
                     <Text semibold size="small">
                       Rep Score
                     </Text>
-                    <Text semibold h1>
-                      {subjectProfile?.relationship_score?.total_score ?? ''}
-                    </Text>
+                    <Link href={paths.soulKeysRepScore(subjectAddress)}>
+                      <Text semibold h1>
+                        {subjectProfile?.reputation_score?.total_score ?? ''}
+                      </Text>
+                    </Link>
                     <Flex>
                       <Button
                         disabled={updatingRepScore}

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -87,6 +87,7 @@ export const paths = {
   soulKeysActivity: '/soulkeys/activity',
   soulKeysWizard: '/soulkeys/wizard',
   soulKeysWizardStart: '/soulkeys/start',
+  soulKeysRepScore: (address: string) => `/soulkeys/score/${address}`,
   soulKey: (address: string) => `/soulkeys/${address}`,
 
   profile: (address: string) => `/profile/${address}`,

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -22,7 +22,7 @@ import {
 } from 'react-router-dom';
 
 import { DebugLogger } from '../common-lib/log';
-import isFeatureEnabled from '../config/features';
+import { isFeatureEnabled } from '../config/features';
 import { CoLinksLayout } from '../features/soulkeys/CoLinksLayout';
 import { SoulKeyWizardLayout } from '../features/soulkeys/SoulKeyWizardLayout';
 import AddMembersPage from '../pages/AddMembersPage/AddMembersPage';

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from 'react';
+import { Fragment, lazy, Suspense } from 'react';
 
 import { RequireAuth, useLoginData } from 'features/auth';
 import {
@@ -11,7 +11,6 @@ import CoSoulArtOnlyLayout from 'features/cosoul/CoSoulArtOnlyLayout';
 import CoSoulLayout from 'features/cosoul/CoSoulLayout';
 import { DebugCoSoulGalleryPage } from 'features/cosoul/DebugCoSoulGalleryPage';
 import { OrgPage, OrgSettingsPage } from 'features/orgs';
-import { SoulKeyWizardLayout } from 'features/soulkeys/SoulKeyWizardLayout';
 import { isUserAdmin, isUserMember } from 'lib/users';
 import {
   Navigate,
@@ -23,15 +22,19 @@ import {
 } from 'react-router-dom';
 
 import { DebugLogger } from '../common-lib/log';
-import { isFeatureEnabled } from '../config/features';
-import { SoulKeyLayout } from '../features/soulkeys/SoulKeyLayout';
+import isFeatureEnabled from '../config/features';
+import { CoLinksLayout } from '../features/soulkeys/CoLinksLayout';
+import { SoulKeyWizardLayout } from '../features/soulkeys/SoulKeyWizardLayout';
 import AddMembersPage from '../pages/AddMembersPage/AddMembersPage';
 import CircleActivityPage from '../pages/CircleActivityPage';
 import CoSoulExplorePage from '../pages/CoSoulExplorePage/CoSoulExplorePage';
 import GivePage from '../pages/GivePage';
 import JoinPage from '../pages/JoinPage';
+import { RepScorePage } from '../pages/RepScorePage';
 import { SoulKeyActivityPage } from '../pages/SoulKeyActivityPage';
 import { SoulKeysTradesPage } from '../pages/SoulKeysTradesPage';
+import { SoulKeysWizardPage } from '../pages/SoulKeysWizardPage';
+import { SoulKeysWizardStart } from '../pages/SoulKeysWizardStart';
 import VerifyEmailPage from '../pages/VerifyEmailPage';
 import ViewMySoulKeyPage from '../pages/ViewSoulKeyPage/ViewMySoulKeyPage';
 import { ViewSoulKeyPage } from '../pages/ViewSoulKeyPage/ViewSoulKeyPage';
@@ -51,8 +54,6 @@ import MembersPage from 'pages/MembersPage';
 import { NewNominationPage } from 'pages/NewNominationPage/NewNominationPage';
 import OrgMembersPage, { OrgMembersAddPage } from 'pages/OrgMembersPage';
 import ProfilePage from 'pages/ProfilePage';
-import { SoulKeysWizardPage } from 'pages/SoulKeysWizardPage';
-import { SoulKeysWizardStart } from 'pages/SoulKeysWizardStart';
 import VaultsPage from 'pages/VaultsPage';
 import { VaultTransactions } from 'pages/VaultsPage/VaultTransactions';
 
@@ -73,6 +74,16 @@ const logger = new DebugLogger('routes');
 // look into this.
 const LazyAssetMapPage = lazy(() => import('pages/MapPage'));
 
+const RedirectAfterLogin = () => {
+  const [params] = useSearchParams();
+  return <Redirect to={params.get('next') || '/'} note="RedirectAfterLogin" />;
+};
+
+const Redirect = ({ to, note = '' }: { to: string; note?: string }) => {
+  const location = useLocation();
+  logger.log(`redirecting ${location.pathname} -> ${to} | ${note}`);
+  return <Navigate to={to} replace />;
+};
 const LoggedInRoutes = () => {
   return (
     <Routes>
@@ -203,57 +214,70 @@ export const AppRoutes = () => {
         />
       </Route>
 
-      {/*SoulKeys Routes*/}
+      {/*CoLinks Routes*/}
       {isFeatureEnabled('soulkeys') && (
-        <Route
-          element={
-            <RequireAuth>
-              <SoulKeyLayout>
-                <Outlet />
-              </SoulKeyLayout>
-            </RequireAuth>
-          }
-        >
-          <Route path={paths.soulKeys} element={<ViewMySoulKeyPage />} />
+        <Fragment>
           <Route
-            path={paths.soulKey(':address')}
-            element={<ViewSoulKeyPage />}
-          />
-          <Route path={paths.soulKeysTrades} element={<SoulKeysTradesPage />} />
-          <Route path={paths.soulKeysExplore} element={<CoSoulExplorePage />} />
-          <Route path={paths.soulKeysAccount} element={<AccountPage />} />
+            element={
+              <RequireAuth>
+                <CoLinksLayout>
+                  <Outlet />
+                </CoLinksLayout>
+              </RequireAuth>
+            }
+          >
+            <Route path={paths.soulKeys} element={<ViewMySoulKeyPage />} />
+            <Route
+              path={paths.soulKey(':address')}
+              element={<ViewSoulKeyPage />}
+            />
+            <Route
+              path={paths.soulKeysTrades}
+              element={<SoulKeysTradesPage />}
+            />
+            <Route
+              path={paths.soulKeysExplore}
+              element={<CoSoulExplorePage />}
+            />
+            <Route path={paths.soulKeysAccount} element={<AccountPage />} />
+            <Route
+              path={paths.soulKeysActivity}
+              element={<SoulKeyActivityPage />}
+            />
+            <Route
+              path={paths.soulKeysRepScore(':address')}
+              element={<RepScorePage />}
+            />
+          </Route>
+
           <Route
-            path={paths.soulKeysActivity}
-            element={<SoulKeyActivityPage />}
-          />
-        </Route>
-      )}
-      {isFeatureEnabled('soulkeys') && (
-        <Route
-          element={
-            <SoulKeyWizardLayout>
-              <Outlet />
-            </SoulKeyWizardLayout>
-          }
-        >
-          <Route
-            path={paths.soulKeysWizardStart}
-            element={<SoulKeysWizardStart />}
-          />
-        </Route>
-      )}
-      {isFeatureEnabled('soulkeys') && (
-        <Route
-          element={
-            <RequireAuth>
+            element={
               <SoulKeyWizardLayout>
                 <Outlet />
               </SoulKeyWizardLayout>
-            </RequireAuth>
-          }
-        >
-          <Route path={paths.soulKeysWizard} element={<SoulKeysWizardPage />} />
-        </Route>
+            }
+          >
+            <Route
+              path={paths.soulKeysWizardStart}
+              element={<SoulKeysWizardStart />}
+            />
+          </Route>
+
+          <Route
+            element={
+              <RequireAuth>
+                <SoulKeyWizardLayout>
+                  <Outlet />
+                </SoulKeyWizardLayout>
+              </RequireAuth>
+            }
+          >
+            <Route
+              path={paths.soulKeysWizard}
+              element={<SoulKeysWizardPage />}
+            />
+          </Route>
+        </Fragment>
       )}
       {/* Main App Pages */}
       <Route
@@ -286,17 +310,6 @@ export const AppRoutes = () => {
       </Route>
     </Routes>
   );
-};
-
-const RedirectAfterLogin = () => {
-  const [params] = useSearchParams();
-  return <Redirect to={params.get('next') || '/'} note="RedirectAfterLogin" />;
-};
-
-const Redirect = ({ to, note = '' }: { to: string; note?: string }) => {
-  const location = useLocation();
-  logger.log(`redirecting ${location.pathname} -> ${to} | ${note}`);
-  return <Navigate to={to} replace />;
 };
 
 const OrgRouteHandler = () => {


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ee71450</samp>

This pull request refactors the codebase to use the term `reputation_score` instead of `relationship_score` for the score that measures the trust and collaboration between users. It also adds a new feature to include GitHub activity as a factor in the reputation score calculation and display, and a new feature to allow users to view their own and other users' reputation scores and breakdowns. Additionally, it renames the `SoulKey` feature to `CoLinks` and improves the routing system. The changes affect several files in the `api-lib`, `hasura`, `src`, and `routes` directories.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ee71450</samp>

> _We are the CoLinks, we forge our destiny_
> _With reputation scores, we measure our legacy_
> _We face the doom of GitHub, we challenge its authority_
> _We are the CoLinks, we rise in solidarity_
<img width="784" alt="image" src="https://github.com/coordinape/coordinape/assets/95149165/5694091f-61e9-4cf3-abd5-c4e9454e5af5">

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ee71450</samp>

*  Rename `relationship_score` to `reputation_score` in various files and interfaces to reflect the purpose and meaning of the score ([link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0L8094-R8094), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0L8103-R8103), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0L8114-R8114), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0L16862-R16862), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-412dbd6aa74a0169e4120157039da14d29381e4a3e1cc6551f78afc1616b8e65L14-R14), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8L30556-R30556), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8L30603-R30603), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8L30622-R30622), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8L30676-R30676), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebL13370-R13370), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebL13385-R13385), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebL13397-R13397), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-5b6a8191793b18faeec237f4b53aa808c1fc3c74e07d9f731a9f5b4d2688a848L61-R61), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-5b6a8191793b18faeec237f4b53aa808c1fc3c74e07d9f731a9f5b4d2688a848L75-R75), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-5b6a8191793b18faeec237f4b53aa808c1fc3c74e07d9f731a9f5b4d2688a848L360-R360), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060L4326-R4326), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060L4334-R4334), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060L8605-R8607), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-4516b939eb12ece82b9da4ad4e1adf5f0000bb7a82b2a0bc51e13dec34c44fb3L125-R126), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-4516b939eb12ece82b9da4ad4e1adf5f0000bb7a82b2a0bc51e13dec34c44fb3L182-R187))
* Add `github_score` field to `reputation_scores` table and related interfaces and queries to include GitHub activity as a factor in the reputation score calculation ([link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-8e3a6fb7bcb7840077cb813fa6cf8a7c18a7cb28a823261b5cf3a2257b74e9a8L8-R13), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebR16755), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebR16772), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebR16786), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebR16807-R16811), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebR16860), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060R5093), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060R5103), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060R8910))
* Add `RepScorePage` component and related routes and paths to allow users to view their own and other users' reputation score details ([link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-14897c5d422765c19a49a059ebb26160b05e4e30063be8e2e3ce122a4428056bR1-R123), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-4516b939eb12ece82b9da4ad4e1adf5f0000bb7a82b2a0bc51e13dec34c44fb3R21), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-26212c7e58b310fe67e20a7cd969dce535cc31c1f843f741c71641dddc7320ddR90), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-0005a5feea8701ddb5aef0d57e1a5a03c36dae6cd62fc3ecf35fd15a88bb5c03L33-R37), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-0005a5feea8701ddb5aef0d57e1a5a03c36dae6cd62fc3ecf35fd15a88bb5c03L206-R280))
* Rename `SoulKey` to `CoLinks` in various files and components to reflect the purpose and meaning of the feature ([link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-74e8b0f657766cf42b0757288b091a3ca54cda4380db788d5ef4ae853e9d4fd5L9-R9), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-0005a5feea8701ddb5aef0d57e1a5a03c36dae6cd62fc3ecf35fd15a88bb5c03L14), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-0005a5feea8701ddb5aef0d57e1a5a03c36dae6cd62fc3ecf35fd15a88bb5c03L26-R27), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-0005a5feea8701ddb5aef0d57e1a5a03c36dae6cd62fc3ecf35fd15a88bb5c03L206-R280))
* Add `RedirectAfterLogin` and `Redirect` components to handle the redirection logic after a user logs in or when a route is not found ([link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-0005a5feea8701ddb5aef0d57e1a5a03c36dae6cd62fc3ecf35fd15a88bb5c03R77-R86), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-0005a5feea8701ddb5aef0d57e1a5a03c36dae6cd62fc3ecf35fd15a88bb5c03L291-L301))
* Remove unused or duplicate imports from `routes.tsx` ([link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-0005a5feea8701ddb5aef0d57e1a5a03c36dae6cd62fc3ecf35fd15a88bb5c03L14), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-0005a5feea8701ddb5aef0d57e1a5a03c36dae6cd62fc3ecf35fd15a88bb5c03L54-L55))
* Use a fragment element to group the CoLinks routes together and improve the readability and maintainability of the routing system ([link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-0005a5feea8701ddb5aef0d57e1a5a03c36dae6cd62fc3ecf35fd15a88bb5c03L1-R1), [link](https://github.com/coordinape/coordinape/pull/2403/files?diff=unified&w=0#diff-0005a5feea8701ddb5aef0d57e1a5a03c36dae6cd62fc3ecf35fd15a88bb5c03L206-R280))
