### PR TITLE
new useProfileId hook, moving coLinksNav query into simpler useCoLinksNavQuery hook

### DIFF
--- a/src/components/AvatarUpload.tsx
+++ b/src/components/AvatarUpload.tsx
@@ -5,6 +5,7 @@ import { updateProfileAvatar } from 'lib/gql/mutations';
 import { MAX_IMAGE_BYTES_LENGTH_BASE64 } from 'lib/images';
 import { useQueryClient } from 'react-query';
 
+import { QUERY_KEY_COLINKS_NAV } from '../features/colinks/useCoLinksNavQuery';
 import { QUERY_KEY_NAV } from '../features/nav';
 import { LoadingModal } from 'components';
 import { useToast } from 'hooks';
@@ -68,6 +69,7 @@ export const AvatarUpload = ({ original }: { original?: string }) => {
         //to be fixed when profile data is fetched separately
         await fetchManifest();
         queryClient.invalidateQueries([QUERY_KEY_NAV]);
+        queryClient.invalidateQueries([QUERY_KEY_COLINKS_NAV]);
         setAvatarFile(undefined);
         setUploadComplete(true);
       }

--- a/src/features/auth/TermsGate.tsx
+++ b/src/features/auth/TermsGate.tsx
@@ -1,16 +1,19 @@
 import assert from 'assert';
 import { useEffect, useState } from 'react';
 
-import { QUERY_KEY_NAV, useNavQuery } from 'features/nav/getNavData';
 import { client } from 'lib/gql/client';
 import { useMutation, useQueryClient } from 'react-query';
 
