### PR TITLE
Refactor Notifications rows so that muted people's activity don't take

### DIFF
--- a/src/pages/colinks/NotificationsPage.tsx
+++ b/src/pages/colinks/NotificationsPage.tsx
@@ -232,18 +232,24 @@ export const NotificationsPage = () => {
         {notifications !== undefined && notifications.length === 0 ? (
           <Panel noBorder>No notifications yet</Panel>
         ) : (
-          notifications?.map(n => (
-            <Flex key={n.id}>
-              {/*// case on types*/}
-              {n.reply ? (
+          notifications?.map(n => {
+            let content;
+
+            {
+              /* case on types */
+            }
+            if (n.reply) {
+              content = (
                 <Reply
                   reply={n.reply}
                   actor={n.actor_profile_public}
                   profile={n.profile}
                 />
-              ) : n.link_tx ? (
-                <LinkTxNotification tx={n.link_tx} />
-              ) : n.invited_profile_public ? (
+              );
+            } else if (n.link_tx) {
+              content = <LinkTxNotification tx={n.link_tx} />;
+            } else if (n.invited_profile_public) {
+              content =
                 n.invited_profile_public.id === profileId ? (
                   <InvitedNotification
                     invitee={n.invited_profile_public}
@@ -254,12 +260,13 @@ export const NotificationsPage = () => {
                     invitee={n.invited_profile_public}
                     n={n}
                   />
-                )
-              ) : n.reaction ? (
-                <ReactionNotification reaction={n.reaction} n={n} />
-              ) : null}
-            </Flex>
-          ))
+                );
+            } else if (n.reaction) {
+              content = <ReactionNotification reaction={n.reaction} n={n} />;
+            }
+
+            return content ? <Flex key={n.id}>{content}</Flex> : null;
+          })
         )}
       </Flex>
     </SingleColumnLayout>


### PR DESCRIPTION
space

Previously this was having a Flex for all notifs, even of muted, causing weird empty spacing.

## What

copilot:summary

copilot:poem

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

copilot:walkthrough
