### PR TITLE
Store pending replies in sessionStorage

### DIFF
--- a/src/features/activities/replies/ReplyForm.tsx
+++ b/src/features/activities/replies/ReplyForm.tsx
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { Dispatch, useState } from 'react';
+import { Dispatch, useEffect, useState } from 'react';
 
 import { MentionsTextArea } from 'features/colinks/MentionsTextArea';
 import { ValueTypes } from 'lib/gql/__generated__/zeus';
@@ -104,8 +104,37 @@ export const ReplyForm = ({
         reply: r,
       });
       setEditingReply && setEditingReply(false);
+      removeReplyStorage();
     }
   };
+
+  const setReplyStorage = (value: string) => {
+    localStorage.setItem(replyStorageKey(), value);
+  };
+
+  const getReplyStorage = () => {
+    return localStorage.getItem(replyStorageKey());
+  };
+
+  const removeReplyStorage = () => {
+    localStorage.removeItem(replyStorageKey());
+  };
+
+  const replyStorageKey = () => {
+    return `colinks.Replies.pending.${activityId}`;
+  };
+
+  const onChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setValue('description', e.target.value);
+    setReplyStorage(e.target.value);
+  };
+
+  useEffect(() => {
+    const replyStorage = getReplyStorage();
+    if (replyStorage) {
+      setValue('description', replyStorage);
+    }
+  }, []);
 
   if (imMuted) {
     return (
@@ -135,7 +164,7 @@ export const ReplyForm = ({
           ) : (
             <Box css={{ position: 'relative', width: '100%' }}>
               <MentionsTextArea
-                onChange={e => setValue('description', e.target.value)}
+                onChange={onChange}
                 value={descriptionField.value as string}
                 placeholder="Leave a reply"
                 onKeyDown={e => {

--- a/src/features/activities/replies/ReplyForm.tsx
+++ b/src/features/activities/replies/ReplyForm.tsx
@@ -109,15 +109,15 @@ export const ReplyForm = ({
   };
 
   const setReplyStorage = (value: string) => {
-    localStorage.setItem(replyStorageKey(), value);
+    sessionStorage.setItem(replyStorageKey(), value);
   };
 
   const getReplyStorage = () => {
-    return localStorage.getItem(replyStorageKey());
+    return sessionStorage.getItem(replyStorageKey());
   };
 
   const removeReplyStorage = () => {
-    localStorage.removeItem(replyStorageKey());
+    sessionStorage.removeItem(replyStorageKey());
   };
 
   const replyStorageKey = () => {

--- a/src/features/colinks/PostForm.tsx
+++ b/src/features/colinks/PostForm.tsx
@@ -321,15 +321,15 @@ export const PostForm = ({
 };
 
 const setFormStorage = (value: string) => {
-  localStorage.setItem(formStorageKey(), value);
+  sessionStorage.setItem(formStorageKey(), value);
 };
 
 const getFormStorage = () => {
-  return localStorage.getItem(formStorageKey());
+  return sessionStorage.getItem(formStorageKey());
 };
 
 const removeFormStorage = () => {
-  localStorage.removeItem(formStorageKey());
+  sessionStorage.removeItem(formStorageKey());
 };
 
 const formStorageKey = () => {


### PR DESCRIPTION
Also switch post storage to sessionStorage

Each tab is unique and has its own storage. If you "duplicate" a tab, it copies storage from first tab but does not share or sync updates between them.

Seems to work fine.