### PR TITLE
return if magic api key is missing or on success

### DIFF
--- a/api/login.ts
+++ b/api/login.ts
@@ -165,7 +165,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
       let userMetadata, email;
       if (connectorName === 'magic') {
-        assert(API_KEY, 'REACT_APP_MAGIC_API_KEY is missing');
+        assert(API_KEY, 'MAGIC_SECRET_API_KEY is missing');
         const magic = await Magic.init(API_KEY);
         userMetadata = await magic.users.getMetadataByPublicAddress(address);
         if (userMetadata) {


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 64ab0b6</samp>

This pull request improves the handling of the magic API key in the login and cron job functions. It also renames the `API_KEY` variable to `MAGIC_SECRET_API_KEY` in `api/login.ts` for clarity and consistency.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 64ab0b6</samp>

> _`API_KEY` changed_
> _To match cron job's secret_
> _Fall leaves no errors_

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 64ab0b6</samp>

*  Rename `API_KEY` to `MAGIC_SECRET_API_KEY` in `api/login.ts` to match the environment variable name used in the cron job ([link](https://github.com/coordinape/coordinape/pull/2468/files?diff=unified&w=0#diff-01abf081aaf21c9dd7749fceb2eaf3c000f88207e51f4a1ab234455045e4d2deL168-R168))
*  Import `assert` module and `IS_LOCAL_ENV` constant in `api/hasura/cron/updateMagicEmails.ts` to check and handle the presence of the magic API key ([link](https://github.com/coordinape/coordinape/pull/2468/files?diff=unified&w=0#diff-30a165f2f32dce2039e1759e4564e44de2a225960ec27b696aa513cd58a192faL1-R6))
*  Skip the magic email update logic in `handler` function if the magic API key is missing and the code is running locally ([link](https://github.com/coordinape/coordinape/pull/2468/files?diff=unified&w=0#diff-30a165f2f32dce2039e1759e4564e44de2a225960ec27b696aa513cd58a192faL11-R21))
*  Add `assert` function to throw an error in `handler` function if the magic API key is missing and the code is not running locally ([link](https://github.com/coordinape/coordinape/pull/2468/files?diff=unified&w=0#diff-30a165f2f32dce2039e1759e4564e44de2a225960ec27b696aa513cd58a192faL11-R21))
*  Add `return` statement to `handler` function to end the execution after sending the response ([link](https://github.com/coordinape/coordinape/pull/2468/files?diff=unified&w=0#diff-30a165f2f32dce2039e1759e4564e44de2a225960ec27b696aa513cd58a192faR71))
