### PR TITLE
use profiles public

### DIFF
--- a/api/hasura/actions/_handlers/getHeadlines.ts
+++ b/api/hasura/actions/_handlers/getHeadlines.ts
@@ -6,7 +6,7 @@ import { getInput } from '../../../../api-lib/handlerHelpers';
 import { InternalServerError } from '../../../../api-lib/HttpError';
 import { genHeadline } from '../../../../api-lib/openai';
 
-const LIMIT = 5;
+const LIMIT = 15;
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   const { session } = await getInput(req);
@@ -69,7 +69,7 @@ const getDataForHeadlines = async ({
         },
         {
           id: true,
-          actor_profile: { name: true, id: true },
+          actor_profile_public: { name: true, id: true },
           replies: [{}, { reply: true, profile: { name: true } }],
           contribution: { description: true },
         },


### PR DESCRIPTION
also bump limit to 15

## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 175d617</samp>

Improved headlines for contributions and respected profile visibility settings. Changed the database query and the OpenAI headline generation logic in `getHeadlines.ts`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 175d617</samp>

> _Sing, O Muse, of the ingenious coder who devised_
> _A way to multiply the `headlines` that the users prized,_
> _And who, with skill and care, the `database query` changed_
> _To honor the `actor_profile_public` field arranged._

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 175d617</samp>

* Increase the number of headlines generated by OpenAI from 5 to 15 for more variety ([link](https://github.com/coordinape/coordinape/pull/2516/files?diff=unified&w=0#diff-2e7f999eb4c293d49491be69e2086320842811f0740062abd5965d4863700ae0L9-R9))
* Rename `actor_profile` field to `actor_profile_public` in `getDataForHeadlines` function to match updated database schema ([link](https://github.com/coordinape/coordinape/pull/2516/files?diff=unified&w=0#diff-2e7f999eb4c293d49491be69e2086320842811f0740062abd5965d4863700ae0L72-R72))
