### PR TITLE
posts_counts in profiles_public and include those in the !expanded cosoul view

### DIFF
--- a/api-lib/gql/__generated__/zeus/const.ts
+++ b/api-lib/gql/__generated__/zeus/const.ts
@@ -5212,9 +5212,6 @@ export const AllTypesProps: Record<string, any> = {
     delete_profiles_by_pk: {
       id: 'bigint',
     },
-    delete_profiles_public: {
-      where: 'profiles_public_bool_exp',
-    },
     delete_reactions: {
       where: 'reactions_bool_exp',
     },
@@ -5623,12 +5620,6 @@ export const AllTypesProps: Record<string, any> = {
     insert_profiles_one: {
       object: 'profiles_insert_input',
       on_conflict: 'profiles_on_conflict',
-    },
-    insert_profiles_public: {
-      objects: 'profiles_public_insert_input',
-    },
-    insert_profiles_public_one: {
-      object: 'profiles_public_insert_input',
     },
     insert_reactions: {
       objects: 'reactions_insert_input',
@@ -6341,14 +6332,6 @@ export const AllTypesProps: Record<string, any> = {
     },
     update_profiles_many: {
       updates: 'profiles_updates',
-    },
-    update_profiles_public: {
-      _inc: 'profiles_public_inc_input',
-      _set: 'profiles_public_set_input',
-      where: 'profiles_public_bool_exp',
-    },
-    update_profiles_public_many: {
-      updates: 'profiles_public_updates',
     },
     update_reactions: {
       _inc: 'reactions_inc_input',
@@ -8382,16 +8365,17 @@ export const AllTypesProps: Record<string, any> = {
     mutes: 'mutes_bool_exp',
     mutes_aggregate: 'mutes_aggregate_bool_exp',
     name: 'citext_comparison_exp',
+    post_count: 'bigint_comparison_exp',
+    post_count_last_30_days: 'bigint_comparison_exp',
     reputation_score: 'reputation_scores_bool_exp',
-  },
-  profiles_public_inc_input: {
-    id: 'bigint',
   },
   profiles_public_insert_input: {
     cosoul: 'cosouls_obj_rel_insert_input',
     id: 'bigint',
     mutes: 'mutes_arr_rel_insert_input',
     name: 'citext',
+    post_count: 'bigint',
+    post_count_last_30_days: 'bigint',
     reputation_score: 'reputation_scores_obj_rel_insert_input',
   },
   profiles_public_obj_rel_insert_input: {
@@ -8404,13 +8388,11 @@ export const AllTypesProps: Record<string, any> = {
     id: 'order_by',
     mutes_aggregate: 'mutes_aggregate_order_by',
     name: 'order_by',
+    post_count: 'order_by',
+    post_count_last_30_days: 'order_by',
     reputation_score: 'reputation_scores_order_by',
   },
   profiles_public_select_column: true,
-  profiles_public_set_input: {
-    id: 'bigint',
-    name: 'citext',
-  },
   profiles_public_stream_cursor_input: {
     initial_value: 'profiles_public_stream_cursor_value_input',
     ordering: 'cursor_ordering',
@@ -8418,11 +8400,8 @@ export const AllTypesProps: Record<string, any> = {
   profiles_public_stream_cursor_value_input: {
     id: 'bigint',
     name: 'citext',
-  },
-  profiles_public_updates: {
-    _inc: 'profiles_public_inc_input',
-    _set: 'profiles_public_set_input',
-    where: 'profiles_public_bool_exp',
+    post_count: 'bigint',
+    post_count_last_30_days: 'bigint',
   },
   profiles_select_column: true,
   profiles_set_input: {
@@ -15727,7 +15706,6 @@ export const ReturnTypes: Record<string, any> = {
     delete_private_stream_visibility_by_pk: 'private_stream_visibility',
     delete_profiles: 'profiles_mutation_response',
     delete_profiles_by_pk: 'profiles',
-    delete_profiles_public: 'profiles_public_mutation_response',
     delete_reactions: 'reactions_mutation_response',
     delete_reactions_by_pk: 'reactions',
     delete_replies: 'replies_mutation_response',
@@ -15845,8 +15823,6 @@ export const ReturnTypes: Record<string, any> = {
     insert_private_stream_visibility_one: 'private_stream_visibility',
     insert_profiles: 'profiles_mutation_response',
     insert_profiles_one: 'profiles',
-    insert_profiles_public: 'profiles_public_mutation_response',
-    insert_profiles_public_one: 'profiles_public',
     insert_reactions: 'reactions_mutation_response',
     insert_reactions_one: 'reactions',
     insert_replies: 'replies_mutation_response',
@@ -16026,8 +16002,6 @@ export const ReturnTypes: Record<string, any> = {
     update_profiles: 'profiles_mutation_response',
     update_profiles_by_pk: 'profiles',
     update_profiles_many: 'profiles_mutation_response',
-    update_profiles_public: 'profiles_public_mutation_response',
-    update_profiles_public_many: 'profiles_public_mutation_response',
     update_reactions: 'reactions_mutation_response',
     update_reactions_by_pk: 'reactions',
     update_reactions_many: 'reactions_mutation_response',
@@ -17434,6 +17408,8 @@ export const ReturnTypes: Record<string, any> = {
     mutes: 'mutes',
     mutes_aggregate: 'mutes_aggregate',
     name: 'citext',
+    post_count: 'bigint',
+    post_count_last_30_days: 'bigint',
     reputation_score: 'reputation_scores',
   },
   profiles_public_aggregate: {
@@ -17455,43 +17431,59 @@ export const ReturnTypes: Record<string, any> = {
   },
   profiles_public_avg_fields: {
     id: 'Float',
+    post_count: 'Float',
+    post_count_last_30_days: 'Float',
   },
   profiles_public_max_fields: {
     address: 'String',
     avatar: 'String',
     id: 'bigint',
     name: 'citext',
+    post_count: 'bigint',
+    post_count_last_30_days: 'bigint',
   },
   profiles_public_min_fields: {
     address: 'String',
     avatar: 'String',
     id: 'bigint',
     name: 'citext',
-  },
-  profiles_public_mutation_response: {
-    affected_rows: 'Int',
-    returning: 'profiles_public',
+    post_count: 'bigint',
+    post_count_last_30_days: 'bigint',
   },
   profiles_public_stddev_fields: {
     id: 'Float',
+    post_count: 'Float',
+    post_count_last_30_days: 'Float',
   },
   profiles_public_stddev_pop_fields: {
     id: 'Float',
+    post_count: 'Float',
+    post_count_last_30_days: 'Float',
   },
   profiles_public_stddev_samp_fields: {
     id: 'Float',
+    post_count: 'Float',
+    post_count_last_30_days: 'Float',
   },
   profiles_public_sum_fields: {
     id: 'bigint',
+    post_count: 'bigint',
+    post_count_last_30_days: 'bigint',
   },
   profiles_public_var_pop_fields: {
     id: 'Float',
+    post_count: 'Float',
+    post_count_last_30_days: 'Float',
   },
   profiles_public_var_samp_fields: {
     id: 'Float',
+    post_count: 'Float',
+    post_count_last_30_days: 'Float',
   },
   profiles_public_variance_fields: {
     id: 'Float',
+    post_count: 'Float',
+    post_count_last_30_days: 'Float',
   },
   profiles_stddev_fields: {
     id: 'Float',

--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -13948,13 +13948,6 @@ export type ValueTypes = {
       { id: ValueTypes['bigint'] },
       ValueTypes['profiles']
     ];
-    delete_profiles_public?: [
-      {
-        /** filter the rows which have to be deleted */
-        where: ValueTypes['profiles_public_bool_exp'];
-      },
-      ValueTypes['profiles_public_mutation_response']
-    ];
     delete_reactions?: [
       {
         /** filter the rows which have to be deleted */
@@ -14987,20 +14980,6 @@ export type ValueTypes = {
         on_conflict?: ValueTypes['profiles_on_conflict'] | undefined | null;
       },
       ValueTypes['profiles']
-    ];
-    insert_profiles_public?: [
-      {
-        /** the rows to be inserted */
-        objects: Array<ValueTypes['profiles_public_insert_input']>;
-      },
-      ValueTypes['profiles_public_mutation_response']
-    ];
-    insert_profiles_public_one?: [
-      {
-        /** the row to be inserted */
-        object: ValueTypes['profiles_public_insert_input'];
-      },
-      ValueTypes['profiles_public']
     ];
     insert_reactions?: [
       {
@@ -16883,28 +16862,6 @@ export type ValueTypes = {
         updates: Array<ValueTypes['profiles_updates']>;
       },
       ValueTypes['profiles_mutation_response']
-    ];
-    update_profiles_public?: [
-      {
-        /** increments the numeric columns with given value of the filtered values */
-        _inc?:
-          | ValueTypes['profiles_public_inc_input']
-          | undefined
-          | null /** sets the columns of the filtered rows to the given values */;
-        _set?:
-          | ValueTypes['profiles_public_set_input']
-          | undefined
-          | null /** filter the rows which have to be updated */;
-        where: ValueTypes['profiles_public_bool_exp'];
-      },
-      ValueTypes['profiles_public_mutation_response']
-    ];
-    update_profiles_public_many?: [
-      {
-        /** updates to execute, in order */
-        updates: Array<ValueTypes['profiles_public_updates']>;
-      },
-      ValueTypes['profiles_public_mutation_response']
     ];
     update_reactions?: [
       {
@@ -22175,6 +22132,8 @@ export type ValueTypes = {
       ValueTypes['mutes_aggregate']
     ];
     name?: boolean | `@${string}`;
+    post_count?: boolean | `@${string}`;
+    post_count_last_30_days?: boolean | `@${string}`;
     /** An object relationship */
     reputation_score?: ValueTypes['reputation_scores'];
     __typename?: boolean | `@${string}`;
@@ -22212,6 +22171,8 @@ export type ValueTypes = {
   /** aggregate avg on columns */
   ['profiles_public_avg_fields']: AliasType<{
     id?: boolean | `@${string}`;
+    post_count?: boolean | `@${string}`;
+    post_count_last_30_days?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** Boolean expression to filter rows from the table "profiles_public". All fields are combined with a logical 'AND'. */
@@ -22226,14 +22187,15 @@ export type ValueTypes = {
     mutes?: ValueTypes['mutes_bool_exp'] | undefined | null;
     mutes_aggregate?: ValueTypes['mutes_aggregate_bool_exp'] | undefined | null;
     name?: ValueTypes['citext_comparison_exp'] | undefined | null;
+    post_count?: ValueTypes['bigint_comparison_exp'] | undefined | null;
+    post_count_last_30_days?:
+      | ValueTypes['bigint_comparison_exp']
+      | undefined
+      | null;
     reputation_score?:
       | ValueTypes['reputation_scores_bool_exp']
       | undefined
       | null;
-  };
-  /** input type for incrementing numeric columns in table "profiles_public" */
-  ['profiles_public_inc_input']: {
-    id?: ValueTypes['bigint'] | undefined | null;
   };
   /** input type for inserting data into table "profiles_public" */
   ['profiles_public_insert_input']: {
@@ -22243,6 +22205,8 @@ export type ValueTypes = {
     id?: ValueTypes['bigint'] | undefined | null;
     mutes?: ValueTypes['mutes_arr_rel_insert_input'] | undefined | null;
     name?: ValueTypes['citext'] | undefined | null;
+    post_count?: ValueTypes['bigint'] | undefined | null;
+    post_count_last_30_days?: ValueTypes['bigint'] | undefined | null;
     reputation_score?:
       | ValueTypes['reputation_scores_obj_rel_insert_input']
       | undefined
@@ -22254,6 +22218,8 @@ export type ValueTypes = {
     avatar?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
     name?: boolean | `@${string}`;
+    post_count?: boolean | `@${string}`;
+    post_count_last_30_days?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregate min on columns */
@@ -22262,14 +22228,8 @@ export type ValueTypes = {
     avatar?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
     name?: boolean | `@${string}`;
-    __typename?: boolean | `@${string}`;
-  }>;
-  /** response of any mutation on the table "profiles_public" */
-  ['profiles_public_mutation_response']: AliasType<{
-    /** number of rows affected by the mutation */
-    affected_rows?: boolean | `@${string}`;
-    /** data from the rows affected by the mutation */
-    returning?: ValueTypes['profiles_public'];
+    post_count?: boolean | `@${string}`;
+    post_count_last_30_days?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** input type for inserting object relation for remote table "profiles_public" */
@@ -22284,6 +22244,8 @@ export type ValueTypes = {
     id?: ValueTypes['order_by'] | undefined | null;
     mutes_aggregate?: ValueTypes['mutes_aggregate_order_by'] | undefined | null;
     name?: ValueTypes['order_by'] | undefined | null;
+    post_count?: ValueTypes['order_by'] | undefined | null;
+    post_count_last_30_days?: ValueTypes['order_by'] | undefined | null;
     reputation_score?:
       | ValueTypes['reputation_scores_order_by']
       | undefined
@@ -22291,26 +22253,25 @@ export type ValueTypes = {
   };
   /** select columns of table "profiles_public" */
   ['profiles_public_select_column']: profiles_public_select_column;
-  /** input type for updating data in table "profiles_public" */
-  ['profiles_public_set_input']: {
-    address?: string | undefined | null;
-    avatar?: string | undefined | null;
-    id?: ValueTypes['bigint'] | undefined | null;
-    name?: ValueTypes['citext'] | undefined | null;
-  };
   /** aggregate stddev on columns */
   ['profiles_public_stddev_fields']: AliasType<{
     id?: boolean | `@${string}`;
+    post_count?: boolean | `@${string}`;
+    post_count_last_30_days?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregate stddev_pop on columns */
   ['profiles_public_stddev_pop_fields']: AliasType<{
     id?: boolean | `@${string}`;
+    post_count?: boolean | `@${string}`;
+    post_count_last_30_days?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregate stddev_samp on columns */
   ['profiles_public_stddev_samp_fields']: AliasType<{
     id?: boolean | `@${string}`;
+    post_count?: boolean | `@${string}`;
+    post_count_last_30_days?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** Streaming cursor of the table "profiles_public" */
@@ -22326,33 +22287,35 @@ export type ValueTypes = {
     avatar?: string | undefined | null;
     id?: ValueTypes['bigint'] | undefined | null;
     name?: ValueTypes['citext'] | undefined | null;
+    post_count?: ValueTypes['bigint'] | undefined | null;
+    post_count_last_30_days?: ValueTypes['bigint'] | undefined | null;
   };
   /** aggregate sum on columns */
   ['profiles_public_sum_fields']: AliasType<{
     id?: boolean | `@${string}`;
+    post_count?: boolean | `@${string}`;
+    post_count_last_30_days?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
-  ['profiles_public_updates']: {
-    /** increments the numeric columns with given value of the filtered values */
-    _inc?: ValueTypes['profiles_public_inc_input'] | undefined | null;
-    /** sets the columns of the filtered rows to the given values */
-    _set?: ValueTypes['profiles_public_set_input'] | undefined | null;
-    /** filter the rows which have to be updated */
-    where: ValueTypes['profiles_public_bool_exp'];
-  };
   /** aggregate var_pop on columns */
   ['profiles_public_var_pop_fields']: AliasType<{
     id?: boolean | `@${string}`;
+    post_count?: boolean | `@${string}`;
+    post_count_last_30_days?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregate var_samp on columns */
   ['profiles_public_var_samp_fields']: AliasType<{
     id?: boolean | `@${string}`;
+    post_count?: boolean | `@${string}`;
+    post_count_last_30_days?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregate variance on columns */
   ['profiles_public_variance_fields']: AliasType<{
     id?: boolean | `@${string}`;
+    post_count?: boolean | `@${string}`;
+    post_count_last_30_days?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** select columns of table "profiles" */
@@ -39873,10 +39836,6 @@ export type ModelTypes = {
     delete_profiles?: GraphQLTypes['profiles_mutation_response'] | undefined;
     /** delete single row from the table: "profiles" */
     delete_profiles_by_pk?: GraphQLTypes['profiles'] | undefined;
-    /** delete data from the table: "profiles_public" */
-    delete_profiles_public?:
-      | GraphQLTypes['profiles_public_mutation_response']
-      | undefined;
     /** delete data from the table: "reactions" */
     delete_reactions?: GraphQLTypes['reactions_mutation_response'] | undefined;
     /** delete single row from the table: "reactions" */
@@ -40210,12 +40169,6 @@ export type ModelTypes = {
     insert_profiles?: GraphQLTypes['profiles_mutation_response'] | undefined;
     /** insert a single row into the table: "profiles" */
     insert_profiles_one?: GraphQLTypes['profiles'] | undefined;
-    /** insert data into the table: "profiles_public" */
-    insert_profiles_public?:
-      | GraphQLTypes['profiles_public_mutation_response']
-      | undefined;
-    /** insert a single row into the table: "profiles_public" */
-    insert_profiles_public_one?: GraphQLTypes['profiles_public'] | undefined;
     /** insert data into the table: "reactions" */
     insert_reactions?: GraphQLTypes['reactions_mutation_response'] | undefined;
     /** insert a single row into the table: "reactions" */
@@ -40759,14 +40712,6 @@ export type ModelTypes = {
     /** update multiples rows of table: "profiles" */
     update_profiles_many?:
       | Array<GraphQLTypes['profiles_mutation_response'] | undefined>
-      | undefined;
-    /** update data of the table: "profiles_public" */
-    update_profiles_public?:
-      | GraphQLTypes['profiles_public_mutation_response']
-      | undefined;
-    /** update multiples rows of table: "profiles_public" */
-    update_profiles_public_many?:
-      | Array<GraphQLTypes['profiles_public_mutation_response'] | undefined>
       | undefined;
     /** update data of the table: "reactions" */
     update_reactions?: GraphQLTypes['reactions_mutation_response'] | undefined;
@@ -43068,6 +43013,8 @@ export type ModelTypes = {
     /** An aggregate relationship */
     mutes_aggregate: GraphQLTypes['mutes_aggregate'];
     name?: GraphQLTypes['citext'] | undefined;
+    post_count?: GraphQLTypes['bigint'] | undefined;
+    post_count_last_30_days?: GraphQLTypes['bigint'] | undefined;
     /** An object relationship */
     reputation_score?: GraphQLTypes['reputation_scores'] | undefined;
   };
@@ -43095,11 +43042,11 @@ export type ModelTypes = {
   /** aggregate avg on columns */
   ['profiles_public_avg_fields']: {
     id?: number | undefined;
+    post_count?: number | undefined;
+    post_count_last_30_days?: number | undefined;
   };
   /** Boolean expression to filter rows from the table "profiles_public". All fields are combined with a logical 'AND'. */
   ['profiles_public_bool_exp']: GraphQLTypes['profiles_public_bool_exp'];
-  /** input type for incrementing numeric columns in table "profiles_public" */
-  ['profiles_public_inc_input']: GraphQLTypes['profiles_public_inc_input'];
   /** input type for inserting data into table "profiles_public" */
   ['profiles_public_insert_input']: GraphQLTypes['profiles_public_insert_input'];
   /** aggregate max on columns */
@@ -43108,6 +43055,8 @@ export type ModelTypes = {
     avatar?: string | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
     name?: GraphQLTypes['citext'] | undefined;
+    post_count?: GraphQLTypes['bigint'] | undefined;
+    post_count_last_30_days?: GraphQLTypes['bigint'] | undefined;
   };
   /** aggregate min on columns */
   ['profiles_public_min_fields']: {
@@ -43115,13 +43064,8 @@ export type ModelTypes = {
     avatar?: string | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
     name?: GraphQLTypes['citext'] | undefined;
-  };
-  /** response of any mutation on the table "profiles_public" */
-  ['profiles_public_mutation_response']: {
-    /** number of rows affected by the mutation */
-    affected_rows: number;
-    /** data from the rows affected by the mutation */
-    returning: Array<GraphQLTypes['profiles_public']>;
+    post_count?: GraphQLTypes['bigint'] | undefined;
+    post_count_last_30_days?: GraphQLTypes['bigint'] | undefined;
   };
   /** input type for inserting object relation for remote table "profiles_public" */
   ['profiles_public_obj_rel_insert_input']: GraphQLTypes['profiles_public_obj_rel_insert_input'];
@@ -43129,19 +43073,23 @@ export type ModelTypes = {
   ['profiles_public_order_by']: GraphQLTypes['profiles_public_order_by'];
   /** select columns of table "profiles_public" */
   ['profiles_public_select_column']: GraphQLTypes['profiles_public_select_column'];
-  /** input type for updating data in table "profiles_public" */
-  ['profiles_public_set_input']: GraphQLTypes['profiles_public_set_input'];
   /** aggregate stddev on columns */
   ['profiles_public_stddev_fields']: {
     id?: number | undefined;
+    post_count?: number | undefined;
+    post_count_last_30_days?: number | undefined;
   };
   /** aggregate stddev_pop on columns */
   ['profiles_public_stddev_pop_fields']: {
     id?: number | undefined;
+    post_count?: number | undefined;
+    post_count_last_30_days?: number | undefined;
   };
   /** aggregate stddev_samp on columns */
   ['profiles_public_stddev_samp_fields']: {
     id?: number | undefined;
+    post_count?: number | undefined;
+    post_count_last_30_days?: number | undefined;
   };
   /** Streaming cursor of the table "profiles_public" */
   ['profiles_public_stream_cursor_input']: GraphQLTypes['profiles_public_stream_cursor_input'];
@@ -43150,19 +43098,26 @@ export type ModelTypes = {
   /** aggregate sum on columns */
   ['profiles_public_sum_fields']: {
     id?: GraphQLTypes['bigint'] | undefined;
+    post_count?: GraphQLTypes['bigint'] | undefined;
+    post_count_last_30_days?: GraphQLTypes['bigint'] | undefined;
   };
-  ['profiles_public_updates']: GraphQLTypes['profiles_public_updates'];
   /** aggregate var_pop on columns */
   ['profiles_public_var_pop_fields']: {
     id?: number | undefined;
+    post_count?: number | undefined;
+    post_count_last_30_days?: number | undefined;
   };
   /** aggregate var_samp on columns */
   ['profiles_public_var_samp_fields']: {
     id?: number | undefined;
+    post_count?: number | undefined;
+    post_count_last_30_days?: number | undefined;
   };
   /** aggregate variance on columns */
   ['profiles_public_variance_fields']: {
     id?: number | undefined;
+    post_count?: number | undefined;
+    post_count_last_30_days?: number | undefined;
   };
   /** select columns of table "profiles" */
   ['profiles_select_column']: GraphQLTypes['profiles_select_column'];
@@ -57383,10 +57338,6 @@ export type GraphQLTypes = {
     delete_profiles?: GraphQLTypes['profiles_mutation_response'] | undefined;
     /** delete single row from the table: "profiles" */
     delete_profiles_by_pk?: GraphQLTypes['profiles'] | undefined;
-    /** delete data from the table: "profiles_public" */
-    delete_profiles_public?:
-      | GraphQLTypes['profiles_public_mutation_response']
-      | undefined;
     /** delete data from the table: "reactions" */
     delete_reactions?: GraphQLTypes['reactions_mutation_response'] | undefined;
     /** delete single row from the table: "reactions" */
@@ -57720,12 +57671,6 @@ export type GraphQLTypes = {
     insert_profiles?: GraphQLTypes['profiles_mutation_response'] | undefined;
     /** insert a single row into the table: "profiles" */
     insert_profiles_one?: GraphQLTypes['profiles'] | undefined;
-    /** insert data into the table: "profiles_public" */
-    insert_profiles_public?:
-      | GraphQLTypes['profiles_public_mutation_response']
-      | undefined;
-    /** insert a single row into the table: "profiles_public" */
-    insert_profiles_public_one?: GraphQLTypes['profiles_public'] | undefined;
     /** insert data into the table: "reactions" */
     insert_reactions?: GraphQLTypes['reactions_mutation_response'] | undefined;
     /** insert a single row into the table: "reactions" */
@@ -58269,14 +58214,6 @@ export type GraphQLTypes = {
     /** update multiples rows of table: "profiles" */
     update_profiles_many?:
       | Array<GraphQLTypes['profiles_mutation_response'] | undefined>
-      | undefined;
-    /** update data of the table: "profiles_public" */
-    update_profiles_public?:
-      | GraphQLTypes['profiles_public_mutation_response']
-      | undefined;
-    /** update multiples rows of table: "profiles_public" */
-    update_profiles_public_many?:
-      | Array<GraphQLTypes['profiles_public_mutation_response'] | undefined>
       | undefined;
     /** update data of the table: "reactions" */
     update_reactions?: GraphQLTypes['reactions_mutation_response'] | undefined;
@@ -62483,6 +62420,8 @@ export type GraphQLTypes = {
     /** An aggregate relationship */
     mutes_aggregate: GraphQLTypes['mutes_aggregate'];
     name?: GraphQLTypes['citext'] | undefined;
+    post_count?: GraphQLTypes['bigint'] | undefined;
+    post_count_last_30_days?: GraphQLTypes['bigint'] | undefined;
     /** An object relationship */
     reputation_score?: GraphQLTypes['reputation_scores'] | undefined;
   };
@@ -62513,6 +62452,8 @@ export type GraphQLTypes = {
   ['profiles_public_avg_fields']: {
     __typename: 'profiles_public_avg_fields';
     id?: number | undefined;
+    post_count?: number | undefined;
+    post_count_last_30_days?: number | undefined;
   };
   /** Boolean expression to filter rows from the table "profiles_public". All fields are combined with a logical 'AND'. */
   ['profiles_public_bool_exp']: {
@@ -62526,11 +62467,9 @@ export type GraphQLTypes = {
     mutes?: GraphQLTypes['mutes_bool_exp'] | undefined;
     mutes_aggregate?: GraphQLTypes['mutes_aggregate_bool_exp'] | undefined;
     name?: GraphQLTypes['citext_comparison_exp'] | undefined;
+    post_count?: GraphQLTypes['bigint_comparison_exp'] | undefined;
+    post_count_last_30_days?: GraphQLTypes['bigint_comparison_exp'] | undefined;
     reputation_score?: GraphQLTypes['reputation_scores_bool_exp'] | undefined;
-  };
-  /** input type for incrementing numeric columns in table "profiles_public" */
-  ['profiles_public_inc_input']: {
-    id?: GraphQLTypes['bigint'] | undefined;
   };
   /** input type for inserting data into table "profiles_public" */
   ['profiles_public_insert_input']: {
@@ -62540,6 +62479,8 @@ export type GraphQLTypes = {
     id?: GraphQLTypes['bigint'] | undefined;
     mutes?: GraphQLTypes['mutes_arr_rel_insert_input'] | undefined;
     name?: GraphQLTypes['citext'] | undefined;
+    post_count?: GraphQLTypes['bigint'] | undefined;
+    post_count_last_30_days?: GraphQLTypes['bigint'] | undefined;
     reputation_score?:
       | GraphQLTypes['reputation_scores_obj_rel_insert_input']
       | undefined;
@@ -62551,6 +62492,8 @@ export type GraphQLTypes = {
     avatar?: string | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
     name?: GraphQLTypes['citext'] | undefined;
+    post_count?: GraphQLTypes['bigint'] | undefined;
+    post_count_last_30_days?: GraphQLTypes['bigint'] | undefined;
   };
   /** aggregate min on columns */
   ['profiles_public_min_fields']: {
@@ -62559,14 +62502,8 @@ export type GraphQLTypes = {
     avatar?: string | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
     name?: GraphQLTypes['citext'] | undefined;
-  };
-  /** response of any mutation on the table "profiles_public" */
-  ['profiles_public_mutation_response']: {
-    __typename: 'profiles_public_mutation_response';
-    /** number of rows affected by the mutation */
-    affected_rows: number;
-    /** data from the rows affected by the mutation */
-    returning: Array<GraphQLTypes['profiles_public']>;
+    post_count?: GraphQLTypes['bigint'] | undefined;
+    post_count_last_30_days?: GraphQLTypes['bigint'] | undefined;
   };
   /** input type for inserting object relation for remote table "profiles_public" */
   ['profiles_public_obj_rel_insert_input']: {
@@ -62580,31 +62517,32 @@ export type GraphQLTypes = {
     id?: GraphQLTypes['order_by'] | undefined;
     mutes_aggregate?: GraphQLTypes['mutes_aggregate_order_by'] | undefined;
     name?: GraphQLTypes['order_by'] | undefined;
+    post_count?: GraphQLTypes['order_by'] | undefined;
+    post_count_last_30_days?: GraphQLTypes['order_by'] | undefined;
     reputation_score?: GraphQLTypes['reputation_scores_order_by'] | undefined;
   };
   /** select columns of table "profiles_public" */
   ['profiles_public_select_column']: profiles_public_select_column;
-  /** input type for updating data in table "profiles_public" */
-  ['profiles_public_set_input']: {
-    address?: string | undefined;
-    avatar?: string | undefined;
-    id?: GraphQLTypes['bigint'] | undefined;
-    name?: GraphQLTypes['citext'] | undefined;
-  };
   /** aggregate stddev on columns */
   ['profiles_public_stddev_fields']: {
     __typename: 'profiles_public_stddev_fields';
     id?: number | undefined;
+    post_count?: number | undefined;
+    post_count_last_30_days?: number | undefined;
   };
   /** aggregate stddev_pop on columns */
   ['profiles_public_stddev_pop_fields']: {
     __typename: 'profiles_public_stddev_pop_fields';
     id?: number | undefined;
+    post_count?: number | undefined;
+    post_count_last_30_days?: number | undefined;
   };
   /** aggregate stddev_samp on columns */
   ['profiles_public_stddev_samp_fields']: {
     __typename: 'profiles_public_stddev_samp_fields';
     id?: number | undefined;
+    post_count?: number | undefined;
+    post_count_last_30_days?: number | undefined;
   };
   /** Streaming cursor of the table "profiles_public" */
   ['profiles_public_stream_cursor_input']: {
@@ -62619,34 +62557,36 @@ export type GraphQLTypes = {
     avatar?: string | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
     name?: GraphQLTypes['citext'] | undefined;
+    post_count?: GraphQLTypes['bigint'] | undefined;
+    post_count_last_30_days?: GraphQLTypes['bigint'] | undefined;
   };
   /** aggregate sum on columns */
   ['profiles_public_sum_fields']: {
     __typename: 'profiles_public_sum_fields';
     id?: GraphQLTypes['bigint'] | undefined;
-  };
-  ['profiles_public_updates']: {
-    /** increments the numeric columns with given value of the filtered values */
-    _inc?: GraphQLTypes['profiles_public_inc_input'] | undefined;
-    /** sets the columns of the filtered rows to the given values */
-    _set?: GraphQLTypes['profiles_public_set_input'] | undefined;
-    /** filter the rows which have to be updated */
-    where: GraphQLTypes['profiles_public_bool_exp'];
+    post_count?: GraphQLTypes['bigint'] | undefined;
+    post_count_last_30_days?: GraphQLTypes['bigint'] | undefined;
   };
   /** aggregate var_pop on columns */
   ['profiles_public_var_pop_fields']: {
     __typename: 'profiles_public_var_pop_fields';
     id?: number | undefined;
+    post_count?: number | undefined;
+    post_count_last_30_days?: number | undefined;
   };
   /** aggregate var_samp on columns */
   ['profiles_public_var_samp_fields']: {
     __typename: 'profiles_public_var_samp_fields';
     id?: number | undefined;
+    post_count?: number | undefined;
+    post_count_last_30_days?: number | undefined;
   };
   /** aggregate variance on columns */
   ['profiles_public_variance_fields']: {
     __typename: 'profiles_public_variance_fields';
     id?: number | undefined;
+    post_count?: number | undefined;
+    post_count_last_30_days?: number | undefined;
   };
   /** select columns of table "profiles" */
   ['profiles_select_column']: profiles_select_column;
@@ -69111,6 +69051,8 @@ export const enum profiles_public_select_column {
   avatar = 'avatar',
   id = 'id',
   name = 'name',
+  post_count = 'post_count',
+  post_count_last_30_days = 'post_count_last_30_days',
 }
 /** select columns of table "profiles" */
 export const enum profiles_select_column {

--- a/hasura/metadata/databases/default/tables/public_link_tx.yaml
+++ b/hasura/metadata/databases/default/tables/public_link_tx.yaml
@@ -35,4 +35,18 @@ select_permissions:
         - holder
         - tx_hash
       filter: {}
-    comment: ""
+    comment: ''
+event_triggers:
+  - name: linkTxInteractionEvent
+    definition:
+      enable_manual: false
+      insert:
+        columns: '*'
+    retry_conf:
+      interval_sec: 3600
+      num_retries: 5
+      timeout_sec: 360
+    webhook: '{{HASURA_API_BASE_URL}}/event_triggers/eventManager?=linkTxInteractionEvent'
+    headers:
+      - name: verification_key
+        value_from_env: HASURA_EVENT_SECRET

--- a/hasura/metadata/databases/default/tables/public_link_tx.yaml
+++ b/hasura/metadata/databases/default/tables/public_link_tx.yaml
@@ -35,18 +35,4 @@ select_permissions:
         - holder
         - tx_hash
       filter: {}
-    comment: ''
-event_triggers:
-  - name: linkTxInteractionEvent
-    definition:
-      enable_manual: false
-      insert:
-        columns: '*'
-    retry_conf:
-      interval_sec: 3600
-      num_retries: 5
-      timeout_sec: 360
-    webhook: '{{HASURA_API_BASE_URL}}/event_triggers/eventManager?=linkTxInteractionEvent'
-    headers:
-      - name: verification_key
-        value_from_env: HASURA_EVENT_SECRET
+    comment: ""

--- a/hasura/metadata/databases/default/tables/public_profiles_public.yaml
+++ b/hasura/metadata/databases/default/tables/public_profiles_public.yaml
@@ -43,9 +43,11 @@ select_permissions:
   - role: user
     permission:
       columns:
-        - id
         - address
         - avatar
+        - id
         - name
+        - post_count
+        - post_count_last_30_days
       filter: {}
     comment: ""

--- a/hasura/migrations/default/1700202495620_update_profiles_public_with_post_count/down.sql
+++ b/hasura/migrations/default/1700202495620_update_profiles_public_with_post_count/down.sql
@@ -1,0 +1,6 @@
+CREATE OR REPLACE VIEW "public"."profiles_public" AS
+ SELECT p.id,
+    p.address,
+    p.name,
+    p.avatar
+   FROM profiles p;

--- a/hasura/migrations/default/1700202495620_update_profiles_public_with_post_count/up.sql
+++ b/hasura/migrations/default/1700202495620_update_profiles_public_with_post_count/up.sql
@@ -1,0 +1,10 @@
+CREATE OR REPLACE VIEW "public"."profiles_public" AS 
+ SELECT p.id,
+    p.address,
+    p.name,
+    p.avatar,
+    count(c.*) AS post_count,
+    COUNT(CASE WHEN c.created_at >= CURRENT_DATE - INTERVAL '30 days' THEN 1 END) AS post_count_last_30_days
+   FROM (profiles p
+     LEFT JOIN contributions c ON (((c.profile_id = p.id) AND (c.private_stream = true))))
+  GROUP BY p.id, p.address, p.name, p.avatar;

--- a/hasura/schema/admin/schema.graphql
+++ b/hasura/schema/admin/schema.graphql
@@ -19918,16 +19918,6 @@ type mutation_root {
   delete_profiles_by_pk(id: bigint!): profiles
 
   """
-  delete data from the table: "profiles_public"
-  """
-  delete_profiles_public(
-    """
-    filter the rows which have to be deleted
-    """
-    where: profiles_public_bool_exp!
-  ): profiles_public_mutation_response
-
-  """
   delete data from the table: "reactions"
   """
   delete_reactions(
@@ -21362,26 +21352,6 @@ type mutation_root {
     """
     on_conflict: profiles_on_conflict
   ): profiles
-
-  """
-  insert data into the table: "profiles_public"
-  """
-  insert_profiles_public(
-    """
-    the rows to be inserted
-    """
-    objects: [profiles_public_insert_input!]!
-  ): profiles_public_mutation_response
-
-  """
-  insert a single row into the table: "profiles_public"
-  """
-  insert_profiles_public_one(
-    """
-    the row to be inserted
-    """
-    object: profiles_public_insert_input!
-  ): profiles_public
 
   """
   insert data into the table: "reactions"
@@ -23885,36 +23855,6 @@ type mutation_root {
     """
     updates: [profiles_updates!]!
   ): [profiles_mutation_response]
-
-  """
-  update data of the table: "profiles_public"
-  """
-  update_profiles_public(
-    """
-    increments the numeric columns with given value of the filtered values
-    """
-    _inc: profiles_public_inc_input
-
-    """
-    sets the columns of the filtered rows to the given values
-    """
-    _set: profiles_public_set_input
-
-    """
-    filter the rows which have to be updated
-    """
-    where: profiles_public_bool_exp!
-  ): profiles_public_mutation_response
-
-  """
-  update multiples rows of table: "profiles_public"
-  """
-  update_profiles_public_many(
-    """
-    updates to execute, in order
-    """
-    updates: [profiles_public_updates!]!
-  ): [profiles_public_mutation_response]
 
   """
   update data of the table: "reactions"
@@ -31738,6 +31678,8 @@ type profiles_public {
     where: mutes_bool_exp
   ): mutes_aggregate!
   name: citext
+  post_count: bigint
+  post_count_last_30_days: bigint
 
   """
   An object relationship
@@ -31775,6 +31717,8 @@ aggregate avg on columns
 """
 type profiles_public_avg_fields {
   id: Float
+  post_count: Float
+  post_count_last_30_days: Float
 }
 
 """
@@ -31791,14 +31735,9 @@ input profiles_public_bool_exp {
   mutes: mutes_bool_exp
   mutes_aggregate: mutes_aggregate_bool_exp
   name: citext_comparison_exp
+  post_count: bigint_comparison_exp
+  post_count_last_30_days: bigint_comparison_exp
   reputation_score: reputation_scores_bool_exp
-}
-
-"""
-input type for incrementing numeric columns in table "profiles_public"
-"""
-input profiles_public_inc_input {
-  id: bigint
 }
 
 """
@@ -31811,6 +31750,8 @@ input profiles_public_insert_input {
   id: bigint
   mutes: mutes_arr_rel_insert_input
   name: citext
+  post_count: bigint
+  post_count_last_30_days: bigint
   reputation_score: reputation_scores_obj_rel_insert_input
 }
 
@@ -31822,6 +31763,8 @@ type profiles_public_max_fields {
   avatar: String
   id: bigint
   name: citext
+  post_count: bigint
+  post_count_last_30_days: bigint
 }
 
 """
@@ -31832,21 +31775,8 @@ type profiles_public_min_fields {
   avatar: String
   id: bigint
   name: citext
-}
-
-"""
-response of any mutation on the table "profiles_public"
-"""
-type profiles_public_mutation_response {
-  """
-  number of rows affected by the mutation
-  """
-  affected_rows: Int!
-
-  """
-  data from the rows affected by the mutation
-  """
-  returning: [profiles_public!]!
+  post_count: bigint
+  post_count_last_30_days: bigint
 }
 
 """
@@ -31866,6 +31796,8 @@ input profiles_public_order_by {
   id: order_by
   mutes_aggregate: mutes_aggregate_order_by
   name: order_by
+  post_count: order_by
+  post_count_last_30_days: order_by
   reputation_score: reputation_scores_order_by
 }
 
@@ -31892,16 +31824,16 @@ enum profiles_public_select_column {
   column name
   """
   name
-}
 
-"""
-input type for updating data in table "profiles_public"
-"""
-input profiles_public_set_input {
-  address: String
-  avatar: String
-  id: bigint
-  name: citext
+  """
+  column name
+  """
+  post_count
+
+  """
+  column name
+  """
+  post_count_last_30_days
 }
 
 """
@@ -31909,6 +31841,8 @@ aggregate stddev on columns
 """
 type profiles_public_stddev_fields {
   id: Float
+  post_count: Float
+  post_count_last_30_days: Float
 }
 
 """
@@ -31916,6 +31850,8 @@ aggregate stddev_pop on columns
 """
 type profiles_public_stddev_pop_fields {
   id: Float
+  post_count: Float
+  post_count_last_30_days: Float
 }
 
 """
@@ -31923,6 +31859,8 @@ aggregate stddev_samp on columns
 """
 type profiles_public_stddev_samp_fields {
   id: Float
+  post_count: Float
+  post_count_last_30_days: Float
 }
 
 """
@@ -31948,6 +31886,8 @@ input profiles_public_stream_cursor_value_input {
   avatar: String
   id: bigint
   name: citext
+  post_count: bigint
+  post_count_last_30_days: bigint
 }
 
 """
@@ -31955,23 +31895,8 @@ aggregate sum on columns
 """
 type profiles_public_sum_fields {
   id: bigint
-}
-
-input profiles_public_updates {
-  """
-  increments the numeric columns with given value of the filtered values
-  """
-  _inc: profiles_public_inc_input
-
-  """
-  sets the columns of the filtered rows to the given values
-  """
-  _set: profiles_public_set_input
-
-  """
-  filter the rows which have to be updated
-  """
-  where: profiles_public_bool_exp!
+  post_count: bigint
+  post_count_last_30_days: bigint
 }
 
 """
@@ -31979,6 +31904,8 @@ aggregate var_pop on columns
 """
 type profiles_public_var_pop_fields {
   id: Float
+  post_count: Float
+  post_count_last_30_days: Float
 }
 
 """
@@ -31986,6 +31913,8 @@ aggregate var_samp on columns
 """
 type profiles_public_var_samp_fields {
   id: Float
+  post_count: Float
+  post_count_last_30_days: Float
 }
 
 """
@@ -31993,6 +31922,8 @@ aggregate variance on columns
 """
 type profiles_public_variance_fields {
   id: Float
+  post_count: Float
+  post_count_last_30_days: Float
 }
 
 """

--- a/hasura/schema/user/schema.graphql
+++ b/hasura/schema/user/schema.graphql
@@ -13769,6 +13769,8 @@ type profiles_public {
     where: mutes_bool_exp
   ): [mutes!]!
   name: citext
+  post_count: bigint
+  post_count_last_30_days: bigint
 
   """
   An object relationship
@@ -13789,6 +13791,8 @@ input profiles_public_bool_exp {
   id: bigint_comparison_exp
   mutes: mutes_bool_exp
   name: citext_comparison_exp
+  post_count: bigint_comparison_exp
+  post_count_last_30_days: bigint_comparison_exp
   reputation_score: reputation_scores_bool_exp
 }
 
@@ -13802,6 +13806,8 @@ input profiles_public_order_by {
   id: order_by
   mutes_aggregate: mutes_aggregate_order_by
   name: order_by
+  post_count: order_by
+  post_count_last_30_days: order_by
   reputation_score: reputation_scores_order_by
 }
 
@@ -13828,6 +13834,16 @@ enum profiles_public_select_column {
   column name
   """
   name
+
+  """
+  column name
+  """
+  post_count
+
+  """
+  column name
+  """
+  post_count_last_30_days
 }
 
 """
@@ -13853,6 +13869,8 @@ input profiles_public_stream_cursor_value_input {
   avatar: String
   id: bigint
   name: citext
+  post_count: bigint
+  post_count_last_30_days: bigint
 }
 
 """

--- a/src/features/activities/ActivityList.tsx
+++ b/src/features/activities/ActivityList.tsx
@@ -8,12 +8,9 @@ import { QueryKey, useQueryClient } from 'react-query';
 
 import { LoadingIndicator } from '../../components/LoadingIndicator';
 import { Box, Flex } from '../../ui';
-import {
-  useInfiniteActivities,
-  Where,
-} from '../activities/useInfiniteActivities';
 
 import { ActivityRow } from './ActivityRow';
+import { useInfiniteActivities, Where } from './useInfiniteActivities';
 
 export const ACTIVITIES_QUERY_KEY = 'activities';
 
@@ -22,11 +19,13 @@ export const ActivityList = ({
   where,
   drawer,
   onSettled,
+  noPosts,
 }: {
   queryKey: QueryKey;
   where: Where;
   drawer?: boolean;
   onSettled?: () => void;
+  noPosts?: React.ReactNode;
 }) => {
   const observerRef = useRef<HTMLDivElement>(null);
 
@@ -100,6 +99,10 @@ export const ActivityList = ({
 
   if (!data) {
     return <LoadingIndicator />;
+  }
+
+  if (!data.pages[0]?.length && noPosts) {
+    return <>{noPosts}</>;
   }
 
   return (

--- a/src/features/colinks/PostForm.tsx
+++ b/src/features/colinks/PostForm.tsx
@@ -13,9 +13,11 @@ const PROMPTS = [
 export const PostForm = ({
   showLoading,
   onSave,
+  onSuccess,
 }: {
   showLoading?: boolean;
   onSave?: () => void;
+  onSuccess?: () => void;
 }) => {
   return (
     <ContributionForm
@@ -28,6 +30,7 @@ export const PostForm = ({
       itemNounName={'Post'}
       showToolTip={false}
       onSave={onSave}
+      onSuccess={onSuccess}
     />
   );
 };

--- a/src/features/colinks/fetchCoSouls.ts
+++ b/src/features/colinks/fetchCoSouls.ts
@@ -75,9 +75,16 @@ export const fetchCoSoul = async (address: string) => {
     }
   );
   const cosoul = cosouls.pop();
+
   return cosoul
     ? {
         ...cosoul,
+        profile_public: {
+          ...cosoul.profile_public,
+          post_count: cosoul?.profile_public?.post_count ?? 0,
+          post_count_last_30_days:
+            cosoul?.profile_public?.post_count_last_30_days ?? 0,
+        },
         holders: cosoul.link_holders_aggregate?.aggregate?.sum?.amount ?? 0,
         repScore: cosoul.profile_public?.reputation_score?.total_score ?? 0,
       }

--- a/src/lib/gql/__generated__/zeus/const.ts
+++ b/src/lib/gql/__generated__/zeus/const.ts
@@ -4462,6 +4462,8 @@ export const AllTypesProps: Record<string, any> = {
     id: 'bigint_comparison_exp',
     mutes: 'mutes_bool_exp',
     name: 'citext_comparison_exp',
+    post_count: 'bigint_comparison_exp',
+    post_count_last_30_days: 'bigint_comparison_exp',
     reputation_score: 'reputation_scores_bool_exp',
   },
   profiles_public_order_by: {
@@ -4471,6 +4473,8 @@ export const AllTypesProps: Record<string, any> = {
     id: 'order_by',
     mutes_aggregate: 'mutes_aggregate_order_by',
     name: 'order_by',
+    post_count: 'order_by',
+    post_count_last_30_days: 'order_by',
     reputation_score: 'reputation_scores_order_by',
   },
   profiles_public_select_column: true,
@@ -4481,6 +4485,8 @@ export const AllTypesProps: Record<string, any> = {
   profiles_public_stream_cursor_value_input: {
     id: 'bigint',
     name: 'citext',
+    post_count: 'bigint',
+    post_count_last_30_days: 'bigint',
   },
   profiles_select_column: true,
   profiles_set_input: {},
@@ -8824,6 +8830,8 @@ export const ReturnTypes: Record<string, any> = {
     id: 'bigint',
     mutes: 'mutes',
     name: 'citext',
+    post_count: 'bigint',
+    post_count_last_30_days: 'bigint',
     reputation_score: 'reputation_scores',
   },
   query_root: {

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -10141,6 +10141,8 @@ export type ValueTypes = {
       ValueTypes['mutes']
     ];
     name?: boolean | `@${string}`;
+    post_count?: boolean | `@${string}`;
+    post_count_last_30_days?: boolean | `@${string}`;
     /** An object relationship */
     reputation_score?: ValueTypes['reputation_scores'];
     __typename?: boolean | `@${string}`;
@@ -10156,6 +10158,11 @@ export type ValueTypes = {
     id?: ValueTypes['bigint_comparison_exp'] | undefined | null;
     mutes?: ValueTypes['mutes_bool_exp'] | undefined | null;
     name?: ValueTypes['citext_comparison_exp'] | undefined | null;
+    post_count?: ValueTypes['bigint_comparison_exp'] | undefined | null;
+    post_count_last_30_days?:
+      | ValueTypes['bigint_comparison_exp']
+      | undefined
+      | null;
     reputation_score?:
       | ValueTypes['reputation_scores_bool_exp']
       | undefined
@@ -10169,6 +10176,8 @@ export type ValueTypes = {
     id?: ValueTypes['order_by'] | undefined | null;
     mutes_aggregate?: ValueTypes['mutes_aggregate_order_by'] | undefined | null;
     name?: ValueTypes['order_by'] | undefined | null;
+    post_count?: ValueTypes['order_by'] | undefined | null;
+    post_count_last_30_days?: ValueTypes['order_by'] | undefined | null;
     reputation_score?:
       | ValueTypes['reputation_scores_order_by']
       | undefined
@@ -10189,6 +10198,8 @@ export type ValueTypes = {
     avatar?: string | undefined | null;
     id?: ValueTypes['bigint'] | undefined | null;
     name?: ValueTypes['citext'] | undefined | null;
+    post_count?: ValueTypes['bigint'] | undefined | null;
+    post_count_last_30_days?: ValueTypes['bigint'] | undefined | null;
   };
   /** select columns of table "profiles" */
   ['profiles_select_column']: profiles_select_column;
@@ -20420,6 +20431,8 @@ export type ModelTypes = {
     /** An array relationship */
     mutes: Array<GraphQLTypes['mutes']>;
     name?: GraphQLTypes['citext'] | undefined;
+    post_count?: GraphQLTypes['bigint'] | undefined;
+    post_count_last_30_days?: GraphQLTypes['bigint'] | undefined;
     /** An object relationship */
     reputation_score?: GraphQLTypes['reputation_scores'] | undefined;
   };
@@ -29430,6 +29443,8 @@ export type GraphQLTypes = {
     /** An array relationship */
     mutes: Array<GraphQLTypes['mutes']>;
     name?: GraphQLTypes['citext'] | undefined;
+    post_count?: GraphQLTypes['bigint'] | undefined;
+    post_count_last_30_days?: GraphQLTypes['bigint'] | undefined;
     /** An object relationship */
     reputation_score?: GraphQLTypes['reputation_scores'] | undefined;
   };
@@ -29444,6 +29459,8 @@ export type GraphQLTypes = {
     id?: GraphQLTypes['bigint_comparison_exp'] | undefined;
     mutes?: GraphQLTypes['mutes_bool_exp'] | undefined;
     name?: GraphQLTypes['citext_comparison_exp'] | undefined;
+    post_count?: GraphQLTypes['bigint_comparison_exp'] | undefined;
+    post_count_last_30_days?: GraphQLTypes['bigint_comparison_exp'] | undefined;
     reputation_score?: GraphQLTypes['reputation_scores_bool_exp'] | undefined;
   };
   /** Ordering options when selecting data from "profiles_public". */
@@ -29454,6 +29471,8 @@ export type GraphQLTypes = {
     id?: GraphQLTypes['order_by'] | undefined;
     mutes_aggregate?: GraphQLTypes['mutes_aggregate_order_by'] | undefined;
     name?: GraphQLTypes['order_by'] | undefined;
+    post_count?: GraphQLTypes['order_by'] | undefined;
+    post_count_last_30_days?: GraphQLTypes['order_by'] | undefined;
     reputation_score?: GraphQLTypes['reputation_scores_order_by'] | undefined;
   };
   /** select columns of table "profiles_public" */
@@ -29471,6 +29490,8 @@ export type GraphQLTypes = {
     avatar?: string | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
     name?: GraphQLTypes['citext'] | undefined;
+    post_count?: GraphQLTypes['bigint'] | undefined;
+    post_count_last_30_days?: GraphQLTypes['bigint'] | undefined;
   };
   /** select columns of table "profiles" */
   ['profiles_select_column']: profiles_select_column;
@@ -32942,6 +32963,8 @@ export const enum profiles_public_select_column {
   avatar = 'avatar',
   id = 'id',
   name = 'name',
+  post_count = 'post_count',
+  post_count_last_30_days = 'post_count_last_30_days',
 }
 /** select columns of table "profiles" */
 export const enum profiles_select_column {

--- a/src/pages/CoSoulExplorePage/CoSoulItem.tsx
+++ b/src/pages/CoSoulExplorePage/CoSoulItem.tsx
@@ -11,7 +11,7 @@ export const CoSoulItem = ({
   cosoul: CoSoul;
   expandedView?: boolean;
 }) => {
-  const repScore = cosoul.profile_public?.reputation_score?.total_score || 0;
+  const repScore = cosoul.repScore;
   const tier1 = 2;
   const tier2 = 80;
   const tier3 = 100;
@@ -23,6 +23,17 @@ export const CoSoulItem = ({
       : repScore > tier1
       ? 'gold'
       : 'transparent';
+
+  // const { data } = useQuery(['posts_count', cosoul.address], async () => {
+  //   client.query(
+  //     {
+  //       contri,
+  //     },
+  //     {
+  //       operationName: 'posts_count_for_cosoul',
+  //     }
+  //   );
+  // });
   return (
     <AppLink
       to={
@@ -115,9 +126,33 @@ export const CoSoulItem = ({
                 </Text>
               </Flex>
             )}
-            <Flex css={{ alignItems: 'center', flexShrink: 0, gap: '$xs' }}>
-              <Text size={'xs'}>Rep</Text>
-              <Text semibold>{repScore ?? 0}</Text>
+            <Flex
+              css={{
+                alignItems: 'center',
+                flexShrink: 0,
+                width: '100%',
+                gap: '$md',
+                justifyContent: 'space-between',
+              }}
+            >
+              <Flex css={{ gap: '$xs', alignItems: 'center' }}>
+                <Text size={'xs'}>Rep</Text>
+                <Text semibold>{repScore ?? 0}</Text>
+              </Flex>
+              <Flex css={{ gap: '$xs', alignItems: 'center' }}>
+                <Text size={'xs'}>Holders</Text>
+                <Text semibold>{cosoul.holders ?? 0}</Text>
+              </Flex>
+              <Flex css={{ gap: '$xs', alignItems: 'center' }}>
+                <Text size={'xs'}>Posts</Text>
+                <Text semibold>{cosoul.profile_public?.post_count ?? 0}</Text>
+              </Flex>
+              <Flex css={{ gap: '$xs', alignItems: 'center' }}>
+                <Text size={'xs'}>Posts/30d</Text>
+                <Text semibold>
+                  {cosoul.profile_public?.post_count_last_30_days ?? 0}
+                </Text>
+              </Flex>
             </Flex>
           </Flex>
           {expandedView && (
@@ -129,10 +164,10 @@ export const CoSoulItem = ({
                 alignItems: 'flex-start',
               }}
             >
-              {cosoul.link_holders_aggregate.aggregate?.sum?.amount && (
+              {cosoul.holders !== 0 && (
                 <Text tag size="xs" color="complete">
                   <Users />
-                  {cosoul.link_holders_aggregate.aggregate?.sum?.amount}
+                  {cosoul.holders}
                 </Text>
               )}
             </Flex>

--- a/src/pages/CoSoulExplorePage/CoSoulItem.tsx
+++ b/src/pages/CoSoulExplorePage/CoSoulItem.tsx
@@ -6,10 +6,10 @@ import isFeatureEnabled from 'config/features';
 
 export const CoSoulItem = ({
   cosoul,
-  expandedView = true,
+  exploreView = true,
 }: {
   cosoul: CoSoul;
-  expandedView?: boolean;
+  exploreView?: boolean;
 }) => {
   const repScore = cosoul.repScore;
   const tier1 = 2;
@@ -23,21 +23,10 @@ export const CoSoulItem = ({
       : repScore > tier1
       ? 'gold'
       : 'transparent';
-
-  // const { data } = useQuery(['posts_count', cosoul.address], async () => {
-  //   client.query(
-  //     {
-  //       contri,
-  //     },
-  //     {
-  //       operationName: 'posts_count_for_cosoul',
-  //     }
-  //   );
-  // });
   return (
     <AppLink
       to={
-        expandedView && isFeatureEnabled('soulkeys')
+        exploreView && isFeatureEnabled('soulkeys')
           ? paths.coLinksProfile(cosoul.address)
           : paths.cosoulView(cosoul.address)
       }
@@ -48,7 +37,7 @@ export const CoSoulItem = ({
           overflow: 'hidden',
           borderRadius: '$4',
           position: 'relative',
-          '&:hover': expandedView
+          '&:hover': exploreView
             ? {
                 cursor: 'pointer',
                 transition: 'all 0.2s ease-in-out',
@@ -100,7 +89,7 @@ export const CoSoulItem = ({
               color: '$text',
             }}
           >
-            {expandedView && (
+            {exploreView && (
               <Flex
                 css={{
                   gap: '$sm',
@@ -130,7 +119,7 @@ export const CoSoulItem = ({
               css={{
                 alignItems: 'center',
                 flexShrink: 0,
-                width: '100%',
+                width: exploreView ? undefined : '100%',
                 gap: '$md',
                 justifyContent: 'space-between',
               }}
@@ -139,23 +128,29 @@ export const CoSoulItem = ({
                 <Text size={'xs'}>Rep</Text>
                 <Text semibold>{repScore ?? 0}</Text>
               </Flex>
-              <Flex css={{ gap: '$xs', alignItems: 'center' }}>
-                <Text size={'xs'}>Holders</Text>
-                <Text semibold>{cosoul.holders ?? 0}</Text>
-              </Flex>
-              <Flex css={{ gap: '$xs', alignItems: 'center' }}>
-                <Text size={'xs'}>Posts</Text>
-                <Text semibold>{cosoul.profile_public?.post_count ?? 0}</Text>
-              </Flex>
-              <Flex css={{ gap: '$xs', alignItems: 'center' }}>
-                <Text size={'xs'}>Posts/30d</Text>
-                <Text semibold>
-                  {cosoul.profile_public?.post_count_last_30_days ?? 0}
-                </Text>
-              </Flex>
+              {!exploreView && (
+                <>
+                  <Flex css={{ gap: '$xs', alignItems: 'center' }}>
+                    <Text size={'xs'}>Holders</Text>
+                    <Text semibold>{cosoul.holders ?? 0}</Text>
+                  </Flex>
+                  <Flex css={{ gap: '$xs', alignItems: 'center' }}>
+                    <Text size={'xs'}>Posts</Text>
+                    <Text semibold>
+                      {cosoul.profile_public?.post_count ?? 0}
+                    </Text>
+                  </Flex>
+                  <Flex css={{ gap: '$xs', alignItems: 'center' }}>
+                    <Text size={'xs'}>Posts/30d</Text>
+                    <Text semibold>
+                      {cosoul.profile_public?.post_count_last_30_days ?? 0}
+                    </Text>
+                  </Flex>
+                </>
+              )}
             </Flex>
           </Flex>
-          {expandedView && (
+          {exploreView && (
             <Flex
               css={{
                 p: '$sm',

--- a/src/pages/ContributionsPage/ContributionForm.tsx
+++ b/src/pages/ContributionsPage/ContributionForm.tsx
@@ -46,6 +46,7 @@ export const ContributionForm = ({
   css,
   showLoading,
   onSave,
+  onSuccess,
   placeholder = CONT_DEFAULT_HELP_TEXT,
   itemNounName = 'Contribution',
   showToolTip = true,
@@ -60,6 +61,7 @@ export const ContributionForm = ({
   css?: CSS;
   showLoading?: boolean;
   onSave?: () => void;
+  onSuccess?: () => void;
   placeholder?: string;
   itemNounName?: string;
   showToolTip?: boolean;
@@ -179,6 +181,7 @@ export const ContributionForm = ({
     useMutation(createContributionMutation, {
       onSuccess: newContribution => {
         refetchContributions();
+        onSuccess && onSuccess();
         queryClient.invalidateQueries({
           queryKey: [QUERY_KEY_ALLOCATE_CONTRIBUTIONS],
         });

--- a/src/pages/colinks/ViewProfilePage/CoLinksProfileHeader.tsx
+++ b/src/pages/colinks/ViewProfilePage/CoLinksProfileHeader.tsx
@@ -110,22 +110,40 @@ export const CoLinksProfileHeader = ({
                   </Text>
                 )}
                 {socials?.github && (
-                  <Link
+                  <Flex
+                    as={Link}
                     href={`https://github.com/${socials?.github}`}
                     target="_blank"
                     rel="noreferrer"
+                    css={{
+                      alignItems: 'center',
+                      gap: '$xs',
+                      color: '$neutral',
+                      '&:hover': {
+                        color: '$text',
+                      },
+                    }}
                   >
                     <Github nostroke /> {socials?.github}
-                  </Link>
+                  </Flex>
                 )}
                 {socials?.twitter && (
-                  <Link
+                  <Flex
+                    as={Link}
                     href={`https://twitter.com/${socials?.twitter}`}
                     target="_blank"
                     rel="noreferrer"
+                    css={{
+                      alignItems: 'center',
+                      gap: '$xs',
+                      color: '$neutral',
+                      '&:hover': {
+                        color: '$text',
+                      },
+                    }}
                   >
                     <Twitter nostroke /> {socials?.twitter}
-                  </Link>
+                  </Flex>
                 )}
               </Flex>
             </Flex>

--- a/src/pages/colinks/ViewProfilePage/CoLinksProfileHeader.tsx
+++ b/src/pages/colinks/ViewProfilePage/CoLinksProfileHeader.tsx
@@ -1,7 +1,9 @@
+import assert from 'assert';
 import { Dispatch, useEffect, useState } from 'react';
 
 import { CoLinks } from '@coordinape/hardhat/dist/typechain';
 import { QUERY_KEY_COLINKS } from 'features/colinks/CoLinksWizard';
+import { CoSoul } from 'features/colinks/fetchCoSouls';
 import { PostForm } from 'features/colinks/PostForm';
 import { useCoLinks } from 'features/colinks/useCoLinks';
 import { client } from 'lib/gql/client';
@@ -176,11 +178,22 @@ export const CoLinksProfileHeader = ({
             <PostForm
               showLoading={showLoading}
               onSuccess={() =>
-                queryClient.invalidateQueries([
-                  QUERY_KEY_COLINKS,
-                  targetAddress,
-                  'cosoul',
-                ])
+                queryClient.setQueryData<CoSoul>(
+                  [QUERY_KEY_COLINKS, targetAddress, 'cosoul'],
+                  oldData => {
+                    assert(oldData);
+
+                    return {
+                      ...oldData,
+                      profile_public: {
+                        ...oldData.profile_public,
+                        post_count: oldData.profile_public?.post_count + 1,
+                        post_count_last_30_days:
+                          oldData.profile_public?.post_count_last_30_days + 1,
+                      },
+                    };
+                  }
+                )
               }
               onSave={() => setShowLoading(true)}
             />

--- a/src/pages/colinks/ViewProfilePage/CoLinksProfileHeader.tsx
+++ b/src/pages/colinks/ViewProfilePage/CoLinksProfileHeader.tsx
@@ -1,10 +1,11 @@
 import { Dispatch, useEffect, useState } from 'react';
 
 import { CoLinks } from '@coordinape/hardhat/dist/typechain';
+import { QUERY_KEY_COLINKS } from 'features/colinks/CoLinksWizard';
 import { PostForm } from 'features/colinks/PostForm';
 import { useCoLinks } from 'features/colinks/useCoLinks';
 import { client } from 'lib/gql/client';
-import { useQuery } from 'react-query';
+import { useQueryClient, useQuery } from 'react-query';
 
 import { Mutes } from '../../../features/colinks/Mutes';
 import { Github, Settings, Twitter } from 'icons/__generated';
@@ -35,6 +36,7 @@ export const CoLinksProfileHeader = ({
 
   const { profile, imMuted, mutedThem } = target;
 
+  const queryClient = useQueryClient();
   const isCurrentUser =
     targetAddress.toLowerCase() == currentUserAddress.toLowerCase();
 
@@ -173,6 +175,13 @@ export const CoLinksProfileHeader = ({
           <Flex css={{ maxWidth: '$readable' }}>
             <PostForm
               showLoading={showLoading}
+              onSuccess={() =>
+                queryClient.invalidateQueries([
+                  QUERY_KEY_COLINKS,
+                  targetAddress,
+                  'cosoul',
+                ])
+              }
               onSave={() => setShowLoading(true)}
             />
           </Flex>

--- a/src/pages/colinks/ViewProfilePage/ViewProfilePageContents.tsx
+++ b/src/pages/colinks/ViewProfilePage/ViewProfilePageContents.tsx
@@ -174,7 +174,7 @@ const PageContents = ({
     address: currentUserAddress,
     target: targetAddress,
   });
-  const subjectIsCurrentUser =
+  const targetIsCurrentUser =
     targetAddress.toLowerCase() == currentUserAddress.toLowerCase();
 
   const [needsToBuyLink, setNeedsToBuyLink] = useState<boolean | undefined>(
@@ -192,7 +192,7 @@ const PageContents = ({
     }
   );
 
-  const needsBootstrapping = subjectIsCurrentUser && balance == 0;
+  const needsBootstrapping = targetIsCurrentUser && balance == 0;
   const ownedByTarget = targetBalance !== undefined && targetBalance > 0;
   const ownedByMe = balance !== undefined && balance > 0;
   const weAreLinked = ownedByTarget || ownedByMe;
@@ -307,7 +307,10 @@ const PageContents = ({
               }}
               noPosts={
                 <Panel noBorder>
-                  {targetProfile.profile.name} {`hasn't posted yet.`}
+                  {targetIsCurrentUser
+                    ? "You haven't"
+                    : `${targetProfile.profile.name} hasn't`}{' '}
+                  {'posted yet.'}
                 </Panel>
               }
             />
@@ -315,7 +318,7 @@ const PageContents = ({
         )}
       </Flex>
       <Flex column css={{ flex: 1, gap: '$lg', mr: '$xl' }}>
-        <CoSoulItem cosoul={cosoul} expandedView={false} />
+        <CoSoulItem cosoul={cosoul} exploreView={false} />
         {needsToBuyLink === false && (
           <RightColumnSection>
             <Flex column css={{ width: '100%' }}>

--- a/src/pages/colinks/ViewProfilePage/ViewProfilePageContents.tsx
+++ b/src/pages/colinks/ViewProfilePage/ViewProfilePageContents.tsx
@@ -305,6 +305,11 @@ const PageContents = ({
                 private_stream: { _eq: true },
                 actor_profile_id: { _eq: targetProfile.profile.id },
               }}
+              noPosts={
+                <Panel noBorder>
+                  {targetProfile.profile.name} {`hasn't posted yet.`}
+                </Panel>
+              }
             />
           </Flex>
         )}

--- a/src/ui/Panel/Panel.tsx
+++ b/src/ui/Panel/Panel.tsx
@@ -176,6 +176,11 @@ export const Panel = styled(PanelBase, {
         '@sm': { gridTemplateColumns: '1fr' },
       },
     },
+    noBorder: {
+      true: {
+        border: 'none',
+      },
+    },
   },
 
   defaultVariants: {


### PR DESCRIPTION
…soul view

## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ad25853</samp>

This pull request adds new fields and features related to the number of posts and the number of posts in the last 30 days for each profile in the `profiles_public` table. It also improves the GraphQL schema, the performance, the error handling, and the UI of the profile and co-soul pages. It also removes some unnecessary or redundant fields and comments. It includes changes to the `api-lib`, `hasura`, and `src` directories, as well as migration files.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ad25853</samp>

> _We're counting posts and co-souls, me hearties, yo ho ho_
> _We're updating `profiles_public` with SQL, yo ho ho_
> _We're fixing bugs and adding props, me hearties, yo ho ho_
> _We're pulling hard on the code review, on the count of three, yo ho ho_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ad25853</samp>

*  Remove unused fields and input types for the profiles_public table from the GraphQL schema and the Zeus library, as this table is read-only and not updated or deleted by the users ([link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0L5215-L5217), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0L5627-L5632), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0L6345-L6352), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0L8385-R8371), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0L8407-R8395), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0L15730), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0L15848-L15849), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0L16029-L16030), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8L19921-L19930), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8L21367-L21386), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8L23890-L23919), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8L31794-R31743), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8L31835-R31782),  [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060R4476-R4477), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060R4488-R4489))
* Add post_count and post_count_last_30_days fields to the profiles_public table, the GraphQL schema, and the Zeus library, to show the number of posts and the number of posts in the last 30 days for each profile ([link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R8377-R8378), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0L8421-R8405), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R17411-R17412), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R17434-R17435), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R17442-R17443), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0L17470-R17486), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-412dbd6aa74a0169e4120157039da14d29381e4a3e1cc6551f78afc1616b8e65L46-R51), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-e5611acc43de3e85eb1a0b8299a9eea0ab6df72f9c368b56dd10d6953043ae50R1-R6), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-5b4137f8ae8836f03ef415eab8506f6317f31dfdb731999ef93eaf933625c33fR1-R10), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R31681-R31682), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R31720-R31721), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R31753-R31754), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R31766-R31767),  [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R31844-R31845), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R31853-R31854), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R31862-R31863), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R31889-R31890), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R31907-R31908), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R31916-R31917), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R31925-R31926), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebR13772-R13773), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebR13794-R13795), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebR13809-R13810), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebR13837-R13846), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebR13872-R13873), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060R4465-R4466), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060R8833-R8834))
* Remove the comment field from the link_tx table metadata, as it is empty and not needed ([link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-82b116c142ab452801f8e786c39c312d4145d78133982dd9f5881b8cd47a7d88L38-R38))
* Fix the import path of the useInfiniteActivities hook in the `ActivityList.tsx` file, and reorder the imports alphabetically ([link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-fdea9c6f538e8e5aa3ce7995d63738e9742aadac9c6fde698457c945e5659b4cL11-R13))
* Add the noPosts prop to the ActivityList component and the ActivityListProps type, to render a custom message when there are no activities to show ([link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-fdea9c6f538e8e5aa3ce7995d63738e9742aadac9c6fde698457c945e5659b4cR22), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-fdea9c6f538e8e5aa3ce7995d63738e9742aadac9c6fde698457c945e5659b4cR28), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-fdea9c6f538e8e5aa3ce7995d63738e9742aadac9c6fde698457c945e5659b4cR104-R107))
* Fetch the post_count and post_count_last_30_days fields for the co-souls in the fetchCoSouls function, and add the holders and repScore properties to each cosoul object, calculated from the link_holders_aggregate and reputation_score fields ([link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-1744b7807b2980a18d18478d5b5c311567d73069e5fa57dd8d1e102ae4acc85cR15-R16), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-1744b7807b2980a18d18478d5b5c311567d73069e5fa57dd8d1e102ae4acc85cL53-R59), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-1744b7807b2980a18d18478d5b5c311567d73069e5fa57dd8d1e102ae4acc85cL64-R70), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-1744b7807b2980a18d18478d5b5c311567d73069e5fa57dd8d1e102ae4acc85cL93-R84))
* Replace the repScore variable with the repScore property of the cosoul object in the `CoSoulItem.tsx` file, and comment out the code that uses the useQuery hook to fetch the number of posts for each co-soul ([link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-6b70865268dd8a1b15388c44259477b056ccbac3f232cf94cda5f3f514bd94e0L14-R14), [link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-6b70865268dd8a1b15388c44259477b056ccbac3f232cf94cda5f3f514bd94e0R26-R36))
* Add four flex components to the `CoSoulItem.tsx` file, to show the repScore, holders, post_count, and post_count_last_30_days properties of each co-soul, styled with icons, text, and colors ([link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-6b70865268dd8a1b15388c44259477b056ccbac3f232cf94cda5f3f514bd94e0L118-R155))
* Replace the link_holders_aggregate.aggregate?.sum?.amount field with the holders property of the cosoul object in the `CoSoulItem.tsx` file ([link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-6b70865268dd8a1b15388c44259477b056ccbac3f232cf94cda5f3f514bd94e0L132-R170))
* Wrap the links to the github and twitter profiles in flex components in the `CoLinksProfileHeader.tsx` file, styled with icons, text, and colors ([link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-4aa6eb6c4daadd3504e9da12667848694f871f63bd5176ba8efbd34534abdc64L113-R146))
* Add the noPosts prop to the ActivityList component in the `ViewProfilePageContents.tsx` file, to render a custom message when there are no activities to show for the target profile ([link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-cff4a8eedd6bc4e327e10f459d5d7120705b2ccbcf88abb2c175985ad128712cR308-R312))
* Add the noBorder prop to the Panel component and the PanelProps type in the `Panel.tsx` file, to remove the border of the panel when it is set to true ([link](https://github.com/coordinape/coordinape/pull/2447/files?diff=unified&w=0#diff-c6c2d66da2cff003b4aefd655db62662d8cffe76687af1e3b8260af9f410a663R179-R183))
