### PR TITLE
Magic multichain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,7 +58,8 @@ TEST_ON_HARDHAT_NODE=
 #OPTIMISM_GOERLI_MNEMONIC=add a mnemonic for use deploying to optimism goerli
 #COSOUL_OPTIMISM_MNEMONIC=add a mnemonic for use deploying to optimism mainnet
 #OPTIMISM_RPC_URL=get_a_rpc_from_alchemy
-#OPTIMISM_GOERLI_RPC_URL=get_a_rpc_from_alchemy
+OPTIMISM_GOERLI_RPC_URL=get_a_rpc_from_alchemy
+REACT_APP_OPTIMISM_GOERLI_RPC_URL=get_a_rpc_from_alchemy_for_magic
 
 # used to fork mainnet when testing
 HARDHAT_ARCHIVE_RPC_URL=https://mainnet.infura.io/v3/your_infura_project_id

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -34,6 +34,10 @@ export const INFURA_PROJECT_ID = getEnvValue(
   'REACT_APP_INFURA_PROJECT_ID',
   'missing-infura-id'
 );
+export const OPTIMISM_GOERLI_RPC_URL = getEnvValue(
+  'REACT_APP_OPTIMISM_GOERLI_RPC_URL',
+  'https://goerli.optimism.io'
+);
 export const REACT_APP_HASURA_URL = getEnvValue(
   'REACT_APP_HASURA_URL',
   'https://missing-hasura-url.edu'

--- a/src/features/auth/WalletAuthModal.tsx
+++ b/src/features/auth/WalletAuthModal.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef, useState } from 'react';
 
 import { Web3Provider } from '@ethersproject/providers';
 import { loginSupportedChainIds } from 'common-lib/constants';
+import { useIsCoLinksSite } from 'features/colinks/useIsCoLinksSite';
+import { useIsCoSoulSite } from 'features/cosoul/useIsCoSoulSite';
 import { NavLogo } from 'features/nav/NavLogo';
 
 import { CircularProgress } from '@material-ui/core';
