### PR TITLE
Description embeddings

### DIFF
--- a/api-lib/event_triggers/updateDescriptionEmbedding.ts
+++ b/api-lib/event_triggers/updateDescriptionEmbedding.ts
@@ -1,0 +1,98 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+import { adminClient } from '../gql/adminClient';
+import { errorResponse } from '../HttpError';
+import { createEmbedding } from '../openai';
+import { EventTriggerPayload } from '../types';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  try {
+    const { event }: EventTriggerPayload<'profiles', 'INSERT' | 'UPDATE'> =
+      req.body;
+    if (event.data?.new && event.data?.old) {
+      return handleUpdate(event.data.new, event.data.old, res);
+    } else if (event.data?.new) {
+      return handleInsert(event.data.new, res);
+    } else {
+      console.error('Unexpected event payload', event);
+      throw Error('Unexpected event payload');
+    }
+  } catch (e) {
+    return errorResponse(res, e);
+  }
+}
+
+const handleInsert = async (
+  newRow: EventTriggerPayload<'profiles', 'INSERT'>['event']['data']['new'],
+  res: VercelResponse
+) => {
+  const { id, description } = newRow;
+
+  if (!description || description === '') {
+    return res.status(200).json({
+      message: `no description`,
+    });
+  }
+
+  await updateEmbedding(id, description);
+
+  res.status(200).json({
+    message: `description embedding updated for profile.id ${id}`,
+  });
+};
+
+const handleUpdate = async (
+  newRow: EventTriggerPayload<'profiles', 'UPDATE'>['event']['data']['new'],
+  oldRow: EventTriggerPayload<'profiles', 'UPDATE'>['event']['data']['old'],
+  res: VercelResponse
+) => {
+  if (newRow.description === oldRow.description) {
+    return res.status(200).json({
+      message: `no change in description - this shouldn't happen`,
+    });
+  }
+
+  if (!newRow.description || newRow.description === '') {
+    return res.status(200).json({
+      message: `no description`,
+    });
+  }
+
+  await updateEmbedding(newRow.id, newRow.description);
+
+  res.status(200).json({
+    message: `replies notification deleted`,
+  });
+};
+
+async function updateEmbedding(id: number, description: string) {
+  if (!process.env.OPENAI_API_KEY || !process.env.HELICONE_API_KEY) {
+    return console.error(
+      'Environment variables OPENAI_API_KEY, HELICONE_API_KEY are required: skipping description embedding generation'
+    );
+  }
+
+  const embedding = await createEmbedding(description);
+
+  const { update_profiles_by_pk } = await adminClient.mutate(
+    {
+      update_profiles_by_pk: [
+        {
+          pk_columns: {
+            id: id,
+          },
+          _set: {
+            description_embedding: JSON.stringify(embedding),
+          },
+        },
+        {
+          __typename: true,
+        },
+      ],
+    },
+    {
+      operationName: 'updateDescriptionEmbedding',
+    }
+  );
+  return update_profiles_by_pk;
+}

