### PR TITLE
Tos word; error info

### DIFF
--- a/src/features/colinks/wizard/WizardTerms.tsx
+++ b/src/features/colinks/wizard/WizardTerms.tsx
@@ -115,7 +115,7 @@ export const WizardTerms = ({
           </Text>
           <CheckBox
             value={termsAcceptChecked}
-            label={'I have read and accept the Terms of Service'}
+            label={'I have read the Terms of Service'}
             onChange={() => setTermsAcceptChecked(prev => !prev)}
           />
 

--- a/src/pages/AccountPage/EditProfileInfo.tsx
+++ b/src/pages/AccountPage/EditProfileInfo.tsx
@@ -130,6 +130,7 @@ const EditProfileInfoForm = ({
     control,
     handleSubmit,
     setError,
+    watch,
     formState: { isDirty, isValid },
   } = useForm<EditProfileNameFormSchema>({
     resolver: zodResolver(schema),
@@ -177,6 +178,13 @@ const EditProfileInfoForm = ({
 
     updateProfileMutation.mutate(params);
   };
+
+  const watchName = watch('name');
+  const nameIsEmpty = watchName === '' || watchName === undefined;
+  const watchDescription = watch('description');
+  const descriptionIsEmpty =
+    watchDescription === '' || watchDescription === undefined;
+  const bothEmpty = nameIsEmpty && descriptionIsEmpty;
 
   return (
     <Form
@@ -300,7 +308,7 @@ const EditProfileInfoForm = ({
             />
           </Flex>
         </Flex>
-        <Flex>
+        <Flex css={{ gap: '$sm' }}>
           <Button
             disabled={(!isDirty && !preloadProfile) || isSaving || !isValid}
             color="cta"
@@ -308,6 +316,13 @@ const EditProfileInfoForm = ({
           >
             Save
           </Button>
+          {(nameIsEmpty || descriptionIsEmpty) && (
+            <Text size="xs" color="warning">
+              Please fill out {nameIsEmpty && 'name'} {bothEmpty && 'and'}{' '}
+              {descriptionIsEmpty && 'description'} field
+              {bothEmpty && 's'}.
+            </Text>
+          )}
         </Flex>
       </Flex>
     </Form>


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f97d025</samp>

This pull request adds and updates features related to CoLinks, a service that allows users to create and explore links that generate income for themselves and The Coordinape Foundation. It introduces a terms of service gate for CoLinks users, a tooltip component to explain the fee calculation, and a new file with the CoLink creation instructions. It also improves the validation and feedback for the profile editing form, and adds a size prop to the `InfoTooltip` component.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f97d025</samp>

> _We're sailing on the CoLinks ship, we've got some work to do_
> _We're adding props and tooltips, and terms of service too_
> _We're watching fields and validating, we're formatting fees_
> _So heave away, me hearties, heave away on three_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f97d025</samp>

*  Add and modify components for the terms of service gate for CoLinks users ([link](https://github.com/coordinape/coordinape/pull/2568/files?diff=unified&w=0#diff-5a0d1c5c5cea7d47bbd9eb95dea66275810a95cc8728657ca3c1a4ed5b32e3e0R20), [link](https://github.com/coordinape/coordinape/pull/2568/files?diff=unified&w=0#diff-5a0d1c5c5cea7d47bbd9eb95dea66275810a95cc8728657ca3c1a4ed5b32e3e0R79), [link](https://github.com/coordinape/coordinape/pull/2568/files?diff=unified&w=0#diff-e61d18b18cd9086f171bfba2413b05a146cc4da1617cc414d7d573a00f752ed6L1-R6), [link](https://github.com/coordinape/coordinape/pull/2568/files?diff=unified&w=0#diff-e61d18b18cd9086f171bfba2413b05a146cc4da1617cc414d7d573a00f752ed6L37-R42), [link](https://github.com/coordinape/coordinape/pull/2568/files?diff=unified&w=0#diff-e61d18b18cd9086f171bfba2413b05a146cc4da1617cc414d7d573a00f752ed6R52-R60), [link](https://github.com/coordinape/coordinape/pull/2568/files?diff=unified&w=0#diff-63f364b78302c50c2609273b0048e5fbcb708cad342278bb4a1ff1b1285e5e17L2-R2), [link](https://github.com/coordinape/coordinape/pull/2568/files?diff=unified&w=0#diff-63f364b78302c50c2609273b0048e5fbcb708cad342278bb4a1ff1b1285e5e17L14-R14), [link](https://github.com/coordinape/coordinape/pull/2568/files?diff=unified&w=0#diff-63f364b78302c50c2609273b0048e5fbcb708cad342278bb4a1ff1b1285e5e17R31-R32), [link](https://github.com/coordinape/coordinape/pull/2568/files?diff=unified&w=0#diff-63f364b78302c50c2609273b0048e5fbcb708cad342278bb4a1ff1b1285e5e17L98-R105), [link](https://github.com/coordinape/coordinape/pull/2568/files?diff=unified&w=0#diff-63f364b78302c50c2609273b0048e5fbcb708cad342278bb4a1ff1b1285e5e17L106-R130)) in `src/features/auth/TermsGate.tsx`
