### PR TITLE
fix twitter/github visibility, switch leaderboard to similar profiles

### DIFF
--- a/api-lib/colinks/helperAccounts.ts
+++ b/api-lib/colinks/helperAccounts.ts
@@ -17,7 +17,7 @@ export const getEarlyAccessProfileId = async () => {
       insert_profiles_one: [
         {
           object: {
-            address: EARLY_ACCESS_ADDRESS,
+            address: EARLY_ACCESS_ADDRESS.toLowerCase(),
             name: 'CoLinks Early Access',
             avatar:
               'https://coordinape-staging.s3.amazonaws.com/assets/static/images/3e40dc21-8fbf-4e82-8056-2eaa37fd1e0a.jpg',
@@ -47,7 +47,7 @@ export const getWaitListGuardianProfileId = async () => {
       insert_profiles_one: [
         {
           object: {
-            address: WAITLIST_GUARDIAN_ADDRESS,
+            address: WAITLIST_GUARDIAN_ADDRESS.toLowerCase(),
             name: 'CoLinks Bouncer',
             avatar:
               'https://coordinape-staging.s3.amazonaws.com/assets/static/images/91894800-0957-472b-b457-c4970ba456a9.jpg',

--- a/hasura/metadata/databases/default/tables/public_github_accounts.yaml
+++ b/hasura/metadata/databases/default/tables/public_github_accounts.yaml
@@ -14,6 +14,7 @@ select_permissions:
         - profile_id
         - username
       filter: {}
+      limit: 1
     comment: ""
 delete_permissions:
   - role: user

--- a/hasura/metadata/databases/default/tables/public_github_accounts.yaml
+++ b/hasura/metadata/databases/default/tables/public_github_accounts.yaml
@@ -13,9 +13,7 @@ select_permissions:
         - github_id
         - profile_id
         - username
-      filter:
-        profile_id:
-          _eq: X-Hasura-User-Id
+      filter: {}
     comment: ""
 delete_permissions:
   - role: user

--- a/hasura/metadata/databases/default/tables/public_linkedin_accounts.yaml
+++ b/hasura/metadata/databases/default/tables/public_linkedin_accounts.yaml
@@ -11,6 +11,7 @@ select_permissions:
       filter:
         profile_id:
           _eq: X-Hasura-User-Id
+      limit: 1
     comment: ""
 delete_permissions:
   - role: user

--- a/hasura/metadata/databases/default/tables/public_twitter_accounts.yaml
+++ b/hasura/metadata/databases/default/tables/public_twitter_accounts.yaml
@@ -9,22 +9,13 @@ select_permissions:
   - role: user
     permission:
       columns:
-        - created_at
         - description
-        - followers_count
-        - following_count
         - id
-        - location
         - name
         - profile_id
         - profile_image_url
-        - twitter_created_at
-        - url
         - username
-        - verified
-      filter:
-        profile_id:
-          _eq: X-Hasura-User-Id
+      filter: {}
     comment: ""
 delete_permissions:
   - role: user

--- a/hasura/metadata/databases/default/tables/public_twitter_accounts.yaml
+++ b/hasura/metadata/databases/default/tables/public_twitter_accounts.yaml
@@ -16,6 +16,7 @@ select_permissions:
         - profile_image_url
         - username
       filter: {}
+      limit: 1
     comment: ""
 delete_permissions:
   - role: user

--- a/src/pages/colinks/ActivityPage.tsx
+++ b/src/pages/colinks/ActivityPage.tsx
@@ -5,13 +5,13 @@ import { CoLinks } from '@coordinape/hardhat/dist/typechain';
 import { LoadingIndicator } from '../../components/LoadingIndicator';
 import { ActivityList } from '../../features/activities/ActivityList';
 import { CoLinksContext } from '../../features/colinks/CoLinksContext';
-import { LeaderboardMostLinks } from '../../features/colinks/LeaderboardMostLinks';
 import { PostForm } from '../../features/colinks/PostForm';
 import { RecentCoLinkTransactions } from '../../features/colinks/RecentCoLinkTransactions';
 import { RightColumnSection } from '../../features/colinks/RightColumnSection';
+import { SimilarProfiles } from '../../features/colinks/SimilarProfiles';
 import { useCoLinks } from '../../features/colinks/useCoLinks';
 import { QUERY_KEY_COLINKS } from '../../features/colinks/wizard/CoLinksWizard';
-import { Award, BarChart } from '../../icons/__generated';
+import { BarChart } from '../../icons/__generated';
 import { coLinksPaths } from '../../routes/paths';
 import { AppLink, ContentHeader, Flex, Text } from '../../ui';
 import { TwoColumnSmallRightLayout } from '../../ui/layouts';
@@ -97,17 +97,7 @@ const CoLinksActivityPageContents = ({
         >
           <RecentCoLinkTransactions limit={5} />
         </RightColumnSection>
-        <RightColumnSection
-          title={
-            <Flex as={AppLink} to={coLinksPaths.leaderboard}>
-              <Text color={'default'} semibold>
-                <Award /> Leaderboard
-              </Text>
-            </Flex>
-          }
-        >
-          <LeaderboardMostLinks limit={5} size="small" />
-        </RightColumnSection>
+        <SimilarProfiles address={currentUserAddress} />
       </Flex>
     </TwoColumnSmallRightLayout>
   );


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b01feae</samp>

This pull request implements a new feature for CoLinks that shows users similar profiles based on their GitHub and Twitter data. It modifies the `ActivityPage.tsx` file to display the similar profiles instead of the leaderboard, and it adjusts the permissions and columns for the `public_github_accounts` and `public_twitter_accounts` tables in Hasura to enable the query for the feature. It also fixes some constants in `colinks/helperAccounts.ts` for better Ethereum address comparisons.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b01feae</samp>

> _`select` permission_
> _changed for GitHub, Twitter_
> _autumn of profiles_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b01feae</samp>

*  Modify `getEarlyAccessProfileId` and `getWaitListGuardianProfileId` functions to use lower case addresses ([link](https://github.com/coordinape/coordinape/pull/2562/files?diff=unified&w=0#diff-10c5a97b7fc94c0a123edfba327d8ff1053fc438eaa560fb4b20aa67d3d6955dL20-R20),[link](https://github.com/coordinape/coordinape/pull/2562/files?diff=unified&w=0#diff-10c5a97b7fc94c0a123edfba327d8ff1053fc438eaa560fb4b20aa67d3d6955dL50-R50))
*  Remove `profile_id` filter and reduce columns for `select` permission on `public_github_accounts` and `public_twitter_accounts` tables ([link](https://github.com/coordinape/coordinape/pull/2562/files?diff=unified&w=0#diff-b169d0a124485038732434cebea3338751b526a509d138dc344478947734b515L16-R16),[link](https://github.com/coordinape/coordinape/pull/2562/files?diff=unified&w=0#diff-c4ced3a654ee75b7c1ea1106d4d957286b19bb0bd93d7fcd9983343fb788529bL12-R18))
*  Import `SimilarProfiles` component and remove `LeaderboardMostLinks` component in `src/pages/colinks/ActivityPage.tsx` ([link](https://github.com/coordinape/coordinape/pull/2562/files?diff=unified&w=0#diff-b06acfe67570e88d414766102b185f0db62c91015f69f93b59ecc49e215efa04L8-R14))
*  Replace `LeaderboardMostLinks` component with `SimilarProfiles` component in `CoLinksActivityPageContents` component ([link](https://github.com/coordinape/coordinape/pull/2562/files?diff=unified&w=0#diff-b06acfe67570e88d414766102b185f0db62c91015f69f93b59ecc49e215efa04L100-R100))
