### PR TITLE
change colinks to have activity as the home page

### DIFF
--- a/src/features/colinks/CoLinksNav.tsx
+++ b/src/features/colinks/CoLinksNav.tsx
@@ -134,11 +134,15 @@ export const CoLinksNav = () => {
           }}
           column
         >
-          <NavItem path={paths.coLinksWizard}>CoLinks Wizard</NavItem>
-          <NavItem path={paths.coLinks}>Your CoLinks Profile</NavItem>
-          <NavItem path={paths.coLinksActivity}>Activity Stream</NavItem>
-          {/*<NavItem path={paths.coLinksTrades}>Trade Stream</NavItem>*/}
+          <NavItem path={paths.coLinks}>CoLinks Home</NavItem>
+          {data?.profile?.address && (
+            <NavItem path={paths.coLinksProfile(data.profile.address)}>
+              Your Profile
+            </NavItem>
+          )}
           <NavItem path={paths.coLinksExplore}>Explore Souls</NavItem>
+          <NavItem path={paths.coLinksTrades}>Trade Stream</NavItem>
+          <NavItem path={paths.coLinksWizard}>CoLinks Wizard</NavItem>
         </Flex>
       </Flex>
       <Flex column>

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -33,7 +33,6 @@ import { LinkHoldersPage } from '../pages/colinks/LinkHoldersPage';
 import { LinkHoldingsPage } from '../pages/colinks/LinkHoldingsPage';
 import { RepScorePage } from '../pages/colinks/RepScorePage';
 import { TradesPage } from '../pages/colinks/TradesPage';
-import ViewMyProfilePage from '../pages/colinks/ViewProfilePage/ViewMyProfilePage';
 import { ViewProfilePage } from '../pages/colinks/ViewProfilePage/ViewProfilePage';
 import { WizardPage } from '../pages/colinks/WizardPage';
 import { WizardStart } from '../pages/colinks/WizardStart';
@@ -231,7 +230,7 @@ export const AppRoutes = () => {
               </RequireAuth>
             }
           >
-            <Route path={paths.coLinks} element={<ViewMyProfilePage />} />
+            <Route path={paths.coLinks} element={<ActivityPage />} />
             <Route
               path={paths.coLinksProfile(':address')}
               element={<ViewProfilePage />}


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d3643e4</samp>

Updated the `CoLinks` feature to simplify the profile viewing and navigation. Removed the redundant `ViewMyProfilePage` component and replaced it with `ViewProfilePage`. Changed the `CoLinksNav` component to reorder and rename the navigation items.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d3643e4</samp>

> _We are the CoLinks, we defy the norm_
> _We rearrange our nav, we make our profile form_
> _We stream our trades and activities, we unleash the wizard's power_
> _We are the CoLinks, we rock the blockchain tower_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d3643e4</samp>

*  Rearrange and rename CoLinks navigation items to improve user experience and clarity ([link](https://github.com/coordinape/coordinape/pull/2440/files?diff=unified&w=0#diff-e3c22548942033fef181fec2fed0f2421c244527e3d4bc7ff616808cde7aba76L137-R145))
*  Replace `ViewMyProfilePage` component with `ViewProfilePage` component that can handle any address as a parameter and remove unused `ViewMyProfilePage` component from `routes.tsx` ([link](https://github.com/coordinape/coordinape/pull/2440/files?diff=unified&w=0#diff-0005a5feea8701ddb5aef0d57e1a5a03c36dae6cd62fc3ecf35fd15a88bb5c03L36))
*  Render `ActivityPage` component for `paths.coLinks` route instead of `ViewMyProfilePage` component to align with new navigation design and provide more information and functionality to the user ([link](https://github.com/coordinape/coordinape/pull/2440/files?diff=unified&w=0#diff-0005a5feea8701ddb5aef0d57e1a5a03c36dae6cd62fc3ecf35fd15a88bb5c03L234-R233))
