### PR TITLE
fix delete button; add hover on comments

### DIFF
--- a/src/features/activities/ContributionRow.tsx
+++ b/src/features/activities/ContributionRow.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import { useNavQuery } from 'features/nav/getNavData';
+import { scaleBounce } from 'keyframes';
 import { DateTime } from 'luxon';
 
 import { usePathContext } from '../../routes/usePathInfo';
@@ -33,6 +34,8 @@ export const ContributionRow = ({
 
   const { isCoLinksPage } = useIsCoLinksPage();
 
+  const commentCount = activity.replies_aggregate.aggregate?.count ?? 0;
+
   return (
     <Flex css={{ overflowX: 'clip' }}>
       <Flex
@@ -43,6 +46,11 @@ export const ContributionRow = ({
           p: drawer ? '$sm $sm $md 0' : '$md',
           borderRadius: '$2',
           flexGrow: 1,
+          '&:hover': {
+            '.commentCounts': {
+              animation: `${scaleBounce} .5s ease-in-out`,
+            },
+          },
         }}
       >
         {!drawer && <ActivityAvatar profile={activity.actor_profile_public} />}
@@ -123,16 +131,16 @@ export const ContributionRow = ({
                   reactions={activity.reactions}
                   drawer={drawer}
                 />
-
-                {activity.private_stream && (
-                  <IconButton
-                    css={{ width: 'auto', pr: '$xs' }}
-                    onClick={() => setDisplayComments(prev => !prev)}
-                  >
-                    {activity.replies_aggregate.aggregate?.count ?? 0}{' '}
-                    <MessageSquare css={{ ml: '$sm' }} />
-                  </IconButton>
-                )}
+                <Flex className="commentCounts">
+                  {activity.private_stream && (
+                    <IconButton
+                      css={{ width: 'auto', pr: '$xs' }}
+                      onClick={() => setDisplayComments(prev => !prev)}
+                    >
+                      {commentCount} <MessageSquare css={{ ml: '$sm' }} />
+                    </IconButton>
+                  )}
+                </Flex>
               </Flex>
             </>
           )}

--- a/src/features/activities/replies/RepliesBox.tsx
+++ b/src/features/activities/replies/RepliesBox.tsx
@@ -1,3 +1,4 @@
+import { useAuthStore } from 'features/auth';
 import { order_by } from 'lib/gql/__generated__/zeus';
 import { client } from 'lib/gql/client';
 import { DateTime } from 'luxon';
@@ -21,6 +22,8 @@ export const RepliesBox = ({
   activityId: number;
   activityActorId: number;
 }) => {
+  const profileId = useAuthStore(state => state.profileId);
+
   const fetchReplies = async () => {
     const { replies } = await client.query(
       {
@@ -34,6 +37,7 @@ export const RepliesBox = ({
             reply: true,
             updated_at: true,
             profile_public: {
+              id: true,
               name: true,
               address: true,
               avatar: true,
@@ -117,18 +121,20 @@ export const RepliesBox = ({
                         {DateTime.fromISO(reply.updated_at).toRelative()}
                       </Text>
                     </Flex>
-                    <Flex>
-                      <ConfirmationModal
-                        trigger={
-                          <IconButton>
-                            <Trash2 />
-                          </IconButton>
-                        }
-                        action={() => deleteReply(reply.id)}
-                        description="Are you sure you want to delete this reply?"
-                        yesText="Yes, delete it!"
-                      />
-                    </Flex>
+                    {reply.profile_public?.id === profileId && (
+                      <Flex>
+                        <ConfirmationModal
+                          trigger={
+                            <IconButton>
+                              <Trash2 />
+                            </IconButton>
+                          }
+                          action={() => deleteReply(reply.id)}
+                          description="Are you sure you want to delete this reply?"
+                          yesText="Yes, delete it!"
+                        />
+                      </Flex>
+                    )}
                   </Flex>
                   <MarkdownPreview
                     key={reply.id}

--- a/src/keyframes.ts
+++ b/src/keyframes.ts
@@ -51,6 +51,7 @@ export const sync = keyframes({
     rotate: '-20deg',
   },
 });
+
 export const pulse = keyframes({
   '0%': {
     transform: 'scale(1, 0.9)',
@@ -59,6 +60,18 @@ export const pulse = keyframes({
   '100%': {
     transform: 'scale(2, 4)',
     opacity: 0,
+  },
+});
+
+export const scaleBounce = keyframes({
+  '0%': {
+    transform: 'scale(1)',
+  },
+  '50%': {
+    transform: 'scale(1.3)',
+  },
+  '100%': {
+    transform: 'scale(1)',
   },
 });
 


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6cd5456</samp>

This pull request adds a bouncing animation to the comment count icon and enables users to delete their own replies in the activities feature. These changes aim to improve the user experience and engagement with the comments. The pull request also improves the code formatting in `src/keyframes.ts`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6cd5456</samp>

> _Oh we're the coders of the sea, we write the features with glee_
> _We make the icons bounce and scale, with `scaleBounce` we never fail_
> _We let the users delete replies, with `useAuthStore` we're so wise_
> _We pull the ropes and sing along, this is our coding sea shanty song_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6cd5456</samp>

*  Add `scaleBounce` animation to comment count icon in `ContributionRow` component ([link](https://github.com/coordinape/coordinape/pull/2462/files?diff=unified&w=0#diff-023fbc171b14533aea64ceea9c06efab32d5448fe6d51fd5f36dd43b7c711274R4), [link](https://github.com/coordinape/coordinape/pull/2462/files?diff=unified&w=0#diff-023fbc171b14533aea64ceea9c06efab32d5448fe6d51fd5f36dd43b7c711274R49-R53), [link](https://github.com/coordinape/coordinape/pull/2462/files?diff=unified&w=0#diff-023fbc171b14533aea64ceea9c06efab32d5448fe6d51fd5f36dd43b7c711274L126-R143), [link](https://github.com/coordinape/coordinape/pull/2462/files?diff=unified&w=0#diff-de9805e6ee2e4ac7746027e81e81746a5cf8525217340a6df6b431547e75a470R66-R77))
*  Import `scaleBounce` animation from `src/keyframes.ts` file ([link](https://github.com/coordinape/coordinape/pull/2462/files?diff=unified&w=0#diff-023fbc171b14533aea64ceea9c06efab32d5448fe6d51fd5f36dd43b7c711274R4), [link](https://github.com/coordinape/coordinape/pull/2462/files?diff=unified&w=0#diff-de9805e6ee2e4ac7746027e81e81746a5cf8525217340a6df6b431547e75a470R54))
*  Fetch and display number of replies for each activity using `replies_aggregate` field ([link](https://github.com/coordinape/coordinape/pull/2462/files?diff=unified&w=0#diff-023fbc171b14533aea64ceea9c06efab32d5448fe6d51fd5f36dd43b7c711274R37-R38), [link](https://github.com/coordinape/coordinape/pull/2462/files?diff=unified&w=0#diff-023fbc171b14533aea64ceea9c06efab32d5448fe6d51fd5f36dd43b7c711274L126-R143))
*  Enable user to delete their own replies in `RepliesBox` component ([link](https://github.com/coordinape/coordinape/pull/2462/files?diff=unified&w=0#diff-dac31dcfdf8e1be9a441ca0b7d102c3d8c44a8ce3727d7284513802667d99dafL120-R137), [link](https://github.com/coordinape/coordinape/pull/2462/files?diff=unified&w=0#diff-dac31dcfdf8e1be9a441ca0b7d102c3d8c44a8ce3727d7284513802667d99dafR40))
*  Import `useAuthStore` hook to access current user's profile ID in `RepliesBox` component ([link](https://github.com/coordinape/coordinape/pull/2462/files?diff=unified&w=0#diff-dac31dcfdf8e1be9a441ca0b7d102c3d8c44a8ce3727d7284513802667d99dafR1), [link](https://github.com/coordinape/coordinape/pull/2462/files?diff=unified&w=0#diff-dac31dcfdf8e1be9a441ca0b7d102c3d8c44a8ce3727d7284513802667d99dafR25-R26))