@@ -43,6 +45,9 @@ export const WalletAuthModal = () => {
   const [isMetamaskEnabled, setIsMetamaskEnabled] = useState<boolean>(false);
   const [modalOpen, setModalOpen] = useState(true);
   const [explainerOpen, setExplainerOpen] = useState(false);
+  const isCoLinksPage = useIsCoLinksSite();
+  const isCoSoulPage = useIsCoSoulSite();
+  const isCoPage = isCoSoulPage || isCoLinksPage;
 
   const mounted = useRef(false);
   useEffect(() => {
@@ -137,7 +142,7 @@ export const WalletAuthModal = () => {
     try {
       // hide our modal because it interferes with typing into Magic's modal
       setModalOpen(false);
-      const provider = await getMagicProvider();
+      const provider = await getMagicProvider(isCoPage ? 'magic' : undefined);
       web3Context.setProvider(provider, 'magic');
     } catch (e) {
       showError(e);

--- a/src/features/auth/WalletAuthModal.tsx
+++ b/src/features/auth/WalletAuthModal.tsx
@@ -19,7 +19,7 @@ import { EXTERNAL_URL_TOS } from 'routes/paths';
 import { Box, Button, Text, Modal, Flex, HR, Link, Image } from 'ui';
 
 import { connectors } from './connectors';
-import { getMagicProvider } from './magic';
+import { getMagicProvider, KEY_MAGIC_NETWORK } from './magic';
 import { NetworkSelector } from './NetworkSelector';
 import { WalletConnectV2Connector } from './walletconnectv2';
 
@@ -88,6 +88,7 @@ export const WalletAuthModal = () => {
   const isConnecting = !!connectMessage;
 
   const activate = async (connectorName: EConnectorNames) => {
+    window.localStorage.removeItem(KEY_MAGIC_NETWORK);
     const newConnector = connectors[connectorName];
 
     setConnectMessage(
@@ -142,7 +143,9 @@ export const WalletAuthModal = () => {
     try {
       // hide our modal because it interferes with typing into Magic's modal
       setModalOpen(false);
-      const provider = await getMagicProvider(isCoPage ? 'magic' : undefined);
+      const provider = await getMagicProvider(
+        isCoPage ? 'optimism' : 'polygon'
+      );
       web3Context.setProvider(provider, 'magic');
     } catch (e) {
       showError(e);

--- a/src/features/auth/magic.tsx
+++ b/src/features/auth/magic.tsx
@@ -13,12 +13,13 @@ const logger = new DebugLogger('magic');
 
 const API_KEY = process.env.REACT_APP_MAGIC_API_KEY;
 export const PROVIDER_TYPE = 'magic';
-
+export const KEY_MAGIC_NETWORK = 'magic:network';
 // FIXME fix typing here
 //
 // the return type changes depending on the extensions used, so just doing
 // `let magic: Magic` doesn't work
 let magic: any;
+let optMagic: any;
 
 const networks: Record<string, EthNetworkConfiguration> = {
   mainnet: 'mainnet',
@@ -26,6 +27,14 @@ const networks: Record<string, EthNetworkConfiguration> = {
   polygon: {
     rpcUrl: 'https://polygon-rpc.com/',
     chainId: 137,
+  },
+  optimism: {
+    rpcUrl: 'https://mainnet.optimism.io',
+    chainId: 10,
+  },
+  optimism_goerli: {
+    rpcUrl: 'https://goerli.optimism.io',
+    chainId: 420,
   },
 };
 
@@ -45,13 +54,38 @@ export const getMagic = () => {
       extensions: [new ConnectExtension()],
     });
   }
-
+  window.localStorage.setItem(
+    KEY_MAGIC_NETWORK,
+    IN_PRODUCTION ? 'polygon' : 'goerli'
+  );
   (window as any).magic = magic;
   return magic;
 };
 
-export const getMagicProvider = async () => {
-  const m = getMagic();
+export const getOptMagic = () => {
+  assert(API_KEY, 'REACT_APP_MAGIC_API_KEY is missing');
+
+  if (!optMagic) {
+    const network = IN_PRODUCTION
+      ? networks.optimism
+      : networks.optimism_goerli;
+    optMagic = new Magic(API_KEY, {
+      network,
+      extensions: [new ConnectExtension()],
+    });
+  }
+  window.localStorage.setItem(KEY_MAGIC_NETWORK, 'optimism');
+  (window as any).optMagic = optMagic;
+  return optMagic;
+};
+
+export const getMagicProvider = async (network?: string) => {
+  let m;
+  if (network === 'optimism') {
+    m = getOptMagic();
+  } else {
+    m = getMagic();
+  }
   // @ts-ignore
   const provider = new Web3Provider(m.rpcProvider);
   const accounts = await provider.listAccounts();
@@ -67,9 +101,11 @@ export const MagicModalFixer = () => {
   // "pointer-events: none" on document.body; we use the hack below to fix that
 
   const togglePointerEvents = () => {
-    const iframe = document.querySelector('iframe.magic-iframe');
-    const visible = (iframe as HTMLIFrameElement)?.style.display !== 'none';
-    logger.log(`iframe visible? ${visible}`);
+    const iframes = document.querySelectorAll('iframe.magic-iframe');
+    const visible = Array.from(iframes).some(
+      iframe => (iframe as HTMLIFrameElement).style.display !== 'none'
+    );
+    logger.log(`iframes visible? ${visible}`);
     if (visible) document.body.style['pointerEvents'] = 'auto';
   };
 
@@ -82,33 +118,43 @@ export const MagicModalFixer = () => {
     });
 
     let appearanceObs: MutationObserver | undefined;
-    const iframe = document.querySelector('iframe.magic-iframe');
-    logger.log(`iframe present on startup? ${!!iframe}`);
 
-    if (iframe) {
+    const handleIframeAppearance = (iframe: HTMLIFrameElement) => {
+      logger.log('found iframe thru observer');
+      togglePointerEvents();
+      visibilityObs.observe(iframe, { attributes: true });
+    };
+
+    const observeIframe = (iframe: HTMLIFrameElement) => {
+      togglePointerEvents();
+      visibilityObs.observe(iframe, { attributes: true });
+    };
+
+    const iframes = document.querySelectorAll('iframe.magic-iframe');
+    logger.log(`iframes present on startup? ${iframes.length > 0}`);
+
+    if (iframes.length > 0) {
       // in some cases (e.g. the user already has a login token, but it's
       // expired), the iframe will appear right away, and we can already
       // start observing it
-      togglePointerEvents();
-      visibilityObs.observe(iframe, { attributes: true });
+      Array.from(iframes).forEach(iframe =>
+        observeIframe(iframe as HTMLIFrameElement)
+      );
     } else {
       // but for new logins, it doesn't appear until after the user starts the
       // Email Login process, so we need another observer to detect the
       // appearance of the iframe
-      const appearanceObs = new MutationObserver(mutations => {
-        for (const m of mutations) {
-          if (m.addedNodes.length == 0) continue;
-          for (const node of m.addedNodes) {
-            if ((node as HTMLElement).className === 'magic-iframe') {
-              logger.log('found iframe thru observer');
-              togglePointerEvents();
-              visibilityObs.observe(node, { attributes: true });
-              return;
+      appearanceObs = new MutationObserver(mutations => {
+        mutations.forEach(m => {
+          if (m.addedNodes.length === 0) return;
+          Array.from(m.addedNodes).forEach(node => {
+            if ((node as HTMLIFrameElement).className === 'magic-iframe') {
+              handleIframeAppearance(node as HTMLIFrameElement);
             }
-          }
-        }
+          });
+        });
       });
-      appearanceObs.observe(document.body, { childList: true });
+      appearanceObs.observe(document.body, { childList: true, subtree: true });
     }
 
     return () => {

--- a/src/features/auth/magic.tsx
+++ b/src/features/auth/magic.tsx
@@ -42,22 +42,14 @@ export const getMagic = () => {
   assert(API_KEY, 'REACT_APP_MAGIC_API_KEY is missing');
 
   if (!magic) {
-    // TODO have a more integrated way of picking the network
-    // TODO try using arbitrary RPC URLs e.g. testchain
-    const override = localStorage.getItem('magic:network') || '';
-    const network =
-      networks[override] ||
-      (IN_PRODUCTION ? networks.polygon : networks.goerli);
+    const network = IN_PRODUCTION ? networks.polygon : networks.goerli;
 
     magic = new Magic(API_KEY, {
       network,
       extensions: [new ConnectExtension()],
     });
   }
-  window.localStorage.setItem(
-    KEY_MAGIC_NETWORK,
-    IN_PRODUCTION ? 'polygon' : 'goerli'
-  );
+  window.localStorage.setItem(KEY_MAGIC_NETWORK, 'polygon');
   (window as any).magic = magic;
   return magic;
 };
@@ -79,7 +71,7 @@ export const getOptMagic = () => {
   return optMagic;
 };
 
-export const getMagicProvider = async (network?: string) => {
+export const getMagicProvider = async (network: string) => {
   let m;
   if (network === 'optimism') {
     m = getOptMagic();

--- a/src/features/auth/magic.tsx
+++ b/src/features/auth/magic.tsx
@@ -7,7 +7,7 @@ import type { EthNetworkConfiguration } from '@magic-sdk/types';
 import { Magic } from 'magic-sdk';
 
 import { DebugLogger } from '../../common-lib/log';
-import { IN_PRODUCTION } from 'config/env';
+import { IN_PRODUCTION, OPTIMISM_GOERLI_RPC_URL } from 'config/env';
 
 const logger = new DebugLogger('magic');
 
@@ -33,7 +33,7 @@ const networks: Record<string, EthNetworkConfiguration> = {
     chainId: 10,
   },
   optimism_goerli: {
-    rpcUrl: 'https://goerli.optimism.io',
+    rpcUrl: OPTIMISM_GOERLI_RPC_URL,
     chainId: 420,
   },
 };

--- a/src/features/auth/store.ts
+++ b/src/features/auth/store.ts
@@ -1,7 +1,12 @@
 import type { JsonRpcProvider } from '@ethersproject/providers';
 import create from 'zustand';
 
-import { getMagic, PROVIDER_TYPE as MAGIC_PROVIDER_TYPE } from './magic';
+import {
+  getMagic,
+  getOptMagic,
+  KEY_MAGIC_NETWORK,
+  PROVIDER_TYPE as MAGIC_PROVIDER_TYPE,
+} from './magic';
 
 export type ProviderType = typeof MAGIC_PROVIDER_TYPE;
 type Step = 'reuse' | 'connect' | 'sign' | 'done';
@@ -29,7 +34,12 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   setProvider: async (provider?: JsonRpcProvider, type?: ProviderType) => {
     if (!provider) {
       if (get().providerType === 'magic') {
-        getMagic().connect.disconnect();
+        const network = window.localStorage.getItem(KEY_MAGIC_NETWORK);
+        if (network === 'optimism') {
+          getOptMagic().connect.disconnect();
+        } else {
+          getMagic().connect.disconnect();
+        }
       }
       set({
         provider: undefined,

--- a/src/features/colinks/wizard/WizardSwitchToOptimism.tsx
+++ b/src/features/colinks/wizard/WizardSwitchToOptimism.tsx
@@ -1,6 +1,9 @@
 import assert from 'assert';
 import React from 'react';
 
+import { getMagicProvider } from 'features/auth/magic';
+import { useSavedAuth } from 'features/auth/useSavedAuth';
+
 import { useToast } from '../../../hooks';
 import { useWeb3React } from '../../../hooks/useWeb3React';
 import { OptimismLogo } from '../../../icons/__generated';
@@ -14,11 +17,18 @@ import { fullScreenStyles } from './WizardSteps';
 export function WizardSwitchToOptimism() {
   const { showError } = useToast();
 
-  const { library } = useWeb3React();
+  const { library, setProvider } = useWeb3React();
+  const { savedAuth } = useSavedAuth();
+
   const safeSwitchToCorrectChain = async () => {
     try {
-      assert(library);
-      await switchToCorrectChain(library);
+      if (savedAuth.connectorName == 'magic') {
+        const provider = await getMagicProvider('optimism');
+        await setProvider(provider, 'magic');
+      } else {
+        assert(library);
+        await switchToCorrectChain(library);
+      }
     } catch (e: any) {
       showError('Error Switching to ' + chain.chainName + ': ' + e.message);
     }

--- a/src/features/cosoul/CoSoulButton.tsx
+++ b/src/features/cosoul/CoSoulButton.tsx
@@ -1,6 +1,8 @@
 import assert from 'assert';
 
 import { ethers } from 'ethers';
+import { getMagicProvider } from 'features/auth/magic';
+import { useSavedAuth } from 'features/auth/useSavedAuth';
 import { useQuery } from 'react-query';
 
 import { useToast } from '../../hooks';
@@ -12,10 +14,11 @@ import { chain } from './chains';
 import { MintOrBurnButton } from './MintOrBurnButton';
 import { useCoSoulContracts } from './useCoSoulContracts';
 
-const MIN_BALANCE = ethers.utils.parseEther('0.005');
+const MIN_BALANCE = ethers.utils.parseEther('0.004');
 
 export const CoSoulButton = ({ onReveal }: { onReveal(): void }) => {
-  const { library, chainId, account } = useWeb3React();
+  const { library, chainId, account, setProvider } = useWeb3React();
+  const { savedAuth } = useSavedAuth();
   const contracts = useCoSoulContracts();
   const { showError } = useToast();
 
@@ -36,8 +39,13 @@ export const CoSoulButton = ({ onReveal }: { onReveal(): void }) => {
 
   const safeSwitchToCorrectChain = async () => {
     try {
-      assert(library);
-      await switchToCorrectChain(library);
+      if (savedAuth.connectorName == 'magic') {
+        const provider = await getMagicProvider('optimism');
+        await setProvider(provider, 'magic');
+      } else {
+        assert(library);
+        await switchToCorrectChain(library);
+      }
     } catch (e: any) {
       showError('Error Switching to ' + chain.chainName + ': ' + e.message);
     }

--- a/src/features/cosoul/CoSoulNav.tsx
+++ b/src/features/cosoul/CoSoulNav.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 
 import { useWalletStatus } from 'features/auth';
+import { MagicLinkWallet } from 'features/magiclink/MagicLinkWallet';
 import { useNavQuery } from 'features/nav/getNavData';
 import { NavItem } from 'features/nav/NavItem';
 import { NavLink } from 'react-router-dom';
@@ -136,6 +137,7 @@ export const CoSoulNav = () => {
                 )}
                 <NavItem label="About CoSoul" to={coSoulPaths.cosoul} />
                 <NavItem label="Docs" to={`//${EXTERNAL_URL_DOCS}`} />
+                <MagicLinkWallet />
                 <NavItem
                   label="Disconnect"
                   to={`${coSoulPaths.cosoul}?`}

--- a/src/features/cosoul/MintOrBurnButton.tsx
+++ b/src/features/cosoul/MintOrBurnButton.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { ethers } from 'ethers';
+import { MagicModalFixer } from 'features/auth/magic';
 
 import { LoadingModal } from '../../components';
 import { useToast } from '../../hooks';
@@ -177,7 +178,10 @@ const MintButton = ({
   return (
     <>
       {awaitingWallet && (
-        <MintingModal currentStep={mintingStep} onReveal={reveal} />
+        <>
+          <MintingModal currentStep={mintingStep} onReveal={reveal} />
+          <MagicModalFixer />
+        </>
       )}
       <Button color="cta" size="large" onClick={() => mint()}>
         Mint Your CoSoul

--- a/src/features/cosoul/chains.ts
+++ b/src/features/cosoul/chains.ts
@@ -52,5 +52,3 @@ export const chain = IN_PRODUCTION
   : IN_PREVIEW
   ? optimismGoerli
   : localhost;
-
-//TODO make it optimismGoerli in test environment

--- a/src/features/cosoul/chains.ts
+++ b/src/features/cosoul/chains.ts
@@ -52,3 +52,5 @@ export const chain = IN_PRODUCTION
   : IN_PREVIEW
   ? optimismGoerli
   : localhost;
+
+//TODO make it optimismGoerli in test environment

--- a/src/features/cosoul/useIsCoSoulSite.ts
+++ b/src/features/cosoul/useIsCoSoulSite.ts
@@ -1,0 +1,3 @@
+export const useIsCoSoulSite = () => {
+  return window.location.pathname.includes('cosoul');
+};

--- a/src/features/magiclink/MagicLinkWallet.tsx
+++ b/src/features/magiclink/MagicLinkWallet.tsx
@@ -1,24 +1,22 @@
 import { useEffect, useState } from 'react';
 
-import { useIsCoSoulSite } from 'features/cosoul/useIsCoSoulSite';
-
-import { getMagic, getOptMagic } from '../auth/magic';
+import { KEY_MAGIC_NETWORK, getMagic, getOptMagic } from '../auth/magic';
 import { NavItem } from '../nav/NavItem';
 
 export const MagicLinkWallet = () => {
   const [hasMagic, setHasMagic] = useState(false);
-  const isCoSoulPage = useIsCoSoulSite();
+  const magicNetwork = window.localStorage.getItem(KEY_MAGIC_NETWORK);
 
   useEffect(() => {
     // if magic has been loaded, we should show the button
     if ((window as any).magic || (window as any).optMagic) {
       setHasMagic(true);
     }
-  }, [isCoSoulPage]);
+  }, [magicNetwork]);
 
   const showWallet = async () => {
     let magic;
-    if (isCoSoulPage) {
+    if (magicNetwork === 'optimism') {
       magic = getOptMagic();
     } else {
       magic = getMagic();

--- a/src/features/magiclink/MagicLinkWallet.tsx
+++ b/src/features/magiclink/MagicLinkWallet.tsx
@@ -1,20 +1,28 @@
 import { useEffect, useState } from 'react';
 
-import { getMagic } from '../auth/magic';
+import { useIsCoSoulSite } from 'features/cosoul/useIsCoSoulSite';
+
+import { getMagic, getOptMagic } from '../auth/magic';
 import { NavItem } from '../nav/NavItem';
 
 export const MagicLinkWallet = () => {
   const [hasMagic, setHasMagic] = useState(false);
+  const isCoSoulPage = useIsCoSoulSite();
 
   useEffect(() => {
     // if magic has been loaded, we should show the button
-    if ((window as any).magic) {
+    if ((window as any).magic || (window as any).optMagic) {
       setHasMagic(true);
     }
-  });
+  }, [isCoSoulPage]);
 
   const showWallet = async () => {
-    const magic = getMagic();
+    let magic;
+    if (isCoSoulPage) {
+      magic = getOptMagic();
+    } else {
+      magic = getMagic();
+    }
     await magic.wallet.showUI();
   };
 


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 15470dd</samp>

This pull request adds support for Magic Link authentication on the CoSoul and CoLinks features, which use different networks (Optimism and Polygon) than the main Coordinape app. It defines and uses helper functions, hooks, and components to switch between networks and providers, and to handle Magic Link errors. It also fixes some modal interaction issues and persists the network choice in local storage. It modifies the files `src/features/auth/*`, `src/features/cosoul/*`, `src/features/magiclink/*`, and `src/utils/contractHelpers.ts`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 15470dd</samp>

> _We're crossing the bridge to CoSoul_
> _With Magic Link in our hands_
> _We switch the network and provider_
> _To unleash the power of our lands_


## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 15470dd</samp>

*  Add support for Magic Link authentication on the Optimism network for the CoSoul feature ([link](https://github.com/coordinape/coordinape/pull/2489/files?diff=unified&w=0#diff-2724f0c8eeff3ea6eda838dfac123faef13e5e109741b234c910407fb389ac9aL16-R16), [link](https://github.com/coordinape/coordinape/pull/2489/files?diff=unified&w=0#diff-2724f0c8eeff3ea6eda838dfac123faef13e5e109741b234c910407fb389ac9aR22), [link](https://github.com/coordinape/coordinape/pull/2489/files?diff=unified&w=0#diff-2724f0c8eeff3ea6eda838dfac123faef13e5e109741b234c910407fb389ac9aR31-R38), [link](https://github.com/coordinape/coordinape/pull/2489/files?diff=unified&w=0#diff-2724f0c8eeff3ea6eda838dfac123faef13e5e109741b234c910407fb389ac9aL48-R88), [link](https://github.com/coordinape/coordinape/pull/2489/files?diff=unified&w=0#diff-2724f0c8eeff3ea6eda838dfac123faef13e5e109741b234c910407fb389ac9aL70-R108), [link](https://github.com/coordinape/coordinape/pull/2489/files?diff=unified&w=0#diff-2724f0c8eeff3ea6eda838dfac123faef13e5e109741b234c910407fb389ac9aL85-R157), [link](https://github.com/coordinape/coordinape/pull/2489/files?diff=unified&w=0#diff-d629f61b1d1a9c9bdd9214686ad7ccd66da02a50c76ed26db2b68b6c0dbd3c1cL4-R9), [link](https://github.com/coordinape/coordinape/pull/2489/files?diff=unified&w=0#diff-d629f61b1d1a9c9bdd9214686ad7ccd66da02a50c76ed26db2b68b6c0dbd3c1cL32-R42), [link](https://github.com/coordinape/coordinape/pull/2489/files?diff=unified&w=0#diff-f7c2d440a5cadbf60bb711e3b997d2b71abfc3d6b079d9821f62650b02f36707R4-R5), [link](https://github.com/coordinape/coordinape/pull/2489/files?diff=unified&w=0#diff-f7c2d440a5cadbf60bb711e3b997d2b71abfc3d6b079d9821f62650b02f36707L15-R21), [link](https://github.com/coordinape/coordinape/pull/2489/files?diff=unified&w=0#diff-f7c2d440a5cadbf60bb711e3b997d2b71abfc3d6b079d9821f62650b02f36707L39-R48), [link](https://github.com/coordinape/coordinape/pull/2489/files?diff=unified&w=0#diff-daba79fc9c9eee4e8af15a580cebcb4600102609ab7a527345bc5af1701561fbR4), [link](https://github.com/coordinape/coordinape/pull/2489/files?diff=unified&w=0#diff-daba79fc9c9eee4e8af15a580cebcb4600102609ab7a527345bc5af1701561fbR140), [link](https://github.com/coordinape/coordinape/pull/2489/files?diff=unified&w=0#diff-f38e6ed59a7956c585a4215ed549d4216a411629b0e00d8588773733b97503f0R4), [link](https://github.com/coordinape/coordinape/pull/2489/files?diff=unified&w=0#diff-f38e6ed59a7956c585a4215ed549d4216a411629b0e00d8588773733b97503f0L180-R184), [link](https://github.com/coordinape/coordinape/pull/2489/files?diff=unified&w=0#diff-9b9f30e7afc78dd4a1e10bcbf7716d44934445813bd46d6c1d1b3b98ffc4aaf1R1-R3), [link](https://github.com/coordinape/coordinape/pull/2489/files?diff=unified&w=0#diff-2b2e8128011bdb52d1de1afdf7c5429de4dd941c79e166da43fa61c111ff912aL3-R25), [link](https://github.com/coordinape/coordinape/pull/2489/files?diff=unified&w=0#diff-7cda9df198b62326ac698037cbd5bdf4133369e2fcaddd4a10b5103a7ba7469cL88-R98))
*  Modify the `RequireAuth` component to reuse the saved auth connector and provider when switching between CoSoul and CoLinks pages, which use different networks ([link](https://github.com/coordinape/coordinape/pull/2489/files?diff=unified&w=0#diff-19acee9928399fe91bb66daab42642c08a0b1ce1d88f819e48efe2ae34c90e93L2-R6), [link](https://github.com/coordinape/coordinape/pull/2489/files?diff=unified&w=0#diff-19acee9928399fe91bb66daab42642c08a0b1ce1d88f819e48efe2ae34c90e93L25-R30), [link](https://github.com/coordinape/coordinape/pull/2489/files?diff=unified&w=0#diff-19acee9928399fe91bb66daab42642c08a0b1ce1d88f819e48efe2ae34c90e93L53-R58), [link](https://github.com/coordinape/coordinape/pull/2489/files?diff=unified&w=0#diff-19acee9928399fe91bb66daab42642c08a0b1ce1d88f819e48efe2ae34c90e93L63-R78), [link](https://github.com/coordinape/coordinape/pull/2489/files?diff=unified&w=0#diff-19acee9928399fe91bb66daab42642c08a0b1ce1d88f819e48efe2ae34c90e93L94-R107))
*  Modify the `WalletAuthModal` component to pass the correct network argument to the `getMagicProvider` function, depending on the current page ([link](https://github.com/coordinape/coordinape/pull/2489/files?diff=unified&w=0#diff-4b4a0a4b7859ffbf645a3501bb4cdf3bdc689cccc32a4b5c40965e616a137312R5-R6), [link](https://github.com/coordinape/coordinape/pull/2489/files?diff=unified&w=0#diff-4b4a0a4b7859ffbf645a3501bb4cdf3bdc689cccc32a4b5c40965e616a137312R48-R50), [link](https://github.com/coordinape/coordinape/pull/2489/files?diff=unified&w=0#diff-4b4a0a4b7859ffbf645a3501bb4cdf3bdc689cccc32a4b5c40965e616a137312L140-R145))
