### PR TITLE
Invite score highlights on the invite page

### DIFF
--- a/src/features/colinks/ScoreComponent.tsx
+++ b/src/features/colinks/ScoreComponent.tsx
@@ -1,0 +1,35 @@
+import { coLinksPaths } from '../../routes/paths';
+import { AppLink, Flex, Panel, Text } from '../../ui';
+
+export const ScoreComponent = ({
+  label,
+  score,
+  address,
+}: {
+  label: string;
+  score: number;
+  address: string;
+}) => {
+  return (
+    <Panel as={AppLink} to={coLinksPaths.score(address)} noBorder>
+      <Flex column>
+        <Text
+          semibold
+          size={'large'}
+          color={'cta'}
+          css={{ justifyContent: 'flex-end' }}
+        >
+          {score}
+        </Text>
+        <Text
+          color={'default'}
+          semibold
+          size={'small'}
+          css={{ justifyContent: 'flex-end' }}
+        >
+          {label}
+        </Text>
+      </Flex>
+    </Panel>
+  );
+};

--- a/src/pages/colinks/InvitesPage.tsx
+++ b/src/pages/colinks/InvitesPage.tsx
@@ -1,17 +1,28 @@
+import { useState } from 'react';
+
 import { useQuery } from 'react-query';
 
 import CopyCodeTextField from '../../components/CopyCodeTextField';
 import { LoadingIndicator } from '../../components/LoadingIndicator';
+import { LinkTxProgress } from '../../features/colinks/LinkTxProgress';
+import { ScoreComponent } from '../../features/colinks/ScoreComponent';
+import { INVITE_SCORE_PER_INVITE_WITH_COSOUL } from '../../features/rep/api/scoring';
+import useConnectedAddress from '../../hooks/useConnectedAddress';
 import { Check } from '../../icons/__generated';
 import { order_by } from '../../lib/gql/__generated__/zeus';
 import { client } from '../../lib/gql/client';
 import { coLinksPaths } from '../../routes/paths';
-import { AppLink, Avatar, ContentHeader, Flex, Panel, Text } from '../../ui';
+import { AppLink, ContentHeader, Flex, Panel, Text } from '../../ui';
 import { SingleColumnLayout } from '../../ui/layouts';
+
+import { AvatarWithLinks } from './explore/AvatarWithLinks';
+import { coLinksMemberSelector } from './explore/CoLinksMember';
+import { ProfileForCard } from './explore/fetchPeopleWithSkills';
+import { SimpleBuyButtonWithPrice } from './explore/SimpleBuyButtonWithPrice';
 
 const INVITES_QUERY_KEY = 'invites';
 
