### PR TITLE
fix minting button responsiveness on mobiles

### DIFF
--- a/src/features/colinks/wizard/WizardCoSoul.tsx
+++ b/src/features/colinks/wizard/WizardCoSoul.tsx
@@ -15,7 +15,6 @@ export const WizardCoSoul = ({
   setShowStepCoSoul: Dispatch<React.SetStateAction<boolean>>;
 }) => {
   const [minted, setMinted] = useState(false);
-  const [showMintPage, setShowMintPage] = useState(false);
   return (
     <>
       <Flex
@@ -42,12 +41,7 @@ export const WizardCoSoul = ({
           <Text>CoSoul: YOUR key to the network.</Text>
           {!minted && (
             <Flex column css={{ mt: '$md', gap: '$md' }}>
-              <CoSoulButton
-                onReveal={() => {
-                  setShowMintPage(true);
-                  setMinted(true);
-                }}
-              />
+              <CoSoulButton onReveal={() => setMinted(true)} />
               <Text size="small" color="neutral">
                 There is a small {`${COSOUL_MINT_FEE}`} ETH fee to mint a
                 CoSoul, and gas costs are minimal on Optimism..
@@ -56,7 +50,7 @@ export const WizardCoSoul = ({
           )}
         </Flex>
       </WizardInstructions>
-      {showMintPage && (
+      {minted && (
         <Flex
           css={{
             zIndex: 3,

--- a/src/features/colinks/wizard/WizardCoSoul.tsx
+++ b/src/features/colinks/wizard/WizardCoSoul.tsx
@@ -15,6 +15,7 @@ export const WizardCoSoul = ({
   setShowStepCoSoul: Dispatch<React.SetStateAction<boolean>>;
 }) => {
   const [minted, setMinted] = useState(false);
+  const [showMintPage, setShowMintPage] = useState(false);
   return (
     <>
       <Flex
@@ -41,7 +42,12 @@ export const WizardCoSoul = ({
           <Text>CoSoul: YOUR key to the network.</Text>
           {!minted && (
             <Flex column css={{ mt: '$md', gap: '$md' }}>
-              <CoSoulButton onReveal={() => setMinted(true)} />
+              <CoSoulButton
+                onReveal={() => {
+                  setShowMintPage(true);
+                  setMinted(true);
+                }}
+              />
               <Text size="small" color="neutral">
                 There is a small {`${COSOUL_MINT_FEE}`} ETH fee to mint a
                 CoSoul, and gas costs are minimal on Optimism..
@@ -50,19 +56,21 @@ export const WizardCoSoul = ({
           )}
         </Flex>
       </WizardInstructions>
-      <Flex
-        css={{
-          zIndex: 3,
-          pointerEvents: 'none',
-          overflow: 'auto',
-          height: '100vh',
-        }}
-      >
-        <CoLinksMintPage
-          minted={minted}
-          setShowStepCoSoul={setShowStepCoSoul}
-        />
-      </Flex>
+      {showMintPage && (
+        <Flex
+          css={{
+            zIndex: 3,
+            pointerEvents: 'none',
+            overflow: 'auto',
+            height: '100vh',
+          }}
+        >
+          <CoLinksMintPage
+            minted={minted}
+            setShowStepCoSoul={setShowStepCoSoul}
+          />
+        </Flex>
+      )}
     </>
   );
 };


### PR DESCRIPTION
## What
fix mobile minting button responsiveness

## Why
Mint Cosoul is not working on mobile. the button is not responsive or crashing the app although the same button works on main app.
CoLinksMintPage is covering the button.
 
## Test and Deployment Plan
try creating a new user on colinks on one of mobile wallets browser.
minting button should be unresponsive or crashing the app.
to test it's working you can use the preview link to test on mobile apps or in normal browser using responsive design mode