### PR TITLE
Add limits to Rcent tx history

### DIFF
--- a/src/features/colinks/CoLinksHistory.tsx
+++ b/src/features/colinks/CoLinksHistory.tsx
@@ -10,7 +10,13 @@ import { Avatar, Box, Flex, Link, Text } from '../../ui';
 
 import { QUERY_KEY_COLINKS } from './CoLinksWizard';
 
-export const CoLinksHistory = ({ target }: { target?: string }) => {
+export const CoLinksHistory = ({
+  target,
+  limit = 100,
+}: {
+  target?: string;
+  limit?: number;
+}) => {
   const { data: txs } = useQuery(
     [QUERY_KEY_COLINKS, target, 'history'],
     async () => {
@@ -26,7 +32,7 @@ export const CoLinksHistory = ({ target }: { target?: string }) => {
                   }
                 : {},
               order_by: [{ created_at: order_by.desc_nulls_last }],
-              limit: 100,
+              limit,
             },
             {
               created_at: true,

--- a/src/pages/colinks/ActivityPage.tsx
+++ b/src/pages/colinks/ActivityPage.tsx
@@ -100,7 +100,7 @@ const CoLinksActivityPageContents = ({
               </Flex>
             }
           >
-            <CoLinksHistory />
+            <CoLinksHistory limit={10} />
           </RightColumnSection>
         </Flex>
       </Flex>

--- a/src/pages/colinks/LinkHistoryPage.tsx
+++ b/src/pages/colinks/LinkHistoryPage.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useParams } from 'react-router-dom';
 
 import { CoLinksBasicProfileHeader } from '../../features/colinks/CoLinksBasicProfileHeader';

--- a/src/pages/colinks/TradesPage/index.tsx
+++ b/src/pages/colinks/TradesPage/index.tsx
@@ -30,7 +30,7 @@ const PageContents = () => {
     <SingleColumnLayout>
       <ContentHeader>
         <Text h2 display>
-          Last 100 Key Trades
+          Last 100 Link Trades
         </Text>
       </ContentHeader>
       <CoLinksHistory />

--- a/src/pages/colinks/ViewProfilePage/ViewProfilePageContents.tsx
+++ b/src/pages/colinks/ViewProfilePage/ViewProfilePageContents.tsx
@@ -321,7 +321,7 @@ const PageContents = ({
               </Flex>
             }
           >
-            <CoLinksHistory target={targetAddress} />
+            <CoLinksHistory target={targetAddress} limit={5} />
           </RightColumnSection>
           <Poaps address={targetAddress} />
         </Flex>


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1c3c89c</samp>

Improved the performance and usability of the `CoLinksHistory` component by adding a `limit` prop and used it in different pages. Updated the terminology of Coordinape tokens from keys to links. Removed an unused import from `LinkHistoryPage`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1c3c89c</samp>

> _To show the history of link trades_
> _We used `CoLinksHistory` in different ways_
> _With a `limit` prop_
> _We can adjust the crop_
> _And avoid fetching too much from the database_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1c3c89c</samp>

*  Add `limit` prop to `CoLinksHistory` component to control the number of transactions displayed ([link](https://github.com/coordinape/coordinape/pull/2429/files?diff=unified&w=0#diff-7f1b6b568e6babb9d2ee9ddbbc52c6307ba9d5c4c15404acf93b02ef0678b639L13-R19), [link](https://github.com/coordinape/coordinape/pull/2429/files?diff=unified&w=0#diff-7f1b6b568e6babb9d2ee9ddbbc52c6307ba9d5c4c15404acf93b02ef0678b639L29-R35))
*  Use `CoLinksHistory` component with different `limit` values in `ActivityPage` and `ViewProfilePage` to show recent transactions for current or selected user ([link](https://github.com/coordinape/coordinape/pull/2429/files?diff=unified&w=0#diff-b06acfe67570e88d414766102b185f0db62c91015f69f93b59ecc49e215efa04L103-R103), [link](https://github.com/coordinape/coordinape/pull/2429/files?diff=unified&w=0#diff-cff4a8eedd6bc4e327e10f459d5d7120705b2ccbcf88abb2c175985ad128712cL324-R324))
*  Rename "Key Trades" to "Link Trades" in `TradesPage` to match the new token name ([link](https://github.com/coordinape/coordinape/pull/2429/files?diff=unified&w=0#diff-43a22dabadb3c42011c45437ff2b6c4640b4396a02c53ab2b71c602ed1808e43L33-R33))
*  Remove unused `React` import from `LinkHistoryPage` for code cleanup ([link](https://github.com/coordinape/coordinape/pull/2429/files?diff=unified&w=0#diff-6f94a9cb3e827f8be915528e1bde48eda37dfe844fdcacb5d7598fd819522bdcL1-L2))
