### PR TITLE
little toggler for switching between apps

### DIFF
--- a/src/features/colinks/CoLinksNav.tsx
+++ b/src/features/colinks/CoLinksNav.tsx
@@ -5,7 +5,7 @@ import { NavLink } from 'react-router-dom';
 
 import { Menu, X } from '../../icons/__generated';
 import { paths } from '../../routes/paths';
-import { Flex, IconButton, Link, Text } from '../../ui';
+import { Flex, IconButton, Link } from '../../ui';
 import { useNavQuery } from '../nav/getNavData';
 import { NavLogo } from '../nav/NavLogo';
 
@@ -84,24 +84,6 @@ export const CoLinksNav = () => {
         <IconButton onClick={() => setMobileMenuOpen(!mobileMenuOpen)}>
           {mobileMenuOpen ? <X size="lg" /> : <Menu size="lg" />}
         </IconButton>
-      </Flex>
-      <Flex
-        css={{
-          gap: '$xs',
-          py: '$md',
-        }}
-      >
-        <Flex column css={{ '*': { fontFamily: 'monospace' } }}>
-          <Text h1 color="neutral">
-            s0uL
-          </Text>
-          <Text h1 color="neutral">
-            k3yZ
-          </Text>
-        </Flex>
-        <Text h1 css={{ fontSize: '80px', lineHeight: 0 }}>
-          🦭
-        </Text>
       </Flex>
       <Flex
         column

--- a/src/features/nav/NavLogo.tsx
+++ b/src/features/nav/NavLogo.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import { ThemeContext } from 'features/theming/ThemeProvider';
 import { NavLink, useLocation } from 'react-router-dom';
 
@@ -16,13 +18,16 @@ export const NavLogo = ({
   const location = useLocation();
   const isCoLinks = location.pathname.includes('colinks');
 
+  const [showApps, setShowApps] = useState(false);
+
   return (
     <ThemeContext.Consumer>
       {({ theme }) => (
         <Flex column>
           <Box
-            as={NavLink}
-            to={paths.home}
+            onClick={() => setShowApps(prevState => !prevState)}
+            // as={NavLink}
+            // to={paths.home}
             css={{
               ...css,
               'img, svg': {
@@ -36,6 +41,7 @@ export const NavLogo = ({
                 },
               },
               'svg *': { fill: 'white' },
+              cursor: 'pointer',
             }}
           >
             <img
@@ -49,11 +55,31 @@ export const NavLogo = ({
             {/* <img src={'/imgs/logo/coordinape-logo.svg'} alt="coordinape logo" /> */}
           </Box>
           {isFeatureEnabled('soulkeys') && (
-            <Flex css={{ gap: '$md', mt: '$md' }}>
-              <Text as={NavLink} to={paths.coLinks} semibold={isCoLinks}>
+            <Flex column css={{ gap: '$md', mt: '$md', ml: '$md' }}>
+              <Text
+                size={'xl'}
+                as={NavLink}
+                to={paths.coLinks}
+                onClick={() => setShowApps(false)}
+                semibold={isCoLinks}
+                css={{
+                  textDecoration: 'none',
+                  display: isCoLinks || showApps ? 'flex' : 'none',
+                }}
+              >
                 CoLinks
               </Text>
-              <Text as={NavLink} to={paths.home} semibold={!isCoLinks}>
+              <Text
+                as={NavLink}
+                to={paths.home}
+                onClick={() => setShowApps(false)}
+                size={'xl'}
+                css={{
+                  textDecoration: 'none',
+                  display: !isCoLinks || showApps ? 'flex' : 'none',
+                }}
+                semibold={!isCoLinks}
+              >
                 Gift Circle
               </Text>
             </Flex>


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a8995f0</samp>

This pull request improves the user experience of the CoLinks feature by removing clutter and adding a convenient way to switch between CoLinks and Gift Circles. It modifies the `CoLinksNav.tsx` and `NavLogo.tsx` components to achieve this.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a8995f0</samp>

> _`CoLinksNav` trimmed_
> _Logo clicks, menu slides out_
> _Winter of choices_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a8995f0</samp>

*  Add state management and interactivity to the logo component in `NavLogo.tsx` ([link](https://github.com/coordinape/coordinape/pull/2443/files?diff=unified&w=0#diff-e59db5f0d6caeb13b3405fed059b0f57f10ae8a3df65a29be94b3b3197a4e82aR1-R2), [link](https://github.com/coordinape/coordinape/pull/2443/files?diff=unified&w=0#diff-e59db5f0d6caeb13b3405fed059b0f57f10ae8a3df65a29be94b3b3197a4e82aR21-R22), [link](https://github.com/coordinape/coordinape/pull/2443/files?diff=unified&w=0#diff-e59db5f0d6caeb13b3405fed059b0f57f10ae8a3df65a29be94b3b3197a4e82aL24-R30), [link](https://github.com/coordinape/coordinape/pull/2443/files?diff=unified&w=0#diff-e59db5f0d6caeb13b3405fed059b0f57f10ae8a3df65a29be94b3b3197a4e82aR44), [link](https://github.com/coordinape/coordinape/pull/2443/files?diff=unified&w=0#diff-e59db5f0d6caeb13b3405fed059b0f57f10ae8a3df65a29be94b3b3197a4e82aL52-R82))
* Remove unused `Text` import and redundant `Flex` component from `CoLinksNav.tsx` ([link](https://github.com/coordinape/coordinape/pull/2443/files?diff=unified&w=0#diff-e3c22548942033fef181fec2fed0f2421c244527e3d4bc7ff616808cde7aba76L8-R8), [link](https://github.com/coordinape/coordinape/pull/2443/files?diff=unified&w=0#diff-e3c22548942033fef181fec2fed0f2421c244527e3d4bc7ff616808cde7aba76L89-L106))
