### PR TITLE
UI/confirmation modal

### DIFF
--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -1,0 +1,44 @@
+import { ReactNode, useState } from 'react';
+
+import { Modal, Text, Button, Flex } from 'ui';
+
+export const ConfirmationModal = ({
+  action,
+  description = 'Are you sure you want to proceed?',
+  yesText = 'Yes, proceed!',
+  cancelText = 'Cancel',
+  trigger,
+  defaultOpen = false,
+}: {
+  action: () => void;
+  description?: string;
+  yesText?: string;
+  cancelText?: string;
+  trigger: ReactNode;
+  defaultOpen?: boolean;
+}) => {
+  const [visible, setVisible] = useState(defaultOpen);
+
+  const onClose = () => setVisible(prev => !prev);
+
+  return (
+    <>
+      <Button color="transparent" onClick={() => setVisible(true)}>
+        {trigger}
+      </Button>
+      <Modal open={visible} onOpenChange={onClose} css={{ maxWidth: '440px' }}>
+        <Flex column gap={'md'}>
+          <Flex css={{ justifyContent: 'center' }}>
+            <Text>{description}</Text>
+          </Flex>
+          <Flex row css={{ justifyContent: 'space-around', gap: '$3xl' }}>
+            <Button onClick={onClose}>{cancelText}</Button>
+            <Button color="destructive" onClick={action}>
+              {yesText}
+            </Button>
+          </Flex>
+        </Flex>
+      </Modal>
+    </>
+  );
+};

--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useState } from 'react';
 
