### PR TITLE
remove invite link widget that isn't code based

### DIFF
--- a/src/pages/colinks/ActivityPage.tsx
+++ b/src/pages/colinks/ActivityPage.tsx
@@ -5,7 +5,6 @@ import { CoLinks } from '@coordinape/hardhat/dist/typechain';
 import { LoadingIndicator } from '../../components/LoadingIndicator';
 import { isFeatureEnabled } from '../../config/features';
 import { ActivityList } from '../../features/activities/ActivityList';
-import { useAuthStore } from '../../features/auth';
 import { CoLinksContext } from '../../features/colinks/CoLinksContext';
 import { LeaderboardMostLinks } from '../../features/colinks/LeaderboardMostLinks';
 import { PostForm } from '../../features/colinks/PostForm';
@@ -13,7 +12,6 @@ import { RecentCoLinkTransactions } from '../../features/colinks/RecentCoLinkTra
 import { RightColumnSection } from '../../features/colinks/RightColumnSection';
 import { useCoLinks } from '../../features/colinks/useCoLinks';
 import { QUERY_KEY_COLINKS } from '../../features/colinks/wizard/CoLinksWizard';
-import { InviteCodeLink } from '../../features/invites/InviteCodeLink';
 import { Award, BarChart } from '../../icons/__generated';
 import { coLinksPaths } from '../../routes/paths';
 import { AppLink, ContentHeader, Flex, Text } from '../../ui';
@@ -47,8 +45,6 @@ const CoLinksActivityPageContents = ({
   currentUserAddress: string;
 }) => {
   const [showLoading, setShowLoading] = useState(false);
-
-  const profileId = useAuthStore(state => state.profileId);
 
   const { targetBalance } = useCoLinks({
     contract: coLinks,
@@ -99,7 +95,6 @@ const CoLinksActivityPageContents = ({
         >
           <RecentCoLinkTransactions limit={5} />
         </RightColumnSection>
-        {profileId && <InviteCodeLink profileId={profileId} />}
         <RightColumnSection
           title={
             <Flex as={AppLink} to={coLinksPaths.leaderboard}>

--- a/src/pages/colinks/ViewProfilePage/ViewProfilePageContents.tsx
+++ b/src/pages/colinks/ViewProfilePage/ViewProfilePageContents.tsx
@@ -21,7 +21,6 @@ import { RightColumnSection } from '../../../features/colinks/RightColumnSection
 import { SimilarProfiles } from '../../../features/colinks/SimilarProfiles';
 import { useCoLinks } from '../../../features/colinks/useCoLinks';
 import { QUERY_KEY_COLINKS } from '../../../features/colinks/wizard/CoLinksWizard';
-import { InviteCodeLink } from '../../../features/invites/InviteCodeLink';
 import { BarChart, Briefcase, Users } from '../../../icons/__generated';
 import { client } from '../../../lib/gql/client';
 import { coLinksPaths } from '../../../routes/paths';
@@ -329,9 +328,6 @@ const PageContents = ({
           css={{ gap: '$lg', mr: '$xl', width: `${artWidthMobile}` }}
         >
           <CoSoulItem cosoul={cosoul} exploreView={false} />
-          {targetIsCurrentUser && (
-            <InviteCodeLink profileId={currentUserProfileId} />
-          )}
           {targetIsCurrentUser && (
             <CoLinksTaskCards currentUserAddress={currentUserAddress} small />
           )}


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f277f10</samp>

Removed `InviteCodeLink` from activity and profile pages and moved it to user menu. This improves the user experience of inviting others to join co-links.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f277f10</samp>

> _Sing, O Muse, of the skillful coder who refined the app_
> _And removed the `InviteCodeLink` from the activity page_
> _Where it showed not the deeds of the user, but a useless trap_
> _That cluttered the screen with redundant and confusing rage._

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f277f10</samp>

*  Removed `InviteCodeLink` component from activity page and its dependencies ([link](https://github.com/coordinape/coordinape/pull/2511/files?diff=unified&w=0#diff-b06acfe67570e88d414766102b185f0db62c91015f69f93b59ecc49e215efa04L8), [link](https://github.com/coordinape/coordinape/pull/2511/files?diff=unified&w=0#diff-b06acfe67570e88d414766102b185f0db62c91015f69f93b59ecc49e215efa04L16), [link](https://github.com/coordinape/coordinape/pull/2511/files?diff=unified&w=0#diff-b06acfe67570e88d414766102b185f0db62c91015f69f93b59ecc49e215efa04L51-L52), [link](https://github.com/coordinape/coordinape/pull/2511/files?diff=unified&w=0#diff-b06acfe67570e88d414766102b185f0db62c91015f69f93b59ecc49e215efa04L102))
*  Removed `InviteCodeLink` component from view profile page and moved it to user menu in header ([link](https://github.com/coordinape/coordinape/pull/2511/files?diff=unified&w=0#diff-cff4a8eedd6bc4e327e10f459d5d7120705b2ccbcf88abb2c175985ad128712cL24), [link](https://github.com/coordinape/coordinape/pull/2511/files?diff=unified&w=0#diff-cff4a8eedd6bc4e327e10f459d5d7120705b2ccbcf88abb2c175985ad128712cL333-L335))
