### PR TITLE
auto redeem invite code for all current link holders

### DIFF
--- a/hasura/migrations/default/1701844753172_auto_redeem_invite_code_all_existing_link_holders/down.sql
+++ b/hasura/migrations/default/1701844753172_auto_redeem_invite_code_all_existing_link_holders/down.sql
@@ -1,0 +1,3 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- update profiles p set invite_code_redeemed_at=now() where LOWER(p.address) in (select distinct LOWER(target) from link_holders);

--- a/hasura/migrations/default/1701844753172_auto_redeem_invite_code_all_existing_link_holders/up.sql
+++ b/hasura/migrations/default/1701844753172_auto_redeem_invite_code_all_existing_link_holders/up.sql
@@ -1,0 +1,1 @@
+update profiles p set invite_code_redeemed_at=now() where LOWER(p.address) in (select distinct LOWER(target) from link_holders);


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d7798eb</samp>

This pull request adds a migration to automatically redeem invite codes for existing and new link holders who join a circle. It also adds a comment to the down migration file to remind the developer to write a custom script to undo the update.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d7798eb</samp>

> _`invite_code` redeemed_
> _Join a circle with a link_
> _Autumn of friendship_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d7798eb</samp>

*  Update the profiles table to mark the invite codes as redeemed for all existing link holders ([link](https://github.com/coordinape/coordinape/pull/2507/files?diff=unified&w=0#diff-77b8b6de58a8dcbfeb1459badc42a2f19f14883cd63e2d9b49e38742b79cb07aR1))
* Add a comment to the down migration file, indicating that the developer needs to write a custom SQL script to undo the effects of the up migration ([link](https://github.com/coordinape/coordinape/pull/2507/files?diff=unified&w=0#diff-c1a71935d4c15ce896e0604dca3167d311177cd9356163af9b405bce61ec427dR1-R3))
