### PR TITLE
navigate to wizard if tos agreement is outdated

### DIFF
--- a/src/features/colinks/CoLinksContext.tsx
+++ b/src/features/colinks/CoLinksContext.tsx
@@ -13,6 +13,7 @@ import { chain } from '../cosoul/chains';
 import { useCoSoulContracts } from '../cosoul/useCoSoulContracts';
 
 import { useCoLinksNavQuery } from './useCoLinksNavQuery';
+import { TOS_UPDATED_AT } from './wizard/WizardTerms';
 
 // Define the context's type
 interface CoLinksContextType {
@@ -70,6 +71,12 @@ const CoLinksProvider: React.FC<CoLinksProviderProps> = ({ children }) => {
       }
       if (!data.profile.tos_agreed_at) {
         navigate(coLinksPaths.wizard);
+      } else {
+        const tosAgreedAt = new Date(data.profile.tos_agreed_at);
+        const tosUpdatedAt = new Date(TOS_UPDATED_AT);
+        if (tosAgreedAt < tosUpdatedAt) {
+          navigate(coLinksPaths.wizard);
+        }
       }
     }
   }, [data]);


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f64de2c</samp>

Added terms of service consent validation for co-links feature. Users who have not consented are redirected to `WizardTerms` to agree before using co-links.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f64de2c</samp>

> _`CoLinksContext` checks_
> _terms of service consent now_
> _redirects if not_

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f64de2c</samp>

* Import `TOS_UPDATED_AT` constant from `WizardTerms` component to check the latest terms of service date ([link](https://github.com/coordinape/coordinape/pull/2544/files?diff=unified&w=0#diff-96aa5ba0c6e0fe54e8c58399818588ede4ff9ee55d825961864fe2f19aac420dR16))
* Redirect user to wizard component if they have not agreed to the terms of service after they were updated ([link](https://github.com/coordinape/coordinape/pull/2544/files?diff=unified&w=0#diff-96aa5ba0c6e0fe54e8c58399818588ede4ff9ee55d825961864fe2f19aac420dR74-R79))