--- a/api-lib/gql/__generated__/zeus/const.ts
+++ b/api-lib/gql/__generated__/zeus/const.ts
@@ -58,6 +58,7 @@ export const AllTypesProps: Record<string, any> = {
   MarkClaimedInput: {},
   SearchCosoulsInput: {},
   SetPrimaryEmailInput: {},
+  SimilarProfileInput: {},
   String_comparison_exp: {},
   SyncCoSoulInput: {},
   UpdateCircleInput: {},
@@ -5301,6 +5302,12 @@ export const AllTypesProps: Record<string, any> = {
     delete_vaults_by_pk: {
       id: 'bigint',
     },
+    delete_virtual_profiles_similarity: {
+      where: 'virtual_profiles_similarity_bool_exp',
+    },
+    delete_virtual_profiles_similarity_by_pk: {
+      id: 'bigint',
+    },
     delete_vouches: {
       where: 'vouches_bool_exp',
     },
@@ -5773,6 +5780,14 @@ export const AllTypesProps: Record<string, any> = {
     insert_vaults_one: {
       object: 'vaults_insert_input',
       on_conflict: 'vaults_on_conflict',
+    },
+    insert_virtual_profiles_similarity: {
+      objects: 'virtual_profiles_similarity_insert_input',
+      on_conflict: 'virtual_profiles_similarity_on_conflict',
+    },
+    insert_virtual_profiles_similarity_one: {
+      object: 'virtual_profiles_similarity_insert_input',
+      on_conflict: 'virtual_profiles_similarity_on_conflict',
     },
     insert_vouches: {
       objects: 'vouches_insert_input',
@@ -6598,6 +6613,19 @@ export const AllTypesProps: Record<string, any> = {
     },
     update_vaults_many: {
       updates: 'vaults_updates',
+    },
+    update_virtual_profiles_similarity: {
+      _inc: 'virtual_profiles_similarity_inc_input',
+      _set: 'virtual_profiles_similarity_set_input',
+      where: 'virtual_profiles_similarity_bool_exp',
+    },
+    update_virtual_profiles_similarity_by_pk: {
+      _inc: 'virtual_profiles_similarity_inc_input',
+      _set: 'virtual_profiles_similarity_set_input',
+      pk_columns: 'virtual_profiles_similarity_pk_columns_input',
+    },
+    update_virtual_profiles_similarity_many: {
+      updates: 'virtual_profiles_similarity_updates',
     },
     update_vouches: {
       _inc: 'vouches_inc_input',
@@ -8712,6 +8740,7 @@ export const AllTypesProps: Record<string, any> = {
     cosoul: 'cosouls_bool_exp',
     created_at: 'timestamp_comparison_exp',
     description: 'String_comparison_exp',
+    description_embedding: 'vector_comparison_exp',
     discord_username: 'String_comparison_exp',
     distributions: 'distributions_bool_exp',
     distributions_aggregate: 'distributions_aggregate_bool_exp',
@@ -8756,6 +8785,7 @@ export const AllTypesProps: Record<string, any> = {
     claims: 'claims_arr_rel_insert_input',
     cosoul: 'cosouls_obj_rel_insert_input',
     created_at: 'timestamp',
+    description_embedding: 'vector',
     distributions: 'distributions_arr_rel_insert_input',
     emails: 'emails_arr_rel_insert_input',
     id: 'bigint',
@@ -8794,6 +8824,7 @@ export const AllTypesProps: Record<string, any> = {
     cosoul: 'cosouls_order_by',
     created_at: 'order_by',
     description: 'order_by',
+    description_embedding: 'order_by',
     discord_username: 'order_by',
     distributions_aggregate: 'distributions_aggregate_order_by',
     emails_aggregate: 'emails_aggregate_order_by',
@@ -8944,6 +8975,7 @@ export const AllTypesProps: Record<string, any> = {
   profiles_select_column: true,
   profiles_set_input: {
     created_at: 'timestamp',
+    description_embedding: 'vector',
     id: 'bigint',
     invite_code: 'uuid',
     invited_by: 'bigint',
@@ -8957,6 +8989,7 @@ export const AllTypesProps: Record<string, any> = {
   },
   profiles_stream_cursor_value_input: {
     created_at: 'timestamp',
+    description_embedding: 'vector',
     id: 'bigint',
     invite_code: 'uuid',
     invited_by: 'bigint',
@@ -9234,6 +9267,9 @@ export const AllTypesProps: Record<string, any> = {
     },
     getGuildInfo: {
       payload: 'GuildInfoInput',
+    },
+    getSimilarProfiles: {
+      payload: 'SimilarProfileInput',
     },
     gift_private: {
       distinct_on: 'gift_private_select_column',
@@ -9659,6 +9695,18 @@ export const AllTypesProps: Record<string, any> = {
       order_by: 'shared_nfts_order_by',
       where: 'shared_nfts_bool_exp',
     },
+    similar_profiles: {
+      args: 'similar_profiles_args',
+      distinct_on: 'virtual_profiles_similarity_select_column',
+      order_by: 'virtual_profiles_similarity_order_by',
+      where: 'virtual_profiles_similarity_bool_exp',
+    },
+    similar_profiles_aggregate: {
+      args: 'similar_profiles_args',
+      distinct_on: 'virtual_profiles_similarity_select_column',
+      order_by: 'virtual_profiles_similarity_order_by',
+      where: 'virtual_profiles_similarity_bool_exp',
+    },
     skills: {
       distinct_on: 'skills_select_column',
       order_by: 'skills_order_by',
@@ -9792,6 +9840,19 @@ export const AllTypesProps: Record<string, any> = {
       distinct_on: 'poap_holders_select_column',
       order_by: 'poap_holders_order_by',
       where: 'poap_holders_bool_exp',
+    },
+    virtual_profiles_similarity: {
+      distinct_on: 'virtual_profiles_similarity_select_column',
+      order_by: 'virtual_profiles_similarity_order_by',
+      where: 'virtual_profiles_similarity_bool_exp',
+    },
+    virtual_profiles_similarity_aggregate: {
+      distinct_on: 'virtual_profiles_similarity_select_column',
+      order_by: 'virtual_profiles_similarity_order_by',
+      where: 'virtual_profiles_similarity_bool_exp',
+    },
+    virtual_profiles_similarity_by_pk: {
+      id: 'bigint',
     },
     vouches: {
       distinct_on: 'vouches_select_column',
@@ -10243,6 +10304,9 @@ export const AllTypesProps: Record<string, any> = {
     address: 'citext',
     other_address: 'citext',
     shared_count: 'bigint',
+  },
+  similar_profiles_args: {
+    match_threshold: 'float8',
   },
   skills_aggregate_fields: {
     count: {
@@ -11209,6 +11273,18 @@ export const AllTypesProps: Record<string, any> = {
       cursor: 'shared_nfts_stream_cursor_input',
       where: 'shared_nfts_bool_exp',
     },
+    similar_profiles: {
+      args: 'similar_profiles_args',
+      distinct_on: 'virtual_profiles_similarity_select_column',
+      order_by: 'virtual_profiles_similarity_order_by',
+      where: 'virtual_profiles_similarity_bool_exp',
+    },
+    similar_profiles_aggregate: {
+      args: 'similar_profiles_args',
+      distinct_on: 'virtual_profiles_similarity_select_column',
+      order_by: 'virtual_profiles_similarity_order_by',
+      where: 'virtual_profiles_similarity_bool_exp',
+    },
     skills: {
       distinct_on: 'skills_select_column',
       order_by: 'skills_order_by',
@@ -11378,6 +11454,23 @@ export const AllTypesProps: Record<string, any> = {
       distinct_on: 'poap_holders_select_column',
       order_by: 'poap_holders_order_by',
       where: 'poap_holders_bool_exp',
+    },
+    virtual_profiles_similarity: {
+      distinct_on: 'virtual_profiles_similarity_select_column',
+      order_by: 'virtual_profiles_similarity_order_by',
+      where: 'virtual_profiles_similarity_bool_exp',
+    },
+    virtual_profiles_similarity_aggregate: {
+      distinct_on: 'virtual_profiles_similarity_select_column',
+      order_by: 'virtual_profiles_similarity_order_by',
+      where: 'virtual_profiles_similarity_bool_exp',
+    },
+    virtual_profiles_similarity_by_pk: {
+      id: 'bigint',
+    },
+    virtual_profiles_similarity_stream: {
+      cursor: 'virtual_profiles_similarity_stream_cursor_input',
+      where: 'virtual_profiles_similarity_bool_exp',
     },
     vouches: {
       distinct_on: 'vouches_select_column',
@@ -12862,6 +12955,58 @@ export const AllTypesProps: Record<string, any> = {
     match_threshold: 'float8',
     target_vector: 'vector',
   },
+  virtual_profiles_similarity_aggregate_fields: {
+    count: {
+      columns: 'virtual_profiles_similarity_select_column',
+    },
+  },
+  virtual_profiles_similarity_bool_exp: {
+    _and: 'virtual_profiles_similarity_bool_exp',
+    _not: 'virtual_profiles_similarity_bool_exp',
+    _or: 'virtual_profiles_similarity_bool_exp',
+    id: 'bigint_comparison_exp',
+    similarity: 'float8_comparison_exp',
+  },
+  virtual_profiles_similarity_constraint: true,
+  virtual_profiles_similarity_inc_input: {
+    id: 'bigint',
+    similarity: 'float8',
+  },
+  virtual_profiles_similarity_insert_input: {
+    id: 'bigint',
+    similarity: 'float8',
+  },
+  virtual_profiles_similarity_on_conflict: {
+    constraint: 'virtual_profiles_similarity_constraint',
+    update_columns: 'virtual_profiles_similarity_update_column',
+    where: 'virtual_profiles_similarity_bool_exp',
+  },
+  virtual_profiles_similarity_order_by: {
+    id: 'order_by',
+    similarity: 'order_by',
+  },
+  virtual_profiles_similarity_pk_columns_input: {
+    id: 'bigint',
+  },
+  virtual_profiles_similarity_select_column: true,
+  virtual_profiles_similarity_set_input: {
+    id: 'bigint',
+    similarity: 'float8',
+  },
+  virtual_profiles_similarity_stream_cursor_input: {
+    initial_value: 'virtual_profiles_similarity_stream_cursor_value_input',
+    ordering: 'cursor_ordering',
+  },
+  virtual_profiles_similarity_stream_cursor_value_input: {
+    id: 'bigint',
+    similarity: 'float8',
+  },
+  virtual_profiles_similarity_update_column: true,
+  virtual_profiles_similarity_updates: {
+    _inc: 'virtual_profiles_similarity_inc_input',
+    _set: 'virtual_profiles_similarity_set_input',
+    where: 'virtual_profiles_similarity_bool_exp',
+  },
   vouches_aggregate_bool_exp: {
     count: 'vouches_aggregate_bool_exp_count',
   },
@@ -13104,10 +13249,9 @@ export const ReturnTypes: Record<string, any> = {
   SearchCosoulsOutput: {
     cosoul_ids: 'Int',
   },
-  SimilarProfile: {
-    other_address: 'String',
-    other_cosoul: 'cosouls',
-    score: 'Int',
+  SimilarProfileOutput: {
+    profile_id: 'Int',
+    profile_public: 'profiles_public',
   },
   SyncCoSoulOutput: {
     token_id: 'String',
@@ -16550,6 +16694,9 @@ export const ReturnTypes: Record<string, any> = {
     delete_vault_tx_types_by_pk: 'vault_tx_types',
     delete_vaults: 'vaults_mutation_response',
     delete_vaults_by_pk: 'vaults',
+    delete_virtual_profiles_similarity:
+      'virtual_profiles_similarity_mutation_response',
+    delete_virtual_profiles_similarity_by_pk: 'virtual_profiles_similarity',
     delete_vouches: 'vouches_mutation_response',
     delete_vouches_by_pk: 'vouches',
     endEpoch: 'EpochResponse',
@@ -16677,6 +16824,9 @@ export const ReturnTypes: Record<string, any> = {
     insert_vault_tx_types_one: 'vault_tx_types',
     insert_vaults: 'vaults_mutation_response',
     insert_vaults_one: 'vaults',
+    insert_virtual_profiles_similarity:
+      'virtual_profiles_similarity_mutation_response',
+    insert_virtual_profiles_similarity_one: 'virtual_profiles_similarity',
     insert_vouches: 'vouches_mutation_response',
     insert_vouches_one: 'vouches',
     linkDiscordCircle: 'LinkDiscordCircleResponse',
@@ -16881,6 +17031,11 @@ export const ReturnTypes: Record<string, any> = {
     update_vaults: 'vaults_mutation_response',
     update_vaults_by_pk: 'vaults',
     update_vaults_many: 'vaults_mutation_response',
+    update_virtual_profiles_similarity:
+      'virtual_profiles_similarity_mutation_response',
+    update_virtual_profiles_similarity_by_pk: 'virtual_profiles_similarity',
+    update_virtual_profiles_similarity_many:
+      'virtual_profiles_similarity_mutation_response',
     update_vouches: 'vouches_mutation_response',
     update_vouches_by_pk: 'vouches',
     update_vouches_many: 'vouches_mutation_response',
@@ -18474,6 +18629,7 @@ export const ReturnTypes: Record<string, any> = {
     cosoul: 'cosouls',
     created_at: 'timestamp',
     description: 'String',
+    description_embedding: 'vector',
     discord_username: 'String',
     distributions: 'distributions',
     distributions_aggregate: 'distributions_aggregate',
@@ -18820,7 +18976,7 @@ export const ReturnTypes: Record<string, any> = {
     epochs_aggregate: 'epochs_aggregate',
     epochs_by_pk: 'epochs',
     getGuildInfo: 'GuildInfoOutput',
-    getSimilarProfiles: 'SimilarProfile',
+    getSimilarProfiles: 'SimilarProfileOutput',
     gift_private: 'gift_private',
     gift_private_aggregate: 'gift_private_aggregate',
     github_accounts: 'github_accounts',
@@ -18922,6 +19078,8 @@ export const ReturnTypes: Record<string, any> = {
     searchCosouls: 'SearchCosoulsOutput',
     shared_nfts: 'shared_nfts',
     shared_nfts_aggregate: 'shared_nfts_aggregate',
+    similar_profiles: 'virtual_profiles_similarity',
+    similar_profiles_aggregate: 'virtual_profiles_similarity_aggregate',
     skills: 'skills',
     skills_aggregate: 'skills_aggregate',
     skills_by_pk: 'skills',
@@ -18952,6 +19110,10 @@ export const ReturnTypes: Record<string, any> = {
     vector_search_poap_events_aggregate: 'poap_events_aggregate',
     vector_search_poap_holders: 'poap_holders',
     vector_search_poap_holders_aggregate: 'poap_holders_aggregate',
+    virtual_profiles_similarity: 'virtual_profiles_similarity',
+    virtual_profiles_similarity_aggregate:
+      'virtual_profiles_similarity_aggregate',
+    virtual_profiles_similarity_by_pk: 'virtual_profiles_similarity',
     vouches: 'vouches',
     vouches_aggregate: 'vouches_aggregate',
     vouches_by_pk: 'vouches',
@@ -19641,6 +19803,8 @@ export const ReturnTypes: Record<string, any> = {
     shared_nfts: 'shared_nfts',
     shared_nfts_aggregate: 'shared_nfts_aggregate',
     shared_nfts_stream: 'shared_nfts',
+    similar_profiles: 'virtual_profiles_similarity',
+    similar_profiles_aggregate: 'virtual_profiles_similarity_aggregate',
     skills: 'skills',
     skills_aggregate: 'skills_aggregate',
     skills_by_pk: 'skills',
@@ -19680,6 +19844,11 @@ export const ReturnTypes: Record<string, any> = {
     vector_search_poap_events_aggregate: 'poap_events_aggregate',
     vector_search_poap_holders: 'poap_holders',
     vector_search_poap_holders_aggregate: 'poap_holders_aggregate',
+    virtual_profiles_similarity: 'virtual_profiles_similarity',
+    virtual_profiles_similarity_aggregate:
+      'virtual_profiles_similarity_aggregate',
+    virtual_profiles_similarity_by_pk: 'virtual_profiles_similarity',
+    virtual_profiles_similarity_stream: 'virtual_profiles_similarity',
     vouches: 'vouches',
     vouches_aggregate: 'vouches_aggregate',
     vouches_by_pk: 'vouches',
@@ -20549,6 +20718,71 @@ export const ReturnTypes: Record<string, any> = {
     deployment_block: 'Float',
     id: 'Float',
     org_id: 'Float',
+  },
+  virtual_profiles_similarity: {
+    id: 'bigint',
+    similarity: 'float8',
+  },
+  virtual_profiles_similarity_aggregate: {
+    aggregate: 'virtual_profiles_similarity_aggregate_fields',
+    nodes: 'virtual_profiles_similarity',
+  },
+  virtual_profiles_similarity_aggregate_fields: {
+    avg: 'virtual_profiles_similarity_avg_fields',
+    count: 'Int',
+    max: 'virtual_profiles_similarity_max_fields',
+    min: 'virtual_profiles_similarity_min_fields',
+    stddev: 'virtual_profiles_similarity_stddev_fields',
+    stddev_pop: 'virtual_profiles_similarity_stddev_pop_fields',
+    stddev_samp: 'virtual_profiles_similarity_stddev_samp_fields',
+    sum: 'virtual_profiles_similarity_sum_fields',
+    var_pop: 'virtual_profiles_similarity_var_pop_fields',
+    var_samp: 'virtual_profiles_similarity_var_samp_fields',
+    variance: 'virtual_profiles_similarity_variance_fields',
+  },
+  virtual_profiles_similarity_avg_fields: {
+    id: 'Float',
+    similarity: 'Float',
+  },
+  virtual_profiles_similarity_max_fields: {
+    id: 'bigint',
+    similarity: 'float8',
+  },
+  virtual_profiles_similarity_min_fields: {
+    id: 'bigint',
+    similarity: 'float8',
+  },
+  virtual_profiles_similarity_mutation_response: {
+    affected_rows: 'Int',
+    returning: 'virtual_profiles_similarity',
+  },
+  virtual_profiles_similarity_stddev_fields: {
+    id: 'Float',
+    similarity: 'Float',
+  },
+  virtual_profiles_similarity_stddev_pop_fields: {
+    id: 'Float',
+    similarity: 'Float',
+  },
+  virtual_profiles_similarity_stddev_samp_fields: {
+    id: 'Float',
+    similarity: 'Float',
+  },
+  virtual_profiles_similarity_sum_fields: {
+    id: 'bigint',
+    similarity: 'float8',
+  },
+  virtual_profiles_similarity_var_pop_fields: {
+    id: 'Float',
+    similarity: 'Float',
+  },
+  virtual_profiles_similarity_var_samp_fields: {
+    id: 'Float',
+    similarity: 'Float',
+  },
+  virtual_profiles_similarity_variance_fields: {
+    id: 'Float',
+    similarity: 'Float',
   },
   vouches: {
     created_at: 'timestamp',

--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -938,10 +938,12 @@ export type ValueTypes = {
   ['SetPrimaryEmailInput']: {
     email: string;
   };
-  ['SimilarProfile']: AliasType<{
-    other_address?: boolean | `@${string}`;
-    other_cosoul?: ValueTypes['cosouls'];
-    score?: boolean | `@${string}`;
+  ['SimilarProfileInput']: {
+    address: string;
+  };
+  ['SimilarProfileOutput']: AliasType<{
+    profile_id?: boolean | `@${string}`;
+    profile_public?: ValueTypes['profiles_public'];
     __typename?: boolean | `@${string}`;
   }>;
   /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
@@ -14123,6 +14125,17 @@ export type ValueTypes = {
       ValueTypes['vaults_mutation_response']
     ];
     delete_vaults_by_pk?: [{ id: ValueTypes['bigint'] }, ValueTypes['vaults']];
+    delete_virtual_profiles_similarity?: [
+      {
+        /** filter the rows which have to be deleted */
+        where: ValueTypes['virtual_profiles_similarity_bool_exp'];
+      },
+      ValueTypes['virtual_profiles_similarity_mutation_response']
+    ];
+    delete_virtual_profiles_similarity_by_pk?: [
+      { id: ValueTypes['bigint'] },
+      ValueTypes['virtual_profiles_similarity']
+    ];
     delete_vouches?: [
       {
         /** filter the rows which have to be deleted */
@@ -15363,6 +15376,30 @@ export type ValueTypes = {
         on_conflict?: ValueTypes['vaults_on_conflict'] | undefined | null;
       },
       ValueTypes['vaults']
+    ];
+    insert_virtual_profiles_similarity?: [
+      {
+        /** the rows to be inserted */
+        objects: Array<
+          ValueTypes['virtual_profiles_similarity_insert_input']
+        > /** upsert condition */;
+        on_conflict?:
+          | ValueTypes['virtual_profiles_similarity_on_conflict']
+          | undefined
+          | null;
+      },
+      ValueTypes['virtual_profiles_similarity_mutation_response']
+    ];
+    insert_virtual_profiles_similarity_one?: [
+      {
+        /** the row to be inserted */
+        object: ValueTypes['virtual_profiles_similarity_insert_input'] /** upsert condition */;
+        on_conflict?:
+          | ValueTypes['virtual_profiles_similarity_on_conflict']
+          | undefined
+          | null;
+      },
+      ValueTypes['virtual_profiles_similarity']
     ];
     insert_vouches?: [
       {
@@ -17543,6 +17580,43 @@ export type ValueTypes = {
         updates: Array<ValueTypes['vaults_updates']>;
       },
       ValueTypes['vaults_mutation_response']
+    ];
+    update_virtual_profiles_similarity?: [
+      {
+        /** increments the numeric columns with given value of the filtered values */
+        _inc?:
+          | ValueTypes['virtual_profiles_similarity_inc_input']
+          | undefined
+          | null /** sets the columns of the filtered rows to the given values */;
+        _set?:
+          | ValueTypes['virtual_profiles_similarity_set_input']
+          | undefined
+          | null /** filter the rows which have to be updated */;
+        where: ValueTypes['virtual_profiles_similarity_bool_exp'];
+      },
+      ValueTypes['virtual_profiles_similarity_mutation_response']
+    ];
+    update_virtual_profiles_similarity_by_pk?: [
+      {
+        /** increments the numeric columns with given value of the filtered values */
+        _inc?:
+          | ValueTypes['virtual_profiles_similarity_inc_input']
+          | undefined
+          | null /** sets the columns of the filtered rows to the given values */;
+        _set?:
+          | ValueTypes['virtual_profiles_similarity_set_input']
+          | undefined
+          | null;
+        pk_columns: ValueTypes['virtual_profiles_similarity_pk_columns_input'];
+      },
+      ValueTypes['virtual_profiles_similarity']
+    ];
+    update_virtual_profiles_similarity_many?: [
+      {
+        /** updates to execute, in order */
+        updates: Array<ValueTypes['virtual_profiles_similarity_updates']>;
+      },
+      ValueTypes['virtual_profiles_similarity_mutation_response']
     ];
     update_vouches?: [
       {
@@ -22780,6 +22854,7 @@ export type ValueTypes = {
     cosoul?: ValueTypes['cosouls'];
     created_at?: boolean | `@${string}`;
     description?: boolean | `@${string}`;
+    description_embedding?: boolean | `@${string}`;
     discord_username?: boolean | `@${string}`;
     distributions?: [
       {
@@ -23186,6 +23261,10 @@ export type ValueTypes = {
     cosoul?: ValueTypes['cosouls_bool_exp'] | undefined | null;
     created_at?: ValueTypes['timestamp_comparison_exp'] | undefined | null;
     description?: ValueTypes['String_comparison_exp'] | undefined | null;
+    description_embedding?:
+      | ValueTypes['vector_comparison_exp']
+      | undefined
+      | null;
     discord_username?: ValueTypes['String_comparison_exp'] | undefined | null;
     distributions?: ValueTypes['distributions_bool_exp'] | undefined | null;
     distributions_aggregate?:
@@ -23271,6 +23350,7 @@ export type ValueTypes = {
     cosoul?: ValueTypes['cosouls_obj_rel_insert_input'] | undefined | null;
     created_at?: ValueTypes['timestamp'] | undefined | null;
     description?: string | undefined | null;
+    description_embedding?: ValueTypes['vector'] | undefined | null;
     discord_username?: string | undefined | null;
     distributions?:
       | ValueTypes['distributions_arr_rel_insert_input']
@@ -23406,6 +23486,7 @@ export type ValueTypes = {
     cosoul?: ValueTypes['cosouls_order_by'] | undefined | null;
     created_at?: ValueTypes['order_by'] | undefined | null;
     description?: ValueTypes['order_by'] | undefined | null;
+    description_embedding?: ValueTypes['order_by'] | undefined | null;
     discord_username?: ValueTypes['order_by'] | undefined | null;
     distributions_aggregate?:
       | ValueTypes['distributions_aggregate_order_by']
@@ -23933,6 +24014,7 @@ export type ValueTypes = {
     connector?: string | undefined | null;
     created_at?: ValueTypes['timestamp'] | undefined | null;
     description?: string | undefined | null;
+    description_embedding?: ValueTypes['vector'] | undefined | null;
     discord_username?: string | undefined | null;
     github_username?: string | undefined | null;
     id?: ValueTypes['bigint'] | undefined | null;
@@ -23996,6 +24078,7 @@ export type ValueTypes = {
     connector?: string | undefined | null;
     created_at?: ValueTypes['timestamp'] | undefined | null;
     description?: string | undefined | null;
+    description_embedding?: ValueTypes['vector'] | undefined | null;
     discord_username?: string | undefined | null;
     github_username?: string | undefined | null;
     id?: ValueTypes['bigint'] | undefined | null;
@@ -25095,7 +25178,10 @@ export type ValueTypes = {
       { payload: ValueTypes['GuildInfoInput'] },
       ValueTypes['GuildInfoOutput']
     ];
-    getSimilarProfiles?: ValueTypes['SimilarProfile'];
+    getSimilarProfiles?: [
+      { payload: ValueTypes['SimilarProfileInput'] },
+      ValueTypes['SimilarProfileOutput']
+    ];
     gift_private?: [
       {
         /** distinct select on columns */
@@ -26800,6 +26886,60 @@ export type ValueTypes = {
       },
       ValueTypes['shared_nfts_aggregate']
     ];
+    similar_profiles?: [
+      {
+        /** input parameters for function "similar_profiles" */
+        args: ValueTypes['similar_profiles_args'] /** distinct select on columns */;
+        distinct_on?:
+          | Array<ValueTypes['virtual_profiles_similarity_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['virtual_profiles_similarity_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?:
+          | ValueTypes['virtual_profiles_similarity_bool_exp']
+          | undefined
+          | null;
+      },
+      ValueTypes['virtual_profiles_similarity']
+    ];
+    similar_profiles_aggregate?: [
+      {
+        /** input parameters for function "similar_profiles_aggregate" */
+        args: ValueTypes['similar_profiles_args'] /** distinct select on columns */;
+        distinct_on?:
+          | Array<ValueTypes['virtual_profiles_similarity_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['virtual_profiles_similarity_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?:
+          | ValueTypes['virtual_profiles_similarity_bool_exp']
+          | undefined
+          | null;
+      },
+      ValueTypes['virtual_profiles_similarity_aggregate']
+    ];
     skills?: [
       {
         /** distinct select on columns */
@@ -27326,6 +27466,62 @@ export type ValueTypes = {
         where?: ValueTypes['poap_holders_bool_exp'] | undefined | null;
       },
       ValueTypes['poap_holders_aggregate']
+    ];
+    virtual_profiles_similarity?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['virtual_profiles_similarity_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['virtual_profiles_similarity_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?:
+          | ValueTypes['virtual_profiles_similarity_bool_exp']
+          | undefined
+          | null;
+      },
+      ValueTypes['virtual_profiles_similarity']
+    ];
+    virtual_profiles_similarity_aggregate?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['virtual_profiles_similarity_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['virtual_profiles_similarity_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?:
+          | ValueTypes['virtual_profiles_similarity_bool_exp']
+          | undefined
+          | null;
+      },
+      ValueTypes['virtual_profiles_similarity_aggregate']
+    ];
+    virtual_profiles_similarity_by_pk?: [
+      { id: ValueTypes['bigint'] },
+      ValueTypes['virtual_profiles_similarity']
     ];
     vouches?: [
       {
@@ -28525,6 +28721,11 @@ export type ValueTypes = {
     shared_count?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
+  ['similar_profiles_args']: {
+    limit_count?: number | undefined | null;
+    match_threshold?: ValueTypes['float8'] | undefined | null;
+    profile_address?: string | undefined | null;
+  };
   /** columns and relationships of "skills" */
   ['skills']: AliasType<{
     count?: boolean | `@${string}`;
@@ -32098,6 +32299,60 @@ export type ValueTypes = {
       },
       ValueTypes['shared_nfts']
     ];
+    similar_profiles?: [
+      {
+        /** input parameters for function "similar_profiles" */
+        args: ValueTypes['similar_profiles_args'] /** distinct select on columns */;
+        distinct_on?:
+          | Array<ValueTypes['virtual_profiles_similarity_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['virtual_profiles_similarity_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?:
+          | ValueTypes['virtual_profiles_similarity_bool_exp']
+          | undefined
+          | null;
+      },
+      ValueTypes['virtual_profiles_similarity']
+    ];
+    similar_profiles_aggregate?: [
+      {
+        /** input parameters for function "similar_profiles_aggregate" */
+        args: ValueTypes['similar_profiles_args'] /** distinct select on columns */;
+        distinct_on?:
+          | Array<ValueTypes['virtual_profiles_similarity_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['virtual_profiles_similarity_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?:
+          | ValueTypes['virtual_profiles_similarity_bool_exp']
+          | undefined
+          | null;
+      },
+      ValueTypes['virtual_profiles_similarity_aggregate']
+    ];
     skills?: [
       {
         /** distinct select on columns */
@@ -32725,6 +32980,78 @@ export type ValueTypes = {
         where?: ValueTypes['poap_holders_bool_exp'] | undefined | null;
       },
       ValueTypes['poap_holders_aggregate']
+    ];
+    virtual_profiles_similarity?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['virtual_profiles_similarity_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['virtual_profiles_similarity_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?:
+          | ValueTypes['virtual_profiles_similarity_bool_exp']
+          | undefined
+          | null;
+      },
+      ValueTypes['virtual_profiles_similarity']
+    ];
+    virtual_profiles_similarity_aggregate?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['virtual_profiles_similarity_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['virtual_profiles_similarity_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?:
+          | ValueTypes['virtual_profiles_similarity_bool_exp']
+          | undefined
+          | null;
+      },
+      ValueTypes['virtual_profiles_similarity_aggregate']
+    ];
+    virtual_profiles_similarity_by_pk?: [
+      { id: ValueTypes['bigint'] },
+      ValueTypes['virtual_profiles_similarity']
+    ];
+    virtual_profiles_similarity_stream?: [
+      {
+        /** maximum number of rows returned in a single batch */
+        batch_size: number /** cursor to stream the results returned by the query */;
+        cursor: Array<
+          | ValueTypes['virtual_profiles_similarity_stream_cursor_input']
+          | undefined
+          | null
+        > /** filter the rows returned */;
+        where?:
+          | ValueTypes['virtual_profiles_similarity_bool_exp']
+          | undefined
+          | null;
+      },
+      ValueTypes['virtual_profiles_similarity']
     ];
     vouches?: [
       {
@@ -36370,6 +36697,193 @@ export type ValueTypes = {
     match_threshold?: ValueTypes['float8'] | undefined | null;
     target_vector?: ValueTypes['vector'] | undefined | null;
   };
+  /** Virtual table for profiles vector similarity */
+  ['virtual_profiles_similarity']: AliasType<{
+    id?: boolean | `@${string}`;
+    similarity?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  ['virtual_profiles_similarity_aggregate']: AliasType<{
+    aggregate?: ValueTypes['virtual_profiles_similarity_aggregate_fields'];
+    nodes?: ValueTypes['virtual_profiles_similarity'];
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate fields of "virtual_profiles_similarity" */
+  ['virtual_profiles_similarity_aggregate_fields']: AliasType<{
+    avg?: ValueTypes['virtual_profiles_similarity_avg_fields'];
+    count?: [
+      {
+        columns?:
+          | Array<ValueTypes['virtual_profiles_similarity_select_column']>
+          | undefined
+          | null;
+        distinct?: boolean | undefined | null;
+      },
+      boolean | `@${string}`
+    ];
+    max?: ValueTypes['virtual_profiles_similarity_max_fields'];
+    min?: ValueTypes['virtual_profiles_similarity_min_fields'];
+    stddev?: ValueTypes['virtual_profiles_similarity_stddev_fields'];
+    stddev_pop?: ValueTypes['virtual_profiles_similarity_stddev_pop_fields'];
+    stddev_samp?: ValueTypes['virtual_profiles_similarity_stddev_samp_fields'];
+    sum?: ValueTypes['virtual_profiles_similarity_sum_fields'];
+    var_pop?: ValueTypes['virtual_profiles_similarity_var_pop_fields'];
+    var_samp?: ValueTypes['virtual_profiles_similarity_var_samp_fields'];
+    variance?: ValueTypes['virtual_profiles_similarity_variance_fields'];
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate avg on columns */
+  ['virtual_profiles_similarity_avg_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    similarity?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** Boolean expression to filter rows from the table "virtual_profiles_similarity". All fields are combined with a logical 'AND'. */
+  ['virtual_profiles_similarity_bool_exp']: {
+    _and?:
+      | Array<ValueTypes['virtual_profiles_similarity_bool_exp']>
+      | undefined
+      | null;
+    _not?:
+      | ValueTypes['virtual_profiles_similarity_bool_exp']
+      | undefined
+      | null;
+    _or?:
+      | Array<ValueTypes['virtual_profiles_similarity_bool_exp']>
+      | undefined
+      | null;
+    id?: ValueTypes['bigint_comparison_exp'] | undefined | null;
+    similarity?: ValueTypes['float8_comparison_exp'] | undefined | null;
+  };
+  /** unique or primary key constraints on table "virtual_profiles_similarity" */
+  ['virtual_profiles_similarity_constraint']: virtual_profiles_similarity_constraint;
+  /** input type for incrementing numeric columns in table "virtual_profiles_similarity" */
+  ['virtual_profiles_similarity_inc_input']: {
+    id?: ValueTypes['bigint'] | undefined | null;
+    similarity?: ValueTypes['float8'] | undefined | null;
+  };
+  /** input type for inserting data into table "virtual_profiles_similarity" */
+  ['virtual_profiles_similarity_insert_input']: {
+    id?: ValueTypes['bigint'] | undefined | null;
+    similarity?: ValueTypes['float8'] | undefined | null;
+  };
+  /** aggregate max on columns */
+  ['virtual_profiles_similarity_max_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    similarity?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate min on columns */
+  ['virtual_profiles_similarity_min_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    similarity?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** response of any mutation on the table "virtual_profiles_similarity" */
+  ['virtual_profiles_similarity_mutation_response']: AliasType<{
+    /** number of rows affected by the mutation */
+    affected_rows?: boolean | `@${string}`;
+    /** data from the rows affected by the mutation */
+    returning?: ValueTypes['virtual_profiles_similarity'];
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** on_conflict condition type for table "virtual_profiles_similarity" */
+  ['virtual_profiles_similarity_on_conflict']: {
+    constraint: ValueTypes['virtual_profiles_similarity_constraint'];
+    update_columns: Array<
+      ValueTypes['virtual_profiles_similarity_update_column']
+    >;
+    where?:
+      | ValueTypes['virtual_profiles_similarity_bool_exp']
+      | undefined
+      | null;
+  };
+  /** Ordering options when selecting data from "virtual_profiles_similarity". */
+  ['virtual_profiles_similarity_order_by']: {
+    id?: ValueTypes['order_by'] | undefined | null;
+    similarity?: ValueTypes['order_by'] | undefined | null;
+  };
+  /** primary key columns input for table: virtual_profiles_similarity */
+  ['virtual_profiles_similarity_pk_columns_input']: {
+    id: ValueTypes['bigint'];
+  };
+  /** select columns of table "virtual_profiles_similarity" */
+  ['virtual_profiles_similarity_select_column']: virtual_profiles_similarity_select_column;
+  /** input type for updating data in table "virtual_profiles_similarity" */
+  ['virtual_profiles_similarity_set_input']: {
+    id?: ValueTypes['bigint'] | undefined | null;
+    similarity?: ValueTypes['float8'] | undefined | null;
+  };
+  /** aggregate stddev on columns */
+  ['virtual_profiles_similarity_stddev_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    similarity?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate stddev_pop on columns */
+  ['virtual_profiles_similarity_stddev_pop_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    similarity?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate stddev_samp on columns */
+  ['virtual_profiles_similarity_stddev_samp_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    similarity?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** Streaming cursor of the table "virtual_profiles_similarity" */
+  ['virtual_profiles_similarity_stream_cursor_input']: {
+    /** Stream column input with initial value */
+    initial_value: ValueTypes['virtual_profiles_similarity_stream_cursor_value_input'];
+    /** cursor ordering */
+    ordering?: ValueTypes['cursor_ordering'] | undefined | null;
+  };
+  /** Initial value of the column from where the streaming should start */
+  ['virtual_profiles_similarity_stream_cursor_value_input']: {
+    id?: ValueTypes['bigint'] | undefined | null;
+    similarity?: ValueTypes['float8'] | undefined | null;
+  };
+  /** aggregate sum on columns */
+  ['virtual_profiles_similarity_sum_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    similarity?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** update columns of table "virtual_profiles_similarity" */
+  ['virtual_profiles_similarity_update_column']: virtual_profiles_similarity_update_column;
+  ['virtual_profiles_similarity_updates']: {
+    /** increments the numeric columns with given value of the filtered values */
+    _inc?:
+      | ValueTypes['virtual_profiles_similarity_inc_input']
+      | undefined
+      | null;
+    /** sets the columns of the filtered rows to the given values */
+    _set?:
+      | ValueTypes['virtual_profiles_similarity_set_input']
+      | undefined
+      | null;
+    /** filter the rows which have to be updated */
+    where: ValueTypes['virtual_profiles_similarity_bool_exp'];
+  };
+  /** aggregate var_pop on columns */
+  ['virtual_profiles_similarity_var_pop_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    similarity?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate var_samp on columns */
+  ['virtual_profiles_similarity_var_samp_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    similarity?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate variance on columns */
+  ['virtual_profiles_similarity_variance_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    similarity?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
   /** columns and relationships of "vouches" */
   ['vouches']: AliasType<{
     created_at?: boolean | `@${string}`;
@@ -36802,10 +37316,10 @@ export type ModelTypes = {
     cosoul_ids: Array<number>;
   };
   ['SetPrimaryEmailInput']: GraphQLTypes['SetPrimaryEmailInput'];
-  ['SimilarProfile']: {
-    other_address: string;
-    other_cosoul?: GraphQLTypes['cosouls'] | undefined;
-    score: number;
+  ['SimilarProfileInput']: GraphQLTypes['SimilarProfileInput'];
+  ['SimilarProfileOutput']: {
+    profile_id: number;
+    profile_public?: GraphQLTypes['profiles_public'] | undefined;
   };
   /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
   ['String_comparison_exp']: GraphQLTypes['String_comparison_exp'];
@@ -42534,6 +43048,14 @@ export type ModelTypes = {
     delete_vaults?: GraphQLTypes['vaults_mutation_response'] | undefined;
     /** delete single row from the table: "vaults" */
     delete_vaults_by_pk?: GraphQLTypes['vaults'] | undefined;
+    /** delete data from the table: "virtual_profiles_similarity" */
+    delete_virtual_profiles_similarity?:
+      | GraphQLTypes['virtual_profiles_similarity_mutation_response']
+      | undefined;
+    /** delete single row from the table: "virtual_profiles_similarity" */
+    delete_virtual_profiles_similarity_by_pk?:
+      | GraphQLTypes['virtual_profiles_similarity']
+      | undefined;
     /** delete data from the table: "vouches" */
     delete_vouches?: GraphQLTypes['vouches_mutation_response'] | undefined;
     /** delete single row from the table: "vouches" */
@@ -42893,6 +43415,14 @@ export type ModelTypes = {
     insert_vaults?: GraphQLTypes['vaults_mutation_response'] | undefined;
     /** insert a single row into the table: "vaults" */
     insert_vaults_one?: GraphQLTypes['vaults'] | undefined;
+    /** insert data into the table: "virtual_profiles_similarity" */
+    insert_virtual_profiles_similarity?:
+      | GraphQLTypes['virtual_profiles_similarity_mutation_response']
+      | undefined;
+    /** insert a single row into the table: "virtual_profiles_similarity" */
+    insert_virtual_profiles_similarity_one?:
+      | GraphQLTypes['virtual_profiles_similarity']
+      | undefined;
     /** insert data into the table: "vouches" */
     insert_vouches?: GraphQLTypes['vouches_mutation_response'] | undefined;
     /** insert a single row into the table: "vouches" */
@@ -43526,6 +44056,21 @@ export type ModelTypes = {
     /** update multiples rows of table: "vaults" */
     update_vaults_many?:
       | Array<GraphQLTypes['vaults_mutation_response'] | undefined>
+      | undefined;
+    /** update data of the table: "virtual_profiles_similarity" */
+    update_virtual_profiles_similarity?:
+      | GraphQLTypes['virtual_profiles_similarity_mutation_response']
+      | undefined;
+    /** update single row of the table: "virtual_profiles_similarity" */
+    update_virtual_profiles_similarity_by_pk?:
+      | GraphQLTypes['virtual_profiles_similarity']
+      | undefined;
+    /** update multiples rows of table: "virtual_profiles_similarity" */
+    update_virtual_profiles_similarity_many?:
+      | Array<
+          | GraphQLTypes['virtual_profiles_similarity_mutation_response']
+          | undefined
+        >
       | undefined;
     /** update data of the table: "vouches" */
     update_vouches?: GraphQLTypes['vouches_mutation_response'] | undefined;
@@ -46111,6 +46656,7 @@ export type ModelTypes = {
     cosoul?: GraphQLTypes['cosouls'] | undefined;
     created_at: GraphQLTypes['timestamp'];
     description?: string | undefined;
+    description_embedding?: GraphQLTypes['vector'] | undefined;
     discord_username?: string | undefined;
     /** An array relationship */
     distributions: Array<GraphQLTypes['distributions']>;
@@ -46624,9 +47170,7 @@ export type ModelTypes = {
     /** fetch data from the table: "epoches" using primary key columns */
     epochs_by_pk?: GraphQLTypes['epochs'] | undefined;
     getGuildInfo?: GraphQLTypes['GuildInfoOutput'] | undefined;
-    getSimilarProfiles?:
-      | Array<GraphQLTypes['SimilarProfile'] | undefined>
-      | undefined;
+    getSimilarProfiles: Array<GraphQLTypes['SimilarProfileOutput']>;
     /** fetch data from the table: "gift_private" */
     gift_private: Array<GraphQLTypes['gift_private']>;
     /** fetch aggregated fields from the table: "gift_private" */
@@ -46838,6 +47382,10 @@ export type ModelTypes = {
     shared_nfts: Array<GraphQLTypes['shared_nfts']>;
     /** fetch aggregated fields from the table: "shared_nfts" */
     shared_nfts_aggregate: GraphQLTypes['shared_nfts_aggregate'];
+    /** execute function "similar_profiles" which returns "virtual_profiles_similarity" */
+    similar_profiles: Array<GraphQLTypes['virtual_profiles_similarity']>;
+    /** execute function "similar_profiles" and query aggregates on result of table type "virtual_profiles_similarity" */
+    similar_profiles_aggregate: GraphQLTypes['virtual_profiles_similarity_aggregate'];
     /** fetch data from the table: "skills" */
     skills: Array<GraphQLTypes['skills']>;
     /** fetch aggregated fields from the table: "skills" */
@@ -46898,6 +47446,16 @@ export type ModelTypes = {
     vector_search_poap_holders: Array<GraphQLTypes['poap_holders']>;
     /** execute function "vector_search_poap_holders" and query aggregates on result of table type "poap_holders" */
     vector_search_poap_holders_aggregate: GraphQLTypes['poap_holders_aggregate'];
+    /** fetch data from the table: "virtual_profiles_similarity" */
+    virtual_profiles_similarity: Array<
+      GraphQLTypes['virtual_profiles_similarity']
+    >;
+    /** fetch aggregated fields from the table: "virtual_profiles_similarity" */
+    virtual_profiles_similarity_aggregate: GraphQLTypes['virtual_profiles_similarity_aggregate'];
+    /** fetch data from the table: "virtual_profiles_similarity" using primary key columns */
+    virtual_profiles_similarity_by_pk?:
+      | GraphQLTypes['virtual_profiles_similarity']
+      | undefined;
     /** An array relationship */
     vouches: Array<GraphQLTypes['vouches']>;
     /** An aggregate relationship */
@@ -47526,6 +48084,7 @@ export type ModelTypes = {
   ['shared_nfts_variance_fields']: {
     shared_count?: number | undefined;
   };
+  ['similar_profiles_args']: GraphQLTypes['similar_profiles_args'];
   /** columns and relationships of "skills" */
   ['skills']: {
     count: number;
@@ -48097,6 +48656,10 @@ export type ModelTypes = {
     shared_nfts_aggregate: GraphQLTypes['shared_nfts_aggregate'];
     /** fetch data from the table in a streaming manner: "shared_nfts" */
     shared_nfts_stream: Array<GraphQLTypes['shared_nfts']>;
+    /** execute function "similar_profiles" which returns "virtual_profiles_similarity" */
+    similar_profiles: Array<GraphQLTypes['virtual_profiles_similarity']>;
+    /** execute function "similar_profiles" and query aggregates on result of table type "virtual_profiles_similarity" */
+    similar_profiles_aggregate: GraphQLTypes['virtual_profiles_similarity_aggregate'];
     /** fetch data from the table: "skills" */
     skills: Array<GraphQLTypes['skills']>;
     /** fetch aggregated fields from the table: "skills" */
@@ -48175,6 +48738,20 @@ export type ModelTypes = {
     vector_search_poap_holders: Array<GraphQLTypes['poap_holders']>;
     /** execute function "vector_search_poap_holders" and query aggregates on result of table type "poap_holders" */
     vector_search_poap_holders_aggregate: GraphQLTypes['poap_holders_aggregate'];
+    /** fetch data from the table: "virtual_profiles_similarity" */
+    virtual_profiles_similarity: Array<
+      GraphQLTypes['virtual_profiles_similarity']
+    >;
+    /** fetch aggregated fields from the table: "virtual_profiles_similarity" */
+    virtual_profiles_similarity_aggregate: GraphQLTypes['virtual_profiles_similarity_aggregate'];
+    /** fetch data from the table: "virtual_profiles_similarity" using primary key columns */
+    virtual_profiles_similarity_by_pk?:
+      | GraphQLTypes['virtual_profiles_similarity']
+      | undefined;
+    /** fetch data from the table in a streaming manner: "virtual_profiles_similarity" */
+    virtual_profiles_similarity_stream: Array<
+      GraphQLTypes['virtual_profiles_similarity']
+    >;
     /** An array relationship */
     vouches: Array<GraphQLTypes['vouches']>;
     /** An aggregate relationship */
@@ -49564,6 +50141,125 @@ export type ModelTypes = {
   ['vector_comparison_exp']: GraphQLTypes['vector_comparison_exp'];
   ['vector_search_poap_events_args']: GraphQLTypes['vector_search_poap_events_args'];
   ['vector_search_poap_holders_args']: GraphQLTypes['vector_search_poap_holders_args'];
+  /** Virtual table for profiles vector similarity */
+  ['virtual_profiles_similarity']: {
+    id: GraphQLTypes['bigint'];
+    similarity: GraphQLTypes['float8'];
+  };
+  ['virtual_profiles_similarity_aggregate']: {
+    aggregate?:
+      | GraphQLTypes['virtual_profiles_similarity_aggregate_fields']
+      | undefined;
+    nodes: Array<GraphQLTypes['virtual_profiles_similarity']>;
+  };
+  /** aggregate fields of "virtual_profiles_similarity" */
+  ['virtual_profiles_similarity_aggregate_fields']: {
+    avg?: GraphQLTypes['virtual_profiles_similarity_avg_fields'] | undefined;
+    count: number;
+    max?: GraphQLTypes['virtual_profiles_similarity_max_fields'] | undefined;
+    min?: GraphQLTypes['virtual_profiles_similarity_min_fields'] | undefined;
+    stddev?:
+      | GraphQLTypes['virtual_profiles_similarity_stddev_fields']
+      | undefined;
+    stddev_pop?:
+      | GraphQLTypes['virtual_profiles_similarity_stddev_pop_fields']
+      | undefined;
+    stddev_samp?:
+      | GraphQLTypes['virtual_profiles_similarity_stddev_samp_fields']
+      | undefined;
+    sum?: GraphQLTypes['virtual_profiles_similarity_sum_fields'] | undefined;
+    var_pop?:
+      | GraphQLTypes['virtual_profiles_similarity_var_pop_fields']
+      | undefined;
+    var_samp?:
+      | GraphQLTypes['virtual_profiles_similarity_var_samp_fields']
+      | undefined;
+    variance?:
+      | GraphQLTypes['virtual_profiles_similarity_variance_fields']
+      | undefined;
+  };
+  /** aggregate avg on columns */
+  ['virtual_profiles_similarity_avg_fields']: {
+    id?: number | undefined;
+    similarity?: number | undefined;
+  };
+  /** Boolean expression to filter rows from the table "virtual_profiles_similarity". All fields are combined with a logical 'AND'. */
+  ['virtual_profiles_similarity_bool_exp']: GraphQLTypes['virtual_profiles_similarity_bool_exp'];
+  /** unique or primary key constraints on table "virtual_profiles_similarity" */
+  ['virtual_profiles_similarity_constraint']: GraphQLTypes['virtual_profiles_similarity_constraint'];
+  /** input type for incrementing numeric columns in table "virtual_profiles_similarity" */
+  ['virtual_profiles_similarity_inc_input']: GraphQLTypes['virtual_profiles_similarity_inc_input'];
+  /** input type for inserting data into table "virtual_profiles_similarity" */
+  ['virtual_profiles_similarity_insert_input']: GraphQLTypes['virtual_profiles_similarity_insert_input'];
+  /** aggregate max on columns */
+  ['virtual_profiles_similarity_max_fields']: {
+    id?: GraphQLTypes['bigint'] | undefined;
+    similarity?: GraphQLTypes['float8'] | undefined;
+  };
+  /** aggregate min on columns */
+  ['virtual_profiles_similarity_min_fields']: {
+    id?: GraphQLTypes['bigint'] | undefined;
+    similarity?: GraphQLTypes['float8'] | undefined;
+  };
+  /** response of any mutation on the table "virtual_profiles_similarity" */
+  ['virtual_profiles_similarity_mutation_response']: {
+    /** number of rows affected by the mutation */
+    affected_rows: number;
+    /** data from the rows affected by the mutation */
+    returning: Array<GraphQLTypes['virtual_profiles_similarity']>;
+  };
+  /** on_conflict condition type for table "virtual_profiles_similarity" */
+  ['virtual_profiles_similarity_on_conflict']: GraphQLTypes['virtual_profiles_similarity_on_conflict'];
+  /** Ordering options when selecting data from "virtual_profiles_similarity". */
+  ['virtual_profiles_similarity_order_by']: GraphQLTypes['virtual_profiles_similarity_order_by'];
+  /** primary key columns input for table: virtual_profiles_similarity */
+  ['virtual_profiles_similarity_pk_columns_input']: GraphQLTypes['virtual_profiles_similarity_pk_columns_input'];
+  /** select columns of table "virtual_profiles_similarity" */
+  ['virtual_profiles_similarity_select_column']: GraphQLTypes['virtual_profiles_similarity_select_column'];
+  /** input type for updating data in table "virtual_profiles_similarity" */
+  ['virtual_profiles_similarity_set_input']: GraphQLTypes['virtual_profiles_similarity_set_input'];
+  /** aggregate stddev on columns */
+  ['virtual_profiles_similarity_stddev_fields']: {
+    id?: number | undefined;
+    similarity?: number | undefined;
+  };
+  /** aggregate stddev_pop on columns */
+  ['virtual_profiles_similarity_stddev_pop_fields']: {
+    id?: number | undefined;
+    similarity?: number | undefined;
+  };
+  /** aggregate stddev_samp on columns */
+  ['virtual_profiles_similarity_stddev_samp_fields']: {
+    id?: number | undefined;
+    similarity?: number | undefined;
+  };
+  /** Streaming cursor of the table "virtual_profiles_similarity" */
+  ['virtual_profiles_similarity_stream_cursor_input']: GraphQLTypes['virtual_profiles_similarity_stream_cursor_input'];
+  /** Initial value of the column from where the streaming should start */
+  ['virtual_profiles_similarity_stream_cursor_value_input']: GraphQLTypes['virtual_profiles_similarity_stream_cursor_value_input'];
+  /** aggregate sum on columns */
+  ['virtual_profiles_similarity_sum_fields']: {
+    id?: GraphQLTypes['bigint'] | undefined;
+    similarity?: GraphQLTypes['float8'] | undefined;
+  };
+  /** update columns of table "virtual_profiles_similarity" */
+  ['virtual_profiles_similarity_update_column']: GraphQLTypes['virtual_profiles_similarity_update_column'];
+  ['virtual_profiles_similarity_updates']: GraphQLTypes['virtual_profiles_similarity_updates'];
+  /** aggregate var_pop on columns */
+  ['virtual_profiles_similarity_var_pop_fields']: {
+    id?: number | undefined;
+    similarity?: number | undefined;
+  };
+  /** aggregate var_samp on columns */
+  ['virtual_profiles_similarity_var_samp_fields']: {
+    id?: number | undefined;
+    similarity?: number | undefined;
+  };
+  /** aggregate variance on columns */
+  ['virtual_profiles_similarity_variance_fields']: {
+    id?: number | undefined;
+    similarity?: number | undefined;
+  };
   /** columns and relationships of "vouches" */
   ['vouches']: {
     created_at: GraphQLTypes['timestamp'];
@@ -50025,11 +50721,13 @@ export type GraphQLTypes = {
   ['SetPrimaryEmailInput']: {
     email: string;
   };
-  ['SimilarProfile']: {
-    __typename: 'SimilarProfile';
-    other_address: string;
-    other_cosoul?: GraphQLTypes['cosouls'] | undefined;
-    score: number;
+  ['SimilarProfileInput']: {
+    address: string;
+  };
+  ['SimilarProfileOutput']: {
+    __typename: 'SimilarProfileOutput';
+    profile_id: number;
+    profile_public?: GraphQLTypes['profiles_public'] | undefined;
   };
   /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
   ['String_comparison_exp']: {
@@ -61037,6 +61735,14 @@ export type GraphQLTypes = {
     delete_vaults?: GraphQLTypes['vaults_mutation_response'] | undefined;
     /** delete single row from the table: "vaults" */
     delete_vaults_by_pk?: GraphQLTypes['vaults'] | undefined;
+    /** delete data from the table: "virtual_profiles_similarity" */
+    delete_virtual_profiles_similarity?:
+      | GraphQLTypes['virtual_profiles_similarity_mutation_response']
+      | undefined;
+    /** delete single row from the table: "virtual_profiles_similarity" */
+    delete_virtual_profiles_similarity_by_pk?:
+      | GraphQLTypes['virtual_profiles_similarity']
+      | undefined;
     /** delete data from the table: "vouches" */
     delete_vouches?: GraphQLTypes['vouches_mutation_response'] | undefined;
     /** delete single row from the table: "vouches" */
@@ -61396,6 +62102,14 @@ export type GraphQLTypes = {
     insert_vaults?: GraphQLTypes['vaults_mutation_response'] | undefined;
     /** insert a single row into the table: "vaults" */
     insert_vaults_one?: GraphQLTypes['vaults'] | undefined;
+    /** insert data into the table: "virtual_profiles_similarity" */
+    insert_virtual_profiles_similarity?:
+      | GraphQLTypes['virtual_profiles_similarity_mutation_response']
+      | undefined;
+    /** insert a single row into the table: "virtual_profiles_similarity" */
+    insert_virtual_profiles_similarity_one?:
+      | GraphQLTypes['virtual_profiles_similarity']
+      | undefined;
     /** insert data into the table: "vouches" */
     insert_vouches?: GraphQLTypes['vouches_mutation_response'] | undefined;
     /** insert a single row into the table: "vouches" */
@@ -62029,6 +62743,21 @@ export type GraphQLTypes = {
     /** update multiples rows of table: "vaults" */
     update_vaults_many?:
       | Array<GraphQLTypes['vaults_mutation_response'] | undefined>
+      | undefined;
+    /** update data of the table: "virtual_profiles_similarity" */
+    update_virtual_profiles_similarity?:
+      | GraphQLTypes['virtual_profiles_similarity_mutation_response']
+      | undefined;
+    /** update single row of the table: "virtual_profiles_similarity" */
+    update_virtual_profiles_similarity_by_pk?:
+      | GraphQLTypes['virtual_profiles_similarity']
+      | undefined;
+    /** update multiples rows of table: "virtual_profiles_similarity" */
+    update_virtual_profiles_similarity_many?:
+      | Array<
+          | GraphQLTypes['virtual_profiles_similarity_mutation_response']
+          | undefined
+        >
       | undefined;
     /** update data of the table: "vouches" */
     update_vouches?: GraphQLTypes['vouches_mutation_response'] | undefined;
@@ -66757,6 +67486,7 @@ export type GraphQLTypes = {
     cosoul?: GraphQLTypes['cosouls'] | undefined;
     created_at: GraphQLTypes['timestamp'];
     description?: string | undefined;
+    description_embedding?: GraphQLTypes['vector'] | undefined;
     discord_username?: string | undefined;
     /** An array relationship */
     distributions: Array<GraphQLTypes['distributions']>;
@@ -66856,6 +67586,7 @@ export type GraphQLTypes = {
     cosoul?: GraphQLTypes['cosouls_bool_exp'] | undefined;
     created_at?: GraphQLTypes['timestamp_comparison_exp'] | undefined;
     description?: GraphQLTypes['String_comparison_exp'] | undefined;
+    description_embedding?: GraphQLTypes['vector_comparison_exp'] | undefined;
     discord_username?: GraphQLTypes['String_comparison_exp'] | undefined;
     distributions?: GraphQLTypes['distributions_bool_exp'] | undefined;
     distributions_aggregate?:
@@ -66924,6 +67655,7 @@ export type GraphQLTypes = {
     cosoul?: GraphQLTypes['cosouls_obj_rel_insert_input'] | undefined;
     created_at?: GraphQLTypes['timestamp'] | undefined;
     description?: string | undefined;
+    description_embedding?: GraphQLTypes['vector'] | undefined;
     discord_username?: string | undefined;
     distributions?:
       | GraphQLTypes['distributions_arr_rel_insert_input']
@@ -67049,6 +67781,7 @@ export type GraphQLTypes = {
     cosoul?: GraphQLTypes['cosouls_order_by'] | undefined;
     created_at?: GraphQLTypes['order_by'] | undefined;
     description?: GraphQLTypes['order_by'] | undefined;
+    description_embedding?: GraphQLTypes['order_by'] | undefined;
     discord_username?: GraphQLTypes['order_by'] | undefined;
     distributions_aggregate?:
       | GraphQLTypes['distributions_aggregate_order_by']
@@ -67365,6 +68098,7 @@ export type GraphQLTypes = {
     connector?: string | undefined;
     created_at?: GraphQLTypes['timestamp'] | undefined;
     description?: string | undefined;
+    description_embedding?: GraphQLTypes['vector'] | undefined;
     discord_username?: string | undefined;
     github_username?: string | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
@@ -67428,6 +68162,7 @@ export type GraphQLTypes = {
     connector?: string | undefined;
     created_at?: GraphQLTypes['timestamp'] | undefined;
     description?: string | undefined;
+    description_embedding?: GraphQLTypes['vector'] | undefined;
     discord_username?: string | undefined;
     github_username?: string | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
@@ -67625,9 +68360,7 @@ export type GraphQLTypes = {
     /** fetch data from the table: "epoches" using primary key columns */
     epochs_by_pk?: GraphQLTypes['epochs'] | undefined;
     getGuildInfo?: GraphQLTypes['GuildInfoOutput'] | undefined;
-    getSimilarProfiles?:
-      | Array<GraphQLTypes['SimilarProfile'] | undefined>
-      | undefined;
+    getSimilarProfiles: Array<GraphQLTypes['SimilarProfileOutput']>;
     /** fetch data from the table: "gift_private" */
     gift_private: Array<GraphQLTypes['gift_private']>;
     /** fetch aggregated fields from the table: "gift_private" */
@@ -67839,6 +68572,10 @@ export type GraphQLTypes = {
     shared_nfts: Array<GraphQLTypes['shared_nfts']>;
     /** fetch aggregated fields from the table: "shared_nfts" */
     shared_nfts_aggregate: GraphQLTypes['shared_nfts_aggregate'];
+    /** execute function "similar_profiles" which returns "virtual_profiles_similarity" */
+    similar_profiles: Array<GraphQLTypes['virtual_profiles_similarity']>;
+    /** execute function "similar_profiles" and query aggregates on result of table type "virtual_profiles_similarity" */
+    similar_profiles_aggregate: GraphQLTypes['virtual_profiles_similarity_aggregate'];
     /** fetch data from the table: "skills" */
     skills: Array<GraphQLTypes['skills']>;
     /** fetch aggregated fields from the table: "skills" */
@@ -67899,6 +68636,16 @@ export type GraphQLTypes = {
     vector_search_poap_holders: Array<GraphQLTypes['poap_holders']>;
     /** execute function "vector_search_poap_holders" and query aggregates on result of table type "poap_holders" */
     vector_search_poap_holders_aggregate: GraphQLTypes['poap_holders_aggregate'];
+    /** fetch data from the table: "virtual_profiles_similarity" */
+    virtual_profiles_similarity: Array<
+      GraphQLTypes['virtual_profiles_similarity']
+    >;
+    /** fetch aggregated fields from the table: "virtual_profiles_similarity" */
+    virtual_profiles_similarity_aggregate: GraphQLTypes['virtual_profiles_similarity_aggregate'];
+    /** fetch data from the table: "virtual_profiles_similarity" using primary key columns */
+    virtual_profiles_similarity_by_pk?:
+      | GraphQLTypes['virtual_profiles_similarity']
+      | undefined;
     /** An array relationship */
     vouches: Array<GraphQLTypes['vouches']>;
     /** An aggregate relationship */
@@ -69018,6 +69765,11 @@ export type GraphQLTypes = {
     __typename: 'shared_nfts_variance_fields';
     shared_count?: number | undefined;
   };
+  ['similar_profiles_args']: {
+    limit_count?: number | undefined;
+    match_threshold?: GraphQLTypes['float8'] | undefined;
+    profile_address?: string | undefined;
+  };
   /** columns and relationships of "skills" */
   ['skills']: {
     __typename: 'skills';
@@ -69661,6 +70413,10 @@ export type GraphQLTypes = {
     shared_nfts_aggregate: GraphQLTypes['shared_nfts_aggregate'];
     /** fetch data from the table in a streaming manner: "shared_nfts" */
     shared_nfts_stream: Array<GraphQLTypes['shared_nfts']>;
+    /** execute function "similar_profiles" which returns "virtual_profiles_similarity" */
+    similar_profiles: Array<GraphQLTypes['virtual_profiles_similarity']>;
+    /** execute function "similar_profiles" and query aggregates on result of table type "virtual_profiles_similarity" */
+    similar_profiles_aggregate: GraphQLTypes['virtual_profiles_similarity_aggregate'];
     /** fetch data from the table: "skills" */
     skills: Array<GraphQLTypes['skills']>;
     /** fetch aggregated fields from the table: "skills" */
@@ -69739,6 +70495,20 @@ export type GraphQLTypes = {
     vector_search_poap_holders: Array<GraphQLTypes['poap_holders']>;
     /** execute function "vector_search_poap_holders" and query aggregates on result of table type "poap_holders" */
     vector_search_poap_holders_aggregate: GraphQLTypes['poap_holders_aggregate'];
+    /** fetch data from the table: "virtual_profiles_similarity" */
+    virtual_profiles_similarity: Array<
+      GraphQLTypes['virtual_profiles_similarity']
+    >;
+    /** fetch aggregated fields from the table: "virtual_profiles_similarity" */
+    virtual_profiles_similarity_aggregate: GraphQLTypes['virtual_profiles_similarity_aggregate'];
+    /** fetch data from the table: "virtual_profiles_similarity" using primary key columns */
+    virtual_profiles_similarity_by_pk?:
+      | GraphQLTypes['virtual_profiles_similarity']
+      | undefined;
+    /** fetch data from the table in a streaming manner: "virtual_profiles_similarity" */
+    virtual_profiles_similarity_stream: Array<
+      GraphQLTypes['virtual_profiles_similarity']
+    >;
     /** An array relationship */
     vouches: Array<GraphQLTypes['vouches']>;
     /** An aggregate relationship */
@@ -72620,6 +73390,184 @@ export type GraphQLTypes = {
     match_threshold?: GraphQLTypes['float8'] | undefined;
     target_vector?: GraphQLTypes['vector'] | undefined;
   };
+  /** Virtual table for profiles vector similarity */
+  ['virtual_profiles_similarity']: {
+    __typename: 'virtual_profiles_similarity';
+    id: GraphQLTypes['bigint'];
+    similarity: GraphQLTypes['float8'];
+  };
+  ['virtual_profiles_similarity_aggregate']: {
+    __typename: 'virtual_profiles_similarity_aggregate';
+    aggregate?:
+      | GraphQLTypes['virtual_profiles_similarity_aggregate_fields']
+      | undefined;
+    nodes: Array<GraphQLTypes['virtual_profiles_similarity']>;
+  };
+  /** aggregate fields of "virtual_profiles_similarity" */
+  ['virtual_profiles_similarity_aggregate_fields']: {
+    __typename: 'virtual_profiles_similarity_aggregate_fields';
+    avg?: GraphQLTypes['virtual_profiles_similarity_avg_fields'] | undefined;
+    count: number;
+    max?: GraphQLTypes['virtual_profiles_similarity_max_fields'] | undefined;
+    min?: GraphQLTypes['virtual_profiles_similarity_min_fields'] | undefined;
+    stddev?:
+      | GraphQLTypes['virtual_profiles_similarity_stddev_fields']
+      | undefined;
+    stddev_pop?:
+      | GraphQLTypes['virtual_profiles_similarity_stddev_pop_fields']
+      | undefined;
+    stddev_samp?:
+      | GraphQLTypes['virtual_profiles_similarity_stddev_samp_fields']
+      | undefined;
+    sum?: GraphQLTypes['virtual_profiles_similarity_sum_fields'] | undefined;
+    var_pop?:
+      | GraphQLTypes['virtual_profiles_similarity_var_pop_fields']
+      | undefined;
+    var_samp?:
+      | GraphQLTypes['virtual_profiles_similarity_var_samp_fields']
+      | undefined;
+    variance?:
+      | GraphQLTypes['virtual_profiles_similarity_variance_fields']
+      | undefined;
+  };
+  /** aggregate avg on columns */
+  ['virtual_profiles_similarity_avg_fields']: {
+    __typename: 'virtual_profiles_similarity_avg_fields';
+    id?: number | undefined;
+    similarity?: number | undefined;
+  };
+  /** Boolean expression to filter rows from the table "virtual_profiles_similarity". All fields are combined with a logical 'AND'. */
+  ['virtual_profiles_similarity_bool_exp']: {
+    _and?:
+      | Array<GraphQLTypes['virtual_profiles_similarity_bool_exp']>
+      | undefined;
+    _not?: GraphQLTypes['virtual_profiles_similarity_bool_exp'] | undefined;
+    _or?:
+      | Array<GraphQLTypes['virtual_profiles_similarity_bool_exp']>
+      | undefined;
+    id?: GraphQLTypes['bigint_comparison_exp'] | undefined;
+    similarity?: GraphQLTypes['float8_comparison_exp'] | undefined;
+  };
+  /** unique or primary key constraints on table "virtual_profiles_similarity" */
+  ['virtual_profiles_similarity_constraint']: virtual_profiles_similarity_constraint;
+  /** input type for incrementing numeric columns in table "virtual_profiles_similarity" */
+  ['virtual_profiles_similarity_inc_input']: {
+    id?: GraphQLTypes['bigint'] | undefined;
+    similarity?: GraphQLTypes['float8'] | undefined;
+  };
+  /** input type for inserting data into table "virtual_profiles_similarity" */
+  ['virtual_profiles_similarity_insert_input']: {
+    id?: GraphQLTypes['bigint'] | undefined;
+    similarity?: GraphQLTypes['float8'] | undefined;
+  };
+  /** aggregate max on columns */
+  ['virtual_profiles_similarity_max_fields']: {
+    __typename: 'virtual_profiles_similarity_max_fields';
+    id?: GraphQLTypes['bigint'] | undefined;
+    similarity?: GraphQLTypes['float8'] | undefined;
+  };
+  /** aggregate min on columns */
+  ['virtual_profiles_similarity_min_fields']: {
+    __typename: 'virtual_profiles_similarity_min_fields';
+    id?: GraphQLTypes['bigint'] | undefined;
+    similarity?: GraphQLTypes['float8'] | undefined;
+  };
+  /** response of any mutation on the table "virtual_profiles_similarity" */
+  ['virtual_profiles_similarity_mutation_response']: {
+    __typename: 'virtual_profiles_similarity_mutation_response';
+    /** number of rows affected by the mutation */
+    affected_rows: number;
+    /** data from the rows affected by the mutation */
+    returning: Array<GraphQLTypes['virtual_profiles_similarity']>;
+  };
+  /** on_conflict condition type for table "virtual_profiles_similarity" */
+  ['virtual_profiles_similarity_on_conflict']: {
+    constraint: GraphQLTypes['virtual_profiles_similarity_constraint'];
+    update_columns: Array<
+      GraphQLTypes['virtual_profiles_similarity_update_column']
+    >;
+    where?: GraphQLTypes['virtual_profiles_similarity_bool_exp'] | undefined;
+  };
+  /** Ordering options when selecting data from "virtual_profiles_similarity". */
+  ['virtual_profiles_similarity_order_by']: {
+    id?: GraphQLTypes['order_by'] | undefined;
+    similarity?: GraphQLTypes['order_by'] | undefined;
+  };
+  /** primary key columns input for table: virtual_profiles_similarity */
+  ['virtual_profiles_similarity_pk_columns_input']: {
+    id: GraphQLTypes['bigint'];
+  };
+  /** select columns of table "virtual_profiles_similarity" */
+  ['virtual_profiles_similarity_select_column']: virtual_profiles_similarity_select_column;
+  /** input type for updating data in table "virtual_profiles_similarity" */
+  ['virtual_profiles_similarity_set_input']: {
+    id?: GraphQLTypes['bigint'] | undefined;
+    similarity?: GraphQLTypes['float8'] | undefined;
+  };
+  /** aggregate stddev on columns */
+  ['virtual_profiles_similarity_stddev_fields']: {
+    __typename: 'virtual_profiles_similarity_stddev_fields';
+    id?: number | undefined;
+    similarity?: number | undefined;
+  };
+  /** aggregate stddev_pop on columns */
+  ['virtual_profiles_similarity_stddev_pop_fields']: {
+    __typename: 'virtual_profiles_similarity_stddev_pop_fields';
+    id?: number | undefined;
+    similarity?: number | undefined;
+  };
+  /** aggregate stddev_samp on columns */
+  ['virtual_profiles_similarity_stddev_samp_fields']: {
+    __typename: 'virtual_profiles_similarity_stddev_samp_fields';
+    id?: number | undefined;
+    similarity?: number | undefined;
+  };
+  /** Streaming cursor of the table "virtual_profiles_similarity" */
+  ['virtual_profiles_similarity_stream_cursor_input']: {
+    /** Stream column input with initial value */
+    initial_value: GraphQLTypes['virtual_profiles_similarity_stream_cursor_value_input'];
+    /** cursor ordering */
+    ordering?: GraphQLTypes['cursor_ordering'] | undefined;
+  };
+  /** Initial value of the column from where the streaming should start */
+  ['virtual_profiles_similarity_stream_cursor_value_input']: {
+    id?: GraphQLTypes['bigint'] | undefined;
+    similarity?: GraphQLTypes['float8'] | undefined;
+  };
+  /** aggregate sum on columns */
+  ['virtual_profiles_similarity_sum_fields']: {
+    __typename: 'virtual_profiles_similarity_sum_fields';
+    id?: GraphQLTypes['bigint'] | undefined;
+    similarity?: GraphQLTypes['float8'] | undefined;
+  };
+  /** update columns of table "virtual_profiles_similarity" */
+  ['virtual_profiles_similarity_update_column']: virtual_profiles_similarity_update_column;
+  ['virtual_profiles_similarity_updates']: {
+    /** increments the numeric columns with given value of the filtered values */
+    _inc?: GraphQLTypes['virtual_profiles_similarity_inc_input'] | undefined;
+    /** sets the columns of the filtered rows to the given values */
+    _set?: GraphQLTypes['virtual_profiles_similarity_set_input'] | undefined;
+    /** filter the rows which have to be updated */
+    where: GraphQLTypes['virtual_profiles_similarity_bool_exp'];
+  };
+  /** aggregate var_pop on columns */
+  ['virtual_profiles_similarity_var_pop_fields']: {
+    __typename: 'virtual_profiles_similarity_var_pop_fields';
+    id?: number | undefined;
+    similarity?: number | undefined;
+  };
+  /** aggregate var_samp on columns */
+  ['virtual_profiles_similarity_var_samp_fields']: {
+    __typename: 'virtual_profiles_similarity_var_samp_fields';
+    id?: number | undefined;
+    similarity?: number | undefined;
+  };
+  /** aggregate variance on columns */
+  ['virtual_profiles_similarity_variance_fields']: {
+    __typename: 'virtual_profiles_similarity_variance_fields';
+    id?: number | undefined;
+    similarity?: number | undefined;
+  };
   /** columns and relationships of "vouches" */
   ['vouches']: {
     __typename: 'vouches';
@@ -74335,6 +75283,7 @@ export const enum profiles_select_column {
   connector = 'connector',
   created_at = 'created_at',
   description = 'description',
+  description_embedding = 'description_embedding',
   discord_username = 'discord_username',
   github_username = 'github_username',
   id = 'id',
@@ -74364,6 +75313,7 @@ export const enum profiles_update_column {
   connector = 'connector',
   created_at = 'created_at',
   description = 'description',
+  description_embedding = 'description_embedding',
   discord_username = 'discord_username',
   github_username = 'github_username',
   id = 'id',
@@ -74739,6 +75689,20 @@ export const enum vaults_update_column {
   token_address = 'token_address',
   updated_at = 'updated_at',
   vault_address = 'vault_address',
+}
+/** unique or primary key constraints on table "virtual_profiles_similarity" */
+export const enum virtual_profiles_similarity_constraint {
+  virtual_profiles_similarity_pkey = 'virtual_profiles_similarity_pkey',
+}
+/** select columns of table "virtual_profiles_similarity" */
+export const enum virtual_profiles_similarity_select_column {
+  id = 'id',
+  similarity = 'similarity',
+}
+/** update columns of table "virtual_profiles_similarity" */
+export const enum virtual_profiles_similarity_update_column {
+  id = 'id',
+  similarity = 'similarity',
 }
 /** unique or primary key constraints on table "vouches" */
 export const enum vouches_constraint {

--- a/api/hasura/event_triggers/eventManager.ts
+++ b/api/hasura/event_triggers/eventManager.ts
@@ -27,6 +27,7 @@ import refundGiveTelegram from '../../../api-lib/event_triggers/refundGiveTelegr
 import refundPendingGift from '../../../api-lib/event_triggers/refundPendingGift';
 import removeTeammate from '../../../api-lib/event_triggers/removeTeammate';
 import sendInteractionEventToMixpanel from '../../../api-lib/event_triggers/sendInteractionEventToMixpanel';
+import updateDescriptionEmbedding from '../../../api-lib/event_triggers/updateDescriptionEmbedding';
 import updateLinkHolderRepScore from '../../../api-lib/event_triggers/updateLinkHolderRepScore';
 import updatePGIVERepScore from '../../../api-lib/event_triggers/updatePGIVERepScore';
 import updateProfileRepScore from '../../../api-lib/event_triggers/updateProfileRepScore';
@@ -73,12 +74,13 @@ const HANDLERS: HandlerDict = {
   refundPendingGift,
   removeTeammate,
   sendInteractionEventToMixpanel,
+  updateDescriptionEmbedding,
   updateLinkHolderRepScore,
+  updatePGIVERepScore,
   updateProfileRepScore_emails: updateProfileRepScore,
   updateProfileRepScore_github: updateProfileRepScore,
   updateProfileRepScore_linkedin: updateProfileRepScore,
   updateProfileRepScore_twitter: updateProfileRepScore,
-  updatePGIVERepScore,
   vouchDiscord,
   vouchDiscordBot,
   vouchTelegram,

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -95,7 +95,7 @@ type Query {
 }
 
 type Query {
-  getSimilarProfiles: [SimilarProfile]
+  getSimilarProfiles(payload: SimilarProfileInput!): [SimilarProfileOutput!]!
 }
 
 type Mutation {
@@ -521,6 +521,10 @@ input SearchCosoulsInput {
   search_query: String!
 }
 
+input SimilarProfileInput {
+  address: String!
+}
+
 type CreateCircleResponse {
   id: Int!
 }
@@ -690,6 +694,10 @@ type SimilarProfilesOutput {
 type SimilarProfile {
   other_address: String!
   score: Int!
+}
+
+type SimilarProfileOutput {
+  profile_id: Int!
 }
 
 scalar timestamptz

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -524,6 +524,7 @@ custom_types:
     - name: DeleteEmailInput
     - name: SetPrimaryEmailInput
     - name: SearchCosoulsInput
+    - name: SimilarProfileInput
   objects:
     - name: CreateCircleResponse
       relationships:
@@ -758,6 +759,16 @@ custom_types:
           name: other_cosoul
           remote_table:
             name: cosouls
+            schema: public
+          source: default
+          type: object
+    - name: SimilarProfileOutput
+      relationships:
+        - field_mapping:
+            profile_id: id
+          name: profile_public
+          remote_table:
+            name: profiles_public
             schema: public
           source: default
           type: object

--- a/hasura/metadata/databases/default/functions/functions.yaml
+++ b/hasura/metadata/databases/default/functions/functions.yaml
@@ -1,2 +1,3 @@
+- "!include public_similar_profiles.yaml"
 - "!include public_vector_search_poap_events.yaml"
 - "!include public_vector_search_poap_holders.yaml"

--- a/hasura/metadata/databases/default/functions/public_similar_profiles.yaml
+++ b/hasura/metadata/databases/default/functions/public_similar_profiles.yaml
@@ -1,0 +1,3 @@
+function:
+  name: similar_profiles
+  schema: public

--- a/hasura/metadata/databases/default/tables/public_profiles.yaml
+++ b/hasura/metadata/databases/default/tables/public_profiles.yaml
@@ -215,3 +215,20 @@ update_permissions:
       check: null
       set:
         id: X-Hasura-User-Id
+event_triggers:
+  - name: updateDescriptionEmbedding
+    definition:
+      enable_manual: true
+      insert:
+        columns: '*'
+      update:
+        columns:
+          - description
+    retry_conf:
+      interval_sec: 10
+      num_retries: 0
+      timeout_sec: 60
+    webhook: '{{HASURA_API_BASE_URL}}/event_triggers/eventManager?=updateDescriptionEmbedding'
+    headers:
+      - name: verification_key
+        value_from_env: HASURA_EVENT_SECRET

--- a/hasura/metadata/databases/default/tables/public_virtual_profiles_similarity.yaml
+++ b/hasura/metadata/databases/default/tables/public_virtual_profiles_similarity.yaml
@@ -1,0 +1,3 @@
+table:
+  name: virtual_profiles_similarity
+  schema: public

--- a/hasura/metadata/databases/default/tables/tables.yaml
+++ b/hasura/metadata/databases/default/tables/tables.yaml
@@ -62,4 +62,5 @@
 - "!include public_vault_transactions.yaml"
 - "!include public_vault_tx_types.yaml"
 - "!include public_vaults.yaml"
+- "!include public_virtual_profiles_similarity.yaml"
 - "!include public_vouches.yaml"

--- a/hasura/migrations/default/1701449088272_alter_table_public_profiles_add_column_description_embedding/down.sql
+++ b/hasura/migrations/default/1701449088272_alter_table_public_profiles_add_column_description_embedding/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."profiles" drop column "description_embedding";

--- a/hasura/migrations/default/1701449088272_alter_table_public_profiles_add_column_description_embedding/up.sql
+++ b/hasura/migrations/default/1701449088272_alter_table_public_profiles_add_column_description_embedding/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."profiles" add column "description_embedding" vector(1536) null;

--- a/hasura/migrations/default/1701472677298_add_profile_description_similarity_functions/down.sql
+++ b/hasura/migrations/default/1701472677298_add_profile_description_similarity_functions/down.sql
@@ -1,0 +1,3 @@
+DROP FUNCTION IF EXISTS "public".vector_similar_profiles_by_description_embedding;
+DROP FUNCTION IF EXISTS "public".similar_profiles;
+DROP TABLE "public"."virtual_profiles_similarity";

--- a/hasura/migrations/default/1701472677298_add_profile_description_similarity_functions/up.sql
+++ b/hasura/migrations/default/1701472677298_add_profile_description_similarity_functions/up.sql
@@ -1,0 +1,73 @@
+CREATE TABLE
+  "public"."virtual_profiles_similarity" (
+    "id" bigserial NOT NULL,
+    "similarity" double precision NOT NULL,
+    PRIMARY KEY ("id")
+  );
+
+COMMENT ON TABLE "public"."virtual_profiles_similarity" IS E'Virtual table for profiles vector similarity';
+
+CREATE OR REPLACE FUNCTION "public".similar_profiles(
+  match_threshold float,
+  profile_address text,
+  limit_count INT)
+RETURNS SETOF public.virtual_profiles_similarity
+LANGUAGE plpgsql
+AS $$
+
+DECLARE
+  target_vector vector(1536);
+BEGIN
+  -- Retrieve the target_vector for the given profile
+  SELECT description_embedding INTO target_vector
+  FROM public.profiles
+  WHERE LOWER(address) = LOWER(profile_address);
+
+  -- Return empty array if no vector found for address
+  IF target_vector IS NULL THEN
+    RETURN;
+  END IF;
+
+  -- Execute the main query using the retrieved target_vector
+  RETURN QUERY
+  SELECT
+    id,
+    (description_embedding <#> target_vector) * -1 AS similarity
+  FROM
+    public.profiles
+  WHERE
+    LOWER(address) != LOWER(profile_address) AND -- Exclude the profile itself from the results
+    (description_embedding <#> target_vector) * -1 > match_threshold
+  ORDER BY
+    similarity DESC
+  LIMIT
+    limit_count;
+END;
+$$ STABLE;
+
+-- not used right now, but useful for arbitrary vector search in the future
+CREATE OR REPLACE FUNCTION "public".vector_similar_profiles_by_description_embedding(
+  target_vector vector(1536),
+  match_threshold float,
+  limit_count INT)
+RETURNS SETOF public.virtual_profiles_similarity
+LANGUAGE plpgsql
+AS $$
+
+#variable_conflict use_variable
+BEGIN
+  RETURN QUERY
+  SELECT
+    id,
+    (description_embedding <#> target_vector) * -1 AS similarity
+  FROM
+    public.profiles
+  WHERE
+    -- The dot product is negative because of a Postgres limitation, so we negate it
+    (description_embedding <#> target_vector) * -1 > match_threshold
+  ORDER BY
+    similarity DESC
+  LIMIT
+    limit_count;
+END;
+$$ STABLE;

--- a/hasura/schema/admin/schema.graphql
+++ b/hasura/schema/admin/schema.graphql
@@ -418,10 +418,13 @@ input SetPrimaryEmailInput {
   email: String!
 }
 
-type SimilarProfile {
-  other_address: String!
-  other_cosoul: cosouls
-  score: Int!
+input SimilarProfileInput {
+  address: String!
+}
+
+type SimilarProfileOutput {
+  profile_id: Int!
+  profile_public: profiles_public
 }
 
 """
@@ -20174,6 +20177,23 @@ type mutation_root {
   delete_vaults_by_pk(id: bigint!): vaults
 
   """
+  delete data from the table: "virtual_profiles_similarity"
+  """
+  delete_virtual_profiles_similarity(
+    """
+    filter the rows which have to be deleted
+    """
+    where: virtual_profiles_similarity_bool_exp!
+  ): virtual_profiles_similarity_mutation_response
+
+  """
+  delete single row from the table: "virtual_profiles_similarity"
+  """
+  delete_virtual_profiles_similarity_by_pk(
+    id: bigint!
+  ): virtual_profiles_similarity
+
+  """
   delete data from the table: "vouches"
   """
   delete_vouches(
@@ -21908,6 +21928,36 @@ type mutation_root {
     """
     on_conflict: vaults_on_conflict
   ): vaults
+
+  """
+  insert data into the table: "virtual_profiles_similarity"
+  """
+  insert_virtual_profiles_similarity(
+    """
+    the rows to be inserted
+    """
+    objects: [virtual_profiles_similarity_insert_input!]!
+
+    """
+    upsert condition
+    """
+    on_conflict: virtual_profiles_similarity_on_conflict
+  ): virtual_profiles_similarity_mutation_response
+
+  """
+  insert a single row into the table: "virtual_profiles_similarity"
+  """
+  insert_virtual_profiles_similarity_one(
+    """
+    the row to be inserted
+    """
+    object: virtual_profiles_similarity_insert_input!
+
+    """
+    upsert condition
+    """
+    on_conflict: virtual_profiles_similarity_on_conflict
+  ): virtual_profiles_similarity
 
   """
   insert data into the table: "vouches"
@@ -24791,6 +24841,52 @@ type mutation_root {
     """
     updates: [vaults_updates!]!
   ): [vaults_mutation_response]
+
+  """
+  update data of the table: "virtual_profiles_similarity"
+  """
+  update_virtual_profiles_similarity(
+    """
+    increments the numeric columns with given value of the filtered values
+    """
+    _inc: virtual_profiles_similarity_inc_input
+
+    """
+    sets the columns of the filtered rows to the given values
+    """
+    _set: virtual_profiles_similarity_set_input
+
+    """
+    filter the rows which have to be updated
+    """
+    where: virtual_profiles_similarity_bool_exp!
+  ): virtual_profiles_similarity_mutation_response
+
+  """
+  update single row of the table: "virtual_profiles_similarity"
+  """
+  update_virtual_profiles_similarity_by_pk(
+    """
+    increments the numeric columns with given value of the filtered values
+    """
+    _inc: virtual_profiles_similarity_inc_input
+
+    """
+    sets the columns of the filtered rows to the given values
+    """
+    _set: virtual_profiles_similarity_set_input
+    pk_columns: virtual_profiles_similarity_pk_columns_input!
+  ): virtual_profiles_similarity
+
+  """
+  update multiples rows of table: "virtual_profiles_similarity"
+  """
+  update_virtual_profiles_similarity_many(
+    """
+    updates to execute, in order
+    """
+    updates: [virtual_profiles_similarity_updates!]!
+  ): [virtual_profiles_similarity_mutation_response]
 
   """
   update data of the table: "vouches"
@@ -32940,6 +33036,7 @@ type profiles {
   cosoul: cosouls
   created_at: timestamp!
   description: String
+  description_embedding: vector
   discord_username: String
 
   """
@@ -33449,6 +33546,7 @@ input profiles_bool_exp {
   cosoul: cosouls_bool_exp
   created_at: timestamp_comparison_exp
   description: String_comparison_exp
+  description_embedding: vector_comparison_exp
   discord_username: String_comparison_exp
   distributions: distributions_bool_exp
   distributions_aggregate: distributions_aggregate_bool_exp
@@ -33536,6 +33634,7 @@ input profiles_insert_input {
   cosoul: cosouls_obj_rel_insert_input
   created_at: timestamp
   description: String
+  description_embedding: vector
   discord_username: String
   distributions: distributions_arr_rel_insert_input
   emails: emails_arr_rel_insert_input
@@ -33676,6 +33775,7 @@ input profiles_order_by {
   cosoul: cosouls_order_by
   created_at: order_by
   description: order_by
+  description_embedding: order_by
   discord_username: order_by
   distributions_aggregate: distributions_aggregate_order_by
   emails_aggregate: emails_aggregate_order_by
@@ -34341,6 +34441,11 @@ enum profiles_select_column {
   """
   column name
   """
+  description_embedding
+
+  """
+  column name
+  """
   discord_username
 
   """
@@ -34437,6 +34542,7 @@ input profiles_set_input {
   connector: String
   created_at: timestamp
   description: String
+  description_embedding: vector
   discord_username: String
   github_username: String
   id: bigint
@@ -34517,6 +34623,7 @@ input profiles_stream_cursor_value_input {
   connector: String
   created_at: timestamp
   description: String
+  description_embedding: vector
   discord_username: String
   github_username: String
   id: bigint
@@ -34595,6 +34702,11 @@ enum profiles_update_column {
   column name
   """
   description
+
+  """
+  column name
+  """
+  description_embedding
 
   """
   column name
@@ -36088,7 +36200,7 @@ type query_root {
   """
   epochs_by_pk(id: bigint!): epochs
   getGuildInfo(payload: GuildInfoInput!): GuildInfoOutput
-  getSimilarProfiles: [SimilarProfile]
+  getSimilarProfiles(payload: SimilarProfileInput!): [SimilarProfileOutput!]!
 
   """
   fetch data from the table: "gift_private"
@@ -38287,6 +38399,76 @@ type query_root {
   ): shared_nfts_aggregate!
 
   """
+  execute function "similar_profiles" which returns "virtual_profiles_similarity"
+  """
+  similar_profiles(
+    """
+    input parameters for function "similar_profiles"
+    """
+    args: similar_profiles_args!
+
+    """
+    distinct select on columns
+    """
+    distinct_on: [virtual_profiles_similarity_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [virtual_profiles_similarity_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: virtual_profiles_similarity_bool_exp
+  ): [virtual_profiles_similarity!]!
+
+  """
+  execute function "similar_profiles" and query aggregates on result of table type "virtual_profiles_similarity"
+  """
+  similar_profiles_aggregate(
+    """
+    input parameters for function "similar_profiles_aggregate"
+    """
+    args: similar_profiles_args!
+
+    """
+    distinct select on columns
+    """
+    distinct_on: [virtual_profiles_similarity_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [virtual_profiles_similarity_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: virtual_profiles_similarity_bool_exp
+  ): virtual_profiles_similarity_aggregate!
+
+  """
   fetch data from the table: "skills"
   """
   skills(
@@ -39005,6 +39187,71 @@ type query_root {
     """
     where: poap_holders_bool_exp
   ): poap_holders_aggregate!
+
+  """
+  fetch data from the table: "virtual_profiles_similarity"
+  """
+  virtual_profiles_similarity(
+    """
+    distinct select on columns
+    """
+    distinct_on: [virtual_profiles_similarity_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [virtual_profiles_similarity_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: virtual_profiles_similarity_bool_exp
+  ): [virtual_profiles_similarity!]!
+
+  """
+  fetch aggregated fields from the table: "virtual_profiles_similarity"
+  """
+  virtual_profiles_similarity_aggregate(
+    """
+    distinct select on columns
+    """
+    distinct_on: [virtual_profiles_similarity_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [virtual_profiles_similarity_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: virtual_profiles_similarity_bool_exp
+  ): virtual_profiles_similarity_aggregate!
+
+  """
+  fetch data from the table: "virtual_profiles_similarity" using primary key columns
+  """
+  virtual_profiles_similarity_by_pk(id: bigint!): virtual_profiles_similarity
 
   """
   An array relationship
@@ -40874,6 +41121,12 @@ aggregate variance on columns
 """
 type shared_nfts_variance_fields {
   shared_count: Float
+}
+
+input similar_profiles_args {
+  limit_count: Int
+  match_threshold: float8
+  profile_address: String
 }
 
 """
@@ -45837,6 +46090,76 @@ type subscription_root {
   ): [shared_nfts!]!
 
   """
+  execute function "similar_profiles" which returns "virtual_profiles_similarity"
+  """
+  similar_profiles(
+    """
+    input parameters for function "similar_profiles"
+    """
+    args: similar_profiles_args!
+
+    """
+    distinct select on columns
+    """
+    distinct_on: [virtual_profiles_similarity_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [virtual_profiles_similarity_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: virtual_profiles_similarity_bool_exp
+  ): [virtual_profiles_similarity!]!
+
+  """
+  execute function "similar_profiles" and query aggregates on result of table type "virtual_profiles_similarity"
+  """
+  similar_profiles_aggregate(
+    """
+    input parameters for function "similar_profiles_aggregate"
+    """
+    args: similar_profiles_args!
+
+    """
+    distinct select on columns
+    """
+    distinct_on: [virtual_profiles_similarity_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [virtual_profiles_similarity_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: virtual_profiles_similarity_bool_exp
+  ): virtual_profiles_similarity_aggregate!
+
+  """
   fetch data from the table: "skills"
   """
   skills(
@@ -46735,6 +47058,91 @@ type subscription_root {
     """
     where: poap_holders_bool_exp
   ): poap_holders_aggregate!
+
+  """
+  fetch data from the table: "virtual_profiles_similarity"
+  """
+  virtual_profiles_similarity(
+    """
+    distinct select on columns
+    """
+    distinct_on: [virtual_profiles_similarity_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [virtual_profiles_similarity_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: virtual_profiles_similarity_bool_exp
+  ): [virtual_profiles_similarity!]!
+
+  """
+  fetch aggregated fields from the table: "virtual_profiles_similarity"
+  """
+  virtual_profiles_similarity_aggregate(
+    """
+    distinct select on columns
+    """
+    distinct_on: [virtual_profiles_similarity_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [virtual_profiles_similarity_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: virtual_profiles_similarity_bool_exp
+  ): virtual_profiles_similarity_aggregate!
+
+  """
+  fetch data from the table: "virtual_profiles_similarity" using primary key columns
+  """
+  virtual_profiles_similarity_by_pk(id: bigint!): virtual_profiles_similarity
+
+  """
+  fetch data from the table in a streaming manner: "virtual_profiles_similarity"
+  """
+  virtual_profiles_similarity_stream(
+    """
+    maximum number of rows returned in a single batch
+    """
+    batch_size: Int!
+
+    """
+    cursor to stream the results returned by the query
+    """
+    cursor: [virtual_profiles_similarity_stream_cursor_input]!
+
+    """
+    filter the rows returned
+    """
+    where: virtual_profiles_similarity_bool_exp
+  ): [virtual_profiles_similarity!]!
 
   """
   An array relationship
@@ -52113,6 +52521,273 @@ input vector_search_poap_holders_args {
   limit_count: Int
   match_threshold: float8
   target_vector: vector
+}
+
+"""
+Virtual table for profiles vector similarity
+"""
+type virtual_profiles_similarity {
+  id: bigint!
+  similarity: float8!
+}
+
+type virtual_profiles_similarity_aggregate {
+  aggregate: virtual_profiles_similarity_aggregate_fields
+  nodes: [virtual_profiles_similarity!]!
+}
+
+"""
+aggregate fields of "virtual_profiles_similarity"
+"""
+type virtual_profiles_similarity_aggregate_fields {
+  avg: virtual_profiles_similarity_avg_fields
+  count(
+    columns: [virtual_profiles_similarity_select_column!]
+    distinct: Boolean
+  ): Int!
+  max: virtual_profiles_similarity_max_fields
+  min: virtual_profiles_similarity_min_fields
+  stddev: virtual_profiles_similarity_stddev_fields
+  stddev_pop: virtual_profiles_similarity_stddev_pop_fields
+  stddev_samp: virtual_profiles_similarity_stddev_samp_fields
+  sum: virtual_profiles_similarity_sum_fields
+  var_pop: virtual_profiles_similarity_var_pop_fields
+  var_samp: virtual_profiles_similarity_var_samp_fields
+  variance: virtual_profiles_similarity_variance_fields
+}
+
+"""
+aggregate avg on columns
+"""
+type virtual_profiles_similarity_avg_fields {
+  id: Float
+  similarity: Float
+}
+
+"""
+Boolean expression to filter rows from the table "virtual_profiles_similarity". All fields are combined with a logical 'AND'.
+"""
+input virtual_profiles_similarity_bool_exp {
+  _and: [virtual_profiles_similarity_bool_exp!]
+  _not: virtual_profiles_similarity_bool_exp
+  _or: [virtual_profiles_similarity_bool_exp!]
+  id: bigint_comparison_exp
+  similarity: float8_comparison_exp
+}
+
+"""
+unique or primary key constraints on table "virtual_profiles_similarity"
+"""
+enum virtual_profiles_similarity_constraint {
+  """
+  unique or primary key constraint on columns "id"
+  """
+  virtual_profiles_similarity_pkey
+}
+
+"""
+input type for incrementing numeric columns in table "virtual_profiles_similarity"
+"""
+input virtual_profiles_similarity_inc_input {
+  id: bigint
+  similarity: float8
+}
+
+"""
+input type for inserting data into table "virtual_profiles_similarity"
+"""
+input virtual_profiles_similarity_insert_input {
+  id: bigint
+  similarity: float8
+}
+
+"""
+aggregate max on columns
+"""
+type virtual_profiles_similarity_max_fields {
+  id: bigint
+  similarity: float8
+}
+
+"""
+aggregate min on columns
+"""
+type virtual_profiles_similarity_min_fields {
+  id: bigint
+  similarity: float8
+}
+
+"""
+response of any mutation on the table "virtual_profiles_similarity"
+"""
+type virtual_profiles_similarity_mutation_response {
+  """
+  number of rows affected by the mutation
+  """
+  affected_rows: Int!
+
+  """
+  data from the rows affected by the mutation
+  """
+  returning: [virtual_profiles_similarity!]!
+}
+
+"""
+on_conflict condition type for table "virtual_profiles_similarity"
+"""
+input virtual_profiles_similarity_on_conflict {
+  constraint: virtual_profiles_similarity_constraint!
+  update_columns: [virtual_profiles_similarity_update_column!]! = []
+  where: virtual_profiles_similarity_bool_exp
+}
+
+"""
+Ordering options when selecting data from "virtual_profiles_similarity".
+"""
+input virtual_profiles_similarity_order_by {
+  id: order_by
+  similarity: order_by
+}
+
+"""
+primary key columns input for table: virtual_profiles_similarity
+"""
+input virtual_profiles_similarity_pk_columns_input {
+  id: bigint!
+}
+
+"""
+select columns of table "virtual_profiles_similarity"
+"""
+enum virtual_profiles_similarity_select_column {
+  """
+  column name
+  """
+  id
+
+  """
+  column name
+  """
+  similarity
+}
+
+"""
+input type for updating data in table "virtual_profiles_similarity"
+"""
+input virtual_profiles_similarity_set_input {
+  id: bigint
+  similarity: float8
+}
+
+"""
+aggregate stddev on columns
+"""
+type virtual_profiles_similarity_stddev_fields {
+  id: Float
+  similarity: Float
+}
+
+"""
+aggregate stddev_pop on columns
+"""
+type virtual_profiles_similarity_stddev_pop_fields {
+  id: Float
+  similarity: Float
+}
+
+"""
+aggregate stddev_samp on columns
+"""
+type virtual_profiles_similarity_stddev_samp_fields {
+  id: Float
+  similarity: Float
+}
+
+"""
+Streaming cursor of the table "virtual_profiles_similarity"
+"""
+input virtual_profiles_similarity_stream_cursor_input {
+  """
+  Stream column input with initial value
+  """
+  initial_value: virtual_profiles_similarity_stream_cursor_value_input!
+
+  """
+  cursor ordering
+  """
+  ordering: cursor_ordering
+}
+
+"""
+Initial value of the column from where the streaming should start
+"""
+input virtual_profiles_similarity_stream_cursor_value_input {
+  id: bigint
+  similarity: float8
+}
+
+"""
+aggregate sum on columns
+"""
+type virtual_profiles_similarity_sum_fields {
+  id: bigint
+  similarity: float8
+}
+
+"""
+update columns of table "virtual_profiles_similarity"
+"""
+enum virtual_profiles_similarity_update_column {
+  """
+  column name
+  """
+  id
+
+  """
+  column name
+  """
+  similarity
+}
+
+input virtual_profiles_similarity_updates {
+  """
+  increments the numeric columns with given value of the filtered values
+  """
+  _inc: virtual_profiles_similarity_inc_input
+
+  """
+  sets the columns of the filtered rows to the given values
+  """
+  _set: virtual_profiles_similarity_set_input
+
+  """
+  filter the rows which have to be updated
+  """
+  where: virtual_profiles_similarity_bool_exp!
+}
+
+"""
+aggregate var_pop on columns
+"""
+type virtual_profiles_similarity_var_pop_fields {
+  id: Float
+  similarity: Float
+}
+
+"""
+aggregate var_samp on columns
+"""
+type virtual_profiles_similarity_var_samp_fields {
+  id: Float
+  similarity: Float
+}
+
+"""
+aggregate variance on columns
+"""
+type virtual_profiles_similarity_variance_fields {
+  id: Float
+  similarity: Float
 }
 
 """

--- a/hasura/schema/user/schema.graphql
+++ b/hasura/schema/user/schema.graphql
@@ -384,10 +384,13 @@ input SetPrimaryEmailInput {
   email: String!
 }
 
-type SimilarProfile {
-  other_address: String!
-  other_cosoul: cosouls
-  score: Int!
+input SimilarProfileInput {
+  address: String!
+}
+
+type SimilarProfileOutput {
+  profile_id: Int!
+  profile_public: profiles_public
 }
 
 """
@@ -15812,7 +15815,7 @@ type query_root {
   """
   epochs_by_pk(id: bigint!): epochs
   getGuildInfo(payload: GuildInfoInput!): GuildInfoOutput
-  getSimilarProfiles: [SimilarProfile]
+  getSimilarProfiles(payload: SimilarProfileInput!): [SimilarProfileOutput!]!
 
   """
   fetch data from the table: "gift_private"

--- a/src/features/colinks/Leaderboard.tsx
+++ b/src/features/colinks/Leaderboard.tsx
@@ -1,9 +1,7 @@
 import { LoadingIndicator } from '../../components/LoadingIndicator';
-import { AvatarWithLinks } from '../../pages/colinks/explore/AvatarWithLinks';
 import { CoLinksMember } from '../../pages/colinks/explore/CoLinksMember';
 import { ProfileForCard } from '../../pages/colinks/explore/fetchPeopleWithSkills';
-import { coLinksPaths } from '../../routes/paths';
-import { AppLink, Flex, Text } from '../../ui';
+import { Flex } from '../../ui';
 
 export const Leaderboard = ({
   leaders,
@@ -16,24 +14,12 @@ export const Leaderboard = ({
   return (
     <Flex column css={{ gap: '$md', width: '100%' }}>
       {leaders.map((leader, idx) => {
-        if (small) {
-          return (
-            <Flex
-              as={AppLink}
-              to={coLinksPaths.profile(leader.address ?? '')}
-              key={leader.id}
-              css={{ alignItems: 'center', gap: '$md' }}
-            >
-              <AvatarWithLinks profile={leader} size={'medium'} />
-              <Text semibold>{leader.name}</Text>
-            </Flex>
-          );
-        }
         return (
           <CoLinksMember
             key={leader.id}
             profile={leader}
             rankNumber={idx + 1}
+            small={small}
           />
         );
       })}

--- a/src/features/colinks/SimilarProfiles.tsx
+++ b/src/features/colinks/SimilarProfiles.tsx
@@ -1,0 +1,57 @@
+import { useQuery } from 'react-query';
+
+import { Circle2 } from '../../icons/__generated';
+import { client } from '../../lib/gql/client';
+import { Flex, Text } from '../../ui';
+import {
+  CoLinksMember,
+  coLinksMemberSelector,
+} from 'pages/colinks/explore/CoLinksMember';
+
+import { RightColumnSection } from './RightColumnSection';
+
+const getSimilarProfiles = async (addressUnknownCase: string) => {
+  const address = addressUnknownCase.toLowerCase();
+  const { getSimilarProfiles } = await client.query(
+    {
+      getSimilarProfiles: [
+        {
+          payload: {
+            address: address,
+          },
+        },
+        {
+          profile_public: coLinksMemberSelector(address),
+        },
+      ],
+    },
+    { operationName: 'similarProfiles' }
+  );
+
+  return getSimilarProfiles.map(p => p.profile_public);
+};
+
+export const SimilarProfiles = ({ address }: { address: string }) => {
+  const { data } = useQuery(['similar_profiles', address], async () => {
+    return getSimilarProfiles(address);
+  });
+
+  if (!data) return null;
+
+  return (
+    <RightColumnSection
+      title={
+        <Text color={'default'} semibold>
+          <Circle2 />
+          {data?.length} Similar Profiles
+        </Text>
+      }
+    >
+      <Flex column css={{ gap: '$md', width: '100%' }}>
+        {data.map(p => {
+          return p && <CoLinksMember key={p.id} profile={p} small={true} />;
+        })}
+      </Flex>
+    </RightColumnSection>
+  );
+};

--- a/src/features/colinks/wizard/WizardSteps.tsx
+++ b/src/features/colinks/wizard/WizardSteps.tsx
@@ -171,7 +171,7 @@ export const WizardSteps = ({
         />
         <WizardInstructions>
           <ShowOrConnectTwitter
-            callbackPage={'/colinks/wizard'}
+            callbackPage={coLinksPaths.wizard}
             minimal={true}
           />
           {!twitter && (

--- a/src/lib/gql/__generated__/zeus/const.ts
+++ b/src/lib/gql/__generated__/zeus/const.ts
@@ -52,6 +52,7 @@ export const AllTypesProps: Record<string, any> = {
   MarkClaimedInput: {},
   SearchCosoulsInput: {},
   SetPrimaryEmailInput: {},
+  SimilarProfileInput: {},
   String_comparison_exp: {},
   SyncCoSoulInput: {},
   UpdateCircleInput: {},
@@ -4919,6 +4920,9 @@ export const AllTypesProps: Record<string, any> = {
     getGuildInfo: {
       payload: 'GuildInfoInput',
     },
+    getSimilarProfiles: {
+      payload: 'SimilarProfileInput',
+    },
     gift_private: {
       distinct_on: 'gift_private_select_column',
       order_by: 'gift_private_order_by',
@@ -7556,10 +7560,9 @@ export const ReturnTypes: Record<string, any> = {
   SearchCosoulsOutput: {
     cosoul_ids: 'Int',
   },
-  SimilarProfile: {
-    other_address: 'String',
-    other_cosoul: 'cosouls',
-    score: 'Int',
+  SimilarProfileOutput: {
+    profile_id: 'Int',
+    profile_public: 'profiles_public',
   },
   SyncCoSoulOutput: {
     token_id: 'String',
@@ -9432,7 +9435,7 @@ export const ReturnTypes: Record<string, any> = {
     epochs: 'epochs',
     epochs_by_pk: 'epochs',
     getGuildInfo: 'GuildInfoOutput',
-    getSimilarProfiles: 'SimilarProfile',
+    getSimilarProfiles: 'SimilarProfileOutput',
     gift_private: 'gift_private',
     github_accounts: 'github_accounts',
     github_accounts_by_pk: 'github_accounts',

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -910,10 +910,12 @@ export type ValueTypes = {
   ['SetPrimaryEmailInput']: {
     email: string;
   };
-  ['SimilarProfile']: AliasType<{
-    other_address?: boolean | `@${string}`;
-    other_cosoul?: ValueTypes['cosouls'];
-    score?: boolean | `@${string}`;
+  ['SimilarProfileInput']: {
+    address: string;
+  };
+  ['SimilarProfileOutput']: AliasType<{
+    profile_id?: boolean | `@${string}`;
+    profile_public?: ValueTypes['profiles_public'];
     __typename?: boolean | `@${string}`;
   }>;
   /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
@@ -11479,7 +11481,10 @@ export type ValueTypes = {
       { payload: ValueTypes['GuildInfoInput'] },
       ValueTypes['GuildInfoOutput']
     ];
-    getSimilarProfiles?: ValueTypes['SimilarProfile'];
+    getSimilarProfiles?: [
+      { payload: ValueTypes['SimilarProfileInput'] },
+      ValueTypes['SimilarProfileOutput']
+    ];
     gift_private?: [
       {
         /** distinct select on columns */
@@ -18323,10 +18328,10 @@ export type ModelTypes = {
     cosoul_ids: Array<number>;
   };
   ['SetPrimaryEmailInput']: GraphQLTypes['SetPrimaryEmailInput'];
-  ['SimilarProfile']: {
-    other_address: string;
-    other_cosoul?: GraphQLTypes['cosouls'] | undefined;
-    score: number;
+  ['SimilarProfileInput']: GraphQLTypes['SimilarProfileInput'];
+  ['SimilarProfileOutput']: {
+    profile_id: number;
+    profile_public?: GraphQLTypes['profiles_public'] | undefined;
   };
   /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
   ['String_comparison_exp']: GraphQLTypes['String_comparison_exp'];
@@ -21933,9 +21938,7 @@ export type ModelTypes = {
     /** fetch data from the table: "epoches" using primary key columns */
     epochs_by_pk?: GraphQLTypes['epochs'] | undefined;
     getGuildInfo?: GraphQLTypes['GuildInfoOutput'] | undefined;
-    getSimilarProfiles?:
-      | Array<GraphQLTypes['SimilarProfile'] | undefined>
-      | undefined;
+    getSimilarProfiles: Array<GraphQLTypes['SimilarProfileOutput']>;
     /** fetch data from the table: "gift_private" */
     gift_private: Array<GraphQLTypes['gift_private']>;
     /** fetch data from the table: "github_accounts" */
@@ -23799,11 +23802,13 @@ export type GraphQLTypes = {
   ['SetPrimaryEmailInput']: {
     email: string;
   };
-  ['SimilarProfile']: {
-    __typename: 'SimilarProfile';
-    other_address: string;
-    other_cosoul?: GraphQLTypes['cosouls'] | undefined;
-    score: number;
+  ['SimilarProfileInput']: {
+    address: string;
+  };
+  ['SimilarProfileOutput']: {
+    __typename: 'SimilarProfileOutput';
+    profile_id: number;
+    profile_public?: GraphQLTypes['profiles_public'] | undefined;
   };
   /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
   ['String_comparison_exp']: {
@@ -31630,9 +31635,7 @@ export type GraphQLTypes = {
     /** fetch data from the table: "epoches" using primary key columns */
     epochs_by_pk?: GraphQLTypes['epochs'] | undefined;
     getGuildInfo?: GraphQLTypes['GuildInfoOutput'] | undefined;
-    getSimilarProfiles?:
-      | Array<GraphQLTypes['SimilarProfile'] | undefined>
-      | undefined;
+    getSimilarProfiles: Array<GraphQLTypes['SimilarProfileOutput']>;
     /** fetch data from the table: "gift_private" */
     gift_private: Array<GraphQLTypes['gift_private']>;
     /** fetch data from the table: "github_accounts" */

--- a/src/pages/colinks/NFTPage.tsx
+++ b/src/pages/colinks/NFTPage.tsx
@@ -1,8 +1,8 @@
+import { SimilarProfiles } from 'features/colinks/SimilarProfiles';
 import { useQuery } from 'react-query';
 
 import { LoadingIndicator } from '../../components/LoadingIndicator';
 import { CoLinksBasicProfileHeader } from '../../features/colinks/CoLinksBasicProfileHeader';
-import { FeaturedLink } from '../../features/colinks/FeaturedLink';
 import useConnectedAddress from '../../hooks/useConnectedAddress';
 import { client } from '../../lib/gql/client';
 import { Box, Flex, Image, Link, Text } from '../../ui';
@@ -10,26 +10,6 @@ import { SingleColumnLayout } from '../../ui/layouts';
 
 export const NFTPage = () => {
   const address = useConnectedAddress(true);
-
-  const { data: similar } = useQuery(['NFTS', address, 'similar'], async () => {
-    const { getSimilarProfiles } = await client.query(
-      {
-        getSimilarProfiles: {
-          score: true,
-          other_address: true,
-          other_cosoul: {
-            address: true,
-            profile_public: {
-              name: true,
-              avatar: true,
-            },
-          },
-        },
-      },
-      { operationName: 'similarProfiles' }
-    );
-    return getSimilarProfiles;
-  });
 
   const { data: nfts } = useQuery(['NFTS', address, 'holdings'], async () => {
     const { nft_holdings } = await client.query(
@@ -66,36 +46,7 @@ export const NFTPage = () => {
         title={'NFT Explorer'}
       />
       <Text h2>Similar Profiles</Text>
-      {similar === undefined ? (
-        <Flex>
-          <LoadingIndicator />
-        </Flex>
-      ) : (
-        <Flex column css={{ gap: '$md', maxWidth: '300px' }}>
-          {similar.length === 0 ? (
-            <Text>No data - no NFTs maybe?</Text>
-          ) : (
-            similar.map(s =>
-              !s.other_cosoul?.profile_public ? (
-                <Text key={s.other_address}>
-                  no profile for {s.other_address}
-                </Text>
-              ) : (
-                <FeaturedLink
-                  key={s.other_address}
-                  target={{
-                    name: s.other_cosoul.profile_public.name,
-                    address: s.other_address,
-                    avatar: s.other_cosoul.profile_public.avatar,
-                    count: s.score,
-                    countName: 'shared NFT' + (s.score == 1 ? '' : 's'),
-                  }}
-                />
-              )
-            )
-          )}
-        </Flex>
-      )}
+      <SimilarProfiles address={address} />
 
       {nfts === undefined ? (
         <Flex>

--- a/src/pages/colinks/ViewProfilePage/ViewProfilePageContents.tsx
+++ b/src/pages/colinks/ViewProfilePage/ViewProfilePageContents.tsx
@@ -18,6 +18,7 @@ import { LinkHoldings } from '../../../features/colinks/LinkHoldings';
 import { Poaps } from '../../../features/colinks/Poaps';
 import { RecentCoLinkTransactions } from '../../../features/colinks/RecentCoLinkTransactions';
 import { RightColumnSection } from '../../../features/colinks/RightColumnSection';
+import { SimilarProfiles } from '../../../features/colinks/SimilarProfiles';
 import { useCoLinks } from '../../../features/colinks/useCoLinks';
 import { QUERY_KEY_COLINKS } from '../../../features/colinks/wizard/CoLinksWizard';
 import { InviteCodeLink } from '../../../features/invites/InviteCodeLink';
@@ -445,6 +446,7 @@ const PageContents = ({
             <RecentCoLinkTransactions target={targetAddress} limit={5} />
           </RightColumnSection>
           <Poaps address={targetAddress} />
+          <SimilarProfiles address={targetAddress} />
         </Flex>
       </Flex>
     </SingleColumnLayout>

--- a/src/pages/colinks/explore/CoLinksMember.tsx
+++ b/src/pages/colinks/explore/CoLinksMember.tsx
@@ -17,9 +17,11 @@ export const linkHolderGradient = `linear-gradient(.15turn, color-mix(in srgb, $
 export const CoLinksMember = ({
   profile,
   rankNumber,
+  small = false,
 }: {
   profile: ProfileForCard;
   rankNumber?: number;
+  small?: boolean;
 }) => {
   const [buyProgress, setBuyProgress] = useState('');
   const holdingAmount = !profile.link_target
@@ -33,6 +35,27 @@ export const CoLinksMember = ({
   if (!profile.address) {
     return null;
   }
+
+  if (small)
+    return (
+      <Flex
+        as={NavLink}
+        to={coLinksPaths.profile(profile.address || '')}
+        css={{
+          position: 'relative',
+          color: '$text',
+          textDecoration: 'none',
+          background: '$surface',
+          borderRadius: '$3',
+          gap: '$md',
+          width: '100%',
+        }}
+      >
+        <AvatarWithLinks profile={profile} size={'medium'} />
+        <Text semibold>{profile.name}</Text>
+      </Flex>
+    );
+
   return (
     <Flex css={{ alignItems: 'center', gap: '$md', position: 'relative' }}>
       <Flex


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b52a689</samp>

This pull request adds a new feature to generate and store vector embeddings of profile descriptions using OpenAI and Hasura vector extension. It also updates the schema, migrations, and event triggers for the `profiles` table to include the new `description_embedding` field. Additionally, it fixes a minor issue with the co-links wizard paths and the URL validation schema.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b52a689</samp>

> _`description_embedding`_
> _Vector of words, spring of meaning_
> _Hasura triggers it_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b52a689</samp>

*  Add a new column `description_embedding` to the `profiles` table to store the vector representation of the profile description generated by OpenAI ([link](https://github.com/coordinape/coordinape/pull/2488/files?diff=unified&w=0#diff-964e1b382b3b8c51202e5f51aef98305e188dd0f034fa038a43c6cd4cccf4b1dR1), [link](https://github.com/coordinape/coordinape/pull/2488/files?diff=unified&w=0#diff-e082e1cc10c82e50e88c456d5fd289f4a3f021616a1c7520b615014d932648aaR1), [link](https://github.com/coordinape/coordinape/pull/2488/files?diff=unified&w=0#diff-8a805eab88da264de96c08096667337e06066993a6aa70395cd913c3c3feffaeR218-R235), [link](https://github.com/coordinape/coordinape/pull/2488/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R32935), [link](https://github.com/coordinape/coordinape/pull/2488/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R34320), [link](https://github.com/coordinape/coordinape/pull/2488/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R34399-R34403), [link](https://github.com/coordinape/coordinape/pull/2488/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R8712), [link](https://github.com/coordinape/coordinape/pull/2488/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R8755), [link](https://github.com/coordinape/coordinape/pull/2488/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R8911), [link](https://github.com/coordinape/coordinape/pull/2488/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R8925), [link](https://github.com/coordinape/coordinape/pull/2488/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R18442))
*  Add a new event trigger `updateDescriptionEmbedding` to the `profiles` table that invokes a handler function to update the `description_embedding` column when the `description` column is inserted or updated ([link](https://github.com/coordinape/coordinape/pull/2488/files?diff=unified&w=0#diff-8a805eab88da264de96c08096667337e06066993a6aa70395cd913c3c3feffaeR218-R235), [link](https://github.com/coordinape/coordinape/pull/2488/files?diff=unified&w=0#diff-1ff9bd45a785b1be61a7dc4d3b900604ffeaaf8c11f49e2c81fcfdff758d10f0R30), [link](https://github.com/coordinape/coordinape/pull/2488/files?diff=unified&w=0#diff-1ff9bd45a785b1be61a7dc4d3b900604ffeaaf8c11f49e2c81fcfdff758d10f0L76-R83), [link](https://github.com/coordinape/coordinape/pull/2488/files?diff=unified&w=0#diff-9a6b64102a2e91351395e622cc1c35de95d0f43ab261fe3cac8530edddb64269R1-R101))
*  Add the `description_embedding` field to the GraphQL schema for the Hasura admin role and expose it in the comparison expressions, ordering options, and input and output types for the `profiles` type ([link](https://github.com/coordinape/coordinape/pull/2488/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R33441), [link](https://github.com/coordinape/coordinape/pull/2488/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R33525), [link](https://github.com/coordinape/coordinape/pull/2488/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R33660), [link](https://github.com/coordinape/coordinape/pull/2488/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R34156-R34160), [link](https://github.com/coordinape/coordinape/pull/2488/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R34247), [link](https://github.com/coordinape/coordinape/pull/2488/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R8794))
*  Replace the hard-coded string `'/colinks/wizard'` with the constant `coLinksPaths.wizard` in the `WizardSteps.tsx` file for the co-links wizard feature ([link](https://github.com/coordinape/coordinape/pull/2488/files?diff=unified&w=0#diff-6d1da6784638c085f8a5454682860ecdac3984f19743788e83f3dfe75e12b69fL174-R174))
*  Replace the `url` schema with the `url.nullish()` schema in the `formHelpers.ts` file to allow optional URL inputs to be null or undefined ([link](https://github.com/coordinape/coordinape/pull/2488/files?diff=unified&w=0#diff-202cd0d9fab26ea2104d2ad832a19b5f159a1e6140481dae3ff4be0ead918634L68-R68))
