### PR TITLE
Add superfriend tag on profile pages

### DIFF
--- a/src/features/rep/api/updateRepScore.ts
+++ b/src/features/rep/api/updateRepScore.ts
@@ -10,7 +10,17 @@ import { getRepScore } from './getRepScore';
 
 export const updateRepScore = async (profileId: number) => {
   const score = await getRepScore(profileId);
-  const { pgive, twitter, email, keys, poap, gitHub, invites, linkedIn, total } = score;
+  const {
+    pgive,
+    twitter,
+    email,
+    keys,
+    poap,
+    gitHub,
+    invites,
+    linkedIn,
+    total,
+  } = score;
 
   const { insert_reputation_scores_one } = await adminClient.mutate(
     {

--- a/src/features/soulkeys/useSoulKeys.ts
+++ b/src/features/soulkeys/useSoulKeys.ts
@@ -13,14 +13,16 @@ export const useSoulKeys = ({
   const { data: balances, refetch } = useQuery(
     ['soulKeys', address],
     async () => {
-      const balance = (
+      const balance = ( // your balance of them
         await soulKeys.sharesBalance(subject, address)
       ).toNumber();
+      // their balance of you
       const subjectBalance = (
         await soulKeys.sharesBalance(address, subject)
       ).toNumber();
       const supply = (await soulKeys.sharesSupply(subject)).toNumber();
-      return { balance, subjectBalance, supply };
+      const superFriend = subjectBalance > 0 && balance > 0;
+      return { balance, subjectBalance, supply, superFriend };
     }
   );
 

--- a/src/features/soulkeys/useSoulKeys.ts
+++ b/src/features/soulkeys/useSoulKeys.ts
@@ -13,7 +13,8 @@ export const useSoulKeys = ({
   const { data: balances, refetch } = useQuery(
     ['soulKeys', address],
     async () => {
-      const balance = ( // your balance of them
+      // your balance of them
+      const balance = (
         await soulKeys.sharesBalance(subject, address)
       ).toNumber();
       // their balance of you

--- a/src/pages/ViewSoulKeyPage/ViewSoulKeyPageContents.tsx
+++ b/src/pages/ViewSoulKeyPage/ViewSoulKeyPageContents.tsx
@@ -73,7 +73,7 @@ const PageContents = ({
   currentUserAddress: string;
   subjectAddress: string;
 }) => {
-  const { balance, subjectBalance, supply } = useSoulKeys({
+  const { balance, subjectBalance, supply, superFriend } = useSoulKeys({
     soulKeys,
     address: currentUserAddress,
     subject: subjectAddress,
@@ -164,6 +164,11 @@ const PageContents = ({
                     </Text>
                     {!needsBootstrapping && (
                       <Flex css={{ gap: '$sm', mt: '$xs' }}>
+                        {!subjectIsCurrentUser && superFriend && (
+                          <Text tag color={'alert'}>
+                            You are superfriends!
+                          </Text>
+                        )}
                         <Text tag color={balance == 0 ? 'warning' : 'complete'}>
                           You own {balance} Key
                           {balance == 1 ? '' : 's'}


### PR DESCRIPTION
## What

![image](https://github.com/coordinape/coordinape/assets/83605543/dead911f-553d-4182-bc6f-f0c660b31e80)


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0804361</samp>

Added a feature to show a special message when users have exchanged soul keys with each other. Modified the `useSoulKeys` hook and the `SoulKeyCard` component to implement this feature.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0804361</samp>

> _We share the keys to our souls_
> _We forge a bond that never breaks_
> _We are the super friends of old_
> _We face the doom that awaits_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0804361</samp>

* Add a `superFriend` property to the `useSoulKeys` hook to indicate mutual soul key balance between current user and subject ([link](https://github.com/coordinape/coordinape/pull/2406/files?diff=unified&w=0#diff-e1dcec4d7e694c7cd94e476f2e2099294f248ced1bc7341d1fab10a18d869922L16-R25))
* Pass the `superFriend` property to the `SoulKeyCard` component as a prop in the `ViewSoulKeyPageContents` component ([link](https://github.com/coordinape/coordinape/pull/2406/files?diff=unified&w=0#diff-4516b939eb12ece82b9da4ad4e1adf5f0000bb7a82b2a0bc51e13dec34c44fb3L76-R76))
* Display a special message `You are superfriends!` in the `SoulKeyCard` component when the `superFriend` prop is true and the subject is not the current user ([link](https://github.com/coordinape/coordinape/pull/2406/files?diff=unified&w=0#diff-4516b939eb12ece82b9da4ad4e1adf5f0000bb7a82b2a0bc51e13dec34c44fb3R167-R171))
