### PR TITLE
split post search to separate query, fix width and pointer stuff

### DIFF
--- a/hasura/migrations/default/1702627676015_alter_search_contributions_add_private_stream_filter/down.sql
+++ b/hasura/migrations/default/1702627676015_alter_search_contributions_add_private_stream_filter/down.sql
@@ -1,0 +1,16 @@
+
+
+CREATE OR REPLACE FUNCTION search_contributions(
+    search TEXT,
+    result_limit INT
+)
+RETURNS SETOF contributions
+AS $$
+    SELECT *
+    FROM contributions
+    WHERE search <% description
+    ORDER BY similarity(search, description) DESC
+    LIMIT result_limit;
+$$
+LANGUAGE sql STABLE;
+

--- a/hasura/migrations/default/1702627676015_alter_search_contributions_add_private_stream_filter/up.sql
+++ b/hasura/migrations/default/1702627676015_alter_search_contributions_add_private_stream_filter/up.sql
@@ -1,0 +1,13 @@
+CREATE OR REPLACE FUNCTION search_contributions(
+    search TEXT, 
+    result_limit INT
+) 
+RETURNS SETOF contributions 
+AS $$
+    SELECT * 
+    FROM contributions 
+    WHERE private_stream=true AND search <% description
+    ORDER BY similarity(search, description) DESC 
+    LIMIT result_limit; 
+$$ 
+LANGUAGE sql STABLE;

