### PR TITLE
eliminate soulkeys and repscore feature flags

### DIFF
--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -1,26 +1,15 @@
 // add your own feature names here
 
-import { DOMAIN_IS_LOCALHOST } from '../utils/domain';
-
 export type FeatureName =
   | 'debug'
-  | 'soulkeys'
   | 'vector_search'
-  | 'rep_cosouls'
   | 'highlights'
   // dnt = Do Not Track. enable this feature to debug Mixpanel
   | 'ignore_dnt';
 
 // this is a very simple implementation of build-time feature flags that you can
 // hardcode or set with environment variables
-const staticFeatureFlags: Partial<Record<FeatureName, boolean>> = {
-  rep_cosouls: process.env.REP_COSOULS == 'true',
-  soulkeys:
-    process.env.REACT_APP_COLINKS_ENABLED == 'true' ||
-    process.env.COLINKS_ENABLED == 'true' ||
-    process.env.NODE_ENV === 'development' ||
-    DOMAIN_IS_LOCALHOST !== null,
-};
+const staticFeatureFlags: Partial<Record<FeatureName, boolean>> = {};
 
 // this code is safe to use in a non-browser environment because of the typeof
 // check, but our setup in tsconfig-backend.json still flags the use of `window`

--- a/src/features/cosoul/CoLinksSplashLayout.tsx
+++ b/src/features/cosoul/CoLinksSplashLayout.tsx
@@ -3,17 +3,12 @@ import { dark } from 'stitches.config';
 
 import { GlobalUi } from 'components/GlobalUi';
 import HelpButton from 'components/HelpButton';
