### PR TITLE
default OS theme to 'auto'

### DIFF
--- a/src/features/theming/storage.ts
+++ b/src/features/theming/storage.ts
@@ -20,10 +20,10 @@ export const getSavedThemePreference = (): ThemePreference | null => {
     const savedMode = window.localStorage.getItem(themeLocalStorageKey);
     // If the user has explicitly chosen a colour mode,
     // let's use it. Otherwise, this value will be null.
-    return isValidThemePreference(savedMode) ? savedMode : null;
+    return isValidThemePreference(savedMode) ? savedMode : 'auto';
   } catch (e) {
     // When Chrome in incognito, localStorage cannot be accessed
     console.warn(e);
-    return null;
+    return 'auto';
   }
 };


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 34a3ece</samp>

Changed the default theme preference to `'auto'` in `storage.ts` to make the app more responsive and accessible.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 34a3ece</samp>

> _Theme adapts to `auto`_
> _No choice or storage needed_
> _Winter or summer_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 34a3ece</samp>

* Change the default theme preference to 'auto' to adapt to the system preference ([link](https://github.com/coordinape/coordinape/pull/2530/files?diff=unified&w=0#diff-8cd9874357d7dbfd7a98cd0f38c62426a37423866dc93c5ebd4e220915fdabf8L23-R27))
