### PR TITLE
CoLinks CoSoul ui scroll fix

### DIFF
--- a/src/features/colinks/WizardSteps.tsx
+++ b/src/features/colinks/WizardSteps.tsx
@@ -162,7 +162,14 @@ export const WizardSteps = ({
             </>
           )}
         </WizardInstructions>
-        <Flex css={{ zIndex: 3, pointerEvents: 'none' }}>
+        <Flex
+          css={{
+            zIndex: 3,
+            pointerEvents: 'none',
+            overflow: 'auto',
+            height: '100vh',
+          }}
+        >
           <CoLinksMintPage
             minted={minted}
             setShowStepCoSoul={setShowStepCoSoul}


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0ed34dc</samp>

Fixed mint page layout for smaller screens by adding scrolling and viewport height to `Flex` component in `src/features/colinks/WizardSteps.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0ed34dc</samp>

> _`Flex` component_
> _scrolls and fits the screen size_
> _bug fixed in autumn_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0ed34dc</samp>

*  Fixed mint page content being cut off on smaller screens by adding CSS properties to the `Flex` component that wraps the `CoLinksMintPage` component ([link](https://github.com/coordinape/coordinape/pull/2419/files?diff=unified&w=0#diff-adbb343b118b342f8c6d8d3fe161f1d83edc6d8a511637878a8ceb34a17ed515L165-R172))
