### PR TITLE
overflow bug squash in markdown and skill tags

### DIFF
--- a/src/features/colinks/RecentCoLinkTransactions.tsx
+++ b/src/features/colinks/RecentCoLinkTransactions.tsx
@@ -137,11 +137,17 @@ export const Transaction = ({ tx }: { tx: LinkTx }) => {
             link{tx.link_amount === '1' ? '' : 's'}
           </Text>
         </Box>
-        <Flex css={{ justifyContent: 'flex-start' }}>
+        <Flex
+          css={{
+            justifyContent: 'flex-start',
+            flexWrap: 'wrap',
+            columnGap: '$xs',
+          }}
+        >
           <Text size="xs" semibold color={tx.buy ? 'complete' : 'warning'}>
             {ethers.utils.formatEther(tx.eth_amount)} ETH
           </Text>
-          <Text size="xs" color="neutral" css={{ pl: '$sm' }}>
+          <Text size="xs" color="neutral">
             {DateTime.fromISO(tx.created_at).toLocal().toRelative()}
           </Text>
         </Flex>

--- a/src/features/colinks/SkillTag.tsx
+++ b/src/features/colinks/SkillTag.tsx
@@ -41,6 +41,7 @@ export const SkillTag = ({
         justifyContent: 'space-between',
         '&:hover': { opacity: 1 },
         cursor: active ? 'auto' : 'pointer',
+        maxWidth: '11rem',
       }}
     >
       <Text semibold ellipsis css={{ flexShrink: 1, textDecoration: 'none' }}>

--- a/src/pages/colinks/ExplorePage.tsx
+++ b/src/pages/colinks/ExplorePage.tsx
@@ -52,9 +52,10 @@ export const ExplorePage = () => {
       <Flex column css={{ mb: '$4xl', gap: '$2xl' }}>
         <Flex
           css={{
-            display: 'grid',
-            gap: '$4xl',
-            gridTemplateColumns: '2fr 1fr',
+            gap: '$xl',
+            '@tablet': {
+              flexWrap: 'wrap',
+            },
           }}
         >
           <Flex column css={{ gap: '$md' }}>

--- a/src/ui/MarkdownPreview/MarkdownPreview.tsx
+++ b/src/ui/MarkdownPreview/MarkdownPreview.tsx
@@ -12,13 +12,17 @@ const StyledMarkdownPreview = styled(ReactMarkdownPreview, {
   color: '$text !important',
   width: '100%',
   background: 'transparent !important',
-  wordBreak: 'break-all',
-  // background: '$surfaceNested !important',
+  wordBreak: 'break-word',
+  display: 'grid',
+  gridTemplateColumns: 'repeat(1, minmax(0, 1fr))',
   'h1, h2, h3, h4, h5': {
     borderBottom: 'none !important',
     mt: '$md !important',
     pt: '0 !important',
     fontSize: '$large !important',
+  },
+  table: {
+    overflow: 'auto',
   },
   img: {
     display: 'block',


### PR DESCRIPTION
bugfix for:
* skill tag overflow
* markdown table overflow
* markdown unbroken string overflow
* preserve natural word breaks 

![Screenshot 2023-12-22 at 10 21 57 AM](https://github.com/coordinape/coordinape/assets/100873710/220fc4dd-46f9-4bb7-8314-251772a931ea)
