### PR TITLE
Improve login: only create sample circles for non-colinks users

### DIFF
--- a/api-test/login.test.ts
+++ b/api-test/login.test.ts
@@ -1,7 +1,7 @@
 import { hashMessage } from '@ethersproject/hash';
 
-import { adminClient } from '../api-lib/gql/adminClient';
 import handler from '../api/login';
+import { adminClient } from '../api-lib/gql/adminClient';
 import { generateMessage } from '../src/features/auth/login';
 import { provider } from '../src/utils/testing/provider';
 
@@ -30,7 +30,10 @@ const sendMockReq = async (chainId: number, bad?: boolean) => {
 
   if (bad) payload.signature = payload.signature.replace('1', '2');
 
-  const req = { body: { input: { payload } } };
+  const req = {
+    body: { input: { payload } },
+    headers: { host: 'localhost:3000' },
+  };
   // @ts-ignore
   return handler(req, res);
 };


### PR DESCRIPTION
Add error handling to create sample circle

## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 228271d</samp>

Add support for CoLinks users to sign in without a web3 wallet. Skip sample circle creation and track hostname for CoLinks users in `api/login.ts`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 228271d</samp>

> _Sing, O Muse, of the cunning Coordinape_
> _Who gave his users a new way to shape_
> _Their circles of collaboration and trust_
> _Without a web3 wallet, as they must._

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 228271d</samp>

*  Define CoLinks domains and check hostname for CoLinks users ([link](https://github.com/coordinape/coordinape/pull/2469/files?diff=unified&w=0#diff-01abf081aaf21c9dd7749fceb2eaf3c000f88207e51f4a1ab234455045e4d2deR28-R32), [link](https://github.com/coordinape/coordinape/pull/2469/files?diff=unified&w=0#diff-01abf081aaf21c9dd7749fceb2eaf3c000f88207e51f4a1ab234455045e4d2deR51-R53), [link](https://github.com/coordinape/coordinape/pull/2469/files?diff=unified&w=0#diff-01abf081aaf21c9dd7749fceb2eaf3c000f88207e51f4a1ab234455045e4d2deL222-R240))
* Pass hostname to profile and event creation functions ([link](https://github.com/coordinape/coordinape/pull/2469/files?diff=unified&w=0#diff-01abf081aaf21c9dd7749fceb2eaf3c000f88207e51f4a1ab234455045e4d2deR222), [link](https://github.com/coordinape/coordinape/pull/2469/files?diff=unified&w=0#diff-01abf081aaf21c9dd7749fceb2eaf3c000f88207e51f4a1ab234455045e4d2deL261-R278))
* Add error handling for sample circle creation ([link](https://github.com/coordinape/coordinape/pull/2469/files?diff=unified&w=0#diff-01abf081aaf21c9dd7749fceb2eaf3c000f88207e51f4a1ab234455045e4d2deL222-R240))
