### PR TITLE
navigate to wizard if TOS is not accepted

### DIFF
--- a/src/features/colinks/CoLinksContext.tsx
+++ b/src/features/colinks/CoLinksContext.tsx
@@ -68,6 +68,9 @@ const CoLinksProvider: React.FC<CoLinksProviderProps> = ({ children }) => {
       if (!data.profile.invite_code_redeemed_at) {
         navigate(coLinksPaths.wizard);
       }
+      if (!data.profile.tos_agreed_at) {
+        navigate(coLinksPaths.wizard);
+      }
     }
   }, [data]);
 


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a06a5c4</samp>

Redirect users to terms of service wizard in `CoLinksContext.tsx`. This ensures that users agree to the terms of service before using the app.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a06a5c4</samp>

> _`tos_agreed_at`?_
> _If not, `navigate` to_
> _`wizard` in spring_



## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a06a5c4</samp>

*  Redirect user to wizard page if they have not agreed to terms of service ([link](https://github.com/coordinape/coordinape/pull/2541/files?diff=unified&w=0#diff-96aa5ba0c6e0fe54e8c58399818588ede4ff9ee55d825961864fe2f19aac420dR71-R73))
