### PR TITLE
break out link holders and total links counts

### DIFF
--- a/src/pages/colinks/LinkHoldersPage.tsx
+++ b/src/pages/colinks/LinkHoldersPage.tsx
@@ -19,11 +19,21 @@ export const LinkHoldersPage = () => {
     <SingleColumnLayout>
       <CoLinksBasicProfileHeader address={address} title={'Link Holders'} />
       <LinkHolders target={address}>
-        {(list: React.ReactNode, heldCount?: number) => (
+        {(
+          list: React.ReactNode,
+          counts?: { link_holders: number; total_links: number }
+        ) => (
           <Flex column css={{ gap: '$lg' }}>
-            <Text h1 css={{ gap: '$md' }}>
-              <Users size={'xl'} /> {heldCount} Link Holder
-              {heldCount == 1 ? '' : 's'}
+            <Text h1 css={{ gap: '$lg' }}>
+              <Users size={'xl'} />
+              <Flex>
+                {counts?.link_holders} Link Holder
+                {counts?.link_holders == 1 ? '' : 's'}
+              </Flex>
+              <Flex>
+                {counts?.total_links} Total Link
+                {counts?.total_links == 1 ? '' : 's'}
+              </Flex>
             </Text>
             {list}
           </Flex>

--- a/src/pages/colinks/ViewProfilePage/ViewProfilePageContents.tsx
+++ b/src/pages/colinks/ViewProfilePage/ViewProfilePageContents.tsx
@@ -258,28 +258,46 @@ const PageContents = ({
           </RightColumnSection>
 
           <LinkHolders target={targetAddress} limit={LINK_HOLDERS_LIMIT}>
-            {(list: React.ReactNode, holdersCount?: number) => (
+            {(
+              list: React.ReactNode,
+              counts?: { link_holders: number; total_links: number }
+            ) => (
               <RightColumnSection
                 title={
-                  <Text
-                    as={AppLink}
-                    to={paths.coLinksLinkHolders(targetAddress)}
-                    color={'default'}
-                    semibold
+                  <Flex
+                    css={{ justifyContent: 'space-between', width: '100%' }}
                   >
-                    <Users /> {holdersCount} Link Holders
-                  </Text>
+                    <Text
+                      as={AppLink}
+                      to={paths.coLinksLinkHolders(targetAddress)}
+                      color={'default'}
+                      semibold
+                    >
+                      <Users /> {counts?.link_holders} Link Holders
+                    </Text>
+                    <Text
+                      as={AppLink}
+                      to={paths.coLinksLinkHolders(targetAddress)}
+                      color={'default'}
+                      semibold
+                    >
+                      {counts?.total_links} Total Links
+                    </Text>
+                  </Flex>
                 }
               >
                 <Flex column css={{ width: '100%' }}>
                   {list}
-                  {holdersCount && holdersCount > LINK_HOLDERS_LIMIT && (
-                    <Flex css={{ justifyContent: 'flex-end' }}>
-                      <AppLink to={paths.coLinksLinkHolders(targetAddress)}>
-                        <Text size="xs">View all {holdersCount} Holders</Text>
-                      </AppLink>
-                    </Flex>
-                  )}
+                  {counts?.link_holders &&
+                    counts.link_holders > LINK_HOLDERS_LIMIT && (
+                      <Flex css={{ justifyContent: 'flex-end' }}>
+                        <AppLink to={paths.coLinksLinkHolders(targetAddress)}>
+                          <Text size="xs">
+                            View all {counts.link_holders} Holders
+                          </Text>
+                        </AppLink>
+                      </Flex>
+                    )}
                 </Flex>
               </RightColumnSection>
             )}


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e5fbd06</samp>

Improved the display of link holders and links for colinks feature. Refactored the query and the props to use an object with aliases. Updated the `LinkHolders`, `LinkHoldersPage`, and `ViewProfilePageContents` components to use the new object and adjust the layout.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e5fbd06</samp>

> _Sing, O Muse, of the glorious deeds of the code reviewers,_
> _Who with skill and wisdom refined the `LinkHoldersPage` component,_
> _And made it show the mighty counts of links and holders in the header,_
> _With a graceful flexbox layout that pleased the eyes of all who saw it._

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e5fbd06</samp>

*  Modify query for `LinkHolders` component to return both link holders count and total links for target address ([link](https://github.com/coordinape/coordinape/pull/2433/files?diff=unified&w=0#diff-9caaac854a6780930daa3b33185494e33728ca2503ca913058007fe868479b73L58-R107))
*  Change return value of query to an object with `link_holders` and `total_links` properties ([link](https://github.com/coordinape/coordinape/pull/2433/files?diff=unified&w=0#diff-9caaac854a6780930daa3b33185494e33728ca2503ca913058007fe868479b73L90-R116))
*  Update `children` prop of `LinkHolders` component to accept the new object as `counts` argument ([link](https://github.com/coordinape/coordinape/pull/2433/files?diff=unified&w=0#diff-9caaac854a6780930daa3b33185494e33728ca2503ca913058007fe868479b73L105-R131))
*  Display both link holders count and total links in the header of `LinkHoldersPage` component using flexbox layout ([link](https://github.com/coordinape/coordinape/pull/2433/files?diff=unified&w=0#diff-076f8a5a8f0f2b2da2bb98955accdb08c63a173dd8a2226cc8de24014164c35cL22-R36))
*  Display both link holders count and total links in the title of right column section of `PageContents` component using flexbox layout ([link](https://github.com/coordinape/coordinape/pull/2433/files?diff=unified&w=0#diff-cff4a8eedd6bc4e327e10f459d5d7120705b2ccbcf88abb2c175985ad128712cL261-R300))
