### PR TITLE
Fix auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@ COORDINAPE_USER_ADDRESS=0xfad763da9051953fea58c2304395719a3b6ba361
 IMAGES_AWS_BUCKET=coordinape
 IMAGE_DIR=assets/static/images/
 # separate allowed domains with commas
-SIWE_ALLOWED_DOMAINS=localhost,colinks.local
+SIWE_ALLOWED_DOMAINS=localhost,colinks.local.host,local.host
 
 # MAGIC PUBLISHABLE API KEY for front end
 REACT_APP_MAGIC_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -11,8 +11,8 @@ REACT_APP_INFURA_PROJECT_ID=your_project_id
 COORDINAPE_USER_ADDRESS=0xfad763da9051953fea58c2304395719a3b6ba361
 IMAGES_AWS_BUCKET=coordinape
 IMAGE_DIR=assets/static/images/
-# separate allowed domains with commas
-SIWE_ALLOWED_DOMAINS=localhost,colinks.local.host,local.host
+# separate allowed domains with commas, only used for production
+# SIWE_ALLOWED_DOMAINS=
 
 # MAGIC PUBLISHABLE API KEY for front end
 REACT_APP_MAGIC_API_KEY=

--- a/api/log.ts
+++ b/api/log.ts
@@ -34,7 +34,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       Number(id),
       hashTokenString(token)
     );
+
+    if (!profile) {
+      res.status(401).json({ ok: false, message: 'invalid auth' });
+      return;
+    }
     assert(profile, 'Invalid authorization token');
