### PR TITLE
removing fetchManifest from the CoLinks app

### DIFF
--- a/src/features/auth/useFinishAuth.ts
+++ b/src/features/auth/useFinishAuth.ts
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/react';
 import { identify } from 'features/analytics';
 
 import { DebugLogger } from '../../common-lib/log';
+import { useIsCoLinksSite } from '../colinks/useIsCoLinksSite';
 import { useFetchManifest } from 'hooks/legacyApi';
 import { useToast } from 'hooks/useToast';
 import { useWeb3React } from 'hooks/useWeb3React';
@@ -23,6 +24,8 @@ export const useFinishAuth = () => {
   const { setSavedAuth, getAndUpdate } = useSavedAuth();
   const web3Context = useWeb3React();
   const setProfileId = useAuthStore(state => state.setProfileId);
+
+  const isCoLinks = useIsCoLinksSite();
 
   return async () => {
     const { connector, account: address, library, providerType } = web3Context;
@@ -57,6 +60,10 @@ export const useFinishAuth = () => {
         address.substr(0, 8) + '...' + address.substr(address.length - 8, 8)
       );
 
+      if (isCoLinks) {
+        // no need to fetch manifest for colinks
+        return Promise.resolve(true);
+      }
       // this setTimeout is needed so that the Recoil effects of updateSavedAuth
       // are finished before fetchManifest is called. in particular,
       // setAuthToken needs to be called

--- a/src/hooks/legacyApi.ts
+++ b/src/hooks/legacyApi.ts
@@ -5,6 +5,7 @@ import { useSavedAuth } from 'features/auth/useSavedAuth';
 import { client } from 'lib/gql/client';
 import { useQueryClient } from 'react-query';
 
+import { useIsCoLinksSite } from '../features/colinks/useIsCoLinksSite';
 import { useRecoilLoadCatch } from 'hooks';
 import type { IApiManifest } from 'recoilState';
 import { rApiManifest } from 'recoilState';
@@ -183,10 +184,12 @@ const formatLegacyManifest = async (
 export const useFetchManifest = () => {
   const { savedAuth } = useSavedAuth();
   const queryClient = useQueryClient();
+  const isCoLinksSite = useIsCoLinksSite();
 
   return useRecoilLoadCatch(
     ({ set }) =>
       async (profileId?: number) => {
+        if (isCoLinksSite) return { profiles_by_pk: undefined };
         if (!profileId) profileId = savedAuth.id;
         assert(profileId, 'no profile ID for fetchManifest');
         const data = await queryManifest(profileId);

--- a/src/pages/CoSoulExplorePage/CoSoulItem.tsx
+++ b/src/pages/CoSoulExplorePage/CoSoulItem.tsx
@@ -175,15 +175,16 @@ export const CoSoulItem = ({
               </Flex>
             </Flex>
             {!exploreView && (
-              <AppLink
-                to={coLinksPaths.score(cosoul.address)}
+              <Text
                 css={{
+                  width: '100%',
+                  color: '$cta',
                   fontSize: '$xs',
-                  textAlign: 'center',
+                  justifyContent: 'center',
                 }}
               >
                 View Details
-              </AppLink>
+              </Text>
             )}
           </Flex>
           {exploreView && (


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1ff25c7</samp>

Updated the app to support CoLinks sites as a special case, by skipping the manifest fetch and using a different UI component for viewing CoSoul scores. Modified `useFinishAuth`, `useFetchManifest`, and `CoSoulItem` accordingly.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1ff25c7</samp>

> _To support CoLinks in our app_
> _We made some changes to adapt_
> _We skipped manifest fetch_
> _And used `Text` not `AppLink`_
> _To show CoSoul score in a snap_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1ff25c7</samp>

* Skip fetching manifest data for CoLinks sites in `useFinishAuth` hook ([link](https://github.com/coordinape/coordinape/pull/2498/files?diff=unified&w=0#diff-9364f778b5d58002aee011b7f30b5acf78b68de864caa758194fb49ea89b8bccR63-R66))
* Return empty object instead of manifest data for CoLinks sites in `useFetchManifest` hook ([link](https://github.com/coordinape/coordinape/pull/2498/files?diff=unified&w=0#diff-e62b950b94784333ac920a0cdd946b27d7a7c292af43c1cfcc541ece0fa312e1L186-R192))
* Use `useIsCoLinksSite` hook to determine if the site is a CoLinks site in `useFinishAuth` and `useFetchManifest` hooks ([link](https://github.com/coordinape/coordinape/pull/2498/files?diff=unified&w=0#diff-9364f778b5d58002aee011b7f30b5acf78b68de864caa758194fb49ea89b8bccR7), [link](https://github.com/coordinape/coordinape/pull/2498/files?diff=unified&w=0#diff-9364f778b5d58002aee011b7f30b5acf78b68de864caa758194fb49ea89b8bccR28-R29), [link](https://github.com/coordinape/coordinape/pull/2498/files?diff=unified&w=0#diff-e62b950b94784333ac920a0cdd946b27d7a7c292af43c1cfcc541ece0fa312e1R8))
* Replace `AppLink` with `Text` component for "View Details" button in `CoSoulItem` component ([link](https://github.com/coordinape/coordinape/pull/2498/files?diff=unified&w=0#diff-6b70865268dd8a1b15388c44259477b056ccbac3f232cf94cda5f3f514bd94e0L178-R187))
