### PR TITLE
do not send notifications for sample org circles

### DIFF
--- a/api/hasura/cron/epochs.ts
+++ b/api/hasura/cron/epochs.ts
@@ -286,7 +286,7 @@ export async function notifyEpochStart({
       });
     }
 
-    if (!epoch.circle?.organization.sample) {
+    if (!circle.organization.sample) {
       const epochStartDate = DateTime.fromISO(start_date);
       const epochEndDate = DateTime.fromISO(end_date);
       const eligibleUsersCount = circle.users_aggregate.aggregate?.count;
@@ -375,7 +375,7 @@ export async function notifyEpochEnd({
     const { circle } = epoch;
     assert(circle, 'panic: no circle for epoch');
 
-    if (!epoch.circle?.organization.sample) {
+    if (!circle.organization.sample) {
       const usersHodlingGive = circle.users.map(u => u.profile.name);
 
       const message = dedent`
@@ -540,7 +540,7 @@ export async function endEpochHandler(
   // set epoch number if not existent yet
   if (epoch.number == null) await setNextEpochNumber(epoch);
 
-  if (!epoch.circle?.organization.sample) {
+  if (!circle.organization.sample) {
     // send message if notification channel is enabled
     const message = dedent`
       ${circle.organization?.name}/${circle.name} epoch has just ended!

--- a/api/hasura/cron/epochs.ts
+++ b/api/hasura/cron/epochs.ts
@@ -73,7 +73,7 @@ async function getEpochsToNotify() {
                 name: true,
                 telegram_id: true,
                 discord_webhook: true,
-                organization: { id: true, name: true },
+                organization: { id: true, name: true, sample: true },
                 users: [
                   { where: { deleted_at: { _is_null: true } } },
                   {
@@ -121,6 +121,7 @@ async function getEpochsToNotify() {
                 ],
                 start_date: { _lt: 'now()' },
                 notified_before_end: { _is_null: true },
+                circle: { organization: { sample: { _neq: true } } },
               },
             },
             {
@@ -134,7 +135,7 @@ async function getEpochsToNotify() {
                 telegram_id: true,
                 token_name: true,
                 discord_webhook: true,
-                organization: { id: true, name: true },
+                organization: { id: true, name: true, sample: true },
                 users: [
                   {
                     where: {
@@ -188,7 +189,12 @@ async function getEpochsToNotify() {
                 auto_opt_out: true,
                 telegram_id: true,
                 discord_webhook: true,
-                organization: { id: true, name: true, telegram_id: true },
+                organization: {
+                  id: true,
+                  name: true,
+                  telegram_id: true,
+                  sample: true,
+                },
                 users: [
                   {
                     where: {
@@ -273,52 +279,6 @@ export async function notifyEpochStart({
     }
 
     assert(circle, 'panic: no circle for epoch');
-    const epochStartDate = DateTime.fromISO(start_date);
-    const epochEndDate = DateTime.fromISO(end_date);
-    const eligibleUsersCount = circle.users_aggregate.aggregate?.count;
-
-    const message = dedent`
-      A new ${circle.organization?.name}/${circle.name} epoch is active!
-      ${eligibleUsersCount} users will be participating and the duration of the epoch will be:
-      **${epochStartDate.toLocaleString(
-        DateTime.DATETIME_FULL
-      )}** to **${epochEndDate.toLocaleString(DateTime.DATETIME_FULL)}**
-    `;
-
-    const {
-      discord_channel_id: channelId,
-      discord_role_id: roleId,
-      alerts,
-    } = circle?.discord_circle || {};
-
-    if (channelId && roleId && alerts?.['epoch-start']) {
-      await sendSocialMessage({
-        message,
-        circleId: circle.id,
-        channels: {
-          isDiscordBot: true,
-          discordBot: {
-            type: 'start' as const,
-            channelId,
-            roleId,
-            epochName: `Epoch ${epochNumber}`,
-            circleId: circle.id,
-            circleName: `${circle.organization?.name}/${circle.name}`,
-            startTime: start_date,
-            endTime: end_date,
-          },
-        },
-        sanitize: false,
-      });
-    }
-
-    if (circle.discord_webhook) {
-      await notifyEpochStatus(message, { discord: true }, epoch);
-    }
-
-    if (circle.telegram_id)
-      await notifyEpochStatus(message, { telegram: true }, epoch);
-
     if (epoch.circle) {
       await insertEpochStartActivity({
         ...epoch,
@@ -326,25 +286,72 @@ export async function notifyEpochStart({
       });
     }
 
-    const membersData = (epoch.circle?.users || []).reduce<{ email: string }[]>(
-      (acc, u) => {
+    if (!epoch.circle?.organization.sample) {
+      const epochStartDate = DateTime.fromISO(start_date);
+      const epochEndDate = DateTime.fromISO(end_date);
+      const eligibleUsersCount = circle.users_aggregate.aggregate?.count;
+
+      const message = dedent`
+        A new ${circle.organization?.name}/${circle.name} epoch is active!
+        ${eligibleUsersCount} users will be participating and the duration of the epoch will be:
+        **${epochStartDate.toLocaleString(
+          DateTime.DATETIME_FULL
+        )}** to **${epochEndDate.toLocaleString(DateTime.DATETIME_FULL)}**
+      `;
+
+      const {
+        discord_channel_id: channelId,
+        discord_role_id: roleId,
+        alerts,
+      } = circle?.discord_circle || {};
+
+      if (channelId && roleId && alerts?.['epoch-start']) {
+        await sendSocialMessage({
+          message,
+          circleId: circle.id,
+          channels: {
+            isDiscordBot: true,
+            discordBot: {
+              type: 'start' as const,
+              channelId,
+              roleId,
+              epochName: `Epoch ${epochNumber}`,
+              circleId: circle.id,
+              circleName: `${circle.organization?.name}/${circle.name}`,
+              startTime: start_date,
+              endTime: end_date,
+            },
+          },
+          sanitize: false,
+        });
+      }
+
+      if (circle.discord_webhook) {
+        await notifyEpochStatus(message, { discord: true }, epoch);
+      }
+
+      if (circle.telegram_id)
+        await notifyEpochStatus(message, { telegram: true }, epoch);
+
+      const membersData = (epoch.circle?.users || []).reduce<
+        { email: string }[]
+      >((acc, u) => {
         const email: string = u.profile?.emails?.[0]?.email;
         if (email) {
           acc.push({ email: email });
         }
         return acc;
-      },
-      []
-    );
+      }, []);
 
-    if (membersData && membersData.length > 0) {
-      await emailEpochStatus({
-        status: 'started',
-        circleId: epoch.circle_id,
-        circleName: circle.name,
-        epochId: epoch.id,
-        membersData,
-      });
+      if (membersData && membersData.length > 0) {
+        await emailEpochStatus({
+          status: 'started',
+          circleId: epoch.circle_id,
+          circleName: circle.name,
+          epochId: epoch.id,
+          membersData,
+        });
+      }
     }
 
     await updateEpochStartNotification(epoch.id);
@@ -368,45 +375,46 @@ export async function notifyEpochEnd({
     const { circle } = epoch;
     assert(circle, 'panic: no circle for epoch');
 
-    const usersHodlingGive = circle.users.map(u => u.profile.name);
+    if (!epoch.circle?.organization.sample) {
+      const usersHodlingGive = circle.users.map(u => u.profile.name);
 
-    const message = dedent`
+      const message = dedent`
       ${circle.organization?.name}/${
-      circle.name
-    } epoch ends in less than 24 hours!
+        circle.name
+      } epoch ends in less than 24 hours!
       Users that have yet to fully allocate their ${
         circle.token_name || 'GIVE'
       }:
       ${usersHodlingGive.join(', ')}
     `;
 
-    if (circle?.discord_webhook) {
-      await notifyEpochStatus(message, { discord: true }, epoch);
-    }
+      if (circle?.discord_webhook) {
+        await notifyEpochStatus(message, { discord: true }, epoch);
+      }
 
-    if (circle?.telegram_id) {
-      await notifyEpochStatus(message, { telegram: true }, epoch);
-    }
+      if (circle?.telegram_id) {
+        await notifyEpochStatus(message, { telegram: true }, epoch);
+      }
 
-    const membersData = (epoch.circle?.users || []).reduce<{ email: string }[]>(
-      (acc, u) => {
+      const membersData = (epoch.circle?.users || []).reduce<
+        { email: string }[]
+      >((acc, u) => {
         const email: string = u.profile?.emails?.[0]?.email;
         if (email) {
           acc.push({ email: email });
         }
         return acc;
-      },
-      []
-    );
+      }, []);
 
-    if (membersData && membersData.length > 0) {
-      await emailEpochStatus({
-        status: 'endingSoon',
-        circleId: epoch.circle_id,
-        circleName: circle.name,
-        epochId: epoch.id,
-        membersData,
-      });
+      if (membersData && membersData.length > 0) {
+        await emailEpochStatus({
+          status: 'endingSoon',
+          circleId: epoch.circle_id,
+          circleName: circle.name,
+          epochId: epoch.id,
+          membersData,
+        });
+      }
     }
 
     await updateEpochEndSoonNotification(epoch.id);
@@ -532,70 +540,72 @@ export async function endEpochHandler(
   // set epoch number if not existent yet
   if (epoch.number == null) await setNextEpochNumber(epoch);
 
-  // send message if notification channel is enabled
-  const message = dedent`
+  if (!epoch.circle?.organization.sample) {
+    // send message if notification channel is enabled
+    const message = dedent`
       ${circle.organization?.name}/${circle.name} epoch has just ended!
       Users who did not allocate any ${circle.token_name}:
       ${usersWithStartingGive.join(', ')}
     `;
 
-  const {
-    discord_channel_id: channelId,
-    discord_role_id: roleId,
-    alerts,
-  } = circle?.discord_circle || {};
+    const {
+      discord_channel_id: channelId,
+      discord_role_id: roleId,
+      alerts,
+    } = circle?.discord_circle || {};
 
-  if (channelId && roleId && alerts?.['epoch-end']) {
-    await sendSocialMessage({
-      message,
-      circleId: circle.id,
-      channels: {
-        isDiscordBot: true,
-        discordBot: {
-          type: 'end' as const,
-          channelId,
-          roleId,
-          epochName: `Epoch ${epoch.number}`,
-          circleId: circle.id,
-          circleName: `${circle.organization?.name}/${circle.name}`,
-          endTime: epoch.end_date,
-          // use the pending gifts because we don't have a handle on the permanent ones yet, but these are equivalent
-          giveCount: pending_gifts?.reduce(
-            (total, { tokens }) => tokens + total,
-            0
-          ),
-          userCount: circle.users.length,
+    if (channelId && roleId && alerts?.['epoch-end']) {
+      await sendSocialMessage({
+        message,
+        circleId: circle.id,
+        channels: {
+          isDiscordBot: true,
+          discordBot: {
+            type: 'end' as const,
+            channelId,
+            roleId,
+            epochName: `Epoch ${epoch.number}`,
+            circleId: circle.id,
+            circleName: `${circle.organization?.name}/${circle.name}`,
+            endTime: epoch.end_date,
+            // use the pending gifts because we don't have a handle on the permanent ones yet, but these are equivalent
+            giveCount: pending_gifts?.reduce(
+              (total, { tokens }) => tokens + total,
+              0
+            ),
+            userCount: circle.users.length,
+          },
         },
-      },
-      sanitize: false,
-    });
-  }
+        sanitize: false,
+      });
+    }
 
-  if (circle.discord_webhook)
-    await notifyEpochStatus(message, { discord: true }, epoch);
+    if (circle.discord_webhook)
+      await notifyEpochStatus(message, { discord: true }, epoch);
 
-  if (circle.telegram_id)
-    await notifyEpochStatus(message, { telegram: true }, epoch);
+    if (circle.telegram_id)
+      await notifyEpochStatus(message, { telegram: true }, epoch);
 
-  if (circle.organization?.telegram_id)
-    await notifyEpochStatus(message, { telegram: true }, epoch, true);
+    if (circle.organization?.telegram_id)
+      await notifyEpochStatus(message, { telegram: true }, epoch, true);
 
-  if (epoch.circle) {
-    await insertEpochEndActivity({
-      ...epoch,
-      organization_id: epoch.circle.organization.id,
-    });
-  }
+    if (epoch.circle) {
+      await insertEpochEndActivity({
+        ...epoch,
+        organization_id: epoch.circle.organization.id,
+      });
+    }
 
-  const membersData = calculateNumReceived(epoch);
-  if (membersData && membersData.length > 0) {
-    await emailEpochStatus({
-      status: 'ended',
-      circleId: epoch.circle_id,
-      circleName: circle.name,
-      epochId: epoch.id,
-      membersData,
-    });
+    const membersData = calculateNumReceived(epoch);
+    if (membersData && membersData.length > 0) {
+      await emailEpochStatus({
+        status: 'ended',
+        circleId: epoch.circle_id,
+        circleName: circle.name,
+        epochId: epoch.id,
+        membersData,
+      });
+    }
   }
 
   await updateEndEpochNotification(epoch.id);


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 47f9cd9</samp>

This pull request improves the testing and production code for the email and social notifications logic for epochs. It updates the test files `api-test/hasura/cron/epochs_emails_stubbed.test.ts` and `api-test/hasura/cron/epochs_stubbed.test.ts` to use the same functions as the production file `api/hasura/cron/epochs.ts` and to add test cases for sample circles. It also adds logic to skip notifications for sample circles in the production file.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 47f9cd9</samp>

> _Sing, O Muse, of the skillful coder who refined the tests_
> _Of the epochs cron job, the source of many notifications_
> _That reach the eager circles, the groups of noble learners_
> _But not the sample circles, the mockeries of the real ones_


## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 47f9cd9</samp>

*  Add conditions to skip email and social notifications for sample circles in `api/hasura/cron/epochs.ts` ([link](https://github.com/coordinape/coordinape/pull/2437/files?diff=unified&w=0#diff-ac1f75a435bbaedbc21a6db941465f7d22fd4da453de64217474857c2be131a5L76-R76), [link](https://github.com/coordinape/coordinape/pull/2437/files?diff=unified&w=0#diff-ac1f75a435bbaedbc21a6db941465f7d22fd4da453de64217474857c2be131a5R124), [link](https://github.com/coordinape/coordinape/pull/2437/files?diff=unified&w=0#diff-ac1f75a435bbaedbc21a6db941465f7d22fd4da453de64217474857c2be131a5L137-R138), [link](https://github.com/coordinape/coordinape/pull/2437/files?diff=unified&w=0#diff-ac1f75a435bbaedbc21a6db941465f7d22fd4da453de64217474857c2be131a5L191-R197), [link](https://github.com/coordinape/coordinape/pull/2437/files?diff=unified&w=0#diff-ac1f75a435bbaedbc21a6db941465f7d22fd4da453de64217474857c2be131a5L276-R338), [link](https://github.com/coordinape/coordinape/pull/2437/files?diff=unified&w=0#diff-ac1f75a435bbaedbc21a6db941465f7d22fd4da453de64217474857c2be131a5L336-R354), [link](https://github.com/coordinape/coordinape/pull/2437/files?diff=unified&w=0#diff-ac1f75a435bbaedbc21a6db941465f7d22fd4da453de64217474857c2be131a5L371-R384), [link](https://github.com/coordinape/coordinape/pull/2437/files?diff=unified&w=0#diff-ac1f75a435bbaedbc21a6db941465f7d22fd4da453de64217474857c2be131a5L383-R401), [link](https://github.com/coordinape/coordinape/pull/2437/files?diff=unified&w=0#diff-ac1f75a435bbaedbc21a6db941465f7d22fd4da453de64217474857c2be131a5L398-R417), [link](https://github.com/coordinape/coordinape/pull/2437/files?diff=unified&w=0#diff-ac1f75a435bbaedbc21a6db941465f7d22fd4da453de64217474857c2be131a5L535-R545), [link](https://github.com/coordinape/coordinape/pull/2437/files?diff=unified&w=0#diff-ac1f75a435bbaedbc21a6db941465f7d22fd4da453de64217474857c2be131a5L542-R608))
*  Import functions from `api/hasura/cron/epochs.ts` to `api-test/hasura/cron/epochs_emails_stubbed.test.ts` and remove unused imports from `api-test/hasura/cron/epochs_stubbed.test.ts` ([link](https://github.com/coordinape/coordinape/pull/2437/files?diff=unified&w=0#diff-e5a13fa0ec57b6e4622a89fdea5b914d5b18a0eb540c60318a3ababd4b31425bR4-R9), [link](https://github.com/coordinape/coordinape/pull/2437/files?diff=unified&w=0#diff-e5a13fa0ec57b6e4622a89fdea5b914d5b18a0eb540c60318a3ababd4b31425bL12-L17), [link](https://github.com/coordinape/coordinape/pull/2437/files?diff=unified&w=0#diff-61512c4d79bff6c09c0e81ac9606c5820190989dc9f3c28040625c8edbe3f254L4-L6), [link](https://github.com/coordinape/coordinape/pull/2437/files?diff=unified&w=0#diff-61512c4d79bff6c09c0e81ac9606c5820190989dc9f3c28040625c8edbe3f254R11-R13))
*  Add test cases to verify that no email or social notifications are sent for sample circles in `api-test/hasura/cron/epochs_stubbed.test.ts` and `api-test/hasura/cron/epochs_emails_stubbed.test.ts` ([link](https://github.com/coordinape/coordinape/pull/2437/files?diff=unified&w=0#diff-61512c4d79bff6c09c0e81ac9606c5820190989dc9f3c28040625c8edbe3f254R322-R341), [link](https://github.com/coordinape/coordinape/pull/2437/files?diff=unified&w=0#diff-61512c4d79bff6c09c0e81ac9606c5820190989dc9f3c28040625c8edbe3f254R975-R1006), [link](https://github.com/coordinape/coordinape/pull/2437/files?diff=unified&w=0#diff-e5a13fa0ec57b6e4622a89fdea5b914d5b18a0eb540c60318a3ababd4b31425bR262-R302))
