### PR TITLE
Change cosoul mint fee pricing

### DIFF
--- a/hardhat/hardhat.config.ts
+++ b/hardhat/hardhat.config.ts
@@ -248,7 +248,7 @@ const config: HardhatUserConfig = {
     feeDestination: {
       default: 14,
       10: '0x537d1979CF214d69619894280e133C54ED4EA020',
-      420: '0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65',
+      420: '0x6c84AA3dF5ED2b4DfbDd198c1ec8aC3cc2c7dEf5',
     },
   },
   paths: {

--- a/hardhat/scripts/manage/colinks_setup.ts
+++ b/hardhat/scripts/manage/colinks_setup.ts
@@ -67,6 +67,8 @@ async function main() {
       ' with tx: ',
       transferOwnershipTx.hash
     );
+
+    console.log("Don't forget to setup the webhooks!");
   } catch (e) {
     console.log(e);
   }

--- a/hardhat/scripts/manage/cosoul_set_mint_fee.ts
+++ b/hardhat/scripts/manage/cosoul_set_mint_fee.ts
@@ -18,11 +18,10 @@ async function main() {
   ).attach(deployed_cosoul.address);
 
   // set mint fee
-  const setMintFeeTx = await cosoul.setMintFee(
-    ethers.utils.parseEther('0.0032')
-  );
+  const fee = ethers.utils.parseEther('0.0022');
+  const setMintFeeTx = await cosoul.setMintFee(fee);
   console.log(
-    `cosoul.setMintFee set to 0.0032 eth via tx: `,
+    `cosoul.setMintFee set to ${fee.toString()} wei via tx: `,
     setMintFeeTx.hash
   );
 }

--- a/src/features/cosoul/CoSoulCreate.tsx
+++ b/src/features/cosoul/CoSoulCreate.tsx
@@ -8,8 +8,8 @@ import { numberWithCommas } from 'utils';
 import { artWidth, artWidthMobile } from './constants';
 import { CoSoulButton } from './CoSoulButton';
 import { QueryCoSoulResult } from './getCoSoulData';
+import { COSOUL_MINT_FEE } from './MintOrBurnButton';
 import { generateRandomNumber, scrambleNumber } from './numberScramble';
-
 import './glitch.css';
 
 type CoSoulData = QueryCoSoulResult;
@@ -128,8 +128,8 @@ export const CoSoulCreate = ({
         <Flex column css={{ gap: '$sm' }}>
           <CoSoulButton onReveal={onReveal} />
           <Text color="secondary">
-            There is a small 0.0032 ETH fee to mint a CoSoul, and gas costs are
-            minimal.
+            There is a small {`${COSOUL_MINT_FEE}`} ETH fee to mint a CoSoul,
+            and gas costs are minimal.
           </Text>
         </Flex>
       </Panel>

--- a/src/features/cosoul/MintOrBurnButton.tsx
+++ b/src/features/cosoul/MintOrBurnButton.tsx
@@ -13,6 +13,8 @@ import { Contracts } from './contracts';
 import { MINTING_STEPS, MintingModal, MintingStep } from './MintingModal';
 import { useCoSoulToken } from './useCoSoulToken';
 
+export const COSOUL_MINT_FEE = '0.0022';
+
 export const MintOrBurnButton = ({
   contracts,
   address,
@@ -141,7 +143,7 @@ const MintButton = ({
       const { receipt, error /*, tx*/ } = await sendAndTrackTx(
         () =>
           contracts.cosoul.mint({
-            value: ethers.utils.parseUnits('.0032', 'ether'),
+            value: ethers.utils.parseUnits(COSOUL_MINT_FEE, 'ether'),
           }),
         {
           showDefault: showProgress,


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0548029</samp>

This pull request introduces a constant for the mint fee of CoSouls and updates the components and scripts that use it. It also adds a console log message to the CoLinks setup script.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0548029</samp>

> _Oh we're the crew of the CoSoul ship, and we sail the blockchain sea_
> _We mint and burn our tokens fair, with a constant mint fee_
> _We set up our webhooks right, for the CoLinks feature_
> _And we log a message to the console, so we don't forget the procedure_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0548029</samp>

* Lower the mint fee for CoSouls from 0.0032 eth to 0.0022 eth ([link](https://github.com/coordinape/coordinape/pull/2552/files?diff=unified&w=0#diff-3512d8ce578f709a57527179c6779fa9149df02c2eb3aad86ccc72fc9a391cb0L21-R24), [link](https://github.com/coordinape/coordinape/pull/2552/files?diff=unified&w=0#diff-977da59b488c5f16f8b27e21dde7c7f7cb4f774074fe9c8b33ff78cf89077e88L131-R132), [link](https://github.com/coordinape/coordinape/pull/2552/files?diff=unified&w=0#diff-f38e6ed59a7956c585a4215ed549d4216a411629b0e00d8588773733b97503f0R16-R17), [link](https://github.com/coordinape/coordinape/pull/2552/files?diff=unified&w=0#diff-f38e6ed59a7956c585a4215ed549d4216a411629b0e00d8588773733b97503f0L144-R146))
* Import the `COSOUL_MINT_FEE` constant from `MintOrBurnButton.tsx` to `CoSoulCreate.tsx` to avoid hard-coding the fee value ([link](https://github.com/coordinape/coordinape/pull/2552/files?diff=unified&w=0#diff-977da59b488c5f16f8b27e21dde7c7f7cb4f774074fe9c8b33ff78cf89077e88L11-R12))
* Add a console log message to the `colinks_setup.ts` script to remind the user to setup the webhooks for the CoLinks feature ([link](https://github.com/coordinape/coordinape/pull/2552/files?diff=unified&w=0#diff-b27f347de4503ee83eba4d59b4c3b164e7fa37e464978bec7be6e4573cef7e0cR70-R71))
