### PR TITLE
fix activity stream for link targets vs holders. move Buy link panel into main stream

### DIFF
--- a/src/features/colinks/BuyOrSellCoLinks.tsx
+++ b/src/features/colinks/BuyOrSellCoLinks.tsx
@@ -9,7 +9,7 @@ import { useToast } from '../../hooks';
 import { useWeb3React } from '../../hooks/useWeb3React';
 import { Link2 } from '../../icons/__generated';
 import { client } from '../../lib/gql/client';
-import { Avatar, Button, Flex, Link, Text } from '../../ui';
+import { Button, Flex, Link, Text } from '../../ui';
 import { sendAndTrackTx } from '../../utils/contractHelpers';
 
 import { QUERY_KEY_COLINKS } from './CoLinksWizard';
@@ -20,18 +20,18 @@ export const BuyOrSellCoLinks = ({
   chainId,
   subject,
   address,
-  hideName,
+  hideTitle = false,
 }: {
   coLinks: CoLinks;
   chainId: string;
   subject: string;
   address: string;
-  hideName?: boolean;
+  hideTitle?: boolean;
 }) => {
   const { balance, refresh } = useCoLinks({
     contract: coLinks,
     address,
-    subject,
+    target: subject,
   });
   const { showError } = useToast();
   const [awaitingWallet, setAwaitingWallet] = useState<boolean>(false);
@@ -42,8 +42,6 @@ export const BuyOrSellCoLinks = ({
   const [supply, setSupply] = useState<number | null>(null);
 
   const subjectIsCurrentUser = subject.toLowerCase() == address.toLowerCase();
-
-  const needsBootstrapping = subjectIsCurrentUser && balance == 0;
 
   const [progress, setProgress] = useState('');
 
@@ -202,39 +200,12 @@ export const BuyOrSellCoLinks = ({
           gap: '$sm',
         }}
       >
-        <Text size={'medium'} semibold css={{ gap: '$sm' }}>
-          <Link2 /> You Have {balance !== null ? balance : ''}{' '}
-          {subjectProfile.name} Links
-        </Text>
-        <Flex alignItems="center">
-          {!hideName && (
-            <Flex alignItems="center">
-              <Avatar
-                size="large"
-                name={subjectProfile.name}
-                path={subjectProfile.avatar}
-                margin="none"
-                css={{ mr: '$sm' }}
-              />
-              <Flex column>
-                <Text h2 display css={{ color: '$secondaryButtonText' }}>
-                  {subjectProfile.name}
-                </Text>
-                {!needsBootstrapping && (
-                  <Flex css={{ gap: '$sm' }}>
-                    <Text tag color={balance == 0 ? 'warning' : 'complete'}>
-                      You own {balance} Key
-                      {balance == 1 ? '' : 's'}
-                    </Text>
-                    <Text tag color="neutral">
-                      {supply !== null && supply + ` Total Keys Issued`}
-                    </Text>
-                  </Flex>
-                )}
-              </Flex>
-            </Flex>
-          )}
-        </Flex>
+        {!hideTitle && (
+          <Text size={'medium'} semibold css={{ gap: '$sm' }}>
+            <Link2 /> You Have {balance !== null ? balance : ''}{' '}
+            {subjectProfile.name} Links
+          </Text>
+        )}
         <Flex css={{ gap: '$md' }}>
           <Flex
             css={{
@@ -261,6 +232,7 @@ export const BuyOrSellCoLinks = ({
                     justifyContent: 'space-between',
                     flexGrow: 1,
                     width: '100%',
+                    gap: '$md',
                   }}
                 >
                   <Button
@@ -287,6 +259,7 @@ export const BuyOrSellCoLinks = ({
                       justifyContent: 'space-between',
                       flexGrow: 1,
                       width: '100%',
+                      gap: '$md',
                     }}
                   >
                     <Button
@@ -368,6 +341,7 @@ export const BuyOrSellCoLinks = ({
             textAlign: 'center',
             background: '$surfaceNested',
             zIndex: 3,
+            borderRadius: '$3',
           }}
         >
           <Text color="complete" semibold>

--- a/src/features/colinks/WizardSteps.tsx
+++ b/src/features/colinks/WizardSteps.tsx
@@ -233,7 +233,6 @@ export const WizardSteps = ({
                 address={address}
                 coLinks={coLinks}
                 chainId={chainId.toString()}
-                hideName={true}
               />
             )}
           </CoLinksChainGate>

--- a/src/features/colinks/useCoLinks.ts
+++ b/src/features/colinks/useCoLinks.ts
@@ -6,24 +6,24 @@ import { QUERY_KEY_COLINKS } from './CoLinksWizard';
 export const useCoLinks = ({
   contract,
   address,
-  subject,
+  target,
 }: {
   contract: CoLinks;
   address: string;
-  subject: string;
+  target: string;
 }) => {
   const { data: balances, refetch } = useQuery(
-    [QUERY_KEY_COLINKS, address, subject],
+    [QUERY_KEY_COLINKS, address, target],
     async () => {
       // your balance of them
-      const balance = (await contract.linkBalance(subject, address)).toNumber();
+      const balance = (await contract.linkBalance(target, address)).toNumber();
       // their balance of you
-      const subjectBalance = (
-        await contract.linkBalance(address, subject)
+      const targetBalance = (
+        await contract.linkBalance(address, target)
       ).toNumber();
-      const supply = (await contract.linkSupply(subject)).toNumber();
-      const superFriend = subjectBalance > 0 && balance > 0;
-      return { balance, subjectBalance, supply, superFriend };
+      const supply = (await contract.linkSupply(target)).toNumber();
+      const superFriend = targetBalance > 0 && balance > 0;
+      return { balance, targetBalance, supply, superFriend };
     }
   );
 
@@ -31,7 +31,7 @@ export const useCoLinks = ({
   const refresh = () => {
     refetch();
     setTimeout(() => {
-      queryClient.invalidateQueries([QUERY_KEY_COLINKS, subject]);
+      queryClient.invalidateQueries([QUERY_KEY_COLINKS, target]);
       queryClient.invalidateQueries([QUERY_KEY_COLINKS, address]);
     }, 2000);
   };

--- a/src/pages/CoSoulExplorePage/CoSoulItem.tsx
+++ b/src/pages/CoSoulExplorePage/CoSoulItem.tsx
@@ -2,6 +2,7 @@ import { CoSoul } from '../../features/colinks/fetchCoSouls';
 import { Users } from '../../icons/__generated';
 import { paths } from '../../routes/paths';
 import { AppLink, Avatar, Box, Flex, Image, Text } from '../../ui';
+import isFeatureEnabled from 'config/features';
 
 export const CoSoulItem = ({
   cosoul,
@@ -23,7 +24,13 @@ export const CoSoulItem = ({
       ? 'gold'
       : 'transparent';
   return (
-    <AppLink to={paths.cosoulView(cosoul.address)}>
+    <AppLink
+      to={
+        expandedView && isFeatureEnabled('soulkeys')
+          ? paths.coLinksProfile(cosoul.address)
+          : paths.cosoulView(cosoul.address)
+      }
+    >
       <Box
         key={cosoul.id}
         css={{

--- a/src/pages/colinks/ActivityPage.tsx
+++ b/src/pages/colinks/ActivityPage.tsx
@@ -50,10 +50,10 @@ const CoLinksActivityPageContents = ({
 }) => {
   const [showLoading, setShowLoading] = useState(false);
 
-  const { subjectBalance } = useCoLinks({
+  const { targetBalance } = useCoLinks({
     contract: coLinks,
     address: currentUserAddress,
-    subject: currentUserAddress,
+    target: currentUserAddress,
   });
   return (
     <SingleColumnLayout css={{ flexGrow: 1 }}>
@@ -71,7 +71,7 @@ const CoLinksActivityPageContents = ({
               <Text h2 display>
                 Activity Stream
               </Text>
-              {subjectBalance !== undefined && subjectBalance > 0 && (
+              {targetBalance !== undefined && targetBalance > 0 && (
                 <PostForm
                   showLoading={showLoading}
                   onSave={() => setShowLoading(true)}

--- a/src/pages/colinks/ViewProfilePage/CoLinksProfileHeader.tsx
+++ b/src/pages/colinks/ViewProfilePage/CoLinksProfileHeader.tsx
@@ -27,10 +27,10 @@ export const CoLinksProfileHeader = ({
   currentUserAddress: string;
   targetAddress: string;
 }) => {
-  const { subjectBalance, superFriend } = useCoLinks({
+  const { targetBalance, superFriend } = useCoLinks({
     contract,
     address: currentUserAddress,
-    subject: targetAddress,
+    target: targetAddress,
   });
 
   const { profile, imMuted, mutedThem } = target;
@@ -151,7 +151,7 @@ export const CoLinksProfileHeader = ({
             )}
           </Flex>
         </Flex>
-        {isCurrentUser && subjectBalance !== undefined && subjectBalance > 0 && (
+        {isCurrentUser && targetBalance !== undefined && targetBalance > 0 && (
           <Flex css={{ maxWidth: '$readable' }}>
             <PostForm
               showLoading={showLoading}


### PR DESCRIPTION
Fixes not being able to see activity stream for someone who owns your link but you don't own theirs. Moves the buy widget into the main column when you don't own their key. 

## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 54430b8</samp>

This pull request improves the code quality and the user interface of the CoLinks feature. It renames some props and variables to match the contract and the UI, refactors some components and hooks to enhance readability and consistency, and adds a new UI to allow users to buy links of other profiles. It affects the files `BuyOrSellCoLinks.tsx`, `useCoLinks.ts`, `ActivityPage.tsx`, `ViewProfilePageContents.tsx`, `CoLinksProfileHeader.tsx`, `WizardSteps.tsx`, and `LinkHoldersPage.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 54430b8</samp>

> _We're coding up a storm, me hearties, coding up a storm_
> _We're refactoring the hooks and the props, coding up a storm_
> _We're renaming `subject` to `target`, coding up a storm_
> _And we're adding a new UI to buy a link, coding up a storm_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 54430b8</samp>

*  Rename `subject` prop to `target` in `BuyOrSellCoLinks`, `useCoLinks`, and `ActivityPage` components to match contract terminology and avoid confusion ([link](https://github.com/coordinape/coordinape/pull/2434/files?diff=unified&w=0#diff-d3e5d35d9664d8906b4f0deb056d55d6d3bc583514f25f98fed0728e0ccaa538L21-R21), [link](https://github.com/coordinape/coordinape/pull/2434/files?diff=unified&w=0#diff-d3e5d35d9664d8906b4f0deb056d55d6d3bc583514f25f98fed0728e0ccaa538L27-R32), [link](https://github.com/coordinape/coordinape/pull/2434/files?diff=unified&w=0#diff-549746208b13f46b099bf26f4436733c5c88d8828d99a119e77f2174c8676d40L9-R26), [link](https://github.com/coordinape/coordinape/pull/2434/files?diff=unified&w=0#diff-549746208b13f46b099bf26f4436733c5c88d8828d99a119e77f2174c8676d40L34-R34), [link](https://github.com/coordinape/coordinape/pull/2434/files?diff=unified&w=0#diff-b06acfe67570e88d414766102b185f0db62c91015f69f93b59ecc49e215efa04L53-R56), [link](https://github.com/coordinape/coordinape/pull/2434/files?diff=unified&w=0#diff-b06acfe67570e88d414766102b185f0db62c91015f69f93b59ecc49e215efa04L74-R74), [link](https://github.com/coordinape/coordinape/pull/2434/files?diff=unified&w=0#diff-4aa6eb6c4daadd3504e9da12667848694f871f63bd5176ba8efbd34534abdc64L30-R33), [link](https://github.com/coordinape/coordinape/pull/2434/files?diff=unified&w=0#diff-4aa6eb6c4daadd3504e9da12667848694f871f63bd5176ba8efbd34534abdc64L154-R154), [link](https://github.com/coordinape/coordinape/pull/2434/files?diff=unified&w=0#diff-cff4a8eedd6bc4e327e10f459d5d7120705b2ccbcf88abb2c175985ad128712cL171-R181))
* Remove unused or redundant imports, variables, and components from `BuyOrSellCoLinks` and `WizardSteps` components ([link](https://github.com/coordinape/coordinape/pull/2434/files?diff=unified&w=0#diff-d3e5d35d9664d8906b4f0deb056d55d6d3bc583514f25f98fed0728e0ccaa538L10-R10), [link](https://github.com/coordinape/coordinape/pull/2434/files?diff=unified&w=0#diff-d3e5d35d9664d8906b4f0deb056d55d6d3bc583514f25f98fed0728e0ccaa538L43-L44), [link](https://github.com/coordinape/coordinape/pull/2434/files?diff=unified&w=0#diff-d3e5d35d9664d8906b4f0deb056d55d6d3bc583514f25f98fed0728e0ccaa538L181-R184), [link](https://github.com/coordinape/coordinape/pull/2434/files?diff=unified&w=0#diff-adbb343b118b342f8c6d8d3fe161f1d83edc6d8a511637878a8ceb34a17ed515L236))
* Add `gap` prop to `Flex` components in `BuyOrSellCoLinks` and `LinkHoldersPage` components to create space between elements ([link](https://github.com/coordinape/coordinape/pull/2434/files?diff=unified&w=0#diff-d3e5d35d9664d8906b4f0deb056d55d6d3bc583514f25f98fed0728e0ccaa538R212), [link](https://github.com/coordinape/coordinape/pull/2434/files?diff=unified&w=0#diff-d3e5d35d9664d8906b4f0deb056d55d6d3bc583514f25f98fed0728e0ccaa538R246), [link](https://github.com/coordinape/coordinape/pull/2434/files?diff=unified&w=0#diff-076f8a5a8f0f2b2da2bb98955accdb08c63a173dd8a2226cc8de24014164c35cL24-R24))
* Add `borderRadius` prop to `Panel` component in `BuyOrSellCoLinks` component to make it consistent with other panels ([link](https://github.com/coordinape/coordinape/pull/2434/files?diff=unified&w=0#diff-d3e5d35d9664d8906b4f0deb056d55d6d3bc583514f25f98fed0728e0ccaa538R280))
* Update `PageContents` component in `ViewProfilePageContents` to show different UI depending on whether user needs to buy target's link or not ([link](https://github.com/coordinape/coordinape/pull/2434/files?diff=unified&w=0#diff-cff4a8eedd6bc4e327e10f459d5d7120705b2ccbcf88abb2c175985ad128712cL2-R2), [link](https://github.com/coordinape/coordinape/pull/2434/files?diff=unified&w=0#diff-cff4a8eedd6bc4e327e10f459d5d7120705b2ccbcf88abb2c175985ad128712cR8), [link](https://github.com/coordinape/coordinape/pull/2434/files?diff=unified&w=0#diff-cff4a8eedd6bc4e327e10f459d5d7120705b2ccbcf88abb2c175985ad128712cL25-R26), [link](https://github.com/coordinape/coordinape/pull/2434/files?diff=unified&w=0#diff-cff4a8eedd6bc4e327e10f459d5d7120705b2ccbcf88abb2c175985ad128712cR195-R202), [link](https://github.com/coordinape/coordinape/pull/2434/files?diff=unified&w=0#diff-cff4a8eedd6bc4e327e10f459d5d7120705b2ccbcf88abb2c175985ad128712cL208-R336), [link](https://github.com/coordinape/coordinape/pull/2434/files?diff=unified&w=0#diff-cff4a8eedd6bc4e327e10f459d5d7120705b2ccbcf88abb2c175985ad128712cL332-L371))
