### PR TITLE
Fix nav error

### DIFF
--- a/src/features/colinks/wizard/WizardSteps.tsx
+++ b/src/features/colinks/wizard/WizardSteps.tsx
@@ -74,12 +74,13 @@ export const WizardSteps = ({
     }
   }, [error]);
 
-  if (onCorrectChain && redirect) {
-    navigate(redirect, {
-      replace: true,
-    });
-    return null;
-  }
+  useEffect(() => {
+    if (onCorrectChain && redirect) {
+      navigate(redirect, {
+        replace: true,
+      });
+    }
+  }, [onCorrectChain, redirect]);
 
   if (!onCorrectChain) {
     return <WizardSwitchToOptimism />;


### PR DESCRIPTION
## What

Fixes error when navigate is called in component




<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d2db381</samp>

Fixed a bug in `colinks` feature that caused a blank screen when the user was on the wrong chain. Moved the chain redirection logic into a `useEffect` hook in `WizardSteps.tsx`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d2db381</samp>

> _`useEffect` hook_
> _fixes blank screen bug for users_
> _autumn leaves redirect_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d2db381</samp>

*  Move chain redirection logic into a `useEffect` hook to fix blank screen bug ([link](https://github.com/coordinape/coordinape/pull/2515/files?diff=unified&w=0#diff-6d1da6784638c085f8a5454682860ecdac3984f19743788e83f3dfe75e12b69fL77-R83))
