### PR TITLE
Log errors in updateLinkHolderRepScore

### DIFF
--- a/api-lib/event_triggers/updateLinkHolderRepScore.ts
+++ b/api-lib/event_triggers/updateLinkHolderRepScore.ts
@@ -19,6 +19,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     res.status(200).json({ message: 'ok' });
   } catch (e) {
+    console.error(e);
     res.status(500).json({
       error: '500',
       message: (e as Error).message || 'Unexpected error',


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 85940f6</samp>

Add error logging to `updateLinkHolderRepScore` function. This change helps to identify and handle any failures in updating the reputation score of link holders in the `api-lib` module.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 85940f6</samp>

> _`updateLinkHolderRepScore`_
> _throws exceptions sometimes_
> _log them in console_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 85940f6</samp>

* Log any errors thrown by `updateLinkHolderRepScore` function for debugging and error handling ([link](https://github.com/coordinape/coordinape/pull/2560/files?diff=unified&w=0#diff-b4b6da422370f53365da30ca3a67cb779e6bb397e7df6b6b065ef4e55ac1c5b5R22))
