### PR TITLE
Add website to profile

### DIFF
--- a/api-lib/gql/__generated__/zeus/const.ts
+++ b/api-lib/gql/__generated__/zeus/const.ts
@@ -8862,6 +8862,7 @@ export const AllTypesProps: Record<string, any> = {
     profile_skills: 'profile_skills_bool_exp',
     profile_skills_aggregate: 'profile_skills_aggregate_bool_exp',
     reputation_score: 'reputation_scores_bool_exp',
+    website: 'String_comparison_exp',
   },
   profiles_public_insert_input: {
     cosoul: 'cosouls_obj_rel_insert_input',
@@ -8888,6 +8889,7 @@ export const AllTypesProps: Record<string, any> = {
     post_count_last_30_days: 'order_by',
     profile_skills_aggregate: 'profile_skills_aggregate_order_by',
     reputation_score: 'reputation_scores_order_by',
+    website: 'order_by',
   },
   profiles_public_select_column: true,
   profiles_public_stream_cursor_input: {
@@ -18553,6 +18555,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_skills: 'profile_skills',
     profile_skills_aggregate: 'profile_skills_aggregate',
     reputation_score: 'reputation_scores',
+    website: 'String',
   },
   profiles_public_aggregate: {
     aggregate: 'profiles_public_aggregate_fields',
@@ -18584,6 +18587,7 @@ export const ReturnTypes: Record<string, any> = {
     name: 'citext',
     post_count: 'bigint',
     post_count_last_30_days: 'bigint',
+    website: 'String',
   },
   profiles_public_min_fields: {
     address: 'String',
@@ -18593,6 +18597,7 @@ export const ReturnTypes: Record<string, any> = {
     name: 'citext',
     post_count: 'bigint',
     post_count_last_30_days: 'bigint',
+    website: 'String',
   },
   profiles_public_stddev_fields: {
     id: 'Float',

--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -23540,6 +23540,7 @@ export type ValueTypes = {
     ];
     /** An object relationship */
     reputation_score?: ValueTypes['reputation_scores'];
+    website?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregated selection of "profiles_public" */
@@ -23606,6 +23607,7 @@ export type ValueTypes = {
       | ValueTypes['reputation_scores_bool_exp']
       | undefined
       | null;
+    website?: ValueTypes['String_comparison_exp'] | undefined | null;
   };
   /** input type for inserting data into table "profiles_public" */
   ['profiles_public_insert_input']: {
@@ -23626,6 +23628,7 @@ export type ValueTypes = {
       | ValueTypes['reputation_scores_obj_rel_insert_input']
       | undefined
       | null;
+    website?: string | undefined | null;
   };
   /** aggregate max on columns */
   ['profiles_public_max_fields']: AliasType<{
@@ -23636,6 +23639,7 @@ export type ValueTypes = {
     name?: boolean | `@${string}`;
     post_count?: boolean | `@${string}`;
     post_count_last_30_days?: boolean | `@${string}`;
+    website?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregate min on columns */
@@ -23647,6 +23651,7 @@ export type ValueTypes = {
     name?: boolean | `@${string}`;
     post_count?: boolean | `@${string}`;
     post_count_last_30_days?: boolean | `@${string}`;
+    website?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** input type for inserting object relation for remote table "profiles_public" */
@@ -23672,6 +23677,7 @@ export type ValueTypes = {
       | ValueTypes['reputation_scores_order_by']
       | undefined
       | null;
+    website?: ValueTypes['order_by'] | undefined | null;
   };
   /** select columns of table "profiles_public" */
   ['profiles_public_select_column']: profiles_public_select_column;
@@ -23712,6 +23718,7 @@ export type ValueTypes = {
     name?: ValueTypes['citext'] | undefined | null;
     post_count?: ValueTypes['bigint'] | undefined | null;
     post_count_last_30_days?: ValueTypes['bigint'] | undefined | null;
+    website?: string | undefined | null;
   };
   /** aggregate sum on columns */
   ['profiles_public_sum_fields']: AliasType<{
@@ -46081,6 +46088,7 @@ export type ModelTypes = {
     profile_skills_aggregate: GraphQLTypes['profile_skills_aggregate'];
     /** An object relationship */
     reputation_score?: GraphQLTypes['reputation_scores'] | undefined;
+    website?: string | undefined;
   };
   /** aggregated selection of "profiles_public" */
   ['profiles_public_aggregate']: {
@@ -46122,6 +46130,7 @@ export type ModelTypes = {
     name?: GraphQLTypes['citext'] | undefined;
     post_count?: GraphQLTypes['bigint'] | undefined;
     post_count_last_30_days?: GraphQLTypes['bigint'] | undefined;
+    website?: string | undefined;
   };
   /** aggregate min on columns */
   ['profiles_public_min_fields']: {
@@ -46132,6 +46141,7 @@ export type ModelTypes = {
     name?: GraphQLTypes['citext'] | undefined;
     post_count?: GraphQLTypes['bigint'] | undefined;
     post_count_last_30_days?: GraphQLTypes['bigint'] | undefined;
+    website?: string | undefined;
   };
   /** input type for inserting object relation for remote table "profiles_public" */
   ['profiles_public_obj_rel_insert_input']: GraphQLTypes['profiles_public_obj_rel_insert_input'];
@@ -66834,6 +66844,7 @@ export type GraphQLTypes = {
     profile_skills_aggregate: GraphQLTypes['profile_skills_aggregate'];
     /** An object relationship */
     reputation_score?: GraphQLTypes['reputation_scores'] | undefined;
+    website?: string | undefined;
   };
   /** aggregated selection of "profiles_public" */
   ['profiles_public_aggregate']: {
@@ -66885,6 +66896,7 @@ export type GraphQLTypes = {
       | GraphQLTypes['profile_skills_aggregate_bool_exp']
       | undefined;
     reputation_score?: GraphQLTypes['reputation_scores_bool_exp'] | undefined;
+    website?: GraphQLTypes['String_comparison_exp'] | undefined;
   };
   /** input type for inserting data into table "profiles_public" */
   ['profiles_public_insert_input']: {
@@ -66903,6 +66915,7 @@ export type GraphQLTypes = {
     reputation_score?:
       | GraphQLTypes['reputation_scores_obj_rel_insert_input']
       | undefined;
+    website?: string | undefined;
   };
   /** aggregate max on columns */
   ['profiles_public_max_fields']: {
@@ -66914,6 +66927,7 @@ export type GraphQLTypes = {
     name?: GraphQLTypes['citext'] | undefined;
     post_count?: GraphQLTypes['bigint'] | undefined;
     post_count_last_30_days?: GraphQLTypes['bigint'] | undefined;
+    website?: string | undefined;
   };
   /** aggregate min on columns */
   ['profiles_public_min_fields']: {
@@ -66925,6 +66939,7 @@ export type GraphQLTypes = {
     name?: GraphQLTypes['citext'] | undefined;
     post_count?: GraphQLTypes['bigint'] | undefined;
     post_count_last_30_days?: GraphQLTypes['bigint'] | undefined;
+    website?: string | undefined;
   };
   /** input type for inserting object relation for remote table "profiles_public" */
   ['profiles_public_obj_rel_insert_input']: {
@@ -66945,6 +66960,7 @@ export type GraphQLTypes = {
       | GraphQLTypes['profile_skills_aggregate_order_by']
       | undefined;
     reputation_score?: GraphQLTypes['reputation_scores_order_by'] | undefined;
+    website?: GraphQLTypes['order_by'] | undefined;
   };
   /** select columns of table "profiles_public" */
   ['profiles_public_select_column']: profiles_public_select_column;
@@ -66985,6 +67001,7 @@ export type GraphQLTypes = {
     name?: GraphQLTypes['citext'] | undefined;
     post_count?: GraphQLTypes['bigint'] | undefined;
     post_count_last_30_days?: GraphQLTypes['bigint'] | undefined;
+    website?: string | undefined;
   };
   /** aggregate sum on columns */
   ['profiles_public_sum_fields']: {
@@ -73964,6 +73981,7 @@ export const enum profiles_public_select_column {
   name = 'name',
   post_count = 'post_count',
   post_count_last_30_days = 'post_count_last_30_days',
+  website = 'website',
 }
 /** select columns of table "profiles" */
 export const enum profiles_select_column {

--- a/api/hasura/actions/_handlers/updateProfile.ts
+++ b/api/hasura/actions/_handlers/updateProfile.ts
@@ -28,6 +28,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const { session, payload } = await getInput(req, updateProfileSchemaInput);
   const { name } = payload;
 
+  // convert empty string website to null for db validation
+  if (payload.website === '') {
+    payload.website = null;
+  }
+
   if (name.endsWith('.eth')) {
     const validENS = await isValidENS(name, session.hasuraAddress);
     if (!validENS)

--- a/hasura/metadata/databases/default/tables/public_profiles_public.yaml
+++ b/hasura/metadata/databases/default/tables/public_profiles_public.yaml
@@ -59,5 +59,6 @@ select_permissions:
         - name
         - post_count
         - post_count_last_30_days
+        - website
       filter: {}
     comment: ""

--- a/hasura/migrations/default/1701389705866_add_website_profiles_public/down.sql
+++ b/hasura/migrations/default/1701389705866_add_website_profiles_public/down.sql
@@ -1,0 +1,16 @@
+CREATE OR REPLACE VIEW "public"."profiles_public" AS
+ SELECT p.id,
+    p.address,
+    p.name,
+    p.avatar,
+    p.description,
+    count(c.*) AS post_count,
+    count(
+        CASE
+            WHEN (c.created_at >= (CURRENT_DATE - '30 days'::interval)) THEN 1
+            ELSE NULL::integer
+        END) AS post_count_last_30_days,
+                p.website
+   FROM (profiles p
+     LEFT JOIN contributions c ON (((c.profile_id = p.id) AND (c.private_stream = true))))
+  GROUP BY p.id, p.address, p.name, p.avatar;

--- a/hasura/migrations/default/1701389705866_add_website_profiles_public/up.sql
+++ b/hasura/migrations/default/1701389705866_add_website_profiles_public/up.sql
@@ -1,0 +1,16 @@
+CREATE OR REPLACE VIEW "public"."profiles_public" AS 
+ SELECT p.id,
+    p.address,
+    p.name,
+    p.avatar,
+    p.description,
+    count(c.*) AS post_count,
+    count(
+        CASE
+            WHEN (c.created_at >= (CURRENT_DATE - '30 days'::interval)) THEN 1
+            ELSE NULL::integer
+        END) AS post_count_last_30_days,
+                p.website
+   FROM (profiles p
+     LEFT JOIN contributions c ON (((c.profile_id = p.id) AND (c.private_stream = true))))
+  GROUP BY p.id, p.address, p.name, p.avatar;

--- a/hasura/schema/admin/schema.graphql
+++ b/hasura/schema/admin/schema.graphql
@@ -33829,6 +33829,7 @@ type profiles_public {
   An object relationship
   """
   reputation_score: reputation_scores
+  website: String
 }
 
 """
@@ -33885,6 +33886,7 @@ input profiles_public_bool_exp {
   profile_skills: profile_skills_bool_exp
   profile_skills_aggregate: profile_skills_aggregate_bool_exp
   reputation_score: reputation_scores_bool_exp
+  website: String_comparison_exp
 }
 
 """
@@ -33902,6 +33904,7 @@ input profiles_public_insert_input {
   post_count_last_30_days: bigint
   profile_skills: profile_skills_arr_rel_insert_input
   reputation_score: reputation_scores_obj_rel_insert_input
+  website: String
 }
 
 """
@@ -33915,6 +33918,7 @@ type profiles_public_max_fields {
   name: citext
   post_count: bigint
   post_count_last_30_days: bigint
+  website: String
 }
 
 """
@@ -33928,6 +33932,7 @@ type profiles_public_min_fields {
   name: citext
   post_count: bigint
   post_count_last_30_days: bigint
+  website: String
 }
 
 """
@@ -33952,6 +33957,7 @@ input profiles_public_order_by {
   post_count_last_30_days: order_by
   profile_skills_aggregate: profile_skills_aggregate_order_by
   reputation_score: reputation_scores_order_by
+  website: order_by
 }
 
 """
@@ -33992,6 +33998,11 @@ enum profiles_public_select_column {
   column name
   """
   post_count_last_30_days
+
+  """
+  column name
+  """
+  website
 }
 
 """
@@ -34047,6 +34058,7 @@ input profiles_public_stream_cursor_value_input {
   name: citext
   post_count: bigint
   post_count_last_30_days: bigint
+  website: String
 }
 
 """

--- a/hasura/schema/user/schema.graphql
+++ b/hasura/schema/user/schema.graphql
@@ -14655,6 +14655,7 @@ type profiles_public {
   An object relationship
   """
   reputation_score: reputation_scores
+  website: String
 }
 
 """
@@ -14675,6 +14676,7 @@ input profiles_public_bool_exp {
   post_count_last_30_days: bigint_comparison_exp
   profile_skills: profile_skills_bool_exp
   reputation_score: reputation_scores_bool_exp
+  website: String_comparison_exp
 }
 
 """
@@ -14692,6 +14694,7 @@ input profiles_public_order_by {
   post_count_last_30_days: order_by
   profile_skills_aggregate: profile_skills_aggregate_order_by
   reputation_score: reputation_scores_order_by
+  website: order_by
 }
 
 """
@@ -14732,6 +14735,11 @@ enum profiles_public_select_column {
   column name
   """
   post_count_last_30_days
+
+  """
+  column name
+  """
+  website
 }
 
 """
@@ -14760,6 +14768,7 @@ input profiles_public_stream_cursor_value_input {
   name: citext
   post_count: bigint
   post_count_last_30_days: bigint
+  website: String
 }
 
 """

--- a/src/lib/gql/__generated__/zeus/const.ts
+++ b/src/lib/gql/__generated__/zeus/const.ts
@@ -4696,6 +4696,7 @@ export const AllTypesProps: Record<string, any> = {
     post_count_last_30_days: 'bigint_comparison_exp',
     profile_skills: 'profile_skills_bool_exp',
     reputation_score: 'reputation_scores_bool_exp',
+    website: 'String_comparison_exp',
   },
   profiles_public_order_by: {
     address: 'order_by',
@@ -4709,6 +4710,7 @@ export const AllTypesProps: Record<string, any> = {
     post_count_last_30_days: 'order_by',
     profile_skills_aggregate: 'profile_skills_aggregate_order_by',
     reputation_score: 'reputation_scores_order_by',
+    website: 'order_by',
   },
   profiles_public_select_column: true,
   profiles_public_stream_cursor_input: {
@@ -9352,6 +9354,7 @@ export const ReturnTypes: Record<string, any> = {
     post_count_last_30_days: 'bigint',
     profile_skills: 'profile_skills',
     reputation_score: 'reputation_scores',
+    website: 'String',
   },
   query_root: {
     activities: 'activities',

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -10711,6 +10711,7 @@ export type ValueTypes = {
     ];
     /** An object relationship */
     reputation_score?: ValueTypes['reputation_scores'];
+    website?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** Boolean expression to filter rows from the table "profiles_public". All fields are combined with a logical 'AND'. */
@@ -10735,6 +10736,7 @@ export type ValueTypes = {
       | ValueTypes['reputation_scores_bool_exp']
       | undefined
       | null;
+    website?: ValueTypes['String_comparison_exp'] | undefined | null;
   };
   /** Ordering options when selecting data from "profiles_public". */
   ['profiles_public_order_by']: {
@@ -10755,6 +10757,7 @@ export type ValueTypes = {
       | ValueTypes['reputation_scores_order_by']
       | undefined
       | null;
+    website?: ValueTypes['order_by'] | undefined | null;
   };
   /** select columns of table "profiles_public" */
   ['profiles_public_select_column']: profiles_public_select_column;
@@ -10774,6 +10777,7 @@ export type ValueTypes = {
     name?: ValueTypes['citext'] | undefined | null;
     post_count?: ValueTypes['bigint'] | undefined | null;
     post_count_last_30_days?: ValueTypes['bigint'] | undefined | null;
+    website?: string | undefined | null;
   };
   /** select columns of table "profiles" */
   ['profiles_select_column']: profiles_select_column;
@@ -21700,6 +21704,7 @@ export type ModelTypes = {
     profile_skills: Array<GraphQLTypes['profile_skills']>;
     /** An object relationship */
     reputation_score?: GraphQLTypes['reputation_scores'] | undefined;
+    website?: string | undefined;
   };
   /** Boolean expression to filter rows from the table "profiles_public". All fields are combined with a logical 'AND'. */
   ['profiles_public_bool_exp']: GraphQLTypes['profiles_public_bool_exp'];
@@ -31267,6 +31272,7 @@ export type GraphQLTypes = {
     profile_skills: Array<GraphQLTypes['profile_skills']>;
     /** An object relationship */
     reputation_score?: GraphQLTypes['reputation_scores'] | undefined;
+    website?: string | undefined;
   };
   /** Boolean expression to filter rows from the table "profiles_public". All fields are combined with a logical 'AND'. */
   ['profiles_public_bool_exp']: {
@@ -31284,6 +31290,7 @@ export type GraphQLTypes = {
     post_count_last_30_days?: GraphQLTypes['bigint_comparison_exp'] | undefined;
     profile_skills?: GraphQLTypes['profile_skills_bool_exp'] | undefined;
     reputation_score?: GraphQLTypes['reputation_scores_bool_exp'] | undefined;
+    website?: GraphQLTypes['String_comparison_exp'] | undefined;
   };
   /** Ordering options when selecting data from "profiles_public". */
   ['profiles_public_order_by']: {
@@ -31300,6 +31307,7 @@ export type GraphQLTypes = {
       | GraphQLTypes['profile_skills_aggregate_order_by']
       | undefined;
     reputation_score?: GraphQLTypes['reputation_scores_order_by'] | undefined;
+    website?: GraphQLTypes['order_by'] | undefined;
   };
   /** select columns of table "profiles_public" */
   ['profiles_public_select_column']: profiles_public_select_column;
@@ -31319,6 +31327,7 @@ export type GraphQLTypes = {
     name?: GraphQLTypes['citext'] | undefined;
     post_count?: GraphQLTypes['bigint'] | undefined;
     post_count_last_30_days?: GraphQLTypes['bigint'] | undefined;
+    website?: string | undefined;
   };
   /** select columns of table "profiles" */
   ['profiles_select_column']: profiles_select_column;
@@ -34964,6 +34973,7 @@ export const enum profiles_public_select_column {
   name = 'name',
   post_count = 'post_count',
   post_count_last_30_days = 'post_count_last_30_days',
+  website = 'website',
 }
 /** select columns of table "profiles" */
 export const enum profiles_select_column {

--- a/src/lib/zod/formHelpers.ts
+++ b/src/lib/zod/formHelpers.ts
@@ -60,6 +60,14 @@ export const zUsername = z
 
 export const zDescription = z.string().min(3).max(160);
 
+const urlRegex = /^(https?:\/\/)?([\w\d-]+\.){1,}[\w\d-]+(\/[\w\d-]+)*\/?$/;
+
+const optionalProtocolUrl = z.string().refine(value => urlRegex.test(value), {
+  message: 'Invalid URL format',
+});
+const optionalUrl = z.union([optionalProtocolUrl, z.literal('')]);
+export const zWebsite = optionalUrl;
+
 export const zCircleName = z
   .string()
   .max(255)

--- a/src/lib/zod/formHelpers.ts
+++ b/src/lib/zod/formHelpers.ts
@@ -60,12 +60,12 @@ export const zUsername = z
 
 export const zDescription = z.string().min(3).max(160);
 
-const urlRegex = /^(https?:\/\/)?([\w\d-]+\.){1,}[\w\d-]+(\/[\w\d-]+)*\/?$/;
+const urlRegex = /^https?:\/\/([\w\d-]+\.){1,}[\w\d-]+(\/[\w\d-]+)*\/?$/;
 
-const optionalProtocolUrl = z.string().refine(value => urlRegex.test(value), {
+const url = z.string().refine(value => urlRegex.test(value), {
   message: 'Invalid URL format',
 });
-const optionalUrl = z.union([optionalProtocolUrl, z.literal('')]);
+const optionalUrl = z.union([url, z.literal('')]);
 export const zWebsite = optionalUrl;
 
 export const zCircleName = z

--- a/src/pages/AccountPage/EditProfileInfo.tsx
+++ b/src/pages/AccountPage/EditProfileInfo.tsx
@@ -4,7 +4,12 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useAuthStore } from 'features/auth';
 import { client } from 'lib/gql/client';
 import { updateMyProfile } from 'lib/gql/mutations';
-import { isValidENS, zDescription, zUsername } from 'lib/zod/formHelpers';
+import {
+  isValidENS,
+  zDescription,
+  zUsername,
+  zWebsite,
+} from 'lib/zod/formHelpers';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { z } from 'zod';
@@ -19,6 +24,7 @@ const schema = z
   .object({
     name: zUsername,
     description: zDescription,
+    website: zWebsite,
   })
   .strict();
 
@@ -41,7 +47,13 @@ export const EditProfileInfo = ({
       {
         profiles_by_pk: [
           { id: profileId },
-          { name: true, avatar: true, address: true, description: true },
+          {
+            name: true,
+            avatar: true,
+            address: true,
+            description: true,
+            website: true,
+          },
         ],
       },
       {
@@ -54,6 +66,7 @@ export const EditProfileInfo = ({
       avatar: profiles_by_pk.avatar,
       address: profiles_by_pk.address,
       description: profiles_by_pk.description,
+      website: profiles_by_pk.website,
     };
   });
 
@@ -81,6 +94,7 @@ const EditProfileInfoForm = ({
     avatar?: string;
     description?: string;
     address: string;
+    website?: string;
   };
   vertical: boolean;
   preloadProfile?: {
@@ -108,6 +122,8 @@ const EditProfileInfoForm = ({
     ? userData.description
     : preloadProfile?.description;
 
+  const website = userData.website;
+
   const {
     control,
     handleSubmit,
@@ -119,6 +135,7 @@ const EditProfileInfoForm = ({
     defaultValues: {
       name,
       description,
+      website,
     },
   });
 
@@ -128,9 +145,9 @@ const EditProfileInfoForm = ({
     },
     onSettled: () => {
       setIsSaving(false);
-      showSuccess('Profile Saved');
     },
     onSuccess: async () => {
+      showSuccess('Profile Saved');
       refetchData();
       queryClient.invalidateQueries([QUERY_KEY_NAV]);
     },
@@ -226,6 +243,30 @@ const EditProfileInfoForm = ({
           column
           css={{ justifyContent: 'space-between', gap: '$md', flexGrow: 1 }}
         >
+          <Flex
+            column
+            css={{
+              gap: '$sm',
+              width: '100%',
+            }}
+          >
+            <Flex
+              css={{
+                justifyContent: 'space-between',
+              }}
+            >
+              <Text variant="label">Website</Text>
+            </Flex>
+            <FormInputField
+              id="website"
+              name="website"
+              textArea={false}
+              control={control}
+              defaultValue={website}
+              showFieldErrors
+              placeholder={'https://myspace.com/cryptochad12'}
+            />
+          </Flex>
           <Flex
             column
             css={{

--- a/src/pages/colinks/ViewProfilePage/CoLinksProfileHeader.tsx
+++ b/src/pages/colinks/ViewProfilePage/CoLinksProfileHeader.tsx
@@ -11,7 +11,7 @@ import { useQuery, useQueryClient } from 'react-query';
 import { Mutes } from '../../../features/colinks/Mutes';
 import { QUERY_KEY_COLINKS } from '../../../features/colinks/wizard/CoLinksWizard';
 import { order_by } from '../../../lib/gql/__generated__/zeus';
-import { Github, Settings, Twitter } from 'icons/__generated';
+import { Github, Settings, Twitter, Link as LinkIcon } from 'icons/__generated';
 import { Avatar, Button, ContentHeader, Flex, Link, Text } from 'ui';
 
 import { CoLinksProfile } from './ViewProfilePageContents';
@@ -187,6 +187,24 @@ export const CoLinksProfileHeader = ({
               }}
             >
               <Twitter nostroke /> {details?.twitter}
+            </Flex>
+          )}
+          {profile?.website && (
+            <Flex
+              as={Link}
+              href={profile.website as string}
+              target="_blank"
+              rel="noreferrer"
+              css={{
+                alignItems: 'center',
+                gap: '$xs',
+                color: '$neutral',
+                '&:hover': {
+                  color: '$text',
+                },
+              }}
+            >
+              <LinkIcon /> {profile.website as string}
             </Flex>
           )}
           {details?.skills.map(s => (

--- a/src/pages/colinks/ViewProfilePage/ViewProfilePageContents.tsx
+++ b/src/pages/colinks/ViewProfilePage/ViewProfilePageContents.tsx
@@ -123,6 +123,7 @@ const fetchCoLinksProfile = async (
           name: true,
           avatar: true,
           address: true,
+          website: true,
           description: true,
           reputation_score: {
             total_score: true,


### PR DESCRIPTION
## What

<img width="697" alt="Screenshot 2023-11-30 at 4 33 58 PM" src="https://github.com/coordinape/coordinape/assets/83605543/3e41bc26-d960-43c5-853a-1f83c75c5a78">

<img width="875" alt="Screenshot 2023-11-30 at 4 36 49 PM" src="https://github.com/coordinape/coordinape/assets/83605543/821ef20d-880b-4549-b3a3-b746bd51972a">


<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d58f137</samp>

This pull request adds a new `website` field to the user profile data model, schema, and UI. It allows users to query, update, and display their website URL in their profile edit form and co-link profile header. It also adds validation logic and database migration scripts for the new field.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d58f137</samp>

> _Oh we're the coders of the `website` field_
> _We add it to the types and the views_
> _We query and update it with Zod and Zeus_
> _And we show it on the profiles too_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d58f137</samp>

*  Add a new `website` column to the `profiles` table and the `profiles_public` view in the Hasura database to store the personal website URL of each user profile ([link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-412dbd6aa74a0169e4120157039da14d29381e4a3e1cc6551f78afc1616b8e65R62), [link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-83979233646fe0525e5c9459421b3b3d067d81b74da452448c4046b82f64516dR1-R16), [link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-b83596a5a513907f8c422375d5871d057bff0b7ddff46e858f6e679fbe7bde8dR1-R16))
*  Generate GraphQL schemas for the admin and user roles in Hasura, exposing the `website` field for querying, updating, filtering, ordering, aggregating, and selecting from the `profiles_public` view ([link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R33832), [link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R33889), [link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R33907), [link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R33921), [link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R33935), [link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R33960), [link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R34001-R34005), [link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R34061), [link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebR14658), [link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebR14679), [link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebR14697), [link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebR14738-R14742), [link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebR14771))
*  Generate GraphQL queries and mutations with the Zeus library for the admin and user schemas, allowing the `website` field to be used in the `profiles`, `profiles_by_pk`, and `update_profile_by_pk` operations ([link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R8865), [link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R8892), [link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R18558), [link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R18590), [link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R18600), [link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060R4699), [link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060R4713), [link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060R9357))
*  Handle the custom Hasura action `updateProfile`, which updates the profile data of a user by their address, by converting an empty string `website` to null for database validation ([link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-74809c2deeb193071012fa91881aa2ef817c46a97e40821256674f8fe19110e0R31-R35))
*  Define Zod types for validating optional and required website URLs using a regular expression for URL formats in `./src/lib/zod/formHelpers.ts` ([link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-202cd0d9fab26ea2104d2ad832a19b5f159a1e6140481dae3ff4be0ead918634R63-R70))
*  Render and handle the profile edit form in `./src/pages/AccountPage/EditProfileInfo.tsx`, using the Zod types for validating the website input field, fetching the current user's website URL from the `profiles_by_pk` query, updating the current user's website URL with the `updateProfile` action, and showing the success message only when the action succeeds ([link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-11d8fe5439cb26332cf972ee873d8c1c480aa04239f670a06442c526b0aedafdL7-R12), [link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-11d8fe5439cb26332cf972ee873d8c1c480aa04239f670a06442c526b0aedafdR27), [link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-11d8fe5439cb26332cf972ee873d8c1c480aa04239f670a06442c526b0aedafdL44-R56), [link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-11d8fe5439cb26332cf972ee873d8c1c480aa04239f670a06442c526b0aedafdR69), [link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-11d8fe5439cb26332cf972ee873d8c1c480aa04239f670a06442c526b0aedafdR97), [link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-11d8fe5439cb26332cf972ee873d8c1c480aa04239f670a06442c526b0aedafdR125-R126), [link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-11d8fe5439cb26332cf972ee873d8c1c480aa04239f670a06442c526b0aedafdR138), [link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-11d8fe5439cb26332cf972ee873d8c1c480aa04239f670a06442c526b0aedafdL131-R150), [link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-11d8fe5439cb26332cf972ee873d8c1c480aa04239f670a06442c526b0aedafdR258-R281))
*  Render the header of the profile page for a co-link in `./src/pages/colinks/ViewProfilePage/CoLinksProfileHeader.tsx`, using the `Link` icon to display the website URL of the co-link, if it exists, and allowing the user to visit it ([link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-4aa6eb6c4daadd3504e9da12667848694f871f63bd5176ba8efbd34534abdc64L14-R14), [link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-4aa6eb6c4daadd3504e9da12667848694f871f63bd5176ba8efbd34534abdc64R192-R209))
*  Fetch the website URL of the co-link from the `profiles_by_pk` query in `./src/pages/colinks/ViewProfilePage/ViewProfilePageContents.tsx` ([link](https://github.com/coordinape/coordinape/pull/2483/files?diff=unified&w=0#diff-cff4a8eedd6bc4e327e10f459d5d7120705b2ccbcf88abb2c175985ad128712cR126))
