### PR TITLE
sell link done was stuck, now it isnt

### DIFF
--- a/src/features/colinks/BuyButton.tsx
+++ b/src/features/colinks/BuyButton.tsx
@@ -44,7 +44,7 @@ export const BuyButton = ({
       }
     );
   };
-  const buyKey = async (e: React.MouseEvent<HTMLButtonElement>) => {
+  const buyLink = async (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
     e.preventDefault();
     try {
@@ -89,7 +89,7 @@ export const BuyButton = ({
   return (
     <Button
       size={size}
-      onClick={buyKey}
+      onClick={buyLink}
       color="cta"
       disabled={awaitingWallet || disabled}
     >

--- a/src/features/colinks/BuyOrSellCoLinks.tsx
+++ b/src/features/colinks/BuyOrSellCoLinks.tsx
@@ -134,7 +134,7 @@ export const BuyOrSellCoLinks = ({
       .catch(e => showError('Error getting supply: ' + e.message));
   }, [balance, coLinks]);
 
-  const sellKey = async () => {
+  const sellLink = async () => {
     try {
       assert(coLinks);
       assert(chainId);
@@ -153,6 +153,7 @@ export const BuyOrSellCoLinks = ({
         setProgress('Done!');
         refresh();
         await syncLinks();
+        setProgress('');
       } else if (error) {
         showError(error);
       } else {
@@ -249,7 +250,7 @@ export const BuyOrSellCoLinks = ({
                 }}
               >
                 <Button
-                  onClick={sellKey}
+                  onClick={sellLink}
                   disabled={
                     awaitingWallet || (supply == 1 && subjectIsCurrentUser)
                   }


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 54feb73</samp>

Renamed and refactored some functions in `BuyButton.tsx` and `BuyOrSellCoLinks.tsx` to enhance the co-links feature, which allows users to buy and sell links to circles.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 54feb73</samp>

> _`buyLink` function_
> _renamed and improved for co-links_
> _autumn leaves fall fast_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 54feb73</samp>

*  Rename `buyKey` and `sellKey` functions to `buyLink` and `sellLink` to match CoLinks terminology ([link](https://github.com/coordinape/coordinape/pull/2566/files?diff=unified&w=0#diff-d6f26158d90552085df407ea90a98fa03ff16b3ad6689ce3fa86824a3dde4e98L47-R47), [link](https://github.com/coordinape/coordinape/pull/2566/files?diff=unified&w=0#diff-d3e5d35d9664d8906b4f0deb056d55d6d3bc583514f25f98fed0728e0ccaa538L137-R137))
*  Update `onClick` props of `Button` components to use the renamed functions in `BuyButton.tsx` and `BuyOrSellCoLinks.tsx` ([link](https://github.com/coordinape/coordinape/pull/2566/files?diff=unified&w=0#diff-d6f26158d90552085df407ea90a98fa03ff16b3ad6689ce3fa86824a3dde4e98L92-R92), [link](https://github.com/coordinape/coordinape/pull/2566/files?diff=unified&w=0#diff-d3e5d35d9664d8906b4f0deb056d55d6d3bc583514f25f98fed0728e0ccaa538L252-R253))
*  Add `setProgress` function to reset progress state after transactions in `BuyOrSellCoLinks.tsx` ([link](https://github.com/coordinape/coordinape/pull/2566/files?diff=unified&w=0#diff-d3e5d35d9664d8906b4f0deb056d55d6d3bc583514f25f98fed0728e0ccaa538R156))
