### PR TITLE
Fix profile edits by making bio optional

### DIFF
--- a/src/components/EditProfileModal.tsx
+++ b/src/components/EditProfileModal.tsx
@@ -30,7 +30,7 @@ const schema = z
   .object({
     name: zUsername,
     bio: z.string(),
-    description: z.string(),
+    description: z.string().optional(),
     skills: z.array(z.string()),
     twitter_username: z.string(),
     github_username: z.string(),


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e103376</samp>

Made the `description` field optional in the edit profile modal to fix a bug and improve user experience. Updated the `schema` object in `src/components/EditProfileModal.tsx` using the `zod` library.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e103376</samp>

> _`description` field_
> _now optional with `zod`_
> _winter bug is fixed_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e103376</samp>

*  Made the `description` field optional in the edit profile modal schema ([link](https://github.com/coordinape/coordinape/pull/2482/files?diff=unified&w=0#diff-a597e671faaa136a586de9e340dd394fdc668ae5f648b27e4fd82bae44d6d2b0L33-R33)) to fix a bug where users could not save their profile without a description
