### PR TITLE
Fix twitter callback path - website in wizard

### DIFF
--- a/src/features/colinks/wizard/WizardSteps.tsx
+++ b/src/features/colinks/wizard/WizardSteps.tsx
@@ -171,7 +171,7 @@ export const WizardSteps = ({
         />
         <WizardInstructions>
           <ShowOrConnectTwitter
-            callbackPage={'/colinks/wizard'}
+            callbackPage={coLinksPaths.wizard}
             minimal={true}
           />
           {!twitter && (

--- a/src/lib/zod/formHelpers.ts
+++ b/src/lib/zod/formHelpers.ts
@@ -65,7 +65,7 @@ const urlRegex = /^https?:\/\/([\w\d-]+\.){1,}[\w\d-]+(\/[\w\d-]+)*\/?$/;
 const url = z.string().refine(value => urlRegex.test(value), {
   message: 'Invalid URL format',
 });
-const optionalUrl = z.union([url, z.literal('')]);
+const optionalUrl = z.union([url.nullish(), z.literal('')]);
 export const zWebsite = optionalUrl;
 
 export const zCircleName = z


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ce1643f</samp>

Improved the code quality and validation logic of the co-links wizard feature. Used constants for paths in `WizardSteps.tsx` and allowed null values for optional website fields in `zWebsite` schema.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ce1643f</samp>

> _`callbackPage` fixed_
> _Using constant paths, not strings_
> _Winter code cleanup_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ce1643f</samp>

*  Changed the `callbackPage` prop of `ShowOrConnectTwitter` to use a constant from `coLinksPaths` instead of a hard-coded string ([link](https://github.com/coordinape/coordinape/pull/2493/files?diff=unified&w=0#diff-6d1da6784638c085f8a5454682860ecdac3984f19743788e83f3dfe75e12b69fL174-R174))
*  Allowed null values and empty strings for the `url` schema from `zod` to validate optional website fields in the wizard form ([link](https://github.com/coordinape/coordinape/pull/2493/files?diff=unified&w=0#diff-202cd0d9fab26ea2104d2ad832a19b5f159a1e6140481dae3ff4be0ead918634L68-R68))
