### PR TITLE
hide muting info on your own page, prevent reply if you are muted

### DIFF
--- a/src/features/activities/ActivityProfileName.tsx
+++ b/src/features/activities/ActivityProfileName.tsx
@@ -8,13 +8,19 @@ export const ActivityProfileName = ({
 }: {
   profile: { address: string; name: string };
 }) => {
+  const coLink = location.pathname.includes('colink');
+
   return (
     <Text
       color="heading"
       semibold
       as={NavLink}
       css={{ textDecoration: 'none' }}
-      to={paths.profile(profile.address)}
+      to={
+        coLink
+          ? paths.coLinksProfile(profile.address || '')
+          : paths.profile(profile.address || '')
+      }
     >
       {profile.name}
     </Text>

--- a/src/pages/colinks/ViewProfilePage/ViewProfilePageContents.tsx
+++ b/src/pages/colinks/ViewProfilePage/ViewProfilePageContents.tsx
@@ -264,9 +264,11 @@ const PageContents = ({
               )}
             </Flex>
           </RightColumnSection>
-          <RightColumnSection title={'Muting'}>
-            <Mutes targetProfileId={subjectProfile.id} />
-          </RightColumnSection>
+          {!subjectIsCurrentUser && (
+            <RightColumnSection title={'Muting'}>
+              <Mutes targetProfileId={subjectProfile.id} />
+            </RightColumnSection>
+          )}
           <CoLinksHolders target={targetAddress} />
           <CoLinksHeld holder={targetAddress} />
           <RightColumnSection


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d8ac108</samp>

This pull request adds features to support coLink sharing, muting, and viewing of profiles in the activities feature. It modifies `ActivityProfileName.tsx` to generate coLink URLs, `ReplyForm.tsx` to handle muting logic, and `ViewProfilePageContents.tsx` to show the muting section.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d8ac108</samp>

> _We're coding up a storm, me hearties, on the count of three_
> _We're adding features to the profile, the `ReplyForm`, and the `Mutes`_
> _We're making sure the links are coLink and the warnings are clear_
> _We're rendering the `RightColumnSection` only when it's fit to see_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d8ac108</samp>

*  Add coLink feature to profile name links ([link](https://github.com/coordinape/coordinape/pull/2414/files?diff=unified&w=0#diff-de52eb49e8b66afdcece1de7cfb76f9cd00c1aaf6278414de26a86b18340409cR11-R12), [link](https://github.com/coordinape/coordinape/pull/2414/files?diff=unified&w=0#diff-de52eb49e8b66afdcece1de7cfb76f9cd00c1aaf6278414de26a86b18340409cL17-R23))
  - Define `coLink` variable to check if location pathname includes 'colink' ([link](https://github.com/coordinape/coordinape/pull/2414/files?diff=unified&w=0#diff-de52eb49e8b66afdcece1de7cfb76f9cd00c1aaf6278414de26a86b18340409cR11-R12))
  - Use `coLink` and `paths.coLinksProfile` to generate correct `to` prop for `NavLink` ([link](https://github.com/coordinape/coordinape/pull/2414/files?diff=unified&w=0#diff-de52eb49e8b66afdcece1de7cfb76f9cd00c1aaf6278414de26a86b18340409cL17-R23))
* Add muting status and actions to view profile page ([link](https://github.com/coordinape/coordinape/pull/2414/files?diff=unified&w=0#diff-cff4a8eedd6bc4e327e10f459d5d7120705b2ccbcf88abb2c175985ad128712cL267-R271))
  - Conditionally render `RightColumnSection` with `Mutes` component if subject profile is not current user ([link](https://github.com/coordinape/coordinape/pull/2414/files?diff=unified&w=0#diff-cff4a8eedd6bc4e327e10f459d5d7120705b2ccbcf88abb2c175985ad128712cL267-R271))
* Add muting check and warning to reply form ([link](https://github.com/coordinape/coordinape/pull/2414/files?diff=unified&w=0#diff-ae9a00981f2b77ac792d0ccd885d4656a1cad95ef40aa7857ec11cbe21d69002L7-R13), [link](https://github.com/coordinape/coordinape/pull/2414/files?diff=unified&w=0#diff-ae9a00981f2b77ac792d0ccd885d4656a1cad95ef40aa7857ec11cbe21d69002L32-R65), [link](https://github.com/coordinape/coordinape/pull/2414/files?diff=unified&w=0#diff-ae9a00981f2b77ac792d0ccd885d4656a1cad95ef40aa7857ec11cbe21d69002R99-R105))
  - Import `useAuthStore` and `Text` components ([link](https://github.com/coordinape/coordinape/pull/2414/files?diff=unified&w=0#diff-ae9a00981f2b77ac792d0ccd885d4656a1cad95ef40aa7857ec11cbe21d69002L7-R13))
  - Fetch `imMuted` status of current user by activity actor using `useQuery` and `fetchReplyImMuted` ([link](https://github.com/coordinape/coordinape/pull/2414/files?diff=unified&w=0#diff-ae9a00981f2b77ac792d0ccd885d4656a1cad95ef40aa7857ec11cbe21d69002L32-R65))
  - Render `Text` with warning message if `imMuted` is true ([link](https://github.com/coordinape/coordinape/pull/2414/files?diff=unified&w=0#diff-ae9a00981f2b77ac792d0ccd885d4656a1cad95ef40aa7857ec11cbe21d69002R99-R105))