--- a/src/features/SearchBox/SearchResults.tsx
+++ b/src/features/SearchBox/SearchResults.tsx
@@ -206,7 +206,12 @@ export const SearchResults = ({
                     name={post.profile_public?.name}
                     path={post.profile_public?.avatar}
                   />
-                  <Flex column>
+                  <Flex
+                    column
+                    css={{
+                      width: '100%',
+                    }}
+                  >
                     <Flex
                       css={{
                         justifyContent: 'space-between',

--- a/src/features/SearchBox/SearchResults.tsx
+++ b/src/features/SearchBox/SearchResults.tsx
@@ -12,12 +12,14 @@ import { coLinksPaths } from '../../routes/paths';
 import { Avatar, Flex, Text } from '../../ui';
 import { SkillTag } from '../colinks/SkillTag';
 
+import { fetchPostSearchResults } from './fetchPostSearchResults';
 import { fetchSearchResults } from './fetchSearchResults';
 import { fetchSimilarityResults } from './fetchSimilarityResults';
 import { PeopleResult } from './PeopleResult';
 import { SearchBoxPages } from './SearchBoxPages';
 
 const QUERY_KEY_SEARCH = 'searchBoxQuery';
+const QUERY_KEY_SEARCH_POSTS = 'searchBoxQueryPosts';
 
 export const SearchResults = ({
   setPopoverOpen,
@@ -57,6 +59,16 @@ export const SearchResults = ({
             ? { _ilike: `%${debouncedSearch}%` }
             : undefined,
         },
+      }),
+    {
+      // staleTime: Infinity,
+    }
+  );
+
+  const { data: postResults } = useQuery(
+    [QUERY_KEY_SEARCH_POSTS, JSON.stringify(debouncedSearch)],
+    () =>
+      fetchPostSearchResults({
         search: debouncedSearch,
       }),
     {
@@ -192,7 +204,7 @@ export const SearchResults = ({
           )}
           {debouncedSearch !== '' && (
             <Command.Group heading={'Posts'}>
-              {results?.posts?.map(post => (
+              {postResults?.posts?.map(post => (
                 <Command.Item
                   key={`${post.id}`}
                   value={`${post.id}`}

--- a/src/features/SearchBox/fetchPostSearchResults.ts
+++ b/src/features/SearchBox/fetchPostSearchResults.ts
@@ -1,0 +1,41 @@
+import { order_by } from '../../lib/gql/__generated__/zeus';
+import { client } from '../../lib/gql/client';
+
+export const fetchPostSearchResults = async ({
+  search,
+}: // contributionsWhere,
+{
+  search?: string;
+  // contributionsWhere?: ProfilesWhere;
+}) => {
+  const { search_contributions } = await client.query(
+    {
+      search_contributions: [
+        {
+          args: {
+            search: search,
+            result_limit: 5,
+          },
+          order_by: [{ created_at: order_by.desc }],
+          // where: {
+          //   ...contributionsWhere,
+          // },
+        },
+        {
+          id: true,
+          description: true,
+          created_at: true,
+          profile_public: {
+            name: true,
+            avatar: true,
+            address: true,
+          },
+        },
+      ],
+    },
+    {
+      operationName: 'searchBoxQueryPosts',
+    }
+  );
+  return { posts: search_contributions };
+};

--- a/src/features/SearchBox/fetchSearchResults.ts
+++ b/src/features/SearchBox/fetchSearchResults.ts
@@ -7,15 +7,13 @@ type SkillsWhere = ValueTypes['skills_bool_exp'];
 export const fetchSearchResults = async ({
   where,
   skillsWhere,
-  search,
 }: // contributionsWhere,
 {
   where: ProfilesWhere;
   skillsWhere: SkillsWhere;
-  search?: string;
   // contributionsWhere?: ProfilesWhere;
 }) => {
-  const { profiles_public, skills, search_contributions } = await client.query(
+  const { profiles_public, skills } = await client.query(
     {
       profiles_public: [
         {
@@ -48,32 +46,10 @@ export const fetchSearchResults = async ({
           count: true,
         },
       ],
-      search_contributions: [
-        {
-          args: {
-            search: search,
-            result_limit: 5,
-          },
-          order_by: [{ created_at: order_by.desc }],
-          // where: {
-          //   ...contributionsWhere,
-          // },
-        },
-        {
-          id: true,
-          description: true,
-          created_at: true,
-          profile_public: {
-            name: true,
-            avatar: true,
-            address: true,
-          },
-        },
-      ],
     },
     {
       operationName: 'searchBoxQuery',
     }
   );
-  return { profiles_public, interests: skills, posts: search_contributions };
+  return { profiles_public, interests: skills };
 };

--- a/src/features/colinks/CoLinksStats.tsx
+++ b/src/features/colinks/CoLinksStats.tsx
@@ -26,7 +26,7 @@ export const CoLinksStats = ({
         size={size}
         title={'Rep Score'}
         color={'secondary'}
-        css={{ gap: '$xs' }}
+        css={{ gap: '$xs', cursor: 'pointer' }}
         onClick={e => {
           e.preventDefault();
           navigate(coLinksPaths.score(address ?? ''));
@@ -50,7 +50,7 @@ export const CoLinksStats = ({
           e.preventDefault();
           navigate(coLinksPaths.holders(address ?? ''));
         }}
-        css={{ gap: size === 'xs' ? '$xs' : '$sm' }}
+        css={{ gap: size === 'xs' ? '$xs' : '$sm', cursor: 'pointer' }}
       >
         <Links nostroke css={{ path: { fill: '$secondaryText' } }} />
         <Text semibold size={size}>


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at fe6f68f</samp>

Improved the UI and layout of the search results for profiles and circles by adding cursor feedback, fixing content overflow, and using Radix UI components. Affected files: `CoLinksStats.tsx` and `SearchResults.tsx`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at fe6f68f</samp>

> _We search for the truth in the dark web of lies_
> _We flex our style and align with our allies_
> _We point our cursor to the ones who defy_
> _We co-link our stats and we make them cry_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at fe6f68f</samp>

*  Add rep score and holders stats to the search results for profiles and circles ([link](https://github.com/coordinape/coordinape/pull/2575/files?diff=unified&w=0#diff-6a600b37cfcb484be00a1f5b3fcfad5f3af81b786fce4319caa16866aa9a3b2dL29-R29), [link](https://github.com/coordinape/coordinape/pull/2575/files?diff=unified&w=0#diff-6a600b37cfcb484be00a1f5b3fcfad5f3af81b786fce4319caa16866aa9a3b2dL53-R53))
* Refactor the SearchResults component to use the Flex and Box components from the Radix UI library ([link](https://github.com/coordinape/coordinape/pull/2575/files?diff=unified&w=0#diff-07bd162f355d11eaf210cfd19dd94e9145ba4817e7cf513501b39850cbfae040L209-R214))
