### PR TITLE
FIx nested a tags inside ColinksMember card

### DIFF
--- a/src/features/colinks/CoLinksStats.tsx
+++ b/src/features/colinks/CoLinksStats.tsx
@@ -1,7 +1,9 @@
 import { ComponentProps } from 'react';
 
+import { useNavigate } from 'react-router-dom';
+
 import { coLinksPaths } from '../../routes/paths';
-import { AppLink, Flex, Text } from '../../ui';
+import { Flex, Text } from '../../ui';
 import { CertificateLight, Links } from 'icons/__generated';
 
 export const CoLinksStats = ({
@@ -17,15 +19,18 @@ export const CoLinksStats = ({
   size?: ComponentProps<typeof Text>['size'];
   holdingCount: number;
 }) => {
+  const navigate = useNavigate();
   return (
     <Flex css={{ gap: size === 'xs' ? '$sm' : '$md' }}>
       <Text
-        as={AppLink}
-        to={coLinksPaths.score(address ?? '')}
         size={size}
         title={'Rep Score'}
         color={'secondary'}
         css={{ gap: '$xs' }}
+        onClick={e => {
+          e.preventDefault();
+          navigate(coLinksPaths.score(address ?? ''));
+        }}
       >
         <CertificateLight
           nostroke
@@ -40,9 +45,11 @@ export const CoLinksStats = ({
       <Text
         size={size}
         color={'secondary'}
-        as={AppLink}
         title={'Links'}
-        to={coLinksPaths.holders(address ?? '')}
+        onClick={e => {
+          e.preventDefault();
+          navigate(coLinksPaths.holders(address ?? ''));
+        }}
         css={{ gap: size === 'xs' ? '$xs' : '$sm' }}
       >
         <Links nostroke css={{ path: { fill: '$secondaryText' } }} />

--- a/src/features/colinks/SkillTag.tsx
+++ b/src/features/colinks/SkillTag.tsx
@@ -1,4 +1,4 @@
-import { NavLink } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import { coLinksPaths } from '../../routes/paths';
 import { CSS } from '../../stitches.config';
@@ -19,15 +19,16 @@ export const SkillTag = ({
   css?: CSS;
   active?: boolean;
 }) => {
-  const asTo = active
-    ? {}
-    : {
-        as: NavLink,
-        to: coLinksPaths.exploreSkill(skill),
-      };
+  const navigate = useNavigate();
+  const onClickSkillHandler = (
+    e: React.MouseEvent<HTMLSpanElement, MouseEvent>
+  ) => {
+    e.preventDefault();
+    navigate(coLinksPaths.exploreSkill(skill));
+  };
   return (
     <Text
-      {...asTo}
+      onClick={active ? undefined : onClickSkillHandler}
       size={size === 'large' ? 'large' : size === 'small' ? 'xs' : undefined}
       key={skill}
       tag
@@ -40,6 +41,7 @@ export const SkillTag = ({
         textDecoration: 'none',
         justifyContent: 'space-between',
         '&:hover': { opacity: 1 },
+        cursor: active ? 'auto' : 'pointer',
       }}
     >
       <Text semibold ellipsis css={{ flexShrink: 1, textDecoration: 'none' }}>

--- a/src/features/colinks/wizard/WizardTerms.tsx
+++ b/src/features/colinks/wizard/WizardTerms.tsx
@@ -16,7 +16,7 @@ import { Button, CheckBox, Flex, Link, Text } from 'ui';
 import { WizardInstructions } from './WizardInstructions';
 import { fullScreenStyles } from './WizardSteps';
 
-export const TOS_UPDATED_AT = '2023-11-30';
+export const TOS_UPDATED_AT = '2023-12-14';
 
 export const WizardTerms = ({
   setTermsAccepted,


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5c5c7a4</samp>

Refactored a component to use a new navigation hook and improved its compatibility, accessibility, and performance.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5c5c7a4</samp>

> _We're breaking free from the old ways_
> _We're using hooks to navigate_
> _We're faster, stronger, more accessible_
> _We're the CoLinksStats of fate_


## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5c5c7a4</samp>

* Refactor navigation to use `useNavigate` hook from `react-router-dom` v6 and avoid unnecessary re-rendering of components ([link](https://github.com/coordinape/coordinape/pull/2569/files?diff=unified&w=0#diff-6a600b37cfcb484be00a1f5b3fcfad5f3af81b786fce4319caa16866aa9a3b2dL3-R6), [link](https://github.com/coordinape/coordinape/pull/2569/files?diff=unified&w=0#diff-6a600b37cfcb484be00a1f5b3fcfad5f3af81b786fce4319caa16866aa9a3b2dL20-R33), [link](https://github.com/coordinape/coordinape/pull/2569/files?diff=unified&w=0#diff-6a600b37cfcb484be00a1f5b3fcfad5f3af81b786fce4319caa16866aa9a3b2dL43-R52))
* Replace `as` and `to` props with `onClick` prop on `Text` components that display rep score and links count in `CoLinksStats.tsx` ([link](https://github.com/coordinape/coordinape/pull/2569/files?diff=unified&w=0#diff-6a600b37cfcb484be00a1f5b3fcfad5f3af81b786fce4319caa16866aa9a3b2dL20-R33), [link](https://github.com/coordinape/coordinape/pull/2569/files?diff=unified&w=0#diff-6a600b37cfcb484be00a1f5b3fcfad5f3af81b786fce4319caa16866aa9a3b2dL43-R52))
* Improve accessibility and performance of `Text` components by not rendering anchor elements and using `useNavigate` hook to navigate to score and holders pages ([link](https://github.com/coordinape/coordinape/pull/2569/files?diff=unified&w=0#diff-6a600b37cfcb484be00a1f5b3fcfad5f3af81b786fce4319caa16866aa9a3b2dL20-R33), [link](https://github.com/coordinape/coordinape/pull/2569/files?diff=unified&w=0#diff-6a600b37cfcb484be00a1f5b3fcfad5f3af81b786fce4319caa16866aa9a3b2dL43-R52))
