### PR TITLE
properly invalidate profile when setting name/avatar

### DIFF
--- a/src/components/AvatarUpload.tsx
+++ b/src/components/AvatarUpload.tsx
@@ -3,7 +3,9 @@ import React, { useState } from 'react';
 import { fileToBase64 } from 'lib/base64';
 import { updateProfileAvatar } from 'lib/gql/mutations';
 import { MAX_IMAGE_BYTES_LENGTH_BASE64 } from 'lib/images';
+import { useQueryClient } from 'react-query';
 
+import { QUERY_KEY_NAV } from '../features/nav';
 import { LoadingModal } from 'components';
 import { useToast } from 'hooks';
 import { useFetchManifest } from 'hooks/legacyApi';
@@ -25,6 +27,7 @@ export const AvatarUpload = ({ original }: { original?: string }) => {
 
   const { showError } = useToast();
   const fetchManifest = useFetchManifest();
+  const queryClient = useQueryClient();
 
   const uploadAvatar = async (avatar: File) => {
     const image_data_base64 = await fileToBase64(avatar);
@@ -64,6 +67,7 @@ export const AvatarUpload = ({ original }: { original?: string }) => {
 
         //to be fixed when profile data is fetched separately
         await fetchManifest();
+        queryClient.invalidateQueries([QUERY_KEY_NAV]);
         setAvatarFile(undefined);
         setUploadComplete(true);
       }

--- a/src/pages/AccountPage/EditProfileInfo.tsx
+++ b/src/pages/AccountPage/EditProfileInfo.tsx
@@ -6,9 +6,10 @@ import { client } from 'lib/gql/client';
 import { updateMyProfile } from 'lib/gql/mutations';
 import { isValidENS, zUsername } from 'lib/zod/formHelpers';
 import { SubmitHandler, useForm } from 'react-hook-form';
-import { useMutation, useQuery } from 'react-query';
+import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { z } from 'zod';
 
+import { QUERY_KEY_NAV } from '../../features/nav';
 import { AvatarUpload, FormInputField, LoadingModal } from 'components';
 import { useToast } from 'hooks';
 import { Button, Flex, Form, Text } from 'ui';
@@ -72,6 +73,8 @@ const EditProfileInfoForm = ({
   const [isSaving, setIsSaving] = useState<boolean>(false);
   const { showError, showSuccess } = useToast();
 
+  const queryClient = useQueryClient();
+
   const {
     control,
     handleSubmit,
@@ -95,6 +98,7 @@ const EditProfileInfoForm = ({
     },
     onSuccess: async () => {
       refetchData();
+      queryClient.invalidateQueries([QUERY_KEY_NAV]);
     },
     onError: err => {
       const error = normalizeError(err);


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a069abb</samp>

The pull request improves the user experience of updating the profile avatar and info by using `react-query` to cache and invalidate the navigation data. It modifies `src/components/AvatarUpload.tsx` and `src/pages/AccountPage/EditProfileInfo.tsx` to share the same query key and refetch the data on changes.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a069abb</samp>

> _Oh, we're the crew of the `react-query` ship_
> _And we sail the web with speed and skill_
> _We fetch and cache and invalidate_
> _To keep our profile avatars up to date_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a069abb</samp>

*  Invalidate navigation data when profile avatar or username is updated ([link](https://github.com/coordinape/coordinape/pull/2448/files?diff=unified&w=0#diff-f59bcccd476d06d62380d0c3150a623977085c0b390ed82fc195792e00b8161eL6-R8), [link](https://github.com/coordinape/coordinape/pull/2448/files?diff=unified&w=0#diff-f59bcccd476d06d62380d0c3150a623977085c0b390ed82fc195792e00b8161eR30), [link](https://github.com/coordinape/coordinape/pull/2448/files?diff=unified&w=0#diff-f59bcccd476d06d62380d0c3150a623977085c0b390ed82fc195792e00b8161eR70), [link](https://github.com/coordinape/coordinape/pull/2448/files?diff=unified&w=0#diff-11d8fe5439cb26332cf972ee873d8c1c480aa04239f670a06442c526b0aedafdL9-R12), [link](https://github.com/coordinape/coordinape/pull/2448/files?diff=unified&w=0#diff-11d8fe5439cb26332cf972ee873d8c1c480aa04239f670a06442c526b0aedafdR76-R77), [link](https://github.com/coordinape/coordinape/pull/2448/files?diff=unified&w=0#diff-11d8fe5439cb26332cf972ee873d8c1c480aa04239f670a06442c526b0aedafdR101))
