### PR TITLE
prevent twitter/github accounts from being linked to multiple accounts

### DIFF
--- a/api/linkedin/callback.ts
+++ b/api/linkedin/callback.ts
@@ -65,6 +65,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
       .status(400)
       .send('This LinkedIn account is already linked to another user');
   }
+
   // store/update data in the database
   await adminClient.mutate(
     {

--- a/src/features/rep/api/getLinkedInScore.ts
+++ b/src/features/rep/api/getLinkedInScore.ts
@@ -1,7 +1,7 @@
 import { adminClient } from '../../../../api-lib/gql/adminClient';
 
 import {
-  GITHUB_SCORE_BASE,
+  LINKEDIN_SCORE_BASE,
   LINKEDIN_SCORE_MAX,
   LINKEDIN_SCORE_VERIFIED_EMAIL,
 } from './scoring';
@@ -27,11 +27,11 @@ export const getLinkedInScore = async (profileId: number) => {
     return 0;
   }
 
-  const emailScore = linkedin_accounts_by_pk.email_verified
+  const linkedInScore = linkedin_accounts_by_pk.email_verified
     ? LINKEDIN_SCORE_VERIFIED_EMAIL
     : 0;
 
   return Math.floor(
-    Math.min(LINKEDIN_SCORE_MAX, GITHUB_SCORE_BASE + emailScore)
+    Math.min(LINKEDIN_SCORE_MAX, LINKEDIN_SCORE_BASE + linkedInScore)
   );
 };

--- a/src/features/rep/api/scoring.ts
+++ b/src/features/rep/api/scoring.ts
@@ -8,14 +8,11 @@ export const TWITTER_FOLLOWER_SCORE_VALUE = 0.1;
 export const TWITTER_SCORE_MAX = 400;
 export const POAP_HOLDING_VALUE = 5;
 export const POAP_SCORE_MAX = 200;
-
 export const GITHUB_SCORE_BASE = 100;
 export const GITHUB_SCORE_MAX = 400;
-
 export const INVITE_SCORE_MAX = 400;
 export const INVITE_SCORE_PER_INVITE_WITH_COSOUL = 40;
 export const INVITE_SCORE_PER_INVITE_WITH_NO_COSOUL = 10;
-
 export const LINKEDIN_SCORE_BASE = 100;
 export const LINKEDIN_SCORE_VERIFIED_EMAIL = 200;
 export const LINKEDIN_SCORE_MAX = 300;


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c25a765</samp>

This pull request fixes bugs in the LinkedIn score calculation, adds checks to prevent users from linking multiple profiles to the same social account, and reorders some constants for code style. These changes are part of a feature to integrate social accounts and reputation scores in Coordinape.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c25a765</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A cunning way to link the profiles of Coordinape_
> _With the accounts of Github and Twitter, and who applied_
> _A check to thwart the frauds who would their names reshape._

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c25a765</samp>

*  Prevent users from linking their Github or Twitter account to more than one profile by querying the database and returning an error if a match is found ([link](https://github.com/coordinape/coordinape/pull/2418/files?diff=unified&w=0#diff-bd198690047086eb45babd0448119f734d5bcc2bbf38893e41e2dd271ec7188cR77-R113), [link](https://github.com/coordinape/coordinape/pull/2418/files?diff=unified&w=0#diff-9a4b8d43c07f00583af12730f55307eadc2ba8121b60f5bdde73e5474ca3cc98R53-R90))
* Fix the calculation of the LinkedIn score by using the correct constant and variable names in `getLinkedInScore` and `scoring.ts` ([link](https://github.com/coordinape/coordinape/pull/2418/files?diff=unified&w=0#diff-a31ceab219ce24db9349895f606d6e54d83e86153fdef3d93e1f88b2ee242bc9L4-R4), [link](https://github.com/coordinape/coordinape/pull/2418/files?diff=unified&w=0#diff-a31ceab219ce24db9349895f606d6e54d83e86153fdef3d93e1f88b2ee242bc9L30-R35), [link](https://github.com/coordinape/coordinape/pull/2418/files?diff=unified&w=0#diff-8c836dfa7f7d7c19011c4e0992fe00ab58f99e1294919011f6c4e6a493fb9d32L11-R15))
* Reorder the constants in `scoring.ts` by the social platform they belong to for better readability ([link](https://github.com/coordinape/coordinape/pull/2418/files?diff=unified&w=0#diff-8c836dfa7f7d7c19011c4e0992fe00ab58f99e1294919011f6c4e6a493fb9d32L11-R15))
* Leave an empty change in `api/linkedin/callback.ts` ([link](https://github.com/coordinape/coordinape/pull/2418/files?diff=unified&w=0#diff-1f48fca0ae31089de270ebd9f5a1692b633ec0f8478f4b63c31cb5bf4176fa0fR68))
