### PR TITLE
Fix unknown buyer

### DIFF
--- a/src/features/colinks/RecentCoLinkTransactions.tsx
+++ b/src/features/colinks/RecentCoLinkTransactions.tsx
@@ -39,17 +39,17 @@ export const RecentCoLinkTransactions = ({
               created_at: true,
               tx_hash: true,
               buy: true,
+              holder: true,
+              target: true,
               eth_amount: true,
               link_amount: true,
               target_profile: {
                 name: true,
                 avatar: true,
-                address: true,
               },
               holder_profile: {
                 name: true,
                 avatar: true,
-                address: true,
               },
             },
           ],
@@ -78,12 +78,12 @@ export const Transaction = ({ tx }: { tx: LinkTx }) => {
     <Flex key={tx.tx_hash} css={{ justifyContent: 'flex-start', gap: '$xs' }}>
       <Avatar
         path={tx.holder_profile?.avatar}
-        name={tx.holder_profile?.name}
+        name={tx.holder_profile?.name || '?'}
         size="small"
       />
       <Avatar
         path={tx.target_profile?.avatar}
-        name={tx.target_profile?.name}
+        name={tx.target_profile?.name || '?'}
         size="small"
         css={{ ml: '-$md' }}
       />
@@ -97,10 +97,10 @@ export const Transaction = ({ tx }: { tx: LinkTx }) => {
               gap: '$xs',
               mr: '$xs',
             }}
-            to={coLinksPaths.profile(tx.holder_profile?.address ?? 'FIXME')}
+            to={coLinksPaths.profile(tx.holder ?? '')}
           >
             <Text inline semibold size="small">
-              {tx.holder_profile?.name}
+              {tx.holder_profile?.name || '?'}
             </Text>
           </Link>
 
