### PR TITLE
require links for leaderboards

### DIFF
--- a/src/features/colinks/LeaderboardHoldingMost.tsx
+++ b/src/features/colinks/LeaderboardHoldingMost.tsx
@@ -21,6 +21,9 @@ export const LeaderboardHoldingMost = ({ limit = 100 }: { limit?: number }) => {
                 {
                   where: {
                     cosoul: {},
+                    links_held: {
+                      _gt: 0,
+                    },
                   },
                   order_by: [
                     { links_held: order_by.desc, name: order_by.desc },

--- a/src/features/colinks/LeaderboardMostLinks.tsx
+++ b/src/features/colinks/LeaderboardMostLinks.tsx
@@ -34,6 +34,9 @@ export const LeaderboardMostLinks = ({
                 {
                   where: {
                     cosoul: {},
+                    links_held: {
+                      _gt: 0,
+                    },
                   },
                   order_by: [{ links: order_by.desc, name: order_by.desc }],
                   limit: limit,

--- a/src/features/colinks/LeaderboardRepScore.tsx
+++ b/src/features/colinks/LeaderboardRepScore.tsx
@@ -21,6 +21,9 @@ export const LeaderboardRepScore = ({ limit = 100 }: { limit?: number }) => {
                 {
                   where: {
                     cosoul: {},
+                    links_held: {
+                      _gt: 0,
+                    },
                   },
                   order_by: [
                     {


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e3ea144</samp>

This pull request adds a filter to the queries for the `LeaderboardHoldingMost`, `LeaderboardMostLinks`, and `LeaderboardRepScore` components, which display different rankings of users based on their links (tokens) in the Coordinape app. The filter removes users who have no links or negative links from the leaderboards.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e3ea144</samp>

> _`Leaderboard` query_
> _Filters out zero links users_
> _Autumn leaves falling_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e3ea144</samp>

*  Filter out users with zero or negative links from the leaderboards ([link](https://github.com/coordinape/coordinape/pull/2558/files?diff=unified&w=0#diff-993a511201ef46fae4aed7b9ef422cf83a13735d2407a49eb03cf8a885c59015R24-R26), [link](https://github.com/coordinape/coordinape/pull/2558/files?diff=unified&w=0#diff-6e939595bfa3daf1de4c864bfb34cec30b63697614db1c3404c9c3b705bfc047R37-R39), [link](https://github.com/coordinape/coordinape/pull/2558/files?diff=unified&w=0#diff-04f7bb64a2fe7ed35adc97be197cb7bab9f1258c319eecc6b061181efbd3d887R24-R26))
