### PR TITLE
cron to backfill reputation for everyone

### DIFF
--- a/api/hasura/cron/backfillReputation.ts
+++ b/api/hasura/cron/backfillReputation.ts
@@ -1,0 +1,53 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+import { order_by } from '../../../api-lib/gql/__generated__/zeus';
+import { adminClient } from '../../../api-lib/gql/adminClient';
+import { verifyHasuraRequestMiddleware } from '../../../api-lib/validate';
+import { updateRepScore } from '../../../src/features/rep/api/updateRepScore';
+
+async function handler(req: VercelRequest, res: VercelResponse) {
+  // get profiles without reputation
+  const { profiles } = await adminClient.query(
+    {
+      profiles: [
+        {
+          limit: 100,
+          order_by: [{ id: order_by.asc }],
+          where: {
+            _not: {
+              reputation_score: {},
+            },
+          },
+        },
+        {
+          id: true,
+        },
+      ],
+    },
+    {
+      operationName: 'getProfilesForScoreBackfill',
+    }
+  );
+
+  if (profiles.length) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `updating rep score for ${profiles.length} profiles starting at id ${profiles[0]?.id}`
+    );
+    // Update the batch in parallel
+    await Promise.all(profiles.map(p => updateRepScore(p.id)));
+    // eslint-disable-next-line no-console
+    console.log(
+      `updated rep score for ${profiles.length} profiles starting at id ${profiles[0]?.id}`
+    );
+  } else {
+    // eslint-disable-next-line no-console
+    console.log('no profiles need rep score update');
+  }
+
+  res.status(200).json({
+    success: true,
+  });
+}
+
+export default verifyHasuraRequestMiddleware(handler);

--- a/hasura/metadata/cron_triggers.yaml
+++ b/hasura/metadata/cron_triggers.yaml
@@ -1,3 +1,12 @@
+- name: backfillReputation
+  webhook: '{{HASURA_API_BASE_URL}}/cron/backfillReputation'
+  schedule: '* * * * *'
+  include_in_metadata: true
+  payload: {}
+  headers:
+    - name: verification_key
+      value_from_env: HASURA_EVENT_SECRET
+  comment: make sure everyone has a reputation, in batches
 - name: check-nominee
   webhook: '{{HASURA_API_BASE_URL}}/cron/checkNominee'
   schedule: 1 0 * * *


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e90fba4</samp>

This pull request adds a new API endpoint and a cron trigger to backfill reputation scores for users who don't have them. This improves the consistency and functionality of the reputation feature in the app.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e90fba4</samp>

> _`backfillReputation`_
> _A new endpoint and cron_
> _Winter of old scores_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e90fba4</samp>

*  Add a new API endpoint to backfill reputation scores for users ([link](https://github.com/coordinape/coordinape/pull/2421/files?diff=unified&w=0#diff-652d9b5e06670816162d5dd2c82df7da9fb1f5836f51b71ab18fbb036dc8bb6fR1-R53))
*  Add a new cron trigger to invoke the backfill endpoint periodically ([link](https://github.com/coordinape/coordinape/pull/2421/files?diff=unified&w=0#diff-04d72cab6282bd0e7c1a13021a29b0efdd45cdda4be6fe1ea9d821b2c5e0ae1eR1-R9))
