### PR TITLE
🐞 Text overflow

### DIFF
--- a/src/components/MainLayout/CreateUserNameForm.tsx
+++ b/src/components/MainLayout/CreateUserNameForm.tsx
@@ -141,7 +141,7 @@ export const CreateUserNameForm = ({
               color="neutral"
               css={{
                 width: '100%',
-                wordBreak: 'break-all',
+                overflowWrap: 'anywhere',
                 fontFamily: 'monospace',
               }}
             >

--- a/src/features/colinks/CoLinksStats.tsx
+++ b/src/features/colinks/CoLinksStats.tsx
@@ -29,6 +29,7 @@ export const CoLinksStats = ({
         css={{
           gap: '$xs',
           cursor: 'pointer',
+          whiteSpace: 'nowrap',
           '&:hover': {
             color: '$linkHover',
             'svg path': {
@@ -62,6 +63,7 @@ export const CoLinksStats = ({
         css={{
           gap: size === 'xs' ? '$xs' : '$sm',
           cursor: 'pointer',
+          whiteSpace: 'nowrap',
           '&:hover': {
             color: '$linkHover',
             'svg path': {

--- a/src/features/colinks/SkillTag.tsx
+++ b/src/features/colinks/SkillTag.tsx
@@ -41,7 +41,7 @@ export const SkillTag = ({
         justifyContent: 'space-between',
         '&:hover': { opacity: 1 },
         cursor: active ? 'auto' : 'pointer',
-        maxWidth: '11rem',
+        maxWidth: '14em',
       }}
     >
       <Text semibold ellipsis css={{ flexShrink: 1, textDecoration: 'none' }}>

--- a/src/pages/ProfilePage/ProfilePage.tsx
+++ b/src/pages/ProfilePage/ProfilePage.tsx
@@ -205,7 +205,7 @@ const ProfilePageContent = ({
                       <Text
                         h2
                         css={{
-                          wordBreak: 'break-word',
+                          overflowWrap: 'anywhere',
                           textOverflow: 'ellipsis',
                           overflow: 'hidden',
                         }}

--- a/src/pages/colinks/ExplorePage.tsx
+++ b/src/pages/colinks/ExplorePage.tsx
@@ -58,7 +58,14 @@ export const ExplorePage = () => {
             },
           }}
         >
-          <Flex column css={{ gap: '$md', flexGrow: 1, maxWidth: '$readable' }}>
+          <Flex
+            column
+            css={{
+              gap: '$md',
+              flexGrow: 1,
+              maxWidth: '$readable',
+            }}
+          >
             <Flex css={{ gap: '$md' }}>
               <Flex
                 css={{ flexWrap: 'wrap', gap: '$sm', mb: '$sm', flexGrow: 1 }}
@@ -105,7 +112,7 @@ export const ExplorePage = () => {
               </Flex>
             )}
           </Flex>
-          <Flex column css={{ gap: '$xl' }}>
+          <Flex column css={{ gap: '$xl', maxWidth: '340px' }}>
             <Text
               as={NavLink}
               to={coLinksPaths.linking}

--- a/src/pages/colinks/ExplorePage.tsx
+++ b/src/pages/colinks/ExplorePage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { artWidthMobile } from 'features/cosoul/constants';
 import { Helmet } from 'react-helmet';
 import { NavLink } from 'react-router-dom';
 
@@ -112,7 +113,7 @@ export const ExplorePage = () => {
               </Flex>
             )}
           </Flex>
-          <Flex column css={{ gap: '$xl', maxWidth: '340px' }}>
+          <Flex column css={{ gap: '$xl', maxWidth: `${artWidthMobile}` }}>
             <Text
               as={NavLink}
               to={coLinksPaths.linking}

--- a/src/pages/colinks/explore/CoLinksMember.tsx
+++ b/src/pages/colinks/explore/CoLinksMember.tsx
@@ -182,6 +182,7 @@ export const CoLinksMember = ({
           p: '$md',
           gap: '$lg',
           width: '100%',
+          flexWrap: 'wrap',
         }}
       >
         <Flex column css={{ gap: '$md', alignItems: 'center' }}>
@@ -196,7 +197,7 @@ export const CoLinksMember = ({
               rowGap: '$sm',
               width: '100%',
               flexDirection: size === 'medium' ? 'column' : 'row',
-              '@sm': {
+              '@md': {
                 alignItems: 'flex-start',
                 flexDirection: 'column',
                 gap: '$sm',

--- a/src/pages/colinks/explore/SimpleBuyButtonWithPrice.tsx
+++ b/src/pages/colinks/explore/SimpleBuyButtonWithPrice.tsx
@@ -22,7 +22,12 @@ export const SimpleBuyButtonWithPrice = ({
   const price = getPriceWithFees(links);
   return (
     <Flex css={{ alignItems: 'center', gap: '$sm' }}>
-      <Text size="xs" color={'complete'} semibold>
+      <Text
+        size="xs"
+        color={'complete'}
+        semibold
+        css={{ whiteSpace: 'nowrap' }}
+      >
         {price} ETH
       </Text>
       <BuyButton

--- a/src/ui/MarkdownPreview/MarkdownPreview.tsx
+++ b/src/ui/MarkdownPreview/MarkdownPreview.tsx
@@ -16,7 +16,7 @@ const StyledMarkdownPreview = styled(ReactMarkdownPreview, {
   color: '$text !important',
   width: '100%',
   background: 'transparent !important',
-  wordBreak: 'break-word',
+  overflowWrap: 'anywhere',
   display: 'grid',
   gridTemplateColumns: 'repeat(1, minmax(0, 1fr))',
   '&::before, &::after': {
@@ -30,7 +30,6 @@ const StyledMarkdownPreview = styled(ReactMarkdownPreview, {
   },
   table: {
     overflow: 'auto',
-    wordBreak: 'normal',
     'th, tr, td': {
       fontSize: '$small',
       backgroundColor: 'transparent !important',
@@ -62,14 +61,14 @@ const StyledMarkdownPreview = styled(ReactMarkdownPreview, {
     pt: '$xs',
   },
   a: {
-    wordBreak: 'break-all',
     color: '$link !important',
+    overflowWrap: 'anywhere',
   },
   'pre, code': {
     background: '$surfaceNested !important',
     whiteSpace: 'normal !important',
     '*': {
-      wordBreak: 'break-all',
+      overflowWrap: 'anywhere',
       fontFamily:
         "Consolas, 'Liberation Mono', Menlo, Courier, monospace !important",
     },

--- a/src/ui/Text/Text.tsx
+++ b/src/ui/Text/Text.tsx
@@ -93,7 +93,7 @@ export const Text = styled('span', {
         display: 'block',
         textOverflow: 'ellipsis',
         overflow: 'hidden',
-        wordBreak: 'break-word',
+        overflowWrap: 'anywhere',
         whiteSpace: 'nowrap',
         lineHeight: 'inherit',
       },

--- a/src/ui/Text/Text.tsx
+++ b/src/ui/Text/Text.tsx
@@ -9,6 +9,7 @@ export const Text = styled('span', {
   alignItems: 'center',
   color: '$text',
   textAlign: 'left',
+  overflowWrap: 'anywhere',
 
   variants: {
     h1: {


### PR DESCRIPTION
# 🐞
![Screenshot 2023-12-23 at 10 31 53 AM](https://github.com/coordinape/coordinape/assets/100873710/d7a8784d-9af9-44de-b04f-fae51db7c9c9)
# 🕊️
![Screenshot 2023-12-23 at 10 32 17 AM](https://github.com/coordinape/coordinape/assets/100873710/12e4f468-5cd2-4b0f-80f8-a263d80c3fad)



* use `overflowWrap: 'anywhere',` to break words instead of deprecated break-word
* fix when people be adding long names
