### PR TITLE
add report abuse button to help options

### DIFF
--- a/src/components/HelpButton.tsx
+++ b/src/components/HelpButton.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 
 import { styled } from '@stitches/react';
+import { useIsCoLinksPage } from 'features/colinks/useIsCoLinksPage';
 
 import {
   AlertTriangle,
@@ -38,7 +39,6 @@ const HelpButtonContainer = styled('div', {
   zIndex: 3,
   '&[data-open="true"]': {
     width: '270px', // magic number to make it look nice and not be crazy on mobile -g
-    height: '300px', // magic number, yep. If i do auto the animations are terrible -g
     borderRadius: '$3',
     '.help-icon': {
       transition: null,
@@ -107,10 +107,19 @@ const HelpOption = ({
 };
 
 const HelpButton = () => {
+  const { isCoLinksPage } = useIsCoLinksPage();
   const [open, setOpen] = useState<boolean>(false);
 
   return (
-    <HelpButtonContainer data-open={`${open}`} onClick={() => setOpen(true)}>
+    <HelpButtonContainer
+      data-open={`${open}`}
+      onClick={() => setOpen(true)}
+      css={{
+        '&[data-open="true"]': {
+          height: isCoLinksPage ? '220px' : '300px', // magic number, yep. If i do auto the animations are terrible -g
+        },
+      }}
+    >
       <Box
         className={'help-icon'}
         css={{
@@ -173,26 +182,30 @@ const HelpButton = () => {
         >
           Email Us
         </HelpOption>
-        <HelpOption
-          href={EXTERNAL_URL_SCHEDULE_WALKTHROUGH}
-          icon={<Clock size={'md'} color={'text'} />}
-        >
-          Schedule a Walkthrough
-        </HelpOption>
+        {!isCoLinksPage && (
+          <HelpOption
+            href={EXTERNAL_URL_SCHEDULE_WALKTHROUGH}
+            icon={<Clock size={'md'} color={'text'} />}
+          >
+            Schedule a Walkthrough
+          </HelpOption>
+        )}
         <HelpOption
           href={EXTERNAL_URL_REPORT_ABUSE_FORM}
           icon={<AlertTriangle size={'md'} color={'text'} />}
         >
           Report Abuse
         </HelpOption>
-        <Box css={{ borderTop: '0.5px solid $border', mt: '$sm' }}>
-          <HelpOption
-            href={EXTERNAL_URL_DOCS}
-            icon={<FileText size={'md'} color={'text'} />}
-          >
-            Documentation
-          </HelpOption>
-        </Box>
+        {!isCoLinksPage && (
+          <Box css={{ borderTop: '0.5px solid $border', mt: '$sm' }}>
+            <HelpOption
+              href={EXTERNAL_URL_DOCS}
+              icon={<FileText size={'md'} color={'text'} />}
+            >
+              Documentation
+            </HelpOption>
+          </Box>
+        )}
       </Box>
     </HelpButtonContainer>
   );

--- a/src/components/HelpButton.tsx
+++ b/src/components/HelpButton.tsx
@@ -2,11 +2,19 @@ import React, { useState } from 'react';
 
 import { styled } from '@stitches/react';
 
-import { Clock, Discord, FileText, Mail, X } from '../icons/__generated';
+import {
+  AlertTriangle,
+  Clock,
+  Discord,
+  FileText,
+  Mail,
+  X,
+} from '../icons/__generated';
 import {
   EXTERNAL_URL_DISCORD,
   EXTERNAL_URL_DOCS,
   EXTERNAL_URL_MAILTO_SUPPORT,
+  EXTERNAL_URL_REPORT_ABUSE_FORM,
   EXTERNAL_URL_SCHEDULE_WALKTHROUGH,
 } from '../routes/paths';
 import { Button, Flex } from '../ui';
@@ -30,7 +38,7 @@ const HelpButtonContainer = styled('div', {
   zIndex: 3,
   '&[data-open="true"]': {
     width: '270px', // magic number to make it look nice and not be crazy on mobile -g
-    height: '260px', // magic number, yep. If i do auto the animations are terrible -g
+    height: '300px', // magic number, yep. If i do auto the animations are terrible -g
     borderRadius: '$3',
     '.help-icon': {
       transition: null,
@@ -170,6 +178,12 @@ const HelpButton = () => {
           icon={<Clock size={'md'} color={'text'} />}
         >
           Schedule a Walkthrough
+        </HelpOption>
+        <HelpOption
+          href={EXTERNAL_URL_REPORT_ABUSE_FORM}
+          icon={<AlertTriangle size={'md'} color={'text'} />}
+        >
+          Report Abuse
         </HelpOption>
         <Box css={{ borderTop: '0.5px solid $border', mt: '$sm' }}>
           <HelpOption

--- a/src/features/colinks/CoLinksLayout.tsx
+++ b/src/features/colinks/CoLinksLayout.tsx
@@ -4,6 +4,7 @@ import { useLocation } from 'react-router-dom';
 
 import { scrollToTop } from '../../components';
 import { GlobalUi } from 'components/GlobalUi';
+import HelpButton from 'components/HelpButton';
 import { EmailBanner } from 'pages/ProfilePage/EmailSettings/EmailBanner';
 import { Box, Flex } from 'ui';
 
@@ -34,7 +35,7 @@ export const CoLinksLayout = ({ children }: { children: React.ReactNode }) => {
         <CoLinksNav />
         <Box css={{ width: '100%' }}>
           <GlobalUi />
-          {/*<HelpButton />*/}
+          <HelpButton />
           <Box
             as="main"
             css={{

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -23,6 +23,8 @@ export const EXTERNAL_URL_DISCORD_SUPPORT =
 export const EXTERNAL_URL_WHY_COORDINAPE_IN_CIRCLE =
   'https://coordinape.com/post/why-is-coordinape-in-my-circle?utm_source=coordinape-app&utm_medium=tooltip&utm_campaign=coordinapeincircle';
 export const EXTERNAL_URL_MAILTO_SUPPORT = 'mailto:support@coordinape.com';
+export const EXTERNAL_URL_REPORT_ABUSE_FORM =
+  'https://docs.google.com/forms/d/e/1FAIpQLScqdAJtxv8eKGQJ35RyWLYOIuwO4NsmLa78rS3jKq6k6dsLNw/viewform?usp=pp_url';
 
 const toSearchString = (params: Record<string, string | number>) =>
   Object.entries(params)


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 71d121e</samp>

Added a feature to report abuse from the help button. The `HelpButton` component was modified to include a new option that links to a Google form, and the form URL was defined in `paths.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 71d121e</samp>

> _Oh we're the crew of the app so fine_
> _We code and test and fix bugs in time_
> _We added a link to `EXTERNAL_URL_REPORT_ABUSE_FORM`_
> _So users can report when things go wrong_


## Screenshots (if appropriate):

![image](https://github.com/coordinape/coordinape/assets/34943689/d9bec59c-db47-4b81-a329-6a709a513e66)

