### PR TITLE
no-profile styles

### DIFF
--- a/src/pages/colinks/NotFound.tsx
+++ b/src/pages/colinks/NotFound.tsx
@@ -1,3 +1,4 @@
+import { CSS } from '@stitches/react';
 import { WizardInstructions } from 'features/colinks/wizard/WizardInstructions';
 import { fullScreenStyles } from 'features/colinks/wizard/WizardSteps';
 
@@ -7,10 +8,14 @@ export const NotFound = ({
   header = '404 Not Found',
   children,
   backgroundImage = '/imgs/background/colink-404.jpg',
+  imageCss,
+  gradientCss,
 }: {
   header?: string;
   children?: React.ReactNode;
   backgroundImage?: string;
+  imageCss?: CSS;
+  gradientCss?: CSS;
 }) => {
   return (
     <>
@@ -38,6 +43,7 @@ export const NotFound = ({
             width: '100%',
             background:
               'radial-gradient(circle, #E3A102 10%, #5D778F 68%, #2D3C49 83%, #C1D5E1 100%)',
+            ...gradientCss,
           }}
         />
         <Flex
@@ -49,6 +55,7 @@ export const NotFound = ({
             animationDirection: 'alternate',
             backgroundImage: `url(${backgroundImage})`,
             backgroundPosition: '50% 50% ',
+            ...imageCss,
           }}
         />
       </Flex>

--- a/src/pages/colinks/ViewProfilePage/ViewProfilePageContents.tsx
+++ b/src/pages/colinks/ViewProfilePage/ViewProfilePageContents.tsx
@@ -208,27 +208,25 @@ const PageContents = ({
       <NotFound
         header={'No Profile Found'}
         backgroundImage={'/imgs/background/colink-no-profile.jpg'}
+        imageCss={{ backgroundPosition: '50% 100%' }}
+        gradientCss={{
+          background:
+            'radial-gradient(circle, #FA81B7 10%, #5D778F 68%, #2D3C49 83%, #C1D5E1 100%)',
+        }}
       >
-        <Text
-          inline
-          css={{
-            display: 'flex-column',
-          }}
-        >
-          It seems this address
-          <br />
+        <Flex column css={{ alignItems: 'flex-start' }}>
+          <Text>It seems this address</Text>
           <Text
             tag
             color={'neutral'}
             css={{
               my: '$xs',
-              display: 'flex-column',
             }}
           >
-            {shortenAddressWithFrontLength(targetAddress, 16)}{' '}
+            {shortenAddressWithFrontLength(targetAddress, 6)}{' '}
           </Text>
-          does not have a profile on CoLinks yet.
-        </Text>
+          <Text>does not have a profile on CoLinks yet.</Text>
+        </Flex>
       </NotFound>
     );
   }


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4f3ea07</samp>

Improved the appearance and customization of the `NotFound` component and the colinks profile page. Added new CSS props to `NotFound` and used them in `ViewProfilePageContents.tsx` to adjust the background and overlay styles. Also refined the text layout and formatting of the profile page.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4f3ea07</samp>

> _To style the `NotFound` component_
> _We added some props to augment_
> _The `css` of `Box`_
> _With image and gradient_
> _And tweaked the profile page content_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4f3ea07</samp>

*  Add `imageCss` and `gradientCss` props to `NotFound` component to customize background image and gradient overlay styles ([link](https://github.com/coordinape/coordinape/pull/2570/files?diff=unified&w=0#diff-80d5747abfbf28a98e60466a4a8555e8e0267abbd5972107faf63253fa00f726R1), [link](https://github.com/coordinape/coordinape/pull/2570/files?diff=unified&w=0#diff-80d5747abfbf28a98e60466a4a8555e8e0267abbd5972107faf63253fa00f726L10-R18), [link](https://github.com/coordinape/coordinape/pull/2570/files?diff=unified&w=0#diff-80d5747abfbf28a98e60466a4a8555e8e0267abbd5972107faf63253fa00f726R46), [link](https://github.com/coordinape/coordinape/pull/2570/files?diff=unified&w=0#diff-80d5747abfbf28a98e60466a4a8555e8e0267abbd5972107faf63253fa00f726R58))
*  Use `imageCss` and `gradientCss` props in `PageContents` component in `src/pages/colinks/ViewProfilePage/ViewProfilePageContents.tsx` to adjust background position and color ([link](https://github.com/coordinape/coordinape/pull/2570/files?diff=unified&w=0#diff-cff4a8eedd6bc4e327e10f459d5d7120705b2ccbcf88abb2c175985ad128712cL211-R218))
*  Refactor text elements in `PageContents` component to use `Flex` component with `column` direction and `flex-start` alignment, and shorten address length to 6 characters ([link](https://github.com/coordinape/coordinape/pull/2570/files?diff=unified&w=0#diff-cff4a8eedd6bc4e327e10f459d5d7120705b2ccbcf88abb2c175985ad128712cL225-R229))