+import {
+  QUERY_KEY_COLINKS_NAV,
+  useCoLinksNavQuery,
+} from '../colinks/useCoLinksNavQuery';
 import { useToast } from 'hooks';
 import { EXTERNAL_URL_TOS } from 'routes/paths';
 import { Button, Flex, Link, Modal, Text } from 'ui';
 
 const TermsGate = ({ children }: { children: React.ReactNode }) => {
-  const { data } = useNavQuery();
+  const { data } = useCoLinksNavQuery();
   const profileId = data?.profile?.id;
   const { showError } = useToast();
   const queryClient = useQueryClient();
@@ -37,7 +40,7 @@ const TermsGate = ({ children }: { children: React.ReactNode }) => {
         setTermsAccepted(true);
 
         queryClient.setQueryData<typeof data>(
-          [QUERY_KEY_NAV, profileId],
+          [QUERY_KEY_COLINKS_NAV, profileId],
           oldData => {
             if (oldData) {
               const tos_agreed_at = res.tos_agreed_at;

--- a/src/features/colinks/CoLinksNav.tsx
+++ b/src/features/colinks/CoLinksNav.tsx
@@ -12,7 +12,6 @@ import { NavLink } from 'react-router-dom';
 import { Menu, X } from '../../icons/__generated';
 import { coLinksPaths } from '../../routes/paths';
 import { Flex, IconButton, Link, Text } from '../../ui';
-import { useNavQuery } from '../nav/getNavData';
 import { NavLogo } from '../nav/NavLogo';
 import {
   NOTIFICATIONS_QUERY_KEY,
@@ -21,10 +20,11 @@ import {
 
 import { CoLinksContext } from './CoLinksContext';
 import { CoLinksNavProfile } from './CoLinksNavProfile';
+import { useCoLinksNavQuery } from './useCoLinksNavQuery';
 
 export const CoLinksNav = () => {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const { data } = useNavQuery();
+  const { data } = useCoLinksNavQuery();
   const { address } = useContext(CoLinksContext);
 
   const queryClient = useQueryClient();

--- a/src/features/colinks/useCoLinksNavQuery.ts
+++ b/src/features/colinks/useCoLinksNavQuery.ts
@@ -1,0 +1,44 @@
+import { useQuery } from 'react-query';
+
+import useProfileId from '../../hooks/useProfileId';
+import { client } from '../../lib/gql/client';
+
+export const QUERY_KEY_COLINKS_NAV = 'colinks-nav';
+export const useCoLinksNavQuery = () => {
+  const profileId = useProfileId(true);
+  return useQuery(
+    [QUERY_KEY_COLINKS_NAV, profileId],
+    async () => {
+      const data = await getCoLinksNavData(profileId);
+      const profile = data.profiles_by_pk;
+      if (!profile) {
+        throw new Error('no profile for current user');
+      }
+      return { ...data, profile };
+    },
+    {
+      staleTime: Infinity,
+    }
+  );
+};
+
+const getCoLinksNavData = (profileId: number) =>
+  client.query(
+    {
+      profiles_by_pk: [
+        { id: profileId },
+        {
+          name: true,
+          id: true,
+          avatar: true,
+          address: true,
+          description: true,
+          tos_agreed_at: true,
+          cosoul: {
+            id: true,
+          },
+        },
+      ],
+    },
+    { operationName: 'getCoLinksNavData' }
+  );

--- a/src/features/colinks/wizard/CoLinksWizard.tsx
+++ b/src/features/colinks/wizard/CoLinksWizard.tsx
@@ -1,9 +1,9 @@
 import { useWalletStatus } from 'features/auth';
 import { chain } from 'features/cosoul/chains';
-import { useNavQuery } from 'features/nav/getNavData';
 import { client } from 'lib/gql/client';
 import { useQuery } from 'react-query';
 
+import { useCoLinksNavQuery } from '../useCoLinksNavQuery';
 import { GlobalUi } from 'components/GlobalUi';
 import { useWeb3React } from 'hooks/useWeb3React';
 import { EmailBanner } from 'pages/ProfilePage/EmailSettings/EmailBanner';
@@ -15,7 +15,7 @@ import { WizardSteps } from './WizardSteps';
 export const QUERY_KEY_COLINKS = 'coLinks';
 
 export const CoLinksWizard = () => {
-  const { data } = useNavQuery();
+  const { data } = useCoLinksNavQuery();
   const { chainId, account } = useWeb3React();
   const onCorrectChain = chainId === Number(chain.chainId);
   const { address } = useWalletStatus();

--- a/src/features/colinks/wizard/WizardSteps.tsx
+++ b/src/features/colinks/wizard/WizardSteps.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from 'react';
 
 import { CoLinksMintPage } from 'features/cosoul/CoLinksMintPage';
 import { CoSoulButton } from 'features/cosoul/CoSoulButton';
-import { QUERY_KEY_NAV, useNavQuery } from 'features/nav/getNavData';
 import { client } from 'lib/gql/client';
 import { useMutation, useQueryClient } from 'react-query';
 import { useNavigate } from 'react-router';
@@ -17,6 +16,10 @@ import { ShowOrConnectLinkedIn } from '../../linkedin/ShowOrConnectLinkedIn';
 import { ShowOrConnectTwitter } from '../../twitter/ShowOrConnectTwitter';
 import { useMyTwitter } from '../../twitter/useMyTwitter';
 import { CoLinksProvider } from '../CoLinksContext';
+import {
+  QUERY_KEY_COLINKS_NAV,
+  useCoLinksNavQuery,
+} from '../useCoLinksNavQuery';
 import { useToast } from 'hooks';
 import { EmailCTA } from 'pages/ProfilePage/EmailSettings/EmailCTA';
 import { coLinksPaths, EXTERNAL_URL_TOS } from 'routes/paths';
@@ -81,7 +84,7 @@ export const WizardSteps = ({
   const redirect = searchParams.get('redirect');
 
   // TOS stuff
-  const { data } = useNavQuery();
+  const { data } = useCoLinksNavQuery();
   const queryClient = useQueryClient();
   const [termsAccepted, setTermsAccepted] = useState(false);
 
@@ -113,7 +116,7 @@ export const WizardSteps = ({
         setTermsAccepted(true);
 
         queryClient.setQueryData<typeof data>(
-          [QUERY_KEY_NAV, profileId],
+          [QUERY_KEY_COLINKS_NAV, profileId],
           oldData => {
             if (oldData) {
               const tos_agreed_at = res.tos_agreed_at;

--- a/src/features/cosoul/CoLinksSplashNav.tsx
+++ b/src/features/cosoul/CoLinksSplashNav.tsx
@@ -1,19 +1,19 @@
 import { useEffect, useRef, useState } from 'react';
 
 import { useWalletStatus } from 'features/auth';
-import { useNavQuery } from 'features/nav/getNavData';
 import { NavItem } from 'features/nav/NavItem';
 import { NavLink } from 'react-router-dom';
 
 import useConnectedAddress from '../../hooks/useConnectedAddress';
 import { coLinksPaths } from '../../routes/paths';
+import { useCoLinksNavQuery } from '../colinks/useCoLinksNavQuery';
 import { Network } from 'components';
 import { Avatar, Box, Button, Flex, Text } from 'ui';
 import { shortenAddressWithFrontLength } from 'utils';
 
 export const CoLinksSplashNav = () => {
   const { chainId, logout } = useWalletStatus();
-  const { data } = useNavQuery();
+  const { data } = useCoLinksNavQuery();
   const address = useConnectedAddress();
   const [open, setOpen] = useState(false);
   const name = data?.profile.name;

--- a/src/hooks/useProfileId.ts
+++ b/src/hooks/useProfileId.ts
@@ -1,0 +1,13 @@
+import assert from 'assert';
+
+import { useAuthStore } from '../features/auth';
+
+function useProfileId(required: true): number;
+function useProfileId(required?: boolean): number | undefined;
+function useProfileId(required = false) {
+  const profileId = useAuthStore(state => state.profileId);
+  assert(profileId || !required, 'no profileId found');
+  return profileId || undefined;
+}
+
+export default useProfileId;


### PR DESCRIPTION
Trying to reduce the complexity of the queries required to render CoLinks. No need to fetch orgs and circles and claims. 

## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a9045bb</samp>

This pull request refactors the co-links feature to use a custom query hook `useCoLinksNavQuery` that fetchs the navigation data based on the profile id. This improves the performance, consistency, and readability of the co-links feature and the components that use it. It also adds a new hook `useProfileId` that returns the profile id from the auth store.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a9045bb</samp>

> _Sing, O Muse, of the skillful refactorer_
> _Who improved the co-links feature with hooks_
> _And made the navigation data faster_
> _By using `useCoLinksNavQuery` in many nooks._

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a9045bb</samp>

*  Refactor the colinks navigation data fetching to use a separate query hook and key from the general navigation data ([link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-f59bcccd476d06d62380d0c3150a623977085c0b390ed82fc195792e00b8161eR8), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-5a0d1c5c5cea7d47bbd9eb95dea66275810a95cc8728657ca3c1a4ed5b32e3e0L4-R10), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-5a0d1c5c5cea7d47bbd9eb95dea66275810a95cc8728657ca3c1a4ed5b32e3e0L13-R16), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-5a0d1c5c5cea7d47bbd9eb95dea66275810a95cc8728657ca3c1a4ed5b32e3e0L40-R43), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-e3c22548942033fef181fec2fed0f2421c244527e3d4bc7ff616808cde7aba76L15), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-e3c22548942033fef181fec2fed0f2421c244527e3d4bc7ff616808cde7aba76L24-R27), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-cf79d0a551ee7a48b1b8c9a2353422c0c03890abadd1c9333b23212355860fe3R1-R44), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-55823966dcb02275e178c3105ec5b8d412ec000808bd06a12abcef784a846fe3L3-R6), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-55823966dcb02275e178c3105ec5b8d412ec000808bd06a12abcef784a846fe3L18-R18), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-6d1da6784638c085f8a5454682860ecdac3984f19743788e83f3dfe75e12b69fL6), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-6d1da6784638c085f8a5454682860ecdac3984f19743788e83f3dfe75e12b69fR19-R22), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-6d1da6784638c085f8a5454682860ecdac3984f19743788e83f3dfe75e12b69fL84-R87), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-6d1da6784638c085f8a5454682860ecdac3984f19743788e83f3dfe75e12b69fL116-R119), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-10649d1a357cf1b1a7a87f63f909cd2e18b85d7fe34e8197816221e7dbffa754L4), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-10649d1a357cf1b1a7a87f63f909cd2e18b85d7fe34e8197816221e7dbffa754R9), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-10649d1a357cf1b1a7a87f63f909cd2e18b85d7fe34e8197816221e7dbffa754L16-R16), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-1270328d6f33276d078c78f6e0f1b5b4c933ca4a3c52c9f7a853f4cd3b8e4142R1-R13))
  * Create a new custom hook `useCoLinksNavQuery` in `useCoLinksNavQuery.ts` that fetches the colinks navigation data from the GraphQL client based on the profile id returned by another custom hook `useProfileId` ([link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-cf79d0a551ee7a48b1b8c9a2353422c0c03890abadd1c9333b23212355860fe3R1-R44), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-1270328d6f33276d078c78f6e0f1b5b4c933ca4a3c52c9f7a853f4cd3b8e4142R1-R13))
  * Define and export a new query key constant `QUERY_KEY_COLINKS_NAV` in `useCoLinksNavQuery.ts` and use it in the `useCoLinksNavQuery` hook and other components that need to access or update the colinks navigation data ([link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-cf79d0a551ee7a48b1b8c9a2353422c0c03890abadd1c9333b23212355860fe3R1-R44), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-f59bcccd476d06d62380d0c3150a623977085c0b390ed82fc195792e00b8161eR8), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-5a0d1c5c5cea7d47bbd9eb95dea66275810a95cc8728657ca3c1a4ed5b32e3e0L40-R43), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-e3c22548942033fef181fec2fed0f2421c244527e3d4bc7ff616808cde7aba76L24-R27), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-6d1da6784638c085f8a5454682860ecdac3984f19743788e83f3dfe75e12b69fR19-R22), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-6d1da6784638c085f8a5454682860ecdac3984f19743788e83f3dfe75e12b69fL116-R119))
  * Replace the usage of the `useNavQuery` hook and the `QUERY_KEY_NAV` constant with the `useCoLinksNavQuery` hook and the `QUERY_KEY_COLINKS_NAV` constant in the `TermsGate`, `CoLinksNav`, `CoLinksWizard`, and `WizardSteps` components, and remove the unused imports of the former ([link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-5a0d1c5c5cea7d47bbd9eb95dea66275810a95cc8728657ca3c1a4ed5b32e3e0L4-R10), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-5a0d1c5c5cea7d47bbd9eb95dea66275810a95cc8728657ca3c1a4ed5b32e3e0L13-R16), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-e3c22548942033fef181fec2fed0f2421c244527e3d4bc7ff616808cde7aba76L15), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-e3c22548942033fef181fec2fed0f2421c244527e3d4bc7ff616808cde7aba76L24-R27), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-55823966dcb02275e178c3105ec5b8d412ec000808bd06a12abcef784a846fe3L3-R6), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-55823966dcb02275e178c3105ec5b8d412ec000808bd06a12abcef784a846fe3L18-R18), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-6d1da6784638c085f8a5454682860ecdac3984f19743788e83f3dfe75e12b69fL6), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-6d1da6784638c085f8a5454682860ecdac3984f19743788e83f3dfe75e12b69fR19-R22), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-6d1da6784638c085f8a5454682860ecdac3984f19743788e83f3dfe75e12b69fL84-R87))
  * Remove the unused import of the `useNavQuery` hook from the `CoLinksSplashNav` component and use the `useCoLinksNavQuery` hook instead to access the colinks navigation data ([link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-10649d1a357cf1b1a7a87f63f909cd2e18b85d7fe34e8197816221e7dbffa754L4), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-10649d1a357cf1b1a7a87f63f909cd2e18b85d7fe34e8197816221e7dbffa754R9), [link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-10649d1a357cf1b1a7a87f63f909cd2e18b85d7fe34e8197816221e7dbffa754L16-R16))
* Invalidate the colinks navigation data query after uploading a new avatar image in the `AvatarUpload` component to ensure that the updated avatar is reflected in the colinks navigation components ([link](https://github.com/coordinape/coordinape/pull/2497/files?diff=unified&w=0#diff-f59bcccd476d06d62380d0c3150a623977085c0b390ed82fc195792e00b8161eR72))
