### PR TITLE
dedicated page to view a post

### DIFF
--- a/src/features/activities/ActivityRow.tsx
+++ b/src/features/activities/ActivityRow.tsx
@@ -22,11 +22,13 @@ import {
 export const ActivityRow = ({
   activity,
   drawer,
+  focus = false,
 }: {
   activity: Activity;
   drawer?: boolean;
+  focus?: boolean;
 }) => {
-  const valid = validActivity(activity, drawer);
+  const valid = validActivity(activity, focus, drawer);
 
   if (!valid) {
     if (isFeatureEnabled('debug')) {
@@ -53,9 +55,15 @@ export const ActivityRow = ({
   );
 };
 
-const validActivity = (activity: Activity, drawer?: boolean) => {
+const validActivity = (
+  activity: Activity,
+  focus: boolean,
+  drawer?: boolean
+) => {
   if (IsContribution(activity)) {
-    return <ContributionRow activity={activity} drawer={drawer} />;
+    return (
+      <ContributionRow activity={activity} drawer={drawer} focus={focus} />
+    );
   } else if (IsNewUser(activity)) {
     return <NewUserRow activity={activity} />;
   } else if (IsEpochCreated(activity)) {

--- a/src/features/activities/ContributionRow.tsx
+++ b/src/features/activities/ContributionRow.tsx
@@ -3,7 +3,9 @@ import { useState } from 'react';
 import { useNavQuery } from 'features/nav/getNavData';
 import { scaleBounce } from 'keyframes';
 import { DateTime } from 'luxon';
+import { NavLink } from 'react-router-dom';
 
+import { coLinksPaths } from '../../routes/paths';
 import { usePathContext } from '../../routes/usePathInfo';
 import { useIsCoLinksSite } from '../colinks/useIsCoLinksSite';
 import { Edit, MessageSquare } from 'icons/__generated';
@@ -20,9 +22,11 @@ import { Contribution } from './useInfiniteActivities';
 export const ContributionRow = ({
   activity,
   drawer,
+  focus,
 }: {
   activity: Contribution;
   drawer?: boolean;
+  focus: boolean;
 }) => {
   const { inCircle } = usePathContext();
   const { data } = useNavQuery();
@@ -64,9 +68,25 @@ export const ContributionRow = ({
             {!drawer && (
               <Flex>
                 <ActivityProfileName profile={activity.actor_profile_public} />
-                <Text size="small" css={{ color: '$neutral', ml: '$md' }}>
-                  {DateTime.fromISO(activity.created_at).toRelative()}
-                </Text>
+                {activity.private_stream ? (
+                  <Text
+                    as={NavLink}
+                    size="small"
+                    to={coLinksPaths.post(activity.id)}
+                    css={{
+                      color: '$neutral',
+                      ml: '$md',
+                      textDecoration: 'none',
+                      '&:hover': { textDecoration: 'underline' },
+                    }}
+                  >
+                    {DateTime.fromISO(activity.created_at).toRelative()}
+                  </Text>
+                ) : (
+                  <Text size="small" css={{ color: '$neutral', ml: '$md' }}>
+                    {DateTime.fromISO(activity.created_at).toRelative()}
+                  </Text>
+                )}
               </Flex>
             )}
             <Flex
@@ -144,7 +164,7 @@ export const ContributionRow = ({
               </Flex>
             </>
           )}
-          {displayComments && (
+          {(focus || displayComments) && (
             <RepliesBox
               activityId={activity.id}
               activityActorId={activity.actor_profile_public.id}

--- a/src/features/activities/useInfiniteActivities.tsx
+++ b/src/features/activities/useInfiniteActivities.tsx
@@ -2,7 +2,11 @@ import { Dispatch, SetStateAction } from 'react';
 
 import { QueryKey, useInfiniteQuery } from 'react-query';
 
-import { order_by, ValueTypes } from '../../lib/gql/__generated__/zeus';
+import {
+  order_by,
+  Selector,
+  ValueTypes,
+} from '../../lib/gql/__generated__/zeus';
 import { client } from '../../lib/gql/client';
 import { Awaited } from '../../types/shim';
 
@@ -10,6 +14,65 @@ const PAGE_SIZE = 10;
 
 export type Where = ValueTypes['activities_bool_exp'];
 
+export const activitySelector = Selector('activities')({
+  id: true,
+  action: true,
+  created_at: true,
+  private_stream: true,
+  actor_profile_public: {
+    id: true,
+    name: true,
+    avatar: true,
+    address: true,
+    cosoul: {
+      id: true,
+    },
+  },
+  circle: {
+    id: true,
+    name: true,
+    logo: true,
+  },
+  target_profile: {
+    name: true,
+    avatar: true,
+    address: true,
+    cosoul: {
+      id: true,
+    },
+  },
+  contribution: {
+    description: true,
+    created_at: true,
+    id: true,
+  },
+  epoch: {
+    start_date: true,
+    description: true,
+    end_date: true,
+    number: true,
+    ended: true,
+  },
+  replies_aggregate: [
+    {},
+    {
+      aggregate: {
+        count: [{}, true],
+      },
+    },
+  ],
+  reactions: [
+    {},
+    {
+      id: true,
+      reaction: true,
+      profile: {
+        name: true,
+        id: true,
+      },
+    },
+  ],
+});
 const getActivities = async (where: Where, page: number) => {
   const { activities } = await client.query(
     {
@@ -24,65 +87,7 @@ const getActivities = async (where: Where, page: number) => {
           offset: page * PAGE_SIZE,
           limit: PAGE_SIZE,
         },
-        {
-          id: true,
-          action: true,
-          created_at: true,
-          private_stream: true,
-          actor_profile_public: {
-            id: true,
-            name: true,
-            avatar: true,
-            address: true,
-            cosoul: {
-              id: true,
-            },
-          },
-          circle: {
-            id: true,
-            name: true,
-            logo: true,
-          },
-          target_profile: {
-            name: true,
-            avatar: true,
-            address: true,
-            cosoul: {
-              id: true,
-            },
-          },
-          contribution: {
-            description: true,
-            created_at: true,
-            id: true,
-          },
-          epoch: {
-            start_date: true,
-            description: true,
-            end_date: true,
-            number: true,
-            ended: true,
-          },
-          replies_aggregate: [
-            {},
-            {
-              aggregate: {
-                count: [{}, true],
-              },
-            },
-          ],
-          reactions: [
-            {},
-            {
-              id: true,
-              reaction: true,
-              profile: {
-                name: true,
-                id: true,
-              },
-            },
-          ],
-        },
+        activitySelector,
       ],
     },
     {

--- a/src/pages/PostPage.tsx
+++ b/src/pages/PostPage.tsx
@@ -1,0 +1,68 @@
+import assert from 'assert';
+import React from 'react';
+
+import { useQuery } from 'react-query';
+import { useParams } from 'react-router-dom';
+
+import { LoadingModal } from '../components';
+import { ActivityRow } from '../features/activities/ActivityRow';
+import { activitySelector } from '../features/activities/useInfiniteActivities';
+import { CoLinksBasicProfileHeader } from '../features/colinks/CoLinksBasicProfileHeader';
+import { client } from '../lib/gql/client';
+import { Flex, Panel, Text } from '../ui';
+import { SingleColumnLayout } from '../ui/layouts';
+
+const fetchPost = async (id: number) => {
+  const { activities_by_pk } = await client.query(
+    {
+      activities_by_pk: [
+        {
+          id: id,
+        },
+        activitySelector,
+      ],
+    },
+    {
+      operationName: 'fetchPost',
+    }
+  );
+  return activities_by_pk;
+};
+
+export const PostPage = () => {
+  const { id } = useParams();
+  assert(id);
+  const { data: post, isLoading } = useQuery(['post', id], () =>
+    fetchPost(Number(id))
+  );
+
+  if (!post && isLoading) {
+    return <LoadingModal visible={true} />;
+  }
+  if (!post || !post.private_stream) {
+    return (
+      <Panel alert css={{ m: '$xl' }}>
+        <Text>Post not found.</Text>
+      </Panel>
+    );
+  }
+  if (!post.actor_profile_public?.address) {
+    return (
+      <Panel alert css={{ m: '$xl' }}>
+        <Text>{`User doesn't exist.`}</Text>
+      </Panel>
+    );
+  }
+
+  return (
+    <SingleColumnLayout>
+      <CoLinksBasicProfileHeader
+        address={post.actor_profile_public.address}
+        title={'Post'}
+      />
+      <Flex column css={{ maxWidth: '$readable' }}>
+        <ActivityRow key={post.id} activity={post} focus={true} />
+      </Flex>
+    </SingleColumnLayout>
+  );
+};

--- a/src/routes/coLinksRoutes.tsx
+++ b/src/routes/coLinksRoutes.tsx
@@ -25,6 +25,7 @@ import { WizardPage } from '../pages/colinks/wizard/WizardPage';
 import { WizardStart } from '../pages/colinks/wizard/WizardStart';
 import CoSoulExplorePage from '../pages/CoSoulExplorePage/CoSoulExplorePage';
 import { InviteCodePage } from '../pages/InviteCodePage';
+import { PostPage } from '../pages/PostPage';
 
 import { coLinksPaths } from './paths';
 import { RedirectAfterLogin } from './RedirectAfterLogin';
@@ -100,6 +101,7 @@ export const coLinksRoutes = [
       <Route path={coLinksPaths.score(':address')} element={<RepScorePage />} />
       <Route path={coLinksPaths.leaderboard} element={<LeaderboardPage />} />
       <Route path={coLinksPaths.nfts} element={<NFTPage />} />
+      <Route path={coLinksPaths.post(':id')} element={<PostPage />} />
     </Route>
 
     <Route

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -67,6 +67,7 @@ export const coLinksPaths = {
   holders: (address: string) => `/${address}/holders`,
   // email verification
   verify: (uuid: string) => `/email/verify/${uuid}`,
+  post: (id: string) => `/post/${id}`,
 };
 
 export const coSoulPaths = {


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 394ff96</samp>

Added a new feature to the CoLinks site that allows users to view a single activity post with more details and comments. Refactored some components and hooks to improve code quality and reuse. Modified the `ActivityRow`, `ContributionRow`, `useInfiniteActivities`, `coLinksRoutes`, `PostPage`, and `paths` files.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 394ff96</samp>

> _`PostPage` renders_
> _activity with comments_
> _autumn leaves fall_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 394ff96</samp>

*  Add `PostPage` component to render a single activity with more details and comments ([link](https://github.com/coordinape/coordinape/pull/2464/files?diff=unified&w=0#diff-e4eae72e4885a003a3d5cccc38e5c9dc2446059d69d36ea9aa609b1488b16cfcR1-R68), [link](https://github.com/coordinape/coordinape/pull/2464/files?diff=unified&w=0#diff-d08c22126eecd92dba366ab7e8d8334c4b682c8c713cc5d3e4326655e95808f2R28), [link](https://github.com/coordinape/coordinape/pull/2464/files?diff=unified&w=0#diff-d08c22126eecd92dba366ab7e8d8334c4b682c8c713cc5d3e4326655e95808f2R104), [link](https://github.com/coordinape/coordinape/pull/2464/files?diff=unified&w=0#diff-26212c7e58b310fe67e20a7cd969dce535cc31c1f843f741c71641dddc7320ddR70))
*  Modify `ActivityRow` component to accept `focus` prop and pass it to `validActivity` and `ContributionRow` ([link](https://github.com/coordinape/coordinape/pull/2464/files?diff=unified&w=0#diff-a04dac286205cb5930672a694de8e5444b9d03978b5e28e21909ad88c483f423L25-R31))
*  Modify `validActivity` function to use `focus` parameter and `activitySelector` constant for GraphQL query ([link](https://github.com/coordinape/coordinape/pull/2464/files?diff=unified&w=0#diff-a04dac286205cb5930672a694de8e5444b9d03978b5e28e21909ad88c483f423L56-R66), [link](https://github.com/coordinape/coordinape/pull/2464/files?diff=unified&w=0#diff-de71c4ba5014d75c0e22b56c2dea640e7a20fda5614d3928efcc786e8b663391R17-R75))
*  Modify `ContributionRow` component to use `focus` prop, render `NavLink` for private stream activities, and conditionally render `RepliesBox` ([link](https://github.com/coordinape/coordinape/pull/2464/files?diff=unified&w=0#diff-023fbc171b14533aea64ceea9c06efab32d5448fe6d51fd5f36dd43b7c711274L6-R8), [link](https://github.com/coordinape/coordinape/pull/2464/files?diff=unified&w=0#diff-023fbc171b14533aea64ceea9c06efab32d5448fe6d51fd5f36dd43b7c711274L23-R29), [link](https://github.com/coordinape/coordinape/pull/2464/files?diff=unified&w=0#diff-023fbc171b14533aea64ceea9c06efab32d5448fe6d51fd5f36dd43b7c711274L67-R89), [link](https://github.com/coordinape/coordinape/pull/2464/files?diff=unified&w=0#diff-023fbc171b14533aea64ceea9c06efab32d5448fe6d51fd5f36dd43b7c711274L147-R167))
*  Modify `useInfiniteActivities` hook to use `activitySelector` constant and `fetchPost` function for GraphQL queries ([link](https://github.com/coordinape/coordinape/pull/2464/files?diff=unified&w=0#diff-de71c4ba5014d75c0e22b56c2dea640e7a20fda5614d3928efcc786e8b663391L5-R9), [link](https://github.com/coordinape/coordinape/pull/2464/files?diff=unified&w=0#diff-de71c4ba5014d75c0e22b56c2dea640e7a20fda5614d3928efcc786e8b663391L27-R90))
