### PR TITLE
CoLinks fixups

### DIFF
--- a/src/pages/colinks/ViewProfilePage/ViewProfilePageContents.tsx
+++ b/src/pages/colinks/ViewProfilePage/ViewProfilePageContents.tsx
@@ -295,10 +295,12 @@ const PageContents = ({
               }}
               noPosts={
                 <Panel noBorder>
-                  {targetIsCurrentUser
-                    ? "You haven't"
-                    : `${targetProfile.profile.name} hasn't`}{' '}
-                  {'posted yet.'}
+                  {targetProfile.mutedThem
+                    ? `You have muted ${targetProfile.profile.name}. Unmute to see their posts.`
+                    : (targetIsCurrentUser
+                        ? "You haven't"
+                        : `${targetProfile.profile.name} hasn't`) +
+                      ' posted yet.'}
                 </Panel>
               }
             />

--- a/src/ui/Avatar/Avatar.tsx
+++ b/src/ui/Avatar/Avatar.tsx
@@ -136,7 +136,8 @@ const AvatarFallback = styled('span', {
 export const Avatar = ({
   path,
   name,
-  // hasCoSoul,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  hasCoSoul,
   onClick,
   size,
   margin,


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 07331ae</samp>

This pull request enhances the ViewProfilePage component and fixes a linting issue in the Avatar component. It allows viewing profiles with any case of address, handles loading and error states, shows a message for muted users, and ignores an unused prop in `Avatar.tsx`.

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9906817</samp>

*  Modify the `noPosts` prop of the `PostList` component to display a different message if the current user has muted the target profile ([link](https://github.com/coordinape/coordinape/pull/2470/files?diff=unified&w=0#diff-cff4a8eedd6bc4e327e10f459d5d7120705b2ccbcf88abb2c175985ad128712cL298-R303))