-import { isFeatureEnabled } from 'config/features';
 import { Box, Flex } from 'ui';
 import { SingleColumnLayout } from 'ui/layouts';
 
 import { CoLinksSplashNav } from './CoLinksSplashNav';
 
 const CoLinksSplashLayout = ({ children }: { children: React.ReactNode }) => {
-  if (!isFeatureEnabled('soulkeys')) {
-    return <></>;
-  }
-
   return (
     <Box
       className={dark}

--- a/src/features/cosoul/ViewPage.tsx
+++ b/src/features/cosoul/ViewPage.tsx
@@ -4,7 +4,6 @@ import { useParams } from 'react-router-dom';
 
 import { CosoulData } from '../../../api/cosoul/[address]';
 import { LoadingModal } from 'components';
-import isFeatureEnabled from 'config/features';
 import { Box, Flex, Text } from 'ui';
 import { SingleColumnLayout } from 'ui/layouts';
 
@@ -12,7 +11,6 @@ import { artWidth } from '.';
 import { CoSoulArt } from './art/CoSoulArt';
 import { CoSoulArtContainer, coSoulCloud } from './CoSoulArtContainer';
 import { CoSoulComposition } from './CoSoulComposition';
-import { CoSoulCompositionRep } from './CoSoulCompositionRep';
 import { CoSoulDetails } from './CoSoulDetails';
 import { CoSoulProfileInfo } from './CoSoulProfileInfo';
 import { CoSoulPromo } from './CoSoulPromo';
@@ -86,27 +84,15 @@ export const ViewPage = () => {
         <>
           <CoSoulProfileInfo cosoul_data={data} />
           <CoSoulPromo cosoul_data={data} address={address} />
-          {isFeatureEnabled('soulkeys') ? (
-            <CoSoulCompositionRep cosoul_data={data}>
-              <CoSoulArtContainer cosoul_data={data}>
-                <CoSoulArt
-                  pGive={data.totalPgive}
-                  repScore={data.repScore}
-                  address={address}
-                />
-              </CoSoulArtContainer>
-            </CoSoulCompositionRep>
-          ) : (
-            <CoSoulComposition cosoul_data={data}>
-              <CoSoulArtContainer cosoul_data={data}>
-                <CoSoulArt
-                  pGive={data.totalPgive}
-                  repScore={data.repScore}
-                  address={address}
-                />
-              </CoSoulArtContainer>
-            </CoSoulComposition>
-          )}
+          <CoSoulComposition cosoul_data={data}>
+            <CoSoulArtContainer cosoul_data={data}>
+              <CoSoulArt
+                pGive={data.totalPgive}
+                repScore={data.repScore}
+                address={address}
+              />
+            </CoSoulArtContainer>
+          </CoSoulComposition>
           <CoSoulDetails cosoul_data={data} />
         </>
       ) : (

--- a/src/features/cosoul/art/CoSoulArt.tsx
+++ b/src/features/cosoul/art/CoSoulArt.tsx
@@ -1,4 +1,3 @@
-import { isFeatureEnabled } from '../../../config/features';
 import { artWidth, artWidthMobile } from '../constants';
 
 import Display from './CoSoulArtDisplay.js';
@@ -32,10 +31,7 @@ export const CoSoulArt = ({
 
   // use pGive unless we have feature flagged on backend (w/ env var)
   // this also allows for some usages to not pass in repScore (for now)
-  let score = pGive ?? 0;
-  if (isFeatureEnabled('rep_cosouls')) {
-    score = repScore ?? pGive ?? 0;
-  }
+  let score = repScore ?? pGive ?? 0;
 
   // fall back to pGive if its bigger - we might not have calculated score yet
   if (pGive !== undefined && pGive > score) {

--- a/src/features/nav/NavLogo.tsx
+++ b/src/features/nav/NavLogo.tsx
@@ -124,38 +124,6 @@ export const NavLogo = ({
               </>
             )}
           </Box>
-          {/* TODO: get rid of this nav for now */}
-
-          {/*{isFeatureEnabled('soulkeys') && !suppressAppMenu && (*/}
-          {/*  <Flex column css={{ gap: '$md', mt: '$md', ml: '$md' }}>*/}
-          {/*    <Text*/}
-          {/*      size={'xl'}*/}
-          {/*      as={NavLink}*/}
-          {/*      to={webAppURL('colinks')}*/}
-          {/*      onClick={() => setShowApps(false)}*/}
-          {/*      semibold={isCoLinks}*/}
-          {/*      css={{*/}
-          {/*        textDecoration: 'none',*/}
-          {/*        display: isCoLinks || showApps ? 'flex' : 'none',*/}
-          {/*      }}*/}
-          {/*    >*/}
-          {/*      CoLinks*/}
-          {/*    </Text>*/}
-          {/*    <Text*/}
-          {/*      as={NavLink}*/}
-          {/*      to={webAppURL('give')}*/}
-          {/*      onClick={() => setShowApps(false)}*/}
-          {/*      size={'xl'}*/}
-          {/*      css={{*/}
-          {/*        textDecoration: 'none',*/}
-          {/*        display: !isCoLinks || showApps ? 'flex' : 'none',*/}
-          {/*      }}*/}
-          {/*      semibold={!isCoLinks}*/}
-          {/*    >*/}
-          {/*      Gift Circle*/}
-          {/*    </Text>*/}
-          {/*  </Flex>*/}
-          {/*)}*/}
         </Flex>
       )}
     </ThemeContext.Consumer>

--- a/src/pages/CoSoulExplorePage/Order.ts
+++ b/src/pages/CoSoulExplorePage/Order.ts
@@ -1,4 +1,3 @@
-import { isFeatureEnabled } from '../../config/features';
 import { order_by } from '../../lib/gql/__generated__/zeus';
 
 export const getOrderBy = (val: typeof orderOptions[number]['value']) => {
@@ -91,5 +90,5 @@ export const orderOptions = [
       },
     ],
   },
-  ...(isFeatureEnabled('soulkeys') ? coLinks : []),
+  ...coLinks,
 ];

--- a/src/pages/colinks/ActivityPage.tsx
+++ b/src/pages/colinks/ActivityPage.tsx
@@ -3,7 +3,6 @@ import { useContext, useState } from 'react';
 import { CoLinks } from '@coordinape/hardhat/dist/typechain';
 
 import { LoadingIndicator } from '../../components/LoadingIndicator';
-import { isFeatureEnabled } from '../../config/features';
 import { ActivityList } from '../../features/activities/ActivityList';
 import { CoLinksContext } from '../../features/colinks/CoLinksContext';
 import { LeaderboardMostLinks } from '../../features/colinks/LeaderboardMostLinks';
@@ -23,10 +22,6 @@ export const ActivityPage = () => {
   const { coLinks, address } = useContext(CoLinksContext);
   if (!coLinks || !address) {
     return <LoadingIndicator />;
-  }
-
-  if (!isFeatureEnabled('soulkeys')) {
-    return null;
   }
 
   return (

--- a/src/pages/colinks/TradesPage/index.tsx
+++ b/src/pages/colinks/TradesPage/index.tsx
@@ -1,14 +1,9 @@
-import { isFeatureEnabled } from '../../../config/features';
 import { RecentCoLinkTransactions } from '../../../features/colinks/RecentCoLinkTransactions';
 import { ContentHeader, Flex, Text } from '../../../ui';
 import { SingleColumnLayout } from '../../../ui/layouts';
 import { ExploreBreadCrumbs } from '../explore/ExploreBreadCrumbs';
 
 export const TradesPage = () => {
-  if (!isFeatureEnabled('soulkeys')) {
-    return null;
-  }
-
   return (
     <SingleColumnLayout>
       <ContentHeader>

--- a/src/pages/colinks/ViewProfilePage/ViewProfilePageContents.tsx
+++ b/src/pages/colinks/ViewProfilePage/ViewProfilePageContents.tsx
@@ -7,7 +7,6 @@ import { useQuery } from 'react-query';
 
 import { LoadingModal } from '../../../components';
 import { LoadingIndicator } from '../../../components/LoadingIndicator';
-import { isFeatureEnabled } from '../../../config/features';
 import { ActivityList } from '../../../features/activities/ActivityList';
 import { useAuthStore } from '../../../features/auth';
 import { BuyOrSellCoLinks } from '../../../features/colinks/BuyOrSellCoLinks';
@@ -43,9 +42,6 @@ export const ViewProfilePageContents = ({
 
   const profileId = useAuthStore(state => state.profileId);
   if (!profileId) {
-    return null;
-  }
-  if (!isFeatureEnabled('soulkeys')) {
     return null;
   }
 

--- a/src/pages/colinks/wizard/WizardStart.tsx
+++ b/src/pages/colinks/wizard/WizardStart.tsx
@@ -6,7 +6,6 @@ import { zoomBackground } from 'keyframes';
 import { NavLink } from 'react-router-dom';
 
 import { GlobalUi } from '../../../components/GlobalUi';
-import { isFeatureEnabled } from '../../../config/features';
 import { useAuthStateMachine } from '../../../features/auth/RequireAuth';
 import { RedeemInviteCode } from '../../../features/invites/RedeemInviteCode';
 import useConnectedAddress from '../../../hooks/useConnectedAddress';
@@ -24,10 +23,6 @@ export const WizardStart = () => {
   const address = useConnectedAddress();
 
   const [redeemedInviteCode, setRedeemedInviteCode] = useState(false);
-
-  if (!isFeatureEnabled('soulkeys')) {
-    return null;
-  }
 
   const isLoggedIn = !!profileId;
 


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 43b5af5</samp>

Removed feature flag logic and unused code related to the `soulkeys` feature, which is now permanently enabled. Simplified and cleaned up several components that display or interact with the CoSoul and soulkeys concepts.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 43b5af5</samp>

> _We've sailed the seas of code and flags, we've seen the features come and go_
> _But now we've reached the final port, where `soulkeys` always shine and glow_
> _So haul away the old and unused, and simplify the logic too_
> _And sing along with CoSoul crew, we've cleaned the code for me and you_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 43b5af5</samp>

*  Remove `soulkeys` and `rep_cosouls` feature names from `FeatureName` type ([link](https://github.com/coordinape/coordinape/pull/2537/files?diff=unified&w=0#diff-5c118d9192f4171e7f6592b2205521832975d0666a8673815188b73c9644088aL3-R5))
*  Empty `staticFeatureFlags` object as no feature flags are needed based on environment or domain ([link](https://github.com/coordinape/coordinape/pull/2537/files?diff=unified&w=0#diff-5c118d9192f4171e7f6592b2205521832975d0666a8673815188b73c9644088aL16-R12))
*  Remove conditional rendering or assignment of components or variables based on `soulkeys` or `rep_cosouls` feature flags, as they are always enabled now ([link](https://github.com/coordinape/coordinape/pull/2537/files?diff=unified&w=0#diff-f34b614d98595742639b3e1e6a038c2de093031df628a526679a8f08d0d7f0e4L13-L16), [link](https://github.com/coordinape/coordinape/pull/2537/files?diff=unified&w=0#diff-07a5e546156e72d3af4da968af148298858d1943242859c44c28aea5e4b3c5b5L89-R95), [link](https://github.com/coordinape/coordinape/pull/2537/files?diff=unified&w=0#diff-0d32f46ad080049e96febbbed420394d392db3af9f64f964210bee3bab9d91feL35-R34), [link](https://github.com/coordinape/coordinape/pull/2537/files?diff=unified&w=0#diff-b06acfe67570e88d414766102b185f0db62c91015f69f93b59ecc49e215efa04L28-L31), [link](https://github.com/coordinape/coordinape/pull/2537/files?diff=unified&w=0#diff-43a22dabadb3c42011c45437ff2b6c4640b4396a02c53ab2b71c602ed1808e43L8-L11), [link](https://github.com/coordinape/coordinape/pull/2537/files?diff=unified&w=0#diff-cff4a8eedd6bc4e327e10f459d5d7120705b2ccbcf88abb2c175985ad128712cL48-L50), [link](https://github.com/coordinape/coordinape/pull/2537/files?diff=unified&w=0#diff-852a76bce16dc95f6c675a9df55f7c904a4ff7be5c992b6f8f806666113f8a83L28-L31), [link](https://github.com/coordinape/coordinape/pull/2537/files?diff=unified&w=0#diff-2f68cbb05d6fe00268c6c5ea7534738733aaa28425679296ace2240cf756fce3L94-R93))
*  Remove unused imports of `isFeatureEnabled` from components or modules ([link](https://github.com/coordinape/coordinape/pull/2537/files?diff=unified&w=0#diff-f34b614d98595742639b3e1e6a038c2de093031df628a526679a8f08d0d7f0e4L6), [link](https://github.com/coordinape/coordinape/pull/2537/files?diff=unified&w=0#diff-07a5e546156e72d3af4da968af148298858d1943242859c44c28aea5e4b3c5b5L7), [link](https://github.com/coordinape/coordinape/pull/2537/files?diff=unified&w=0#diff-0d32f46ad080049e96febbbed420394d392db3af9f64f964210bee3bab9d91feL1), [link](https://github.com/coordinape/coordinape/pull/2537/files?diff=unified&w=0#diff-b06acfe67570e88d414766102b185f0db62c91015f69f93b59ecc49e215efa04L6), [link](https://github.com/coordinape/coordinape/pull/2537/files?diff=unified&w=0#diff-43a22dabadb3c42011c45437ff2b6c4640b4396a02c53ab2b71c602ed1808e43L1), [link](https://github.com/coordinape/coordinape/pull/2537/files?diff=unified&w=0#diff-cff4a8eedd6bc4e327e10f459d5d7120705b2ccbcf88abb2c175985ad128712cL10), [link](https://github.com/coordinape/coordinape/pull/2537/files?diff=unified&w=0#diff-852a76bce16dc95f6c675a9df55f7c904a4ff7be5c992b6f8f806666113f8a83L9), [link](https://github.com/coordinape/coordinape/pull/2537/files?diff=unified&w=0#diff-2f68cbb05d6fe00268c6c5ea7534738733aaa28425679296ace2240cf756fce3L1))
*  Remove unused import of `CoSoulCompositionRep` from `ViewPage.tsx` ([link](https://github.com/coordinape/coordinape/pull/2537/files?diff=unified&w=0#diff-07a5e546156e72d3af4da968af148298858d1943242859c44c28aea5e4b3c5b5L15))
*  Remove commented out code that rendered `CoLinks` and `Gift Circle` nav items from `NavLogo.tsx` ([link](https://github.com/coordinape/coordinape/pull/2537/files?diff=unified&w=0#diff-e59db5f0d6caeb13b3405fed059b0f57f10ae8a3df65a29be94b3b3197a4e82aL127-L158))
