### PR TITLE
send plausible data  to both domains

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -28,7 +28,7 @@
     <script
       defer
       data-api="/stats/api/event"
-      data-domain="coordinape.com"
+      data-domain="coordinape.com,colinks.coordinape.com"
       src="/stats/js/script.js"
     ></script>
   </head>


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 074875c</samp>

Added `colinks.coordinape.com` to the `data-domain` attribute of the stats script in `public/index.html` to enable event tracking for the colinks feature.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 074875c</samp>

> _`data-domain` grows_
> _colinks joins the stats service_
> _autumn harvest time_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 074875c</samp>

* Allow the stats service to track events from both the main site and the colinks subdomain by adding `colinks.coordinape.com` to the `data-domain` attribute of the script tag ([link](https://github.com/coordinape/coordinape/pull/2535/files?diff=unified&w=0#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cdL31-R31))