-import { Modal, Text, Button, Flex } from 'ui';
+import { Modal, Text, Button, Flex, Box } from 'ui';
 
 export const ConfirmationModal = ({
   action,
@@ -23,22 +23,26 @@ export const ConfirmationModal = ({
 
   return (
     <>
-      <Button color="transparent" onClick={() => setVisible(true)}>
-        {trigger}
-      </Button>
-      <Modal open={visible} onOpenChange={onClose} css={{ maxWidth: '440px' }}>
-        <Flex column gap={'md'}>
-          <Flex css={{ justifyContent: 'center' }}>
-            <Text>{description}</Text>
+      <Box onClick={() => setVisible(true)}>{trigger}</Box>
+      {visible && (
+        <Modal
+          open={visible}
+          onOpenChange={onClose}
+          css={{ maxWidth: '440px' }}
+        >
+          <Flex column gap={'md'}>
+            <Flex css={{ justifyContent: 'center' }}>
+              <Text>{description}</Text>
+            </Flex>
+            <Flex row css={{ justifyContent: 'space-around', gap: '$3xl' }}>
+              <Button onClick={onClose}>{cancelText}</Button>
+              <Button color="destructive" onClick={action}>
+                {yesText}
+              </Button>
+            </Flex>
           </Flex>
-          <Flex row css={{ justifyContent: 'space-around', gap: '$3xl' }}>
-            <Button onClick={onClose}>{cancelText}</Button>
-            <Button color="destructive" onClick={action}>
-              {yesText}
-            </Button>
-          </Flex>
-        </Flex>
-      </Modal>
+        </Modal>
+      )}
     </>
   );
 };

--- a/src/features/activities/ActivityAvatar.tsx
+++ b/src/features/activities/ActivityAvatar.tsx
@@ -1,10 +1,10 @@
 import { ComponentProps } from 'react';
 
-import { useLocation } from 'react-router';
 import { NavLink } from 'react-router-dom';
 
 import { paths } from '../../routes/paths';
 import { Avatar, Box } from '../../ui';
+import { useIsCoLinksPage } from '../colinks/useIsCoLinksPage';
 
 export const ActivityAvatar = ({
   profile,
@@ -18,15 +18,13 @@ export const ActivityAvatar = ({
   };
   size?: ComponentProps<typeof Avatar>['size'];
 }) => {
-  const location = useLocation();
-
-  const coLink = location.pathname.includes('colink');
+  const { isCoLinksPage } = useIsCoLinksPage();
 
   return (
     <Box
       as={NavLink}
       to={
-        coLink
+        isCoLinksPage
           ? paths.coLinksProfile(profile.address || '')
           : paths.profile(profile.address || '')
       }

--- a/src/features/activities/ActivityProfileName.tsx
+++ b/src/features/activities/ActivityProfileName.tsx
@@ -2,13 +2,14 @@ import { NavLink } from 'react-router-dom';
 
 import { paths } from '../../routes/paths';
 import { Text } from '../../ui';
+import { useIsCoLinksPage } from '../colinks/useIsCoLinksPage';
 
 export const ActivityProfileName = ({
   profile,
 }: {
   profile: { address: string; name: string };
 }) => {
-  const coLink = location.pathname.includes('colink');
+  const { isCoLinksPage } = useIsCoLinksPage();
 
   return (
     <Text
@@ -17,7 +18,7 @@ export const ActivityProfileName = ({
       as={NavLink}
       css={{ textDecoration: 'none' }}
       to={
-        coLink
+        isCoLinksPage
           ? paths.coLinksProfile(profile.address || '')
           : paths.profile(profile.address || '')
       }

--- a/src/features/activities/ContributionRow.tsx
+++ b/src/features/activities/ContributionRow.tsx
@@ -4,6 +4,7 @@ import { useNavQuery } from 'features/nav/getNavData';
 import { DateTime } from 'luxon';
 
 import { usePathContext } from '../../routes/usePathInfo';
+import { useIsCoLinksPage } from '../colinks/useIsCoLinksPage';
 import { Edit, MessageSquare } from 'icons/__generated';
 import { ContributionForm } from 'pages/ContributionsPage/ContributionForm';
 import { Flex, IconButton, MarkdownPreview, Text } from 'ui';
@@ -29,6 +30,8 @@ export const ContributionRow = ({
   const [editingContribution, setEditingContribution] = useState(false);
 
   const [displayComments, setDisplayComments] = useState(false);
+
+  const { isCoLinksPage } = useIsCoLinksPage();
 
   return (
     <Flex css={{ overflowX: 'clip' }}>
@@ -101,7 +104,7 @@ export const ContributionRow = ({
                     setEditingContribution={setEditingContribution}
                     contributionId={activity.contribution.id}
                     circleId={activity.circle ? activity.circle.id : undefined}
-                    itemNounName={'Post'}
+                    itemNounName={isCoLinksPage ? 'Post' : undefined}
                   />
                 </>
               )}

--- a/src/features/activities/ContributionRow.tsx
+++ b/src/features/activities/ContributionRow.tsx
@@ -101,6 +101,7 @@ export const ContributionRow = ({
                     setEditingContribution={setEditingContribution}
                     contributionId={activity.contribution.id}
                     circleId={activity.circle ? activity.circle.id : undefined}
+                    itemNounName={'Post'}
                   />
                 </>
               )}

--- a/src/features/activities/replies/RepliesBox.tsx
+++ b/src/features/activities/replies/RepliesBox.tsx
@@ -5,7 +5,7 @@ import { useMutation, useQuery, useQueryClient } from 'react-query';
 
 import { LoadingIndicator } from '../../../components/LoadingIndicator';
 import { Trash2 } from '../../../icons/__generated';
-import { Flex, HR, MarkdownPreview } from '../../../ui';
+import { Flex, HR, IconButton, MarkdownPreview } from '../../../ui';
 import { ActivityAvatar } from '../ActivityAvatar';
 import { ConfirmationModal } from 'components/ConfirmationModal';
 import { Text } from 'ui';
@@ -119,7 +119,11 @@ export const RepliesBox = ({
                     </Flex>
                     <Flex>
                       <ConfirmationModal
-                        trigger={<Trash2 />}
+                        trigger={
+                          <IconButton>
+                            <Trash2 />
+                          </IconButton>
+                        }
                         action={() => deleteReply(reply.id)}
                         description="Are you sure you want to delete this reply?"
                         yesText="Yes, delete it!"

--- a/src/features/activities/replies/RepliesBox.tsx
+++ b/src/features/activities/replies/RepliesBox.tsx
@@ -5,8 +5,9 @@ import { useMutation, useQuery, useQueryClient } from 'react-query';
 
 import { LoadingIndicator } from '../../../components/LoadingIndicator';
 import { Trash2 } from '../../../icons/__generated';
-import { Flex, HR, IconButton, MarkdownPreview } from '../../../ui';
+import { Flex, HR, MarkdownPreview } from '../../../ui';
 import { ActivityAvatar } from '../ActivityAvatar';
+import { ConfirmationModal } from 'components/ConfirmationModal';
 import { Text } from 'ui';
 
 import { ReplyForm } from './ReplyForm';
@@ -117,9 +118,12 @@ export const RepliesBox = ({
                       </Text>
                     </Flex>
                     <Flex>
-                      <IconButton onClick={() => deleteReply(reply.id)}>
-                        <Trash2 />
-                      </IconButton>
+                      <ConfirmationModal
+                        trigger={<Trash2 />}
+                        action={() => deleteReply(reply.id)}
+                        description="Are you sure you want to delete this reply?"
+                        yesText="Yes, delete it!"
+                      />
                     </Flex>
                   </Flex>
                   <MarkdownPreview

--- a/src/features/colinks/Mutes.tsx
+++ b/src/features/colinks/Mutes.tsx
@@ -6,6 +6,7 @@ import { client } from 'lib/gql/client';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 
 import { Button, Flex, Text } from '../../ui';
+import { ConfirmationModal } from 'components/ConfirmationModal';
 import { LoadingIndicator } from 'components/LoadingIndicator';
 
 import { QUERY_KEY_COLINKS } from './CoLinksWizard';
@@ -142,10 +143,20 @@ export const Mutes = ({ targetProfileId }: { targetProfileId: number }) => {
           <Text>
             You muted this person. You will not see their posts or replies.
           </Text>
-          <Button onClick={() => unmuteThem()}>Unmute</Button>
+          <ConfirmationModal
+            trigger={<Button>Unmute</Button>}
+            action={() => unmuteThem()}
+            description="Are you sure you want to unmute this person?"
+            yesText="Yes, unmute them!"
+          />
         </>
       ) : (
-        <Button onClick={() => muteThem()}>Mute</Button>
+        <ConfirmationModal
+          trigger={<Button>Mute</Button>}
+          action={() => muteThem()}
+          description="Are you sure you want to mute this person?"
+          yesText="Yes, mute them!"
+        />
       )}
       {mutes.imMuted && (
         <Text>

--- a/src/features/colinks/useIsCoLinksPage.ts
+++ b/src/features/colinks/useIsCoLinksPage.ts
@@ -1,0 +1,7 @@
+import { useLocation } from 'react-router-dom';
+
+export const useIsCoLinksPage = () => {
+  const location = useLocation();
+  const isCoLinksPage = location.pathname.includes('colink');
+  return { isCoLinksPage };
+};

--- a/src/pages/AccountPage/AccountPage.tsx
+++ b/src/pages/AccountPage/AccountPage.tsx
@@ -1,6 +1,5 @@
-import { useLocation } from 'react-router-dom';
-
 import { isFeatureEnabled } from '../../config/features';
+import { useIsCoLinksPage } from '../../features/colinks/useIsCoLinksPage';
 import { ShowOrConnectGitHub } from '../../features/github/ShowOrConnectGitHub';
 import { ShowOrConnectLinkedIn } from '../../features/linkedin/ShowOrConnectLinkedIn';
 import { ShowOrConnectTwitter } from '../../features/twitter/ShowOrConnectTwitter';
@@ -11,8 +10,7 @@ import { SingleColumnLayout } from 'ui/layouts';
 import { EditProfileInfo } from './EditProfileInfo';
 
 export default function AccountPage() {
-  const { pathname } = useLocation();
-  const coLink = pathname.includes('colinks');
+  const { isCoLinksPage } = useIsCoLinksPage();
 
   return (
     <SingleColumnLayout>
@@ -22,7 +20,7 @@ export default function AccountPage() {
         </Flex>
       </ContentHeader>
       <Flex column css={{ maxWidth: '$readable', gap: '$lg' }}>
-        {coLink && (
+        {isCoLinksPage && (
           <Panel>
             <Text large semibold>
               Profile

--- a/src/pages/ContributionsPage/ContributionForm.tsx
+++ b/src/pages/ContributionsPage/ContributionForm.tsx
@@ -9,6 +9,7 @@ import { useLocation } from 'react-router';
 import type { CSS } from 'stitches.config';
 
 import { ACTIVITIES_QUERY_KEY } from '../../features/activities/ActivityList';
+import { useIsCoLinksPage } from '../../features/colinks/useIsCoLinksPage';
 import { FormInputField } from 'components';
 import { ConfirmationModal } from 'components/ConfirmationModal';
 import { LoadingBar } from 'components/LoadingBar';
@@ -78,7 +79,9 @@ export const ContributionForm = ({
   const { data } = useNavQuery();
   const [currentOrg, setCurrentOrg] = useState<NavOrg | undefined>(undefined);
 
-  privateStream = privateStream || location.pathname.includes('colinks');
+  const { isCoLinksPage } = useIsCoLinksPage();
+
+  privateStream = privateStream || isCoLinksPage;
 
   const setCircleAndOrgIfMatch = (orgs: NavOrg[]) => {
     for (const o of orgs) {

--- a/src/pages/ContributionsPage/ContributionForm.tsx
+++ b/src/pages/ContributionsPage/ContributionForm.tsx
@@ -10,6 +10,7 @@ import type { CSS } from 'stitches.config';
 
 import { ACTIVITIES_QUERY_KEY } from '../../features/activities/ActivityList';
 import { FormInputField } from 'components';
+import { ConfirmationModal } from 'components/ConfirmationModal';
 import { LoadingBar } from 'components/LoadingBar';
 import { MarkdownGuide } from 'components/MarkdownGuide';
 import { useToast } from 'hooks';
@@ -438,23 +439,29 @@ export const ContributionForm = ({
                     <Button color="secondary" onClick={() => cancelEditing()}>
                       Cancel
                     </Button>
-                    <Button
-                      color="transparent"
-                      css={{
-                        '&:hover, &:focus': { color: '$destructiveButton' },
-                        '&:focus-visible': {
-                          outlineColor: '$destructiveButton',
-                        },
-                        svg: { mr: 0 },
-                      }}
-                      onClick={() => {
+                    <ConfirmationModal
+                      trigger={
+                        <Button
+                          color="transparent"
+                          css={{
+                            '&:hover, &:focus': { color: '$destructiveButton' },
+                            '&:focus-visible': {
+                              outlineColor: '$destructiveButton',
+                            },
+                            svg: { mr: 0 },
+                          }}
+                        >
+                          Delete
+                        </Button>
+                      }
+                      action={() => {
                         deleteContribution({
                           contribution_id: contributionId,
                         });
                       }}
-                    >
-                      Delete
-                    </Button>
+                      description={`Are you sure you want to delete this ${itemNounName.toLowerCase()}?`}
+                      yesText="Yes, delete it!"
+                    />
                   </>
                 )}
               </Flex>


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2dc91d4</samp>

Added `ConfirmationModal` component to various features that involve deleting or muting items or users. This component provides a consistent and user-friendly way to confirm or cancel potentially destructive actions.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2dc91d4</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A wondrous `ConfirmationModal`, a shining shield_
> _To guard the users from the wrath of swift deletion,_
> _And show them clear the consequence of their choice._

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2dc91d4</samp>

*  Add a new component `ConfirmationModal` that renders a modal dialog to confirm or cancel an action ([link](https://github.com/coordinape/coordinape/pull/2424/files?diff=unified&w=0#diff-90107178d492f55e7df34e14e2e86937a4813ffc7a4b247ee1f09ae19bd69493R1-R48))
*  Use `ConfirmationModal` to replace the buttons that delete a contribution, a reply, or mute/unmute a user ([link](https://github.com/coordinape/coordinape/pull/2424/files?diff=unified&w=0#diff-023fbc171b14533aea64ceea9c06efab32d5448fe6d51fd5f36dd43b7c711274R104), [link](https://github.com/coordinape/coordinape/pull/2424/files?diff=unified&w=0#diff-dac31dcfdf8e1be9a441ca0b7d102c3d8c44a8ce3727d7284513802667d99dafL120-R130), [link](https://github.com/coordinape/coordinape/pull/2424/files?diff=unified&w=0#diff-a2a0681f36e570343afbd4cbfacce747efb08bd212a9bc5f7f04663948d79636L145-R159), [link](https://github.com/coordinape/coordinape/pull/2424/files?diff=unified&w=0#diff-8c417a5a2b551e89bf1c0521c1718e4fab41f3439b3b638f8aaa32f2ced22e60L441-R464))
*  Pass the name of the item that is being deleted to the `ContributionForm` and the `ConfirmationModal` components as the `itemNounName` prop ([link](https://github.com/coordinape/coordinape/pull/2424/files?diff=unified&w=0#diff-023fbc171b14533aea64ceea9c06efab32d5448fe6d51fd5f36dd43b7c711274R104), [link](https://github.com/coordinape/coordinape/pull/2424/files?diff=unified&w=0#diff-8c417a5a2b551e89bf1c0521c1718e4fab41f3439b3b638f8aaa32f2ced22e60L441-R464))
*  Import the `ConfirmationModal` component to the `RepliesBox`, `Mutes`, and `ContributionForm` components ([link](https://github.com/coordinape/coordinape/pull/2424/files?diff=unified&w=0#diff-dac31dcfdf8e1be9a441ca0b7d102c3d8c44a8ce3727d7284513802667d99dafR10), [link](https://github.com/coordinape/coordinape/pull/2424/files?diff=unified&w=0#diff-a2a0681f36e570343afbd4cbfacce747efb08bd212a9bc5f7f04663948d79636R9), [link](https://github.com/coordinape/coordinape/pull/2424/files?diff=unified&w=0#diff-8c417a5a2b551e89bf1c0521c1718e4fab41f3439b3b638f8aaa32f2ced22e60R13))
