### PR TITLE
Fix rep score bug

### DIFF
--- a/src/features/rep/api/updateRepScore.ts
+++ b/src/features/rep/api/updateRepScore.ts
@@ -36,7 +36,9 @@ export const updateRepScoreForAddress = async (address: string) => {
 };
 
 export const updateRepScore = async (profileId: number) => {
-  const score = await getRepScore(profileId);
+  // ignore total rep score when inserting
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { total: _total_score, ...scores } = await getRepScore(profileId);
 
   const { insert_reputation_scores_one } = await adminClient.mutate(
     {
@@ -44,7 +46,7 @@ export const updateRepScore = async (profileId: number) => {
         {
           object: {
             profile_id: profileId,
-            ...score,
+            ...scores,
           },
           on_conflict: {
             constraint: reputation_scores_constraint.reputation_scores_pkey,
@@ -72,5 +74,5 @@ export const updateRepScore = async (profileId: number) => {
     }
   );
   assert(insert_reputation_scores_one);
-  return score;
+  return scores;
 };


### PR DESCRIPTION
## What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d1b13e1</samp>

Simplify reputation score data model by removing `total` score from `updateRepScore` function and database.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d1b13e1</samp>

> _`updateRepScore` changed_
> _No more `total` in database_
> _Simpler data, like spring_

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d1b13e1</samp>

*  Destructure `total` score from `score` object and assign the rest to `scores` variable ([link](https://github.com/coordinape/coordinape/pull/2577/files?diff=unified&w=0#diff-764988b09edc0707d406224677aa97a66629d73fdadc033ff158ac99ba8b9caeL39-R41))
