### PR TITLE
Show edit profile button; display mute at top level

### DIFF
--- a/src/pages/colinks/ViewProfilePage/CoLinksProfileHeader.tsx
+++ b/src/pages/colinks/ViewProfilePage/CoLinksProfileHeader.tsx
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { Dispatch, useEffect, useState } from 'react';
+import { Dispatch } from 'react';
 
 import { CoLinks } from '@coordinape/hardhat/dist/typechain';
 import { CoSoul } from 'features/colinks/fetchCoSouls';
@@ -13,7 +13,8 @@ import { SkillTag } from '../../../features/colinks/SkillTag';
 import { QUERY_KEY_COLINKS } from '../../../features/colinks/wizard/CoLinksWizard';
 import { order_by } from '../../../lib/gql/__generated__/zeus';
 import { Github, Link as LinkIcon, Settings, Twitter } from 'icons/__generated';
-import { Avatar, Button, ContentHeader, Flex, Link, Text } from 'ui';
+import { coLinksPaths } from 'routes/paths';
+import { AppLink, Avatar, Button, ContentHeader, Flex, Link, Text } from 'ui';
 
 import { CoLinksProfile } from './ViewProfilePageContents';
 
@@ -93,16 +94,16 @@ export const CoLinksProfileHeader = ({
     };
   });
 
-  const [showMenu, setShowMenu] = useState(false);
-
-  useEffect(() => {
-    setShowMenu(false);
-  }, [target]);
-
   return (
     <ContentHeader>
       <Flex column css={{ gap: '$md', flexGrow: 1, width: '100%' }}>
-        <Flex css={{ justifyContent: 'space-between', alignItems: 'center' }}>
+        <Flex
+          css={{
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            width: '100%',
+          }}
+        >
           <Flex alignItems="center" css={{ gap: '$sm' }}>
             <Avatar
               size="large"
@@ -118,23 +119,23 @@ export const CoLinksProfileHeader = ({
             </Flex>
           </Flex>
           <Flex css={{ alignItems: 'center', gap: '$md' }}>
-            {showMenu && (
-              <Flex column>
+            {isCurrentUser ? (
+              <Button
+                as={AppLink}
+                color="neutral"
+                outlined
+                to={coLinksPaths.account}
+              >
+                <Settings />
+                Edit Profile
+              </Button>
+            ) : (
+              <>
                 <Mutes
                   targetProfileId={target.profile.id}
                   targetProfileAddress={targetAddress}
                 />
-              </Flex>
-            )}
-            {!isCurrentUser && (
-              <Button
-                color="neutral"
-                outlined
-                css={{ borderRadius: 99999, aspectRatio: '1/1', padding: 0 }}
-                onClick={() => setShowMenu(prevState => !prevState)}
-              >
-                <Settings size={'md'} css={{ ml: 4 }} />
-              </Button>
+              </>
             )}
           </Flex>
         </Flex>


### PR DESCRIPTION
## What

<img width="800" alt="Screenshot 2023-12-06 at 1 13 45 PM" src="https://github.com/coordinape/coordinape/assets/83605543/74d61ba4-850a-43da-ba76-cc4d67e89bd2">


<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6a36e5d</samp>

Refactored the profile header component for co-links to improve usability and clarity. Removed the menu button, added an edit profile button, and hid the mutes component for the current user.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6a36e5d</samp>

> _We're sailing on the co-links sea, with profiles to explore_
> _We've simplified the header now, no menu button anymore_
> _We've added an edit button, for the user who's in charge_
> _And only show the mutes component, for the ones who are at large_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6a36e5d</samp>

*  Added navigation to the account page for editing the profile ([link](https://github.com/coordinape/coordinape/pull/2517/files?diff=unified&w=0#diff-4aa6eb6c4daadd3504e9da12667848694f871f63bd5176ba8efbd34534abdc64L16-R17), [link](https://github.com/coordinape/coordinape/pull/2517/files?diff=unified&w=0#diff-4aa6eb6c4daadd3504e9da12667848694f871f63bd5176ba8efbd34534abdc64L121-R138))
*  Simplified the layout and avoided overlapping elements by removing the `showMenu` state and effect and giving the `Flex` component a width of 100% ([link](https://github.com/coordinape/coordinape/pull/2517/files?diff=unified&w=0#diff-4aa6eb6c4daadd3504e9da12667848694f871f63bd5176ba8efbd34534abdc64L2-R2), [link](https://github.com/coordinape/coordinape/pull/2517/files?diff=unified&w=0#diff-4aa6eb6c4daadd3504e9da12667848694f871f63bd5176ba8efbd34534abdc64L96-R106))
*  Replaced the menu button by a conditional rendering of either an edit profile button for the current user or a `Mutes` component for other users in `CoLinksProfileHeader.tsx` ([link](https://github.com/coordinape/coordinape/pull/2517/files?diff=unified&w=0#diff-4aa6eb6c4daadd3504e9da12667848694f871f63bd5176ba8efbd34534abdc64L121-R138))
