### PR TITLE
fetch poap once a day

### DIFF
--- a/hasura/metadata/cron_triggers.yaml
+++ b/hasura/metadata/cron_triggers.yaml
@@ -57,7 +57,7 @@
   comment: manage time-based epoch business logic
 - name: fetchPoapData
   webhook: '{{HASURA_API_BASE_URL}}/cron/fetchPoapData'
-  schedule: 0 * * * *
+  schedule: 0 0 * * *
   include_in_metadata: true
   payload: {}
   headers:


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2d2c3d5</samp>

Reduced the frequency of the `fetchPoapData` cron job from hourly to daily. This improves the performance and reliability of the POAP integration feature.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2d2c3d5</samp>

> _`fetchPoapData` slows_
> _Calls the API less often_
> _Winter of waiting_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2d2c3d5</samp>

* Reduced the frequency of the `fetchPoapData` cron trigger from every hour to once a day ([link](https://github.com/coordinape/coordinape/pull/2459/files?diff=unified&w=0#diff-04d72cab6282bd0e7c1a13021a29b0efdd45cdda4be6fe1ea9d821b2c5e0ae1eL60-R60)) to improve the performance and reliability of the POAP integration feature in `hasura/metadata/cron_triggers.yaml`
