### PR TITLE
add navigate(..,{replace:true}) to a few navigate calls that should replace the history

### DIFF
--- a/src/features/colinks/CoLinksContext.tsx
+++ b/src/features/colinks/CoLinksContext.tsx
@@ -43,7 +43,10 @@ const CoLinksProvider: React.FC = ({ children }) => {
       navigate(
         paths.coLinksWizard +
           '?redirect=' +
-          encodeURIComponent(location.pathname)
+          encodeURIComponent(location.pathname),
+        {
+          replace: true,
+        }
       );
     }
   }, [onCorrectChain]);

--- a/src/features/colinks/wizard/WizardSteps.tsx
+++ b/src/features/colinks/wizard/WizardSteps.tsx
@@ -160,10 +160,11 @@ export const WizardSteps = ({
             </>
           ) : (
             <>
-              <Text>Your rep is synced to your minted CoSoul every month.</Text>
               <Text>
-                Minting will create a public view of your stats, username, and
-                organization/circle names; similar to what is displayed below.
+                Your rep score is synced to your minted CoSoul every month.
+              </Text>
+              <Text>
+                Minting will create a public view of your stats and username.
               </Text>
               <Text>
                 There is a small fee of .0032 ETH + gas to mint a CoSoul.

--- a/src/features/colinks/wizard/WizardSteps.tsx
+++ b/src/features/colinks/wizard/WizardSteps.tsx
@@ -82,7 +82,9 @@ export const WizardSteps = ({
   }, [error]);
 
   if (onCorrectChain && redirect) {
-    navigate(redirect);
+    navigate(redirect, {
+      replace: true,
+    });
     return null;
   }
 

--- a/src/features/cosoul/CoSoulButton.tsx
+++ b/src/features/cosoul/CoSoulButton.tsx
@@ -64,7 +64,12 @@ export const CoSoulButton = ({ onReveal }: { onReveal(): void }) => {
           <Flex>
             <Text>Please deposit more ETH to your wallet.</Text>
           </Flex>
-          <Button as={Link} href="https://app.optimism.io/bridge/deposit">
+          <Button
+            as={Link}
+            href="https://app.optimism.io/bridge/deposit"
+            target={'_blank'}
+            rel="noreferrer"
+          >
             Bridge ETH using the Optimism Bridge
           </Button>
         </Panel>

--- a/src/pages/JoinPage/JoinPage.tsx
+++ b/src/pages/JoinPage/JoinPage.tsx
@@ -76,13 +76,17 @@ export const JoinPage = () => {
     if (profile && tokenJoinInfo) {
       const circleId = tokenJoinInfo.circle?.id;
       if (circleId && profile?.users.some(u => u.circle_id === circleId)) {
-        navigate(paths.circle(tokenJoinInfo.circle?.id));
+        navigate(paths.circle(tokenJoinInfo.circle?.id), {
+          replace: true,
+        });
         return;
       }
 
       const orgId = tokenJoinInfo.organization?.id;
       if (orgId && profile?.org_members.some(m => m.org_id === orgId)) {
-        navigate(paths.organization(tokenJoinInfo.organization?.id));
+        navigate(paths.organization(tokenJoinInfo.organization?.id), {
+          replace: true,
+        });
         return;
       }
 

--- a/src/pages/VerifyEmailPage/VerifyEmailPage.tsx
+++ b/src/pages/VerifyEmailPage/VerifyEmailPage.tsx
@@ -49,7 +49,9 @@ export const VerifyEmailPage = () => {
           {isFeatureEnabled('soulkeys') && (
             <Button
               onClick={() => {
-                navigate(paths.coLinks);
+                navigate(paths.coLinks, {
+                  replace: true,
+                });
               }}
             >
               Continue to CoLinks
@@ -57,7 +59,9 @@ export const VerifyEmailPage = () => {
           )}
           <Button
             onClick={() => {
-              navigate(paths.home);
+              navigate(paths.home, {
+                replace: true,
+              });
             }}
           >
             Continue to Gift Circle
@@ -65,7 +69,9 @@ export const VerifyEmailPage = () => {
           <Button
             color="secondary"
             onClick={() => {
-              navigate(paths.account);
+              navigate(paths.account, {
+                replace: true,
+              });
             }}
           >
             View Email Settings


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at fed66e8</samp>

This pull request adds the `replace` option to various `history.push` or `navigate` calls in different components and contexts, to prevent the user from navigating back to pages that are no longer relevant or valid after joining a circle or an organization, verifying their email, or completing the co-links wizard. This improves the user experience and avoids potential errors.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at fed66e8</samp>

> _`replace` option_
> _avoids extra history_
> _no more going back_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at fed66e8</samp>

*  Add `replace` option to `navigate` function calls to avoid creating extra history entries in browser history when redirecting users to different pages using co-links ([link](https://github.com/coordinape/coordinape/pull/2456/files?diff=unified&w=0#diff-96aa5ba0c6e0fe54e8c58399818588ede4ff9ee55d825961864fe2f19aac420dL46-R49), [link](https://github.com/coordinape/coordinape/pull/2456/files?diff=unified&w=0#diff-6d1da6784638c085f8a5454682860ecdac3984f19743788e83f3dfe75e12b69fL85-R87), [link](https://github.com/coordinape/coordinape/pull/2456/files?diff=unified&w=0#diff-1c09625785ab01a2f268a3afeec7348bc97d7b684b5fe4acb3840bc41f26a933L79-R81), [link](https://github.com/coordinape/coordinape/pull/2456/files?diff=unified&w=0#diff-1c09625785ab01a2f268a3afeec7348bc97d7b684b5fe4acb3840bc41f26a933L85-R89), [link](https://github.com/coordinape/coordinape/pull/2456/files?diff=unified&w=0#diff-ec1f7b442bcce103714aff30c98c72c874e7d99e4b761e2fd1ab2fb2040a17c3L52-R54), [link](https://github.com/coordinape/coordinape/pull/2456/files?diff=unified&w=0#diff-ec1f7b442bcce103714aff30c98c72c874e7d99e4b761e2fd1ab2fb2040a17c3L60-R64), [link](https://github.com/coordinape/coordinape/pull/2456/files?diff=unified&w=0#diff-ec1f7b442bcce103714aff30c98c72c874e7d99e4b761e2fd1ab2fb2040a17c3L68-R74))
