### PR TITLE
Wizard: Add balance check

### DIFF
--- a/src/features/colinks/WizardSteps.tsx
+++ b/src/features/colinks/WizardSteps.tsx
@@ -178,20 +178,15 @@ export const WizardSteps = ({
             </>
           ) : (
             <>
-              <Text>
-                pGIVE is an abstraction of the GIVE you have received in
-                Coordinape.
-              </Text>
-              <Text>pGIVE auto-syncs to your minted CoSoul every month.</Text>
+              <Text>Your rep is synced to your minted CoSoul every month.</Text>
               <Text>
                 Minting will create a public view of your stats, username, and
                 organization/circle names; similar to what is displayed below.
               </Text>
-              <CoSoulButton onReveal={() => setMinted(true)} />
               <Text>
-                There is a small 0.0032 ETH fee to mint a CoSoul, and gas costs
-                are minimal.
+                There is a small fee of .0032 ETH + gas to mint a CoSoul.
               </Text>
+              <CoSoulButton onReveal={() => setMinted(true)} />
             </>
           )}
         </WizardInstructions>

--- a/src/features/cosoul/CoSoulButton.tsx
+++ b/src/features/cosoul/CoSoulButton.tsx
@@ -1,18 +1,36 @@
 import assert from 'assert';
 
+import { ethers } from 'ethers';
+import { useQuery } from 'react-query';
+
 import { useToast } from '../../hooks';
 import { useWeb3React } from '../../hooks/useWeb3React';
-import { Button, Text } from '../../ui';
+import { Button, Flex, Link, Panel, Text } from '../../ui';
 import { switchToCorrectChain } from '../web3/chainswitch';
 
 import { chain } from './chains';
 import { MintOrBurnButton } from './MintOrBurnButton';
 import { useCoSoulContracts } from './useCoSoulContracts';
 
+const MIN_BALANCE = ethers.utils.parseEther('0.005');
+
 export const CoSoulButton = ({ onReveal }: { onReveal(): void }) => {
   const { library, chainId, account } = useWeb3React();
   const contracts = useCoSoulContracts();
   const { showError } = useToast();
+
+  const { data: balance } = useQuery(
+    ['balanceOf', account],
+    async () => {
+      if (account) {
+        return await library?.getBalance(account);
+      }
+    },
+    {
+      refetchInterval: 2000,
+      enabled: !!account,
+    }
+  );
 
   const onCorrectChain = chainId === Number(chain.chainId);
 
@@ -30,6 +48,27 @@ export const CoSoulButton = ({ onReveal }: { onReveal(): void }) => {
       <Button color="cta" size="large" onClick={safeSwitchToCorrectChain}>
         Switch to {chain.chainName} to Mint
       </Button>
+    );
+  }
+
+  if (balance?.lt(MIN_BALANCE)) {
+    return (
+      <>
+        <Panel css={{ gap: '$sm' }}>
+          <Flex>
+            <Text semibold color={'alert'}>
+              Your balance is {ethers.utils.formatEther(balance).slice(0, 10)}{' '}
+              ETH.
+            </Text>
+          </Flex>
+          <Flex>
+            <Text>Please deposit more ETH to your wallet.</Text>
+          </Flex>
+          <Button as={Link} href="https://app.optimism.io/bridge/deposit">
+            Bridge ETH using the Optimism Bridge
+          </Button>
+        </Panel>
+      </>
     );
   }
 


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a1efa8d</samp>

This pull request adds a feature to warn users about low ETH balance on Optimism when minting CoSoul, and simplifies the minting instructions by removing pGIVE. It affects the files `CoSoulButton.tsx` and `WizardSteps.tsx` in the `src/features/cosoul` and `src/features/colinks` directories respectively.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a1efa8d</samp>

> _Mint your `CoSoul` now_
> _No need for `pGIVE` tokens_
> _But watch your ETH balance_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a1efa8d</samp>

*  Simplify the minting process of CoSoul by removing the mention of pGIVE and clarifying the fee and gas costs ([link](https://github.com/coordinape/coordinape/pull/2430/files?diff=unified&w=0#diff-adbb343b118b342f8c6d8d3fe161f1d83edc6d8a511637878a8ceb34a17ed515L181-R189))
*  Add imports for ethers, useQuery, and UI components to CoSoulButton component ([link](https://github.com/coordinape/coordinape/pull/2430/files?diff=unified&w=0#diff-f7c2d440a5cadbf60bb711e3b997d2b71abfc3d6b079d9821f62650b02f36707L3-R8))
*  Fetch the user's ETH balance from the library using useQuery and refetch every 2 seconds ([link](https://github.com/coordinape/coordinape/pull/2430/files?diff=unified&w=0#diff-f7c2d440a5cadbf60bb711e3b997d2b71abfc3d6b079d9821f62650b02f36707R22-R34))
*  Render a panel in CoSoulButton component that informs the user if their balance is lower than the minimum required and provides a link to the Optimism bridge ([link](https://github.com/coordinape/coordinape/pull/2430/files?diff=unified&w=0#diff-f7c2d440a5cadbf60bb711e3b997d2b71abfc3d6b079d9821f62650b02f36707R54-R74))
*  Define a constant for the minimum ETH balance of 0.005 ETH ([link](https://github.com/coordinape/coordinape/pull/2430/files?diff=unified&w=0#diff-f7c2d440a5cadbf60bb711e3b997d2b71abfc3d6b079d9821f62650b02f36707R15-R16))