+
     await addPropsAndTrack({
       profile_id: profile.id,
       event_type: 'pageview',

--- a/api/login.ts
+++ b/api/login.ts
@@ -17,6 +17,7 @@ import { errorResponse } from '../api-lib/HttpError';
 import { getProvider } from '../api-lib/provider';
 import { parseInput } from '../api-lib/signature';
 import { loginSupportedChainIds } from '../src/common-lib/constants';
+import { COLINKS_LOCAL_URL } from '../src/config/webAppURL';
 import { getInviteCodeCookieValue } from '../src/features/invites/invitecodes';
 import { updateRepScore } from '../src/features/rep/api/updateRepScore';
 import { supportedChainIds } from '../src/lib/vaults/contracts';
@@ -24,7 +25,7 @@ import { supportedChainIds } from '../src/lib/vaults/contracts';
 import { createSampleCircleForProfile } from './hasura/actions/_handlers/createSampleCircle';
 
 const COLINKS_DOMAINS = [
-  'colinks.local:3000',
+  COLINKS_LOCAL_URL,
   'https://colinks-staging.coordinape.com',
   'https://colinks.coordinape.com',
 ];
@@ -32,7 +33,8 @@ const COLINKS_DOMAINS = [
 Settings.defaultZone = 'utc';
 
 const allowedDomainsRegex = (
-  process.env.SIWE_ALLOWED_DOMAINS ?? 'localhost,colinks.local'
+  process.env.SIWE_ALLOWED_DOMAINS ??
+  `local.host,${COLINKS_LOCAL_URL.split('/')[2].replace('http://', '')}`
 )
   .split(',')
   .filter(item => item !== '');

--- a/api/login.ts
+++ b/api/login.ts
@@ -21,6 +21,7 @@ import {
   COLINKS_LOCAL_URL,
   COLINKS_STAGING_URL,
   COLINKS_PRODUCTION_URL,
+  GIVE_LOCAL_URL,
 } from '../src/config/webAppURL';
 import { getInviteCodeCookieValue } from '../src/features/invites/invitecodes';
 import { updateRepScore } from '../src/features/rep/api/updateRepScore';
@@ -38,7 +39,10 @@ Settings.defaultZone = 'utc';
 
 const allowedDomainsRegex = (
   process.env.SIWE_ALLOWED_DOMAINS ??
-  `local.host,${COLINKS_LOCAL_URL.split('/')[2].replace('http://', '')}`
+  `${GIVE_LOCAL_URL.split('/')[2].replace(
+    'http://',
+    ''
+  )},${COLINKS_LOCAL_URL.split('/')[2].replace('http://', '')},`
 )
   .split(',')
   .filter(item => item !== '');

--- a/api/login.ts
+++ b/api/login.ts
@@ -17,7 +17,11 @@ import { errorResponse } from '../api-lib/HttpError';
 import { getProvider } from '../api-lib/provider';
 import { parseInput } from '../api-lib/signature';
 import { loginSupportedChainIds } from '../src/common-lib/constants';
-import { COLINKS_LOCAL_URL } from '../src/config/webAppURL';
+import {
+  COLINKS_LOCAL_URL,
+  COLINKS_STAGING_URL,
+  COLINKS_PRODUCTION_URL,
+} from '../src/config/webAppURL';
 import { getInviteCodeCookieValue } from '../src/features/invites/invitecodes';
 import { updateRepScore } from '../src/features/rep/api/updateRepScore';
 import { supportedChainIds } from '../src/lib/vaults/contracts';
@@ -26,8 +30,8 @@ import { createSampleCircleForProfile } from './hasura/actions/_handlers/createS
 
 const COLINKS_DOMAINS = [
   COLINKS_LOCAL_URL,
-  'https://colinks-staging.coordinape.com',
-  'https://colinks.coordinape.com',
+  COLINKS_STAGING_URL,
+  COLINKS_PRODUCTION_URL,
 ];
 
 Settings.defaultZone = 'utc';

--- a/api/login.ts
+++ b/api/login.ts
@@ -42,7 +42,7 @@ const allowedDomainsRegex = (
   `${GIVE_LOCAL_URL.split('/')[2].replace(
     'http://',
     ''
-  )},${COLINKS_LOCAL_URL.split('/')[2].replace('http://', '')},`
+  )},${COLINKS_LOCAL_URL.split('/')[2].replace('http://', '')},localhost`
 )
   .split(',')
   .filter(item => item !== '');

--- a/src/config/webAppURL.ts
+++ b/src/config/webAppURL.ts
@@ -3,11 +3,12 @@ import { IN_PRODUCTION } from './env';
 export const COLINKS_PRODUCTION_URL = 'https://colinks.coordinape.com';
 export const COORDINAPE_MARKETING_URL = 'https://coordinape.com';
 const GIVE_PRODUCTION_URL = 'https://app.coordinape.com';
-export const COLINKS_STAGING_URL = 'https://colinks.costaging.co';
-const GIVE_STAGING_URL = 'https://costaging.co';
 
-export const GIVE_LOCAL_URL = 'http://local.host:3000';
-export const COLINKS_LOCAL_URL = 'http://colinks.local.host:3000';
+export const COLINKS_STAGING_URL = 'https://colinks.costaging.co';
+const GIVE_STAGING_URL = 'https://app.costaging.co';
+
+export const GIVE_LOCAL_URL = 'http://app.co.local:3000';
+export const COLINKS_LOCAL_URL = 'http://colinks.co.local:3000';
 
 export const webAppURL = (app: 'colinks' | 'give' | 'cosoul') => {
   if (IN_PRODUCTION) {

--- a/src/config/webAppURL.ts
+++ b/src/config/webAppURL.ts
@@ -5,6 +5,9 @@ export const COORDINAPE_MARKETING_URL = 'https://coordinape.com';
 const GIVE_PRODUCTION_URL = 'https://app.coordinape.com';
 const COLINKS_STAGING_URL = 'https://colinks-staging.coordinape.com';
 
+export const GIVE_LOCAL_URL = 'http://local.host:3000';
+export const COLINKS_LOCAL_URL = 'http://colinks.local.host:3000';
+
 export const webAppURL = (app: 'colinks' | 'give' | 'cosoul') => {
   if (IN_PRODUCTION) {
     switch (app) {
@@ -28,11 +31,11 @@ export const webAppURL = (app: 'colinks' | 'give' | 'cosoul') => {
     } else {
       switch (app) {
         case 'colinks':
-          return 'http://colinks.local:3000';
+          return COLINKS_LOCAL_URL;
         case 'cosoul':
-          return 'http://localhost:3000';
+          return GIVE_LOCAL_URL;
         case 'give':
-          return 'http://localhost:3000';
+          return GIVE_LOCAL_URL;
       }
     }
   }

--- a/src/config/webAppURL.ts
+++ b/src/config/webAppURL.ts
@@ -3,7 +3,8 @@ import { IN_PRODUCTION } from './env';
 export const COLINKS_PRODUCTION_URL = 'https://colinks.coordinape.com';
 export const COORDINAPE_MARKETING_URL = 'https://coordinape.com';
 const GIVE_PRODUCTION_URL = 'https://app.coordinape.com';
-const COLINKS_STAGING_URL = 'https://colinks-staging.coordinape.com';
+export const COLINKS_STAGING_URL = 'https://colinks.costaging.co';
+const GIVE_STAGING_URL = 'https://costaging.co';
 
 export const GIVE_LOCAL_URL = 'http://local.host:3000';
 export const COLINKS_LOCAL_URL = 'http://colinks.local.host:3000';
@@ -18,25 +19,24 @@ export const webAppURL = (app: 'colinks' | 'give' | 'cosoul') => {
       case 'give':
         return GIVE_PRODUCTION_URL;
     }
-  } else {
-    if (
-      process.env.VERCEL_BRANCH_URL &&
-      process.env.VERCEL_BRANCH_URL.includes('staging')
-    ) {
+  } else if (process.env.VERCEL_BRANCH_URL) {
+    if (process.env.VERCEL_BRANCH_URL.includes('staging')) {
       if (app == 'colinks') {
         return COLINKS_STAGING_URL;
       } else {
-        return 'https://' + process.env.VERCEL_BRANCH_URL;
+        return GIVE_STAGING_URL;
       }
     } else {
-      switch (app) {
-        case 'colinks':
-          return COLINKS_LOCAL_URL;
-        case 'cosoul':
-          return GIVE_LOCAL_URL;
-        case 'give':
-          return GIVE_LOCAL_URL;
-      }
+      return 'https://' + process.env.VERCEL_BRANCH_URL;
+    }
+  } else {
+    switch (app) {
+      case 'colinks':
+        return COLINKS_LOCAL_URL;
+      case 'cosoul':
+        return GIVE_LOCAL_URL;
+      case 'give':
+        return GIVE_LOCAL_URL;
     }
   }
 };

--- a/src/features/auth/useSavedAuth.ts
+++ b/src/features/auth/useSavedAuth.ts
@@ -1,5 +1,7 @@
 import { useMemo } from 'react';
 
+import Cookies from 'js-cookie';
+
 import type { ProviderType } from './store';
 import { setAuthToken } from './token';
 
@@ -19,13 +21,24 @@ export interface IAuth {
   data: { [address: string]: IAuthValue };
 }
 
-const AUTH_STORAGE_KEY = 'capeAuth3';
+const AUTH_COOKIE = 'coordinape_auth_cookie';
+
+function getCookieDomain(): string {
+  const url = new URL(window.origin).hostname;
+  const domainParts = url.split('.').reverse();
+
+  if (domainParts.length < 2) {
+    return domainParts[0];
+  }
+
+  return `${domainParts[1]}.${domainParts[0]}`;
+}
 
 const emptyData = () => ({ data: {} });
 
 const getAllData = (): IAuth => {
   try {
-    const stored = localStorage.getItem(AUTH_STORAGE_KEY);
+    const stored = Cookies.get(AUTH_COOKIE);
     if (!stored) return emptyData();
     return JSON.parse(stored);
   } catch {
@@ -35,7 +48,11 @@ const getAllData = (): IAuth => {
 
 // only exporting for testing purposes
 export const saveAllData = (allData: IAuth) => {
-  localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(allData));
+  const cookieDomain = getCookieDomain();
+  Cookies.set(AUTH_COOKIE, JSON.stringify(allData), {
+    expires: 365,
+    domain: cookieDomain,
+  });
 };
 
 type UseSavedAuthReturn = {

--- a/src/features/auth/useSavedAuth.ts
+++ b/src/features/auth/useSavedAuth.ts
@@ -25,6 +25,11 @@ const AUTH_COOKIE = 'coordinape_auth_cookie';
 
 function getCookieDomain(): string {
   const url = new URL(window.origin).hostname;
+
+  if (url.includes('vercel.app')) {
+    return url;
+  }
+
   const domainParts = url.split('.').reverse();
 
   if (domainParts.length < 2) {


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 547c991</samp>

Refactored and improved the SIWE authentication functionality and code quality. Used constants for colinks URLs from a config file, cookies for storing auth data, and handled query and auth errors. Updated the `.env.example` file and the `api/log.ts` file accordingly.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 547c991</samp>

> _We're sailing on the web with SIWE and colinks_
> _We've updated our code to make it smooth and slick_
> _We've handled all the errors and the queries too_
> _So heave away, me hearties, heave away on two_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 547c991</samp>

*  Allow `local.host` and `colinks.local.host` domains for SIWE authentication by updating the `.env.example` file ([link](https://github.com/coordinape/coordinape/pull/2521/files?diff=unified&w=0#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL15-R15))
*  Use constants for colinks URLs instead of hard-coded values by importing them from `webAppURL.ts` and updating `login.ts` ([link](https://github.com/coordinape/coordinape/pull/2521/files?diff=unified&w=0#diff-01abf081aaf21c9dd7749fceb2eaf3c000f88207e51f4a1ab234455045e4d2deR20-R24), [link](https://github.com/coordinape/coordinape/pull/2521/files?diff=unified&w=0#diff-01abf081aaf21c9dd7749fceb2eaf3c000f88207e51f4a1ab234455045e4d2deL27-R34), [link](https://github.com/coordinape/coordinape/pull/2521/files?diff=unified&w=0#diff-01abf081aaf21c9dd7749fceb2eaf3c000f88207e51f4a1ab234455045e4d2deL35-R41), [link](https://github.com/coordinape/coordinape/pull/2521/files?diff=unified&w=0#diff-571282528813f8618853cc4acc07e069e28d4a7c20c25f2fb89b043c61bac947L6-R11), [link](https://github.com/coordinape/coordinape/pull/2521/files?diff=unified&w=0#diff-571282528813f8618853cc4acc07e069e28d4a7c20c25f2fb89b043c61bac947L18-R40))
*  Use cookies instead of local storage to store auth data by importing and using the `Cookies` library and adding a cookie domain function in `useSavedAuth.ts` ([link](https://github.com/coordinape/coordinape/pull/2521/files?diff=unified&w=0#diff-dd65fb7dce7e4e465ef83cec4a072e523c1a8cb0602e1d5f1538dd26a5cec318R3-R4), [link](https://github.com/coordinape/coordinape/pull/2521/files?diff=unified&w=0#diff-dd65fb7dce7e4e465ef83cec4a072e523c1a8cb0602e1d5f1538dd26a5cec318L22-R46), [link](https://github.com/coordinape/coordinape/pull/2521/files?diff=unified&w=0#diff-dd65fb7dce7e4e465ef83cec4a072e523c1a8cb0602e1d5f1538dd26a5cec318L38-R60))
*  Improve error handling and security for logging and colinks endpoints by checking the validity of the auth token and the profile id and sending appropriate responses in `log.ts` and `useFinishAuth.ts` ([link](https://github.com/coordinape/coordinape/pull/2521/files?diff=unified&w=0#diff-6ae591160dc95955264f7bd4bc9fecd0c8dc889f9382cf92080d0a9ef60ba04cL37-R43), [link](https://github.com/coordinape/coordinape/pull/2521/files?diff=unified&w=0#diff-9364f778b5d58002aee011b7f30b5acf78b68de864caa758194fb49ea89b8bccR5), [link](https://github.com/coordinape/coordinape/pull/2521/files?diff=unified&w=0#diff-9364f778b5d58002aee011b7f30b5acf78b68de864caa758194fb49ea89b8bccL65-R90))