@@ -112,7 +112,7 @@ export const Transaction = ({ tx }: { tx: LinkTx }) => {
             {tx.link_amount}
           </Text>
 
-          {tx.target_profile?.address === tx.holder_profile?.address ? (
+          {tx.target === tx.holder ? (
             <Text inline size="small">
               of their own{' '}
             </Text>
@@ -125,10 +125,10 @@ export const Transaction = ({ tx }: { tx: LinkTx }) => {
                 gap: '$xs',
                 mr: '$xs',
               }}
-              to={coLinksPaths.profile(tx.target_profile?.address ?? 'FIXME')}
+              to={coLinksPaths.profile(tx.target ?? 'FIXME')}
             >
               <Text inline size="small" semibold>
-                {tx.target_profile?.name}
+                {tx.target_profile?.name || '?'}
               </Text>
             </Link>
           )}

--- a/src/pages/colinks/NotFound.tsx
+++ b/src/pages/colinks/NotFound.tsx
@@ -2,9 +2,22 @@ import { Flex, Text } from 'ui';
 
 export const NotFound = () => {
   return (
-    <Flex column css={{ position: 'fixed', top: '25%', left: '25%' }}>
-      <Text color={'alert'}>404 Not Found</Text>
-      <Text p>Thanks for looking under the rock. There is nothing here.</Text>
+    <Flex
+      column
+      css={{
+        gap: '$md',
+        pt: '$2xl',
+        alignItems: 'flex-start',
+        position: 'fixed',
+        left: '25%',
+      }}
+    >
+      <Text h2 display color={'warning'}>
+        404 Not Found!
+      </Text>
+      <Text semibold p>
+        Thanks for looking under the rock. There is nothing here.
+      </Text>
     </Flex>
   );
 };

--- a/src/pages/colinks/NotificationsPage.tsx
+++ b/src/pages/colinks/NotificationsPage.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { useEffect } from 'react';
 
@@ -8,10 +7,7 @@ import { DateTime } from 'luxon';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { NavLink } from 'react-router-dom';
 
-import {
-  NOTIFICATIONS_COUNT_QUERY_KEY,
-  useNotificationCount,
-} from '../../features/notifications/useNotificationCount';
+import { NOTIFICATIONS_COUNT_QUERY_KEY } from '../../features/notifications/useNotificationCount';
 import { Briefcase, MessageSquare, Smile } from '../../icons/__generated';
 import { order_by } from '../../lib/gql/__generated__/zeus';
 import { client } from '../../lib/gql/client';
@@ -75,16 +71,15 @@ const fetchNotifications = async () => {
             link_amount: true,
             eth_amount: true,
             created_at: true,
-            // TODO: remove and refactor
+            holder: true,
+            target: true,
             target_profile: {
               avatar: true,
               name: true,
-              address: true,
             },
             holder_profile: {
               avatar: true,
               name: true,
-              address: true,
             },
           },
         },
@@ -107,8 +102,6 @@ export type Reaction = NonNullable<Notification['reaction']>;
 export type Invitee = NonNullable<Notification['invited_profile_public']>;
 
 export const NotificationsPage = () => {
-  const { count } = useNotificationCount();
-
   const profileId = useAuthStore(state => state.profileId);
 
   const queryClient = useQueryClient();
@@ -322,25 +315,6 @@ export const Reply = ({
                 {DateTime.fromISO(reply.created_at).toLocal().toRelative()}
               </Text>
             </Flex>
-
-            {/* <Link */}
-            {/*   as={NavLink} */}
-            {/*   css={{ */}
-            {/*     display: 'inline', */}
-            {/*     alignItems: 'center', */}
-            {/*     gap: '$xs', */}
-            {/*     mr: '$xs', */}
-            {/*   }} */}
-            {/*   to={paths.coLinksProfile(tx.target_profile?.address ?? 'FIXME')} */}
-            {/* > */}
-            {/*   <Text inline size="small" semibold> */}
-            {/*     {tx.target_profile?.name} */}
-            {/*   </Text> */}
-            {/* </Link> */}
-
-            {/* <Text inline size="small" css={{ mr: '$xs' }}> */}
-            {/*   link */}
-            {/* </Text> */}
           </Flex>
           <Text
             color={'default'}
@@ -364,7 +338,7 @@ export const LinkTxNotification = ({ tx }: { tx: LinkTx }) => {
           <Briefcase size={'lg'} css={{ mt: '-$xs' }} />
         </Icon>
         <Avatar
-          path={tx.holder_profile?.avatar}
+          path={tx.holder_profile?.avatar || '?'}
           name={tx.holder_profile?.name}
           size="small"
         />
@@ -378,7 +352,7 @@ export const LinkTxNotification = ({ tx }: { tx: LinkTx }) => {
                 gap: '$xs',
                 mr: '$xs',
               }}
-              to={coLinksPaths.profile(tx.holder_profile?.address ?? 'FIXME')}
+              to={coLinksPaths.profile(tx.holder ?? 'FIXME')}
             >
               <Text inline semibold size="small">
                 {tx.holder_profile?.name}

--- a/src/pages/colinks/ViewProfilePage/ViewProfilePageContents.tsx
+++ b/src/pages/colinks/ViewProfilePage/ViewProfilePageContents.tsx
@@ -213,15 +213,13 @@ const PageContents = ({
           maxWidth: '$readable',
         }}
       >
-        <Flex column css={{ gap: '$xl', pt: '$2xl', alignItems: 'flex-start' }}>
-          <Text size={'xl'} semibold color={'alert'}>
-            {targetAddress}
+        <Flex column css={{ gap: '$md', pt: '$2xl', alignItems: 'flex-start' }}>
+          <Text h2 display color={'warning'}>
+            No Profile Found!
           </Text>
-          <Flex css={{ gap: '$xs', justifyContent: 'flex-end' }}>
-            <Text>is</Text>
-            <Text semibold>NOT</Text>
-            <Text>on CoLinks</Text>
-          </Flex>
+          <Text>It seems </Text>
+          <Text semibold>{targetAddress}</Text>
+          <Text>does not have a profile on CoLinks yet.</Text>
         </Flex>
       </Flex>
     );


### PR DESCRIPTION
## What

Fixes this:
<img width="329" alt="Screenshot 2023-12-14 at 9 42 02 AM" src="https://github.com/coordinape/coordinape/assets/83605543/7fd63129-1cde-4b63-9b14-96936b407206">

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f029ce1</samp>

This pull request improves the functionality and user experience of the co-links feature. It fixes some issues with the query and display of recent transactions and notifications involving co-links, and updates the fallback values for profile names. It also enhances the styling and content of the `NotFound` and `PageContents` components, which are shown when the user navigates to a non-existing route or profile.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f029ce1</samp>

> _We are the lost, the not found, the forsaken_
> _We wander the dark paths of the web_
> _We face the warnings, the errors, the co-links_
> _We seek the notifications of the dead_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f029ce1</samp>

*  Add `holder` and `target` fields to queries for recent transactions and notifications, and remove redundant `address` fields from subqueries ([link](https://github.com/coordinape/coordinape/pull/2563/files?diff=unified&w=0#diff-decbefdd4f23e27bdd227ef6584703d587135d865bc4194bdb0c6b857bfa1302R42-R43), [link](https://github.com/coordinape/coordinape/pull/2563/files?diff=unified&w=0#diff-decbefdd4f23e27bdd227ef6584703d587135d865bc4194bdb0c6b857bfa1302L47-R52), [link](https://github.com/coordinape/coordinape/pull/2563/files?diff=unified&w=0#diff-a508bfd195b70991227d23f8972333b9fba1abbd498b8dfb0497e4963abb6f43L78-R82))
*  Add fallback values of `'?'` for `name` and `path` props of `Avatar` and `Text` components, in case profile name or avatar is undefined or null ([link](https://github.com/coordinape/coordinape/pull/2563/files?diff=unified&w=0#diff-decbefdd4f23e27bdd227ef6584703d587135d865bc4194bdb0c6b857bfa1302L81-R86), [link](https://github.com/coordinape/coordinape/pull/2563/files?diff=unified&w=0#diff-decbefdd4f23e27bdd227ef6584703d587135d865bc4194bdb0c6b857bfa1302L100-R103), [link](https://github.com/coordinape/coordinape/pull/2563/files?diff=unified&w=0#diff-decbefdd4f23e27bdd227ef6584703d587135d865bc4194bdb0c6b857bfa1302L128-R131), [link](https://github.com/coordinape/coordinape/pull/2563/files?diff=unified&w=0#diff-a508bfd195b70991227d23f8972333b9fba1abbd498b8dfb0497e4963abb6f43L367-R341), [link](https://github.com/coordinape/coordinape/pull/2563/files?diff=unified&w=0#diff-a508bfd195b70991227d23f8972333b9fba1abbd498b8dfb0497e4963abb6f43L381-R355))
*  Replace `address` prop of `Link` component with `holder` or `target` field from transaction or notification, depending on the context ([link](https://github.com/coordinape/coordinape/pull/2563/files?diff=unified&w=0#diff-decbefdd4f23e27bdd227ef6584703d587135d865bc4194bdb0c6b857bfa1302L100-R103), [link](https://github.com/coordinape/coordinape/pull/2563/files?diff=unified&w=0#diff-decbefdd4f23e27bdd227ef6584703d587135d865bc4194bdb0c6b857bfa1302L128-R131), [link](https://github.com/coordinape/coordinape/pull/2563/files?diff=unified&w=0#diff-a508bfd195b70991227d23f8972333b9fba1abbd498b8dfb0497e4963abb6f43L381-R355))
*  Replace comparison of `address` fields from subqueries with comparison of `holder` and `target` fields from transaction, to check if sender and receiver are the same ([link](https://github.com/coordinape/coordinape/pull/2563/files?diff=unified&w=0#diff-decbefdd4f23e27bdd227ef6584703d587135d865bc4194bdb0c6b857bfa1302L115-R115))
*  Modify styling and content of `NotFound` and `PageContents` components, which are displayed when the user navigates to a non-existing route or profile, to be more clear and friendly ([link](https://github.com/coordinape/coordinape/pull/2563/files?diff=unified&w=0#diff-80d5747abfbf28a98e60466a4a8555e8e0267abbd5972107faf63253fa00f726L5-R20), [link](https://github.com/coordinape/coordinape/pull/2563/files?diff=unified&w=0#diff-cff4a8eedd6bc4e327e10f459d5d7120705b2ccbcf88abb2c175985ad128712cL216-R222))
*  Remove unused or commented out code from `NotificationsPage` component, such as the import and variable of `useNotificationCount` hook, the eslint comment, and some testing code ([link](https://github.com/coordinape/coordinape/pull/2563/files?diff=unified&w=0#diff-a508bfd195b70991227d23f8972333b9fba1abbd498b8dfb0497e4963abb6f43L1), [link](https://github.com/coordinape/coordinape/pull/2563/files?diff=unified&w=0#diff-a508bfd195b70991227d23f8972333b9fba1abbd498b8dfb0497e4963abb6f43L11-R10), [link](https://github.com/coordinape/coordinape/pull/2563/files?diff=unified&w=0#diff-a508bfd195b70991227d23f8972333b9fba1abbd498b8dfb0497e4963abb6f43L110-L111), [link](https://github.com/coordinape/coordinape/pull/2563/files?diff=unified&w=0#diff-a508bfd195b70991227d23f8972333b9fba1abbd498b8dfb0497e4963abb6f43L325-L343))