-const fetchInvites = async () => {
+const fetchInvites = async (currentAddress: string) => {
   const { invite_codes } = await client.query(
     {
       invite_codes: [
@@ -23,11 +34,7 @@ const fetchInvites = async () => {
         },
         {
           code: true,
-          invited: {
-            avatar: true,
-            name: true,
-            address: true,
-          },
+          invited: coLinksMemberSelector(currentAddress),
         },
       ],
     },
@@ -39,7 +46,11 @@ const fetchInvites = async () => {
 };
 
 export const InvitesPage = () => {
-  const { data: invites } = useQuery([INVITES_QUERY_KEY], fetchInvites);
+  const address = useConnectedAddress(true);
+
+  const { data: invites } = useQuery([INVITES_QUERY_KEY], () =>
+    fetchInvites(address)
+  );
 
   const availableCodes = invites?.filter(i => !i.invited);
 
@@ -49,13 +60,25 @@ export const InvitesPage = () => {
   return (
     <SingleColumnLayout>
       <ContentHeader>
-        <Flex column>
-          <Text h2 display>
-            Invite Codes
-          </Text>
-          <Text inline>
-            Recruit new CoLinks members to boost your Rep Score
-          </Text>
+        <Flex
+          css={{
+            justifyContent: 'space-between',
+            flexGrow: 1,
+          }}
+        >
+          <Flex column>
+            <Text h2 display>
+              Invite Codes
+            </Text>
+            <Text inline>
+              Recruit new CoLinks members to boost your Rep Score
+            </Text>
+          </Flex>
+          <ScoreComponent
+            label={'Invite Score'}
+            score={999}
+            address={address}
+          />
         </Flex>
       </ContentHeader>
 
@@ -78,34 +101,7 @@ export const InvitesPage = () => {
                 {usedCodes.map(
                   i =>
                     i.invited && (
-                      <Panel
-                        as={AppLink}
-                        to={coLinksPaths.profile(i.invited.address ?? '')}
-                        key={i.code}
-                        noBorder
-                      >
-                        <Flex css={{ gap: '$md' }}>
-                          <Flex css={{ alignItems: 'center', gap: '$md' }}>
-                            <Avatar
-                              name={i.invited.name}
-                              path={i.invited.avatar}
-                            />
-                            <Flex column css={{ gap: '$xs' }}>
-                              <Text semibold>{i.invited.name}</Text>
-                              <Flex css={{ gap: '$xs', alignItems: 'center' }}>
-                                <Check color={'complete'} />
-                                <Text
-                                  css={{
-                                    color: '$dimText',
-                                  }}
-                                >
-                                  {i.code}
-                                </Text>
-                              </Flex>
-                            </Flex>
-                          </Flex>
-                        </Flex>
-                      </Panel>
+                      <Invitee key={i.code} invited={i.invited} code={i.code} />
                     )
                 )}
               </Flex>
@@ -136,5 +132,71 @@ export const InvitesPage = () => {
         </Flex>
       )}
     </SingleColumnLayout>
+  );
+};
+
+const Invitee = ({
+  invited,
+  code,
+}: {
+  invited: ProfileForCard;
+  code: string;
+}) => {
+  const [buyProgress, setBuyProgress] = useState('');
+
+  const onBought = () => {
+    setBuyProgress('');
+  };
+
+  return (
+    <Panel
+      as={AppLink}
+      to={coLinksPaths.profile(invited.address ?? '')}
+      noBorder
+      css={{ position: 'relative' }}
+    >
+      <Flex css={{ gap: '$md', flex: 1 }}>
+        <Flex
+          css={{
+            alignItems: 'center',
+            gap: '$md',
+            flex: 1,
+          }}
+        >
+          <AvatarWithLinks profile={invited} />
+          <Flex column css={{ gap: '$xs', flexGrow: 1 }}>
+            <Flex css={{ flexGrow: 1, justifyContent: 'space-between' }}>
+              <Text semibold color={'default'}>
+                {invited.name}
+              </Text>
+              <SimpleBuyButtonWithPrice
+                links={invited.links ?? 0}
+                target={invited.address ?? ''}
+                setProgress={setBuyProgress}
+                onSuccess={onBought}
+              />
+            </Flex>
+            <Flex css={{ gap: '$md', alignItems: 'center' }}>
+              <Flex css={{ flexShrink: 0 }}>
+                <Text semibold size={'medium'}>
+                  +{INVITE_SCORE_PER_INVITE_WITH_COSOUL} Rep
+                </Text>
+              </Flex>
+              <Flex css={{ gap: '$xs', alignItems: 'center' }}>
+                <Check color={'complete'} />
+                <Text
+                  css={{
+                    color: '$dimText',
+                  }}
+                >
+                  {code}
+                </Text>
+              </Flex>
+            </Flex>
+          </Flex>
+        </Flex>
+      </Flex>
+      <LinkTxProgress message={buyProgress} />
+    </Panel>
   );
 };

--- a/src/pages/colinks/ViewProfilePage/ViewProfilePageContents.tsx
+++ b/src/pages/colinks/ViewProfilePage/ViewProfilePageContents.tsx
@@ -202,10 +202,25 @@ const PageContents = ({
     (!fetchCoSoulIsLoading && !cosoul)
   ) {
     return (
-      <Flex column css={{ gap: '$lg', p: '$xl', alignItems: 'center' }}>
-        <Text h1 color={'alert'}>
-          Error: no profile found
-        </Text>
+      <Flex
+        column
+        css={{
+          gap: '$lg',
+          p: '$xl',
+          alignItems: 'center',
+          maxWidth: '$readable',
+        }}
+      >
+        <Flex column css={{ gap: '$xl', pt: '$2xl' }}>
+          <Text size={'xl'} semibold color={'alert'}>
+            {targetAddress}
+          </Text>
+          <Flex css={{ gap: '$xs', justifyContent: 'flex-end' }}>
+            <Text>is</Text>
+            <Text semibold>NOT</Text>
+            <Text>on CoLinks</Text>
+          </Flex>
+        </Flex>
       </Flex>
     );
   }


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6ed1a54</samp>

Added a new component to show the invite score of a user on the invites page. The component also links to the score page where the user can see more details about their reputation and invites. Improved the UI of the invites page with better layout and styling.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6ed1a54</samp>

> _You have the power to invite your friends_
> _But beware of the score that never ends_
> _`ScoreComponent` shows your fate_
> _Will you rise or fall in the invite state?_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6ed1a54</samp>

* Create a new component `ScoreComponent` to display the invite score and link to the score page ([link](https://github.com/coordinape/coordinape/pull/2509/files?diff=unified&w=0#diff-81cacab70683850a6c6e5885f1dd5461f50d40b9d3aeebbebc1c7fbe56b9b41eR1-R30))
* Import `ScoreComponent`, `INVITE_SCORE_PER_INVITE_WITH_COSOUL`, and `useConnectedAddress` to `InvitesPage` ([link](https://github.com/coordinape/coordinape/pull/2509/files?diff=unified&w=0#diff-b4a5ffe704879e07faf0012becc0ad9e6cdb6544fa36c003de44ae81bc50e03aR5-R7))
* Add `ScoreComponent` to the header of `InvitesPage`, passing the connected address and the label as props ([link](https://github.com/coordinape/coordinape/pull/2509/files?diff=unified&w=0#diff-b4a5ffe704879e07faf0012becc0ad9e6cdb6544fa36c003de44ae81bc50e03aR45-R46), [link](https://github.com/coordinape/coordinape/pull/2509/files?diff=unified&w=0#diff-b4a5ffe704879e07faf0012becc0ad9e6cdb6544fa36c003de44ae81bc50e03aL52-R75))
* Adjust the layout of the invited users list to prevent overflow and add space ([link](https://github.com/coordinape/coordinape/pull/2509/files?diff=unified&w=0#diff-b4a5ffe704879e07faf0012becc0ad9e6cdb6544fa36c003de44ae81bc50e03aL87-R116))
* Add a `Flex` component to show the reputation points for each invite with a CoSoul, using the constant value ([link](https://github.com/coordinape/coordinape/pull/2509/files?diff=unified&w=0#diff-b4a5ffe704879e07faf0012becc0ad9e6cdb6544fa36c003de44ae81bc50e03aR129-R133))
