### PR TITLE
Add events for link_tx buy/sell

### DIFF
--- a/api-lib/event_triggers/linkTxInteractionEvent.ts
+++ b/api-lib/event_triggers/linkTxInteractionEvent.ts
@@ -1,0 +1,76 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+import { adminClient } from '../gql/adminClient';
+import * as mutations from '../gql/mutations';
+import { errorResponse } from '../HttpError';
+import { EventTriggerPayload } from '../types';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  try {
+    const {
+      event: {
+        data: {
+          new: {
+            buy,
+            created_at,
+            eth_amount,
+            holder,
+            link_amount,
+            protocol_fee_amount,
+            supply,
+            target,
+            target_fee_amount,
+            tx_hash,
+          },
+        },
+      },
+    }: EventTriggerPayload<'link_tx', 'INSERT'> = req.body;
+
+    await mutations.insertInteractionEvents({
+      event_type: 'link_tx',
+      profile_id: await getHolderProfileId(holder),
+      event_subtype: buy ? 'buy' : 'sell',
+      data: {
+        created_at: created_at,
+        buy: buy,
+        eth_amount: eth_amount,
+        holder: holder,
+        link_amount: link_amount,
+        protocol_fee_amount: protocol_fee_amount,
+        supply: supply,
+        target: target,
+        target_fee_amount: target_fee_amount,
+        tx_hash: tx_hash,
+      },
+    });
+
+    res.status(200).json({
+      message: `link_tx interaction event recorded`,
+    });
+  } catch (e) {
+    return errorResponse(res, e);
+  }
+}
+
+const getHolderProfileId = async (
+  address: string
+): Promise<number | undefined> => {
+  const { profiles } = await adminClient.query(
+    {
+      profiles: [
+        {
+          where: { address: { _eq: address } },
+          limit: 1,
+        },
+        {
+          id: true,
+        },
+      ],
+    },
+    {
+      operationName: 'link_tx_getHolderProfileId',
+    }
+  );
+
+  return profiles.pop()?.id;
+};

--- a/api/hasura/event_triggers/eventManager.ts
+++ b/api/hasura/event_triggers/eventManager.ts
@@ -13,6 +13,7 @@ import createReactionInteractionEvent from '../../../api-lib/event_triggers/crea
 import createVouchedUser from '../../../api-lib/event_triggers/createVouchedUser';
 import discordUserLinked from '../../../api-lib/event_triggers/discordUserLinked';
 import insertOrgMember from '../../../api-lib/event_triggers/insertOrgMember';
+import linkTxInteractionEvent from '../../../api-lib/event_triggers/linkTxInteractionEvent';
 import muteChanged from '../../../api-lib/event_triggers/muteChanged';
 import optOutDiscord from '../../../api-lib/event_triggers/optOutDiscord';
 import optOutDiscordBot from '../../../api-lib/event_triggers/optOutDiscordBot';
@@ -46,6 +47,7 @@ const HANDLERS: HandlerDict = {
   createCircleCRM,
   createContributionInteractionEvent,
   createReactionInteractionEvent,
+  linkTxInteractionEvent,
   createNomineeDiscord,
   userAddedDiscordBot,
   userRemovedDiscordBot,

--- a/hasura/metadata/databases/default/tables/public_link_tx.yaml
+++ b/hasura/metadata/databases/default/tables/public_link_tx.yaml
@@ -35,4 +35,18 @@ select_permissions:
         - holder
         - tx_hash
       filter: {}
-    comment: ""
+    comment: ''
+event_triggers:
+  - name: linkTxInteractionEvent
+    definition:
+      enable_manual: false
+      insert:
+        columns: '*'
+    retry_conf:
+      interval_sec: 3600
+      num_retries: 5
+      timeout_sec: 360
+    webhook: '{{HASURA_API_BASE_URL}}/event_triggers/eventManager?=linkTxInteractionEvent'
+    headers:
+      - name: verification_key
+        value_from_env: HASURA_EVENT_SECRET


### PR DESCRIPTION
## What

Tested locally: check on Mixpanel staging and events flowing: https://mixpanel.com/project/2798367/view/3333023/app/events

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2d50723</samp>

This pull request adds a new feature to record and handle LINK token transactions in the `interaction_events` table. It defines a new event trigger and handler function for the `link_tx` table, and updates the eventManager to register the handler function. It also modifies the metadata file for the `link_tx` table to enable the event trigger.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2d50723</samp>

> _When a new row is added to `link_tx`_
> _Hasura sends a request with a prefix_
> _The handler function then_
> _Creates an event for the `profile_id`_
> _And inserts it into `interaction_events`_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2d50723</samp>

*  Add a handler function for the Hasura event trigger that inserts a row into the `interaction_events` table based on the data of a new row in the `link_tx` table ([link](https://github.com/coordinape/coordinape/pull/2439/files?diff=unified&w=0#diff-c741beeb13d88f691b0afa6e7a7946ec821081b2fe53ddaa1e824c56ddeef7d0R1-R76))
* Import the handler function into the generic eventManager and map it to the query parameter `=linkTxInteractionEvent` ([link](https://github.com/coordinape/coordinape/pull/2439/files?diff=unified&w=0#diff-1ff9bd45a785b1be61a7dc4d3b900604ffeaaf8c11f49e2c81fcfdff758d10f0R16), [link](https://github.com/coordinape/coordinape/pull/2439/files?diff=unified&w=0#diff-1ff9bd45a785b1be61a7dc4d3b900604ffeaaf8c11f49e2c81fcfdff758d10f0R50))
* Configure the event trigger metadata in the `link_tx` table schema to send a POST request to the eventManager with the verification key and the new row data ([link](https://github.com/coordinape/coordinape/pull/2439/files?diff=unified&w=0#diff-82b116c142ab452801f8e786c39c312d4145d78133982dd9f5881b8cd47a7d88L38-R52))
