### PR TITLE
use colinks email for colinks notifications and support

### DIFF
--- a/api-lib/postmark.ts
+++ b/api-lib/postmark.ts
@@ -8,7 +8,8 @@ import { adminClient } from './gql/adminClient';
 
 const HELP_URL = 'https://docs.coordinape.com';
 const API_BASE_URL = 'https://api.postmarkapp.com';
-const FROM_EMAIL = 'support@coordinape.com';
+const FROM_EMAIL_GIVE = 'support@coordinape.com';
+const FROM_EMAIL_COLINKS = 'colinks@coordinape.com';
 const FROM_NAME = 'Coordinape';
 
 const TEMPLATES = {
@@ -64,7 +65,8 @@ export async function sendCoLinksWaitlistWelcomeEmail(params: {
   const res = await sendEmail(
     params.email,
     TEMPLATES.COLINKS_WAITLIST_WELCOME,
-    input
+    input,
+    FROM_EMAIL_COLINKS
   );
   return res;
 }
@@ -80,7 +82,8 @@ export async function sendCoLinksWaitlistVerifyEmail(params: {
   const res = await sendEmail(
     params.email,
     TEMPLATES.COLINKS_WAITLIST_VERIFY,
-    input
+    input,
+    FROM_EMAIL_COLINKS
   );
   return res;
 }
@@ -98,7 +101,12 @@ export async function sendVerifyEmail(params: {
       '/email/verify/' +
       params.verification_code,
   };
-  const res = await sendEmail(params.email, TEMPLATES.VERIFY, input);
+  const res = await sendEmail(
+    params.email,
+    TEMPLATES.VERIFY,
+    input,
+    params.coLinks ? FROM_EMAIL_COLINKS : FROM_EMAIL_GIVE
+  );
   return res;
 }
 
@@ -118,7 +126,12 @@ export async function sendEpochEndedEmail(params: {
     num_notes_received: params.num_notes_received,
     action_url: `${webAppURL('give')}/circles/${params.circle_id}/epochs`,
   };
-  const res = await sendEmail(params.email, TEMPLATES.EPOCH_ENDED, input);
+  const res = await sendEmail(
+    params.email,
+    TEMPLATES.EPOCH_ENDED,
+    input,
+    FROM_EMAIL_GIVE
+  );
   return res;
 }
 
@@ -133,7 +146,12 @@ export async function sendEpochEndingSoonEmail(params: {
     epoch_id: params.epoch_id,
     action_url: `${webAppURL('give')}/circles/${params.circle_id}/give`,
   };
-  const res = await sendEmail(params.email, TEMPLATES.EPOCH_ENDING_SOON, input);
+  const res = await sendEmail(
+    params.email,
+    TEMPLATES.EPOCH_ENDING_SOON,
+    input,
+    FROM_EMAIL_GIVE
+  );
   return res;
 }
 
@@ -148,14 +166,20 @@ export async function sendEpochStartedEmail(params: {
     epoch_id: params.epoch_id,
     action_url: `${webAppURL('give')}/circles/${params.circle_id}/give`,
   };
-  const res = await sendEmail(params.email, TEMPLATES.EPOCH_STARTED, input);
+  const res = await sendEmail(
+    params.email,
+    TEMPLATES.EPOCH_STARTED,
+    input,
+    FROM_EMAIL_GIVE
+  );
   return res;
 }
 
 async function sendEmail(
   to: string,
   templateAlias: TemplateAliases,
-  templateModel: Record<string, unknown>
+  templateModel: Record<string, unknown>,
+  fromEmail: string
 ) {
   const response = await fetch(`${API_BASE_URL}/email/withTemplate`, {
     method: 'POST',
@@ -165,7 +189,7 @@ async function sendEmail(
       'X-Postmark-Server-Token': POSTMARK_SERVER_TOKEN,
     },
     body: JSON.stringify({
-      From: `${FROM_NAME} <${FROM_EMAIL}>`,
+      From: `${FROM_NAME} <${fromEmail}>`,
       To: to,
       TemplateAlias: templateAlias,
       TemplateModel: { ...BASE_INPUT, ...templateModel },

--- a/api-lib/postmark.ts
+++ b/api-lib/postmark.ts
@@ -8,9 +8,10 @@ import { adminClient } from './gql/adminClient';
 
 const HELP_URL = 'https://docs.coordinape.com';
 const API_BASE_URL = 'https://api.postmarkapp.com';
-const FROM_EMAIL_GIVE = 'support@coordinape.com';
+const FROM_EMAIL_GIFT = 'support@coordinape.com';
 const FROM_EMAIL_COLINKS = 'colinks@coordinape.com';
-const FROM_NAME = 'Coordinape';
+const FROM_NAME_GIFT = 'Coordinape';
+const FROM_NAME_COLINKS = 'CoLinks';
 
 const TEMPLATES = {
   VERIFY: 'verify_email',
@@ -66,7 +67,7 @@ export async function sendCoLinksWaitlistWelcomeEmail(params: {
     params.email,
     TEMPLATES.COLINKS_WAITLIST_WELCOME,
     input,
-    FROM_EMAIL_COLINKS
+    'colinks'
   );
   return res;
 }
@@ -83,7 +84,7 @@ export async function sendCoLinksWaitlistVerifyEmail(params: {
     params.email,
     TEMPLATES.COLINKS_WAITLIST_VERIFY,
     input,
-    FROM_EMAIL_COLINKS
+    'colinks'
   );
   return res;
 }
@@ -105,7 +106,7 @@ export async function sendVerifyEmail(params: {
     params.email,
     TEMPLATES.VERIFY,
     input,
-    params.coLinks ? FROM_EMAIL_COLINKS : FROM_EMAIL_GIVE
+    params.coLinks ? 'colinks' : 'gift_circle'
   );
   return res;
 }
@@ -130,7 +131,7 @@ export async function sendEpochEndedEmail(params: {
     params.email,
     TEMPLATES.EPOCH_ENDED,
     input,
-    FROM_EMAIL_GIVE
+    'gift_circle'
   );
   return res;
 }
@@ -150,7 +151,7 @@ export async function sendEpochEndingSoonEmail(params: {
     params.email,
     TEMPLATES.EPOCH_ENDING_SOON,
     input,
-    FROM_EMAIL_GIVE
+    'gift_circle'
   );
   return res;
 }
@@ -170,7 +171,7 @@ export async function sendEpochStartedEmail(params: {
     params.email,
     TEMPLATES.EPOCH_STARTED,
     input,
-    FROM_EMAIL_GIVE
+    'gift_circle'
   );
   return res;
 }
@@ -179,7 +180,7 @@ async function sendEmail(
   to: string,
   templateAlias: TemplateAliases,
   templateModel: Record<string, unknown>,
-  fromEmail: string
+  from: 'colinks' | 'gift_circle'
 ) {
   const response = await fetch(`${API_BASE_URL}/email/withTemplate`, {
     method: 'POST',
@@ -189,7 +190,10 @@ async function sendEmail(
       'X-Postmark-Server-Token': POSTMARK_SERVER_TOKEN,
     },
     body: JSON.stringify({
-      From: `${FROM_NAME} <${fromEmail}>`,
+      From:
+        from === 'colinks'
+          ? `${FROM_NAME_COLINKS} <${FROM_EMAIL_COLINKS}>`
+          : `${FROM_NAME_GIFT} <${FROM_EMAIL_GIFT}>`,
       To: to,
       TemplateAlias: templateAlias,
       TemplateModel: { ...BASE_INPUT, ...templateModel },

--- a/src/components/HelpButton.tsx
+++ b/src/components/HelpButton.tsx
@@ -14,6 +14,7 @@ import {
 import {
   EXTERNAL_URL_DISCORD,
   EXTERNAL_URL_DOCS,
+  EXTERNAL_URL_MAILTO_COLINKS_SUPPORT,
   EXTERNAL_URL_MAILTO_SUPPORT,
   EXTERNAL_URL_REPORT_ABUSE_FORM,
   EXTERNAL_URL_SCHEDULE_WALKTHROUGH,
@@ -177,7 +178,11 @@ const HelpButton = () => {
           Ask on Discord
         </HelpOption>
         <HelpOption
-          href={EXTERNAL_URL_MAILTO_SUPPORT}
+          href={
+            !isCoLinksPage
+              ? EXTERNAL_URL_MAILTO_SUPPORT
+              : EXTERNAL_URL_MAILTO_COLINKS_SUPPORT
+          }
           icon={<Mail size={'md'} color={'text'} />}
         >
           Email Us

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -23,6 +23,8 @@ export const EXTERNAL_URL_DISCORD_SUPPORT =
 export const EXTERNAL_URL_WHY_COORDINAPE_IN_CIRCLE =
   'https://coordinape.com/post/why-is-coordinape-in-my-circle?utm_source=coordinape-app&utm_medium=tooltip&utm_campaign=coordinapeincircle';
 export const EXTERNAL_URL_MAILTO_SUPPORT = 'mailto:support@coordinape.com';
+export const EXTERNAL_URL_MAILTO_COLINKS_SUPPORT =
+  'mailto:colinks@coordinape.com';
 export const EXTERNAL_URL_REPORT_ABUSE_FORM =
   'https://docs.google.com/forms/d/e/1FAIpQLScqdAJtxv8eKGQJ35RyWLYOIuwO4NsmLa78rS3jKq6k6dsLNw/viewform?usp=pp_url';
 


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 65da397</samp>

This pull request adds the ability to use different sender and support email addresses for Coordinape Give and CoLinks features. It modifies the `sendEmail` function in `api-lib/postmark.ts` and the `HelpButton` component in `src/components/HelpButton.tsx` to accept and use a `fromEmail` parameter. It also adds a new constant `EXTERNAL_URL_MAILTO_COLINKS_SUPPORT` in `src/routes/paths.ts` to store the CoLinks support email address.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 65da397</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A way to send swift messages from different sources_
> _To the eager users of Coordinape Give and CoLinks_
> _The splendid features that enhance the power of circles_

## Screenshots (if appropriate):
![image](https://github.com/coordinape/coordinape/assets/34943689/bb1f54d5-2a05-409e-93b2-0627f41c83ba)

![image](https://github.com/coordinape/coordinape/assets/34943689/603e2ef1-1cfb-4615-87bc-cf0622e8f486)
![image](https://github.com/coordinape/coordinape/assets/34943689/478a8903-1d2d-4915-9fd0-069ef47f8622)

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 65da397</samp>

*  Add and use `FROM_EMAIL_COLINKS` constant to send emails from different addresses for CoLinks and Give features ([link](https://github.com/coordinape/coordinape/pull/2545/files?diff=unified&w=0#diff-0ae55db9a83e75892b84b9d54fe9f1d61d500dadab7966eb9b161e8a92bc8954L11-R12), [link](https://github.com/coordinape/coordinape/pull/2545/files?diff=unified&w=0#diff-0ae55db9a83e75892b84b9d54fe9f1d61d500dadab7966eb9b161e8a92bc8954L67-R69), [link](https://github.com/coordinape/coordinape/pull/2545/files?diff=unified&w=0#diff-0ae55db9a83e75892b84b9d54fe9f1d61d500dadab7966eb9b161e8a92bc8954L83-R86), [link](https://github.com/coordinape/coordinape/pull/2545/files?diff=unified&w=0#diff-0ae55db9a83e75892b84b9d54fe9f1d61d500dadab7966eb9b161e8a92bc8954L101-R109), [link](https://github.com/coordinape/coordinape/pull/2545/files?diff=unified&w=0#diff-0ae55db9a83e75892b84b9d54fe9f1d61d500dadab7966eb9b161e8a92bc8954L121-R134), [link](https://github.com/coordinape/coordinape/pull/2545/files?diff=unified&w=0#diff-0ae55db9a83e75892b84b9d54fe9f1d61d500dadab7966eb9b161e8a92bc8954L136-R154), [link](https://github.com/coordinape/coordinape/pull/2545/files?diff=unified&w=0#diff-0ae55db9a83e75892b84b9d54fe9f1d61d500dadab7966eb9b161e8a92bc8954L151-R174), [link](https://github.com/coordinape/coordinape/pull/2545/files?diff=unified&w=0#diff-0ae55db9a83e75892b84b9d54fe9f1d61d500dadab7966eb9b161e8a92bc8954L158-R182), [link](https://github.com/coordinape/coordinape/pull/2545/files?diff=unified&w=0#diff-0ae55db9a83e75892b84b9d54fe9f1d61d500dadab7966eb9b161e8a92bc8954L168-R192))
*  Modify `sendEmail` function to accept `fromEmail` parameter as the sender of the email ([link](https://github.com/coordinape/coordinape/pull/2545/files?diff=unified&w=0#diff-0ae55db9a83e75892b84b9d54fe9f1d61d500dadab7966eb9b161e8a92bc8954L158-R182), [link](https://github.com/coordinape/coordinape/pull/2545/files?diff=unified&w=0#diff-0ae55db9a83e75892b84b9d54fe9f1d61d500dadab7966eb9b161e8a92bc8954L168-R192))
*  Use conditional expression to set `href` prop of `HelpOption` component based on current page ([link](https://github.com/coordinape/coordinape/pull/2545/files?diff=unified&w=0#diff-7c2cc17f56e9944c1d29d9c18b5c815bac62733fa2645aa4b57e5e948fb09509L180-R185))
*  Import and use `EXTERNAL_URL_MAILTO_COLINKS_SUPPORT` constant as the email address for CoLinks support ([link](https://github.com/coordinape/coordinape/pull/2545/files?diff=unified&w=0#diff-7c2cc17f56e9944c1d29d9c18b5c815bac62733fa2645aa4b57e5e948fb09509R17), [link](https://github.com/coordinape/coordinape/pull/2545/files?diff=unified&w=0#diff-26212c7e58b310fe67e20a7cd969dce535cc31c1f843f741c71641dddc7320ddR26-R27))
