### PR TITLE
search posts return activity id instead of contribution id

### DIFF
--- a/api-lib/gql/__generated__/zeus/const.ts
+++ b/api-lib/gql/__generated__/zeus/const.ts
@@ -2066,6 +2066,7 @@ export const AllTypesProps: Record<string, any> = {
     _and: 'contributions_bool_exp',
     _not: 'contributions_bool_exp',
     _or: 'contributions_bool_exp',
+    activity: 'activities_bool_exp',
     circle: 'circles_bool_exp',
     circle_id: 'bigint_comparison_exp',
     created_at: 'timestamptz_comparison_exp',
@@ -2093,6 +2094,7 @@ export const AllTypesProps: Record<string, any> = {
     user_id: 'bigint',
   },
   contributions_insert_input: {
+    activity: 'activities_obj_rel_insert_input',
     circle: 'circles_obj_rel_insert_input',
     circle_id: 'bigint',
     created_at: 'timestamptz',
@@ -2139,6 +2141,7 @@ export const AllTypesProps: Record<string, any> = {
     where: 'contributions_bool_exp',
   },
   contributions_order_by: {
+    activity: 'activities_order_by',
     circle: 'circles_order_by',
     circle_id: 'order_by',
     created_at: 'order_by',
@@ -14699,6 +14702,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'Float',
   },
   contributions: {
+    activity: 'activities',
     circle: 'circles',
     circle_id: 'bigint',
     created_at: 'timestamptz',

--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -5802,6 +5802,8 @@ export type ValueTypes = {
   /** columns and relationships of "contributions" */
   ['contributions']: AliasType<{
     /** An object relationship */
+    activity?: ValueTypes['activities'];
+    /** An object relationship */
     circle?: ValueTypes['circles'];
     circle_id?: boolean | `@${string}`;
     created_at?: boolean | `@${string}`;
@@ -5986,6 +5988,7 @@ export type ValueTypes = {
     _and?: Array<ValueTypes['contributions_bool_exp']> | undefined | null;
     _not?: ValueTypes['contributions_bool_exp'] | undefined | null;
     _or?: Array<ValueTypes['contributions_bool_exp']> | undefined | null;
+    activity?: ValueTypes['activities_bool_exp'] | undefined | null;
     circle?: ValueTypes['circles_bool_exp'] | undefined | null;
     circle_id?: ValueTypes['bigint_comparison_exp'] | undefined | null;
     created_at?: ValueTypes['timestamptz_comparison_exp'] | undefined | null;
@@ -6027,6 +6030,7 @@ export type ValueTypes = {
   };
   /** input type for inserting data into table "contributions" */
   ['contributions_insert_input']: {
+    activity?: ValueTypes['activities_obj_rel_insert_input'] | undefined | null;
     circle?: ValueTypes['circles_obj_rel_insert_input'] | undefined | null;
     circle_id?: ValueTypes['bigint'] | undefined | null;
     created_at?: ValueTypes['timestamptz'] | undefined | null;
@@ -6125,6 +6129,7 @@ export type ValueTypes = {
   };
   /** Ordering options when selecting data from "contributions". */
   ['contributions_order_by']: {
+    activity?: ValueTypes['activities_order_by'] | undefined | null;
     circle?: ValueTypes['circles_order_by'] | undefined | null;
     circle_id?: ValueTypes['order_by'] | undefined | null;
     created_at?: ValueTypes['order_by'] | undefined | null;
@@ -40059,6 +40064,8 @@ export type ModelTypes = {
   /** columns and relationships of "contributions" */
   ['contributions']: {
     /** An object relationship */
+    activity?: GraphQLTypes['activities'] | undefined;
+    /** An object relationship */
     circle?: GraphQLTypes['circles'] | undefined;
     circle_id?: GraphQLTypes['bigint'] | undefined;
     created_at: GraphQLTypes['timestamptz'];
@@ -55824,6 +55831,8 @@ export type GraphQLTypes = {
   ['contributions']: {
     __typename: 'contributions';
     /** An object relationship */
+    activity?: GraphQLTypes['activities'] | undefined;
+    /** An object relationship */
     circle?: GraphQLTypes['circles'] | undefined;
     circle_id?: GraphQLTypes['bigint'] | undefined;
     created_at: GraphQLTypes['timestamptz'];
@@ -55938,6 +55947,7 @@ export type GraphQLTypes = {
     _and?: Array<GraphQLTypes['contributions_bool_exp']> | undefined;
     _not?: GraphQLTypes['contributions_bool_exp'] | undefined;
     _or?: Array<GraphQLTypes['contributions_bool_exp']> | undefined;
+    activity?: GraphQLTypes['activities_bool_exp'] | undefined;
     circle?: GraphQLTypes['circles_bool_exp'] | undefined;
     circle_id?: GraphQLTypes['bigint_comparison_exp'] | undefined;
     created_at?: GraphQLTypes['timestamptz_comparison_exp'] | undefined;
@@ -55973,6 +55983,7 @@ export type GraphQLTypes = {
   };
   /** input type for inserting data into table "contributions" */
   ['contributions_insert_input']: {
+    activity?: GraphQLTypes['activities_obj_rel_insert_input'] | undefined;
     circle?: GraphQLTypes['circles_obj_rel_insert_input'] | undefined;
     circle_id?: GraphQLTypes['bigint'] | undefined;
     created_at?: GraphQLTypes['timestamptz'] | undefined;
@@ -56068,6 +56079,7 @@ export type GraphQLTypes = {
   };
   /** Ordering options when selecting data from "contributions". */
   ['contributions_order_by']: {
+    activity?: GraphQLTypes['activities_order_by'] | undefined;
     circle?: GraphQLTypes['circles_order_by'] | undefined;
     circle_id?: GraphQLTypes['order_by'] | undefined;
     created_at?: GraphQLTypes['order_by'] | undefined;

--- a/hasura/metadata/databases/default/tables/public_contributions.yaml
+++ b/hasura/metadata/databases/default/tables/public_contributions.yaml
@@ -2,6 +2,15 @@ table:
   name: contributions
   schema: public
 object_relationships:
+  - name: activity
+    using:
+      manual_configuration:
+        column_mapping:
+          id: contribution_id
+        insertion_order: null
+        remote_table:
+          name: activities
+          schema: public
   - name: circle
     using:
       foreign_key_constraint_on: circle_id

--- a/hasura/schema/admin/schema.graphql
+++ b/hasura/schema/admin/schema.graphql
@@ -7704,6 +7704,11 @@ type contributions {
   """
   An object relationship
   """
+  activity: activities
+
+  """
+  An object relationship
+  """
   circle: circles
   circle_id: bigint
   created_at: timestamptz!
@@ -7905,6 +7910,7 @@ input contributions_bool_exp {
   _and: [contributions_bool_exp!]
   _not: contributions_bool_exp
   _or: [contributions_bool_exp!]
+  activity: activities_bool_exp
   circle: circles_bool_exp
   circle_id: bigint_comparison_exp
   created_at: timestamptz_comparison_exp
@@ -7948,6 +7954,7 @@ input contributions_inc_input {
 input type for inserting data into table "contributions"
 """
 input contributions_insert_input {
+  activity: activities_obj_rel_insert_input
   circle: circles_obj_rel_insert_input
   circle_id: bigint
   created_at: timestamptz
@@ -8066,6 +8073,7 @@ input contributions_on_conflict {
 Ordering options when selecting data from "contributions".
 """
 input contributions_order_by {
+  activity: activities_order_by
   circle: circles_order_by
   circle_id: order_by
   created_at: order_by

--- a/hasura/schema/user/schema.graphql
+++ b/hasura/schema/user/schema.graphql
@@ -4082,6 +4082,11 @@ type contributions {
   """
   An object relationship
   """
+  activity: activities
+
+  """
+  An object relationship
+  """
   circle: circles
   circle_id: bigint
   created_at: timestamptz!
@@ -4207,6 +4212,7 @@ input contributions_bool_exp {
   _and: [contributions_bool_exp!]
   _not: contributions_bool_exp
   _or: [contributions_bool_exp!]
+  activity: activities_bool_exp
   circle: circles_bool_exp
   circle_id: bigint_comparison_exp
   created_at: timestamptz_comparison_exp
@@ -4322,6 +4328,7 @@ input contributions_on_conflict {
 Ordering options when selecting data from "contributions".
 """
 input contributions_order_by {
+  activity: activities_order_by
   circle: circles_order_by
   circle_id: order_by
   created_at: order_by

--- a/src/features/SearchBox/SearchResults.tsx
+++ b/src/features/SearchBox/SearchResults.tsx
@@ -206,8 +206,8 @@ export const SearchResults = ({
             <Command.Group heading={'Posts'}>
               {postResults?.posts?.map(post => (
                 <Command.Item
-                  key={`${post.id}`}
-                  value={`${post.id}`}
+                  key={`${post.activity?.id}`}
+                  value={`${post.activity?.id}`}
                   onSelect={id => {
                     onSelectPost(id);
                     setPopoverOpen(false);

--- a/src/features/SearchBox/fetchPostSearchResults.ts
+++ b/src/features/SearchBox/fetchPostSearchResults.ts
@@ -22,7 +22,9 @@ export const fetchPostSearchResults = async ({
           // },
         },
         {
-          id: true,
+          activity: {
+            id: true,
+          },
           description: true,
           created_at: true,
           profile_public: {

--- a/src/lib/gql/__generated__/zeus/const.ts
+++ b/src/lib/gql/__generated__/zeus/const.ts
@@ -1328,6 +1328,7 @@ export const AllTypesProps: Record<string, any> = {
     _and: 'contributions_bool_exp',
     _not: 'contributions_bool_exp',
     _or: 'contributions_bool_exp',
+    activity: 'activities_bool_exp',
     circle: 'circles_bool_exp',
     circle_id: 'bigint_comparison_exp',
     created_at: 'timestamptz_comparison_exp',
@@ -1371,6 +1372,7 @@ export const AllTypesProps: Record<string, any> = {
     where: 'contributions_bool_exp',
   },
   contributions_order_by: {
+    activity: 'activities_order_by',
     circle: 'circles_order_by',
     circle_id: 'order_by',
     created_at: 'order_by',
@@ -8188,6 +8190,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'bigint',
   },
   contributions: {
+    activity: 'activities',
     circle: 'circles',
     circle_id: 'bigint',
     created_at: 'timestamptz',

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -3471,6 +3471,8 @@ export type ValueTypes = {
   /** columns and relationships of "contributions" */
   ['contributions']: AliasType<{
     /** An object relationship */
+    activity?: ValueTypes['activities'];
+    /** An object relationship */
     circle?: ValueTypes['circles'];
     circle_id?: boolean | `@${string}`;
     created_at?: boolean | `@${string}`;
@@ -3593,6 +3595,7 @@ export type ValueTypes = {
     _and?: Array<ValueTypes['contributions_bool_exp']> | undefined | null;
     _not?: ValueTypes['contributions_bool_exp'] | undefined | null;
     _or?: Array<ValueTypes['contributions_bool_exp']> | undefined | null;
+    activity?: ValueTypes['activities_bool_exp'] | undefined | null;
     circle?: ValueTypes['circles_bool_exp'] | undefined | null;
     circle_id?: ValueTypes['bigint_comparison_exp'] | undefined | null;
     created_at?: ValueTypes['timestamptz_comparison_exp'] | undefined | null;
@@ -3680,6 +3683,7 @@ export type ValueTypes = {
   };
   /** Ordering options when selecting data from "contributions". */
   ['contributions_order_by']: {
+    activity?: ValueTypes['activities_order_by'] | undefined | null;
     circle?: ValueTypes['circles_order_by'] | undefined | null;
     circle_id?: ValueTypes['order_by'] | undefined | null;
     created_at?: ValueTypes['order_by'] | undefined | null;
@@ -19706,6 +19710,8 @@ export type ModelTypes = {
   /** columns and relationships of "contributions" */
   ['contributions']: {
     /** An object relationship */
+    activity?: GraphQLTypes['activities'] | undefined;
+    /** An object relationship */
     circle?: GraphQLTypes['circles'] | undefined;
     circle_id?: GraphQLTypes['bigint'] | undefined;
     created_at: GraphQLTypes['timestamptz'];
@@ -26625,6 +26631,8 @@ export type GraphQLTypes = {
   ['contributions']: {
     __typename: 'contributions';
     /** An object relationship */
+    activity?: GraphQLTypes['activities'] | undefined;
+    /** An object relationship */
     circle?: GraphQLTypes['circles'] | undefined;
     circle_id?: GraphQLTypes['bigint'] | undefined;
     created_at: GraphQLTypes['timestamptz'];
@@ -26725,6 +26733,7 @@ export type GraphQLTypes = {
     _and?: Array<GraphQLTypes['contributions_bool_exp']> | undefined;
     _not?: GraphQLTypes['contributions_bool_exp'] | undefined;
     _or?: Array<GraphQLTypes['contributions_bool_exp']> | undefined;
+    activity?: GraphQLTypes['activities_bool_exp'] | undefined;
     circle?: GraphQLTypes['circles_bool_exp'] | undefined;
     circle_id?: GraphQLTypes['bigint_comparison_exp'] | undefined;
     created_at?: GraphQLTypes['timestamptz_comparison_exp'] | undefined;
@@ -26808,6 +26817,7 @@ export type GraphQLTypes = {
   };
   /** Ordering options when selecting data from "contributions". */
   ['contributions_order_by']: {
+    activity?: GraphQLTypes['activities_order_by'] | undefined;
     circle?: GraphQLTypes['circles_order_by'] | undefined;
     circle_id?: GraphQLTypes['order_by'] | undefined;
     created_at?: GraphQLTypes['order_by'] | undefined;


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 61015af</samp>

This pull request adds a new `activity` field to various GraphQL types, inputs, and queries to enable tracking and displaying user actions on the platform. The `activity` field references a new `activities` table in the Hasura database, which is configured in the Hasura metadata files. The React frontend is updated to use the `activity` field in the search box feature.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 61015af</samp>

> _`Activity` is the mark of the beast_
> _Tracking every move on the platform_
> _We are the rebels, we won't be traced_
> _We'll smash the `activities` table with our wrath_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 61015af</samp>

*  Add the `activity` field to the `contributions` table and type to store and query the user actions on the platform ([link](https://github.com/coordinape/coordinape/pull/2576/files?diff=unified&w=0#diff-bacfab372512e82ec75f7dee295fc59f40cf4f14afef1c55021ca775a6e457c0R5-R13), [link](https://github.com/coordinape/coordinape/pull/2576/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R7707-R7711), [link](https://github.com/coordinape/coordinape/pull/2576/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebR4085-R4089))
*  Add the `activity` field to the `AllTypesProps` and `ReturnTypes` types in the `zeus/const.ts` files to provide TypeScript types for GraphQL queries involving the `activities` table ([link](https://github.com/coordinape/coordinape/pull/2576/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R2069), [link](https://github.com/coordinape/coordinape/pull/2576/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R2097), [link](https://github.com/coordinape/coordinape/pull/2576/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R2144), [link](https://github.com/coordinape/coordinape/pull/2576/files?diff=unified&w=0#diff-a2ee1f3a6d4e74be41fc939d9b4741c41904c9aba640b6cd0e879bb54d0822f0R14705), [link](https://github.com/coordinape/coordinape/pull/2576/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060R1331), [link](https://github.com/coordinape/coordinape/pull/2576/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060R1375), [link](https://github.com/coordinape/coordinape/pull/2576/files?diff=unified&w=0#diff-59431741d41d2d93c621efe127df0776fc0f78ea9bab64b60cf7418e9f01f060R8193))
*  Add the `activity` field to the input types in the `schema.graphql` files to enable filtering, ordering, and inserting rows in the `activities` table ([link](https://github.com/coordinape/coordinape/pull/2576/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R7913), [link](https://github.com/coordinape/coordinape/pull/2576/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R7957), [link](https://github.com/coordinape/coordinape/pull/2576/files?diff=unified&w=0#diff-85e7c26aa7c1055bc40e9fd67dfd49ad95964c817816aad24829f3bb1e8ec5a8R8076), [link](https://github.com/coordinape/coordinape/pull/2576/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebR4215), [link](https://github.com/coordinape/coordinape/pull/2576/files?diff=unified&w=0#diff-8435c41f5069c32f84a110adf7ca73963708315c24f4aabdb0285e87471676ebR4331))
*  Modify the `fetchSearchResults` function and the `SearchResults` component to use the `activity` field instead of the `id` field of the `post` object ([link](https://github.com/coordinape/coordinape/pull/2576/files?diff=unified&w=0#diff-b0e8a4963aeca5f48a46539f90adfffc31dfc07b5694e4e10a0f307fb929dce6L63-R67), [link](https://github.com/coordinape/coordinape/pull/2576/files?diff=unified&w=0#diff-07bd162f355d11eaf210cfd19dd94e9145ba4817e7cf513501b39850cbfae040L197-R198))
