### PR TITLE
Show error if colinks profile not found

### DIFF
--- a/src/pages/colinks/ViewProfilePage/ViewProfilePageContents.tsx
+++ b/src/pages/colinks/ViewProfilePage/ViewProfilePageContents.tsx
@@ -171,11 +171,11 @@ const PageContents = ({
     undefined
   );
 
-  const { data: targetProfile } = useQuery(
-    [QUERY_KEY_COLINKS, targetAddress, 'profile'],
-    () => fetchCoLinksProfile(targetAddress, currentUserProfileId)
-  );
-  const { data: cosoul } = useQuery(
+  const { data: targetProfile, isLoading: fetchCoLinksProfileIsLoading } =
+    useQuery([QUERY_KEY_COLINKS, targetAddress, 'profile'], () =>
+      fetchCoLinksProfile(targetAddress, currentUserProfileId)
+    );
+  const { data: cosoul, isLoading: fetchCoSoulIsLoading } = useQuery(
     [QUERY_KEY_COLINKS, targetAddress, 'cosoul'],
     async () => {
       return fetchCoSoul(targetAddress);
@@ -192,6 +192,19 @@ const PageContents = ({
       setNeedsToBuyLink(balance === 0);
     }
   }, [balance]);
+
+  if (
+    (!targetProfile?.profile && !fetchCoLinksProfileIsLoading) ||
+    (!fetchCoSoulIsLoading && !cosoul)
+  ) {
+    return (
+      <Flex column css={{ gap: '$lg', p: '$xl', alignItems: 'center' }}>
+        <Text h1 color={'alert'}>
+          Error: no profile found
+        </Text>
+      </Flex>
+    );
+  }
 
   if (!targetProfile?.profile || !cosoul) {
     return <LoadingModal visible={true} />;


### PR DESCRIPTION
## What

If you go the URL of a profile that doesn't exist , show an error instead of spinning forever.


<img width="1026" alt="Screenshot 2023-11-28 at 3 16 54 PM" src="https://github.com/coordinape/coordinape/assets/83605543/2b89da05-dc0d-42b0-a098-6aff70c999ec">

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 409e02d</samp>

Improve address matching and error handling for `ViewProfilePageContents`. Refactor some variables to use isLoading properties.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 409e02d</samp>

> _`ViewProfilePageContents`_
> _Better matches addresses_
> _Autumn of errors_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 409e02d</samp>

*  Ensure case-insensitive matching of the address parameter in GraphQL queries by:
  - Creating a new variable `addressLower` that holds the lowercase version of the address parameter ([link](https://github.com/coordinape/coordinape/pull/2472/files?diff=unified&w=0#diff-cff4a8eedd6bc4e327e10f459d5d7120705b2ccbcf88abb2c175985ad128712cR67))
  - Using `addressLower` instead of `address` in the _ilike filter of the `target_profile` query ([link](https://github.com/coordinape/coordinape/pull/2472/files?diff=unified&w=0#diff-cff4a8eedd6bc4e327e10f459d5d7120705b2ccbcf88abb2c175985ad128712cL76-R77))
  - Using `addressLower` instead of `address` in the _eq filter of the `profile` query ([link](https://github.com/coordinape/coordinape/pull/2472/files?diff=unified&w=0#diff-cff4a8eedd6bc4e327e10f459d5d7120705b2ccbcf88abb2c175985ad128712cL96-R97))
  - Destructuring the `isLoading` properties of the `useQuery` hooks for fetching the target profile and the cosoul data into two new variables `fetchCoLinksProfileIsLoading` and `fetchCoSoulIsLoading` ([link](https://github.com/coordinape/coordinape/pull/2472/files?diff=unified&w=0#diff-cff4a8eedd6bc4e327e10f459d5d7120705b2ccbcf88abb2c175985ad128712cL174-R179))
  - Conditionally rendering an error message if either the target profile or the cosoul data is not available and not loading ([link](https://github.com/coordinape/coordinape/pull/2472/files?diff=unified&w=0#diff-cff4a8eedd6bc4e327e10f459d5d7120705b2ccbcf88abb2c175985ad128712cR197-R203))
