### PR TITLE
fixing migration

### DIFF
--- a/hasura/migrations/default/1701412112144_bootstrap_profiles_links_and_links_held/up.sql
+++ b/hasura/migrations/default/1701412112144_bootstrap_profiles_links_and_links_held/up.sql
@@ -1,2 +1,2 @@
-update profiles p set links=(select sum(amount) from link_holders lh where lh.target ilike p.address);
-update profiles p set links_held=(select sum(amount) from link_holders lh where lh.holder ilike p.address);
+update profiles p set links=(select COALESCE(sum(amount),0) from link_holders lh where lh.target ilike p.address);
+update profiles p set links_held=(select COALESCE(sum(amount),0) from link_holders lh where lh.holder ilike p.address);


### PR DESCRIPTION
add coalesce to handle nulls

## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5c409ea</samp>

Added `COALESCE` function to migration script `up.sql` to avoid null values in profiles table. This ensures the correct calculation of links and links_held for each profile.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5c409ea</samp>

> _`COALESCE` the sums_
> _Avoid nulls in profiles table_
> _Migration in spring_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5c409ea</samp>

* Initialize the profiles table with data from the link_holders table ([link](https://github.com/coordinape/coordinape/pull/2490/files?diff=unified&w=0#diff-52a1b01b2ede95a936cdf70e81e4b18bbe865974e9dee3e537a4ab1881ae8a02L1-R2))

