### PR TITLE
Oneclick unsubscribe

### DIFF
--- a/api-lib/config.ts
+++ b/api-lib/config.ts
@@ -144,3 +144,7 @@ export const POAP_API_KEY: string = getEnvValue(
   'POAP_API_KEY',
   'default-poap-api-key'
 );
+export const HMAC_SECRET: string = getEnvValue(
+  'HMAC_SECRET',
+  'default-hmac-secret'
+);

--- a/api-lib/email/postmark.ts
+++ b/api-lib/email/postmark.ts
@@ -5,6 +5,8 @@ import { coLinksPaths } from '../../src/routes/paths';
 import { POSTMARK_SERVER_TOKEN } from '../config';
 import { adminClient } from '../gql/adminClient';
 
+import { genToken } from './unsubscribe';
+
 const HELP_URL = 'https://docs.coordinape.com';
 const API_BASE_URL = 'https://api.postmarkapp.com';
 const FROM_EMAIL_GIFT = 'support@coordinape.com';
@@ -110,9 +112,18 @@ export async function sendCoLinksWaitlistInvitedEmail(params: {
   return res;
 }
 
-export async function sendCoLinksNotificationsEmail(params: { email: string }) {
+export async function sendCoLinksNotificationsEmail(params: {
+  email: string;
+  profile_id: number;
+}) {
+  const token = genToken(
+    params.profile_id.toString(),
+    params.email,
+    'notification'
+  );
   const input = {
     action_url: webAppURL('colinks') + coLinksPaths.notifications,
+    unsubscribe_url: webAppURL('colinks') + '/api/email/unsubscribe/' + token,
   };
   const res = await sendEmail(
     params.email,

--- a/api-lib/email/postmark.ts
+++ b/api-lib/email/postmark.ts
@@ -1,5 +1,3 @@
-import fetch from 'node-fetch';
-
 import { webAppURL } from '../../src/config/webAppURL';
 import { coLinksPaths } from '../../src/routes/paths';
 import { POSTMARK_SERVER_TOKEN } from '../config';

--- a/api-lib/email/postmark.ts
+++ b/api-lib/email/postmark.ts
@@ -1,8 +1,9 @@
-import { webAppURL } from '../src/config/webAppURL';
-import { coLinksPaths } from '../src/routes/paths';
+import fetch from 'node-fetch';
 
-import { POSTMARK_SERVER_TOKEN } from './config';
-import { adminClient } from './gql/adminClient';
+import { webAppURL } from '../../src/config/webAppURL';
+import { coLinksPaths } from '../../src/routes/paths';
+import { POSTMARK_SERVER_TOKEN } from '../config';
+import { adminClient } from '../gql/adminClient';
 
 const HELP_URL = 'https://docs.coordinape.com';
 const API_BASE_URL = 'https://api.postmarkapp.com';

--- a/api-lib/email/postmark.ts
+++ b/api-lib/email/postmark.ts
@@ -123,7 +123,7 @@ export async function sendCoLinksNotificationsEmail(params: {
   );
   const input = {
     action_url: webAppURL('colinks') + coLinksPaths.notifications,
-    unsubscribe_url: webAppURL('colinks') + '/api/email/unsubscribe/' + token,
+    unsubscribe_url: webAppURL('colinks') + '/email/unsubscribe/' + token,
   };
   const res = await sendEmail(
     params.email,

--- a/api-lib/email/unsubscribe.ts
+++ b/api-lib/email/unsubscribe.ts
@@ -3,34 +3,40 @@ import { createHmac } from 'crypto';
 import { HMAC_SECRET } from '../config';
 import { UnauthorizedError } from '../HttpError';
 
-export function genToken(profileId: string, email: string): string {
-  const token = genHmac(profileId, email);
+export function genToken(
+  profileId: string,
+  email: string,
+  emailType: string
+): string {
+  const token = genHmac(profileId, email, emailType);
 
-  const params = new URLSearchParams({ profileId, email, token });
+  const params = new URLSearchParams({ profileId, email, emailType, token });
   return params.toString();
 }
 
 export function decodeToken(encodedString: string): {
   profileId: string;
   email: string;
+  emailType: string;
 } {
   const params = new URLSearchParams(encodedString);
   const profileId = params.get('profileId');
   const email = params.get('email');
   const token = params.get('token');
+  const emailType = params.get('emailType');
 
-  if (!profileId || !email || !token) {
+  if (!profileId || !email || !token || !emailType) {
     throw new UnauthorizedError('Invalid unsubscribe token');
   }
 
-  const generatedToken = genHmac(profileId, email);
+  const generatedToken = genHmac(profileId, email, emailType);
   if (token !== generatedToken) {
     throw new UnauthorizedError('Invalid unsubscribe token');
   }
-  return { profileId, email };
+  return { profileId, email, emailType };
 }
 
-function genHmac(profileId: string, email: string): string {
-  const data = `${profileId}:${email}`;
+function genHmac(profileId: string, email: string, emailType: string): string {
+  const data = `${profileId}:${email}:${emailType}`;
   return createHmac('sha256', HMAC_SECRET).update(data).digest('hex');
 }

--- a/api-lib/email/unsubscribe.ts
+++ b/api-lib/email/unsubscribe.ts
@@ -1,0 +1,36 @@
+import { createHmac } from 'crypto';
+
+import { HMAC_SECRET } from '../config';
+import { UnauthorizedError } from '../HttpError';
+
+export function genToken(profileId: string, email: string): string {
+  const token = genHmac(profileId, email);
+
+  const params = new URLSearchParams({ profileId, email, token });
+  return params.toString();
+}
+
+export function decodeToken(encodedString: string): {
+  profileId: string;
+  email: string;
+} {
+  const params = new URLSearchParams(encodedString);
+  const profileId = params.get('profileId');
+  const email = params.get('email');
+  const token = params.get('token');
+
+  if (!profileId || !email || !token) {
+    throw new UnauthorizedError('Invalid unsubscribe token');
+  }
+
+  const generatedToken = genHmac(profileId, email);
+  if (token !== generatedToken) {
+    throw new UnauthorizedError('Invalid unsubscribe token');
+  }
+  return { profileId, email };
+}
+
+function genHmac(profileId: string, email: string): string {
+  const data = `${profileId}:${email}`;
+  return createHmac('sha256', HMAC_SECRET).update(data).digest('hex');
+}

--- a/api-lib/email/unsubscribe.ts
+++ b/api-lib/email/unsubscribe.ts
@@ -3,6 +3,12 @@ import { createHmac } from 'crypto';
 import { HMAC_SECRET } from '../config';
 import { UnauthorizedError } from '../HttpError';
 
+type EmailType = 'product' | 'transactional' | 'notification';
+
+export function isEmailType(emailType: string): emailType is EmailType {
+  return ['product', 'transactional', 'notification'].includes(emailType);
+}
+
 export function genToken(
   profileId: string,
   email: string,
@@ -24,8 +30,7 @@ export function decodeToken(encodedString: string): {
   const email = params.get('email');
   const token = params.get('token');
   const emailType = params.get('emailType');
-
-  if (!profileId || !email || !token || !emailType) {
+  if (!profileId || !email || !token || !emailType || !isEmailType(emailType)) {
     throw new UnauthorizedError('Invalid unsubscribe token');
   }
 

--- a/api-lib/email/unsubscribe.ts
+++ b/api-lib/email/unsubscribe.ts
@@ -1,4 +1,4 @@
-import { createHmac } from 'crypto';
+import { createHmac, timingSafeEqual } from 'crypto';
 
 import { HMAC_SECRET } from '../config';
 import { UnauthorizedError } from '../HttpError';
@@ -35,7 +35,8 @@ export function decodeToken(encodedString: string): {
   }
 
   const generatedToken = genHmac(profileId, email, emailType);
-  if (token !== generatedToken) {
+  const encoder = new TextEncoder();
+  if (!timingSafeEqual(encoder.encode(token), encoder.encode(generatedToken))) {
     throw new UnauthorizedError('Invalid unsubscribe token');
   }
   return { profileId, email, emailType };

--- a/api-test/email/unsubscribe.test.ts
+++ b/api-test/email/unsubscribe.test.ts
@@ -8,17 +8,18 @@ afterEach(() => {
 
 import { genToken, decodeToken } from '../../api-lib/email/unsubscribe';
 
-let profileId, email, token;
+let profileId, email, emailType, token;
 
 describe('unsubscribe tokens', () => {
   beforeEach(() => {
     profileId = '123';
     email = 'jugo@naranja.es';
-    token = genToken(profileId, email);
+    emailType = 'product';
+    token = genToken(profileId, email, emailType);
   });
 
   it('generates and validates token', () => {
-    expect(decodeToken(token)).toEqual({ profileId, email });
+    expect(decodeToken(token)).toEqual({ profileId, email, emailType });
   });
 
   it('throws error on invalid token', () => {

--- a/api-test/email/unsubscribe.test.ts
+++ b/api-test/email/unsubscribe.test.ts
@@ -1,0 +1,38 @@
+beforeEach(() => {
+  process.env.HMAC_SECRET = 'test-key';
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+import { genToken, decodeToken } from '../../api-lib/email/unsubscribe';
+
+let profileId, email, token;
+
+describe('unsubscribe tokens', () => {
+  beforeEach(() => {
+    profileId = '123';
+    email = 'jugo@naranja.es';
+    token = genToken(profileId, email);
+  });
+
+  it('generates and validates token', () => {
+    expect(decodeToken(token)).toEqual({ profileId, email });
+  });
+
+  it('throws error on invalid token', () => {
+    expect(() => {
+      decodeToken('bogus');
+    }).toThrow(/Invalid unsubscribe token/);
+  });
+
+  it('fails to validate token with wrong email', () => {
+    const badToken =
+      'profileId=123&email=jugo%40naranja.es&token=8481b9d81d5766b98e1beaa791ea9625f4c541cf10d6bc7413f2cb238e599994';
+
+    expect(() => {
+      decodeToken(badToken);
+    }).toThrow(/Invalid unsubscribe token/);
+  });
+});

--- a/api-test/hasura/cron/epochs_emails_stubbed.test.ts
+++ b/api-test/hasura/cron/epochs_emails_stubbed.test.ts
@@ -7,13 +7,13 @@ import {
   notifyEpochEnd,
   notifyEpochStart,
 } from '../../../api/hasura/cron/epochs';
-import { insertActivity } from '../../../api-lib/event_triggers/activity/mutations';
-import { adminClient } from '../../../api-lib/gql/adminClient';
 import {
   sendEpochEndedEmail,
   sendEpochEndingSoonEmail,
   sendEpochStartedEmail,
-} from '../../../api-lib/postmark';
+} from '../../../api-lib/email/postmark';
+import { insertActivity } from '../../../api-lib/event_triggers/activity/mutations';
+import { adminClient } from '../../../api-lib/gql/adminClient';
 import { sendSocialMessage } from '../../../api-lib/sendSocialMessage';
 
 jest.mock('../../../api-lib/gql/adminClient', () => ({
@@ -41,7 +41,7 @@ const mockInsertActivity = insertActivity as jest.MockedFunction<
   typeof insertActivity
 >;
 
-jest.mock('../../../api-lib/postmark', () => ({
+jest.mock('../../../api-lib/email/postmark', () => ({
   sendEpochEndedEmail: jest.fn(
     (params: {
       email: string;

--- a/api/email/unsubscribe/[unsubscribeToken].ts
+++ b/api/email/unsubscribe/[unsubscribeToken].ts
@@ -8,10 +8,9 @@ import { NotFoundError, errorResponse } from '../../../api-lib/HttpError';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   let unsubscribeToken: string | undefined;
+
   if (typeof req.query.unsubscribeToken == 'string') {
     unsubscribeToken = req.query.unsubscribeToken;
-  } else if (Array.isArray(req.query.unsubscribeToken)) {
-    unsubscribeToken = req.query.unsubscribeToken.pop();
   }
 
   if (!unsubscribeToken) {

--- a/api/email/unsubscribe/[unsubscribeToken].ts
+++ b/api/email/unsubscribe/[unsubscribeToken].ts
@@ -1,0 +1,61 @@
+import assert from 'assert';
+
+import { VercelRequest, VercelResponse } from '@vercel/node';
+
+import { decodeToken, isEmailType } from '../../../api-lib/email/unsubscribe';
+import { adminClient } from '../../../api-lib/gql/adminClient';
+import { NotFoundError, errorResponse } from '../../../api-lib/HttpError';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  let unsubscribeToken: string | undefined;
+  if (typeof req.query.unsubscribeToken == 'string') {
+    unsubscribeToken = req.query.unsubscribeToken;
+  } else if (Array.isArray(req.query.unsubscribeToken)) {
+    unsubscribeToken = req.query.unsubscribeToken.pop();
+  }
+
+  if (!unsubscribeToken) {
+    throw new NotFoundError('no unsubscription token provided');
+  }
+
+  const { profileId, emailType } = decodeToken(unsubscribeToken);
+
+  return await unsubscribeEmail(res, profileId, emailType);
+}
+
+export async function unsubscribeEmail(
+  res: VercelResponse,
+  profileId: string,
+  emailType: string
+) {
+  try {
+    assert(isEmailType(emailType), 'invalid email type');
+    adminClient.mutate(
+      {
+        update_profiles_by_pk: [
+          {
+            pk_columns: { id: parseInt(profileId) },
+            ...getEmailColumn(emailType),
+          },
+          { id: true },
+        ],
+      },
+      { operationName: 'email_unsubscribtion' }
+    );
+    return res.status(200).send({
+      message: 'Email unsubscribed successfully',
+    });
+  } catch (error: any) {
+    return errorResponse(res, error);
+  }
+}
+
+function getEmailColumn(emailType: string) {
+  if (emailType === 'notification') {
+    return { _set: { colinks_notification_emails: false } };
+  } else if (emailType === 'product') {
+    return { _set: { product_emails: false } };
+  } else {
+    return { _set: { app_emails: false } };
+  }
+}

--- a/api/email/unsubscribe/[unsubscribeToken].ts
+++ b/api/email/unsubscribe/[unsubscribeToken].ts
@@ -43,7 +43,13 @@ export async function unsubscribeEmail(
       { operationName: 'email_unsubscribtion' }
     );
     return res.status(200).send({
-      message: 'Email unsubscribed successfully',
+      message: `Email unsubscribed successfully from ${
+        emailType === 'notification'
+          ? 'unread notifications emails'
+          : emailType === 'product'
+          ? 'product emails'
+          : 'transactional emails'
+      } list`,
     });
   } catch (error: any) {
     return errorResponse(res, error);

--- a/api/hasura/actions/_handlers/addEmail.ts
+++ b/api/hasura/actions/_handlers/addEmail.ts
@@ -3,13 +3,13 @@ import assert from 'assert';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { z } from 'zod';
 
+import { sendVerifyEmail } from '../../../../api-lib/email/postmark';
 import { adminClient } from '../../../../api-lib/gql/adminClient';
 import { getInput } from '../../../../api-lib/handlerHelpers';
 import {
   errorResponse,
   UnprocessableError,
 } from '../../../../api-lib/HttpError';
-import { sendVerifyEmail } from '../../../../api-lib/postmark';
 
 const addEmailInput = z
   .object({

--- a/api/hasura/actions/_handlers/inviteWaitingList.ts
+++ b/api/hasura/actions/_handlers/inviteWaitingList.ts
@@ -4,15 +4,15 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { z } from 'zod';
 
 import { getWaitListGuardianProfileId } from '../../../../api-lib/colinks/helperAccounts';
+import {
+  fetchVerifiedEmail,
+  sendCoLinksWaitlistInvitedEmail,
+} from '../../../../api-lib/email/postmark';
 import { order_by } from '../../../../api-lib/gql/__generated__/zeus';
 import { adminClient } from '../../../../api-lib/gql/adminClient';
 import { getInput } from '../../../../api-lib/handlerHelpers';
 import { errorResponse } from '../../../../api-lib/HttpError';
 import { addInviteCodes } from '../../../../api-lib/invites';
-import {
-  fetchVerifiedEmail,
-  sendCoLinksWaitlistInvitedEmail,
-} from '../../../../api-lib/postmark';
 
 const inviteWaitingListInput = z
   .object({

--- a/api/hasura/actions/_handlers/requestInviteCode.ts
+++ b/api/hasura/actions/_handlers/requestInviteCode.ts
@@ -7,14 +7,14 @@ import {
   checkEligibleEmail,
   insertEmail,
 } from '../../../../api/hasura/actions/_handlers/addEmail';
+import {
+  sendCoLinksWaitlistVerifyEmail,
+  sendCoLinksWaitlistWelcomeEmail,
+} from '../../../../api-lib/email/postmark';
 import { adminClient } from '../../../../api-lib/gql/adminClient';
 import { insertInteractionEvents } from '../../../../api-lib/gql/mutations';
 import { getInput } from '../../../../api-lib/handlerHelpers';
 import { errorResponse } from '../../../../api-lib/HttpError';
-import {
-  sendCoLinksWaitlistVerifyEmail,
-  sendCoLinksWaitlistWelcomeEmail,
-} from '../../../../api-lib/postmark';
 
 const requestInviteCodeInput = z
   .object({

--- a/api/hasura/cron/colinksNotificationEmails.ts
+++ b/api/hasura/cron/colinksNotificationEmails.ts
@@ -1,9 +1,9 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
+import { sendCoLinksNotificationsEmail } from '../../../api-lib/email/postmark';
 import { order_by } from '../../../api-lib/gql/__generated__/zeus';
 import { adminClient } from '../../../api-lib/gql/adminClient';
 import { errorResponse } from '../../../api-lib/HttpError';
-import { sendCoLinksNotificationsEmail } from '../../../api-lib/postmark';
 import { verifyHasuraRequestMiddleware } from '../../../api-lib/validate';
 import { isRejected } from '../../../src/common-lib/epochs';
 import { IN_PRODUCTION } from '../../../src/config/env';

--- a/api/hasura/cron/colinksNotificationEmails.ts
+++ b/api/hasura/cron/colinksNotificationEmails.ts
@@ -19,6 +19,7 @@ async function sendEmailAndUpdateProfile({
 }) {
   await sendCoLinksNotificationsEmail({
     email,
+    profile_id: profileId,
   });
   await adminClient.mutate(
     {

--- a/api/hasura/cron/dailyReportEmail.ts
+++ b/api/hasura/cron/dailyReportEmail.ts
@@ -1,8 +1,8 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
+import { sendDailySpacecar } from '../../../api-lib/email/postmark';
 import { adminClient } from '../../../api-lib/gql/adminClient';
 import { errorResponse } from '../../../api-lib/HttpError';
-import { sendDailySpacecar } from '../../../api-lib/postmark';
 import { verifyHasuraRequestMiddleware } from '../../../api-lib/validate';
 import { IN_PRODUCTION } from '../../../src/config/env';
 

--- a/api/hasura/cron/epochs.ts
+++ b/api/hasura/cron/epochs.ts
@@ -5,16 +5,16 @@ import dedent from 'dedent';
 import { DateTime, Settings } from 'luxon';
 import { z } from 'zod';
 
+import {
+  sendEpochEndedEmail,
+  sendEpochEndingSoonEmail,
+  sendEpochStartedEmail,
+} from '../../../api-lib/email/postmark';
 import { insertActivity } from '../../../api-lib/event_triggers/activity/mutations';
 import { ValueTypes } from '../../../api-lib/gql/__generated__/zeus';
 import { adminClient } from '../../../api-lib/gql/adminClient';
 import { getOverlappingEpoch } from '../../../api-lib/gql/queries';
 import { errorLog } from '../../../api-lib/HttpError';
-import {
-  sendEpochEndedEmail,
-  sendEpochEndingSoonEmail,
-  sendEpochStartedEmail,
-} from '../../../api-lib/postmark';
 import { sendSocialMessage } from '../../../api-lib/sendSocialMessage';
 import { Awaited } from '../../../api-lib/ts4.5shim';
 import { verifyHasuraRequestMiddleware } from '../../../api-lib/validate';

--- a/api/hasura/cron/hourlyReportEmail.ts
+++ b/api/hasura/cron/hourlyReportEmail.ts
@@ -1,8 +1,8 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
+import { sendHourlyReport } from '../../../api-lib/email/postmark';
 import { adminClient } from '../../../api-lib/gql/adminClient';
 import { errorResponse } from '../../../api-lib/HttpError';
-import { sendHourlyReport } from '../../../api-lib/postmark';
 import { IN_PRODUCTION } from '../../../src/config/env';
 
 import { EMAIL_FOR_REPORTS } from './dailyReportEmail';

--- a/scripts/repl.ts
+++ b/scripts/repl.ts
@@ -15,14 +15,14 @@ import { DateTime } from 'luxon';
 
 import { syncCoSouls } from '../api/hasura/cron/syncCoSouls';
 import { updateProfileNFTs } from '../api/nfts/alchemy';
-import { adminClient as client } from '../api-lib/gql/adminClient';
-import { genPgives } from '../api-lib/pgives';
-import { syncPoapDataForCoLinksUsers } from '../api-lib/poap/poap-api';
 import {
   sendEpochEndedEmail,
   sendEpochEndingSoonEmail,
   sendEpochStartedEmail,
-} from '../api-lib/postmark';
+} from '../api-lib/email/postmark';
+import { adminClient as client } from '../api-lib/gql/adminClient';
+import { genPgives } from '../api-lib/pgives';
+import { syncPoapDataForCoLinksUsers } from '../api-lib/poap/poap-api';
 import {
   getOnChainPGIVE,
   getTokenId,

--- a/scripts/serve_dev.ts
+++ b/scripts/serve_dev.ts
@@ -9,6 +9,7 @@ import tokenId from '../api/cosoul/metadata/[tokenId]';
 import screenshot from '../api/cosoul/screenshot/[tokenId]';
 import verify from '../api/cosoul/verify';
 import discord from '../api/discord/oauth';
+import unsubscribeToken from '../api/email/unsubscribe/[unsubscribeToken]';
 import verifyEmail from '../api/email/verify/[uuid]';
 import verifyEmailWaitList from '../api/email/verifywaitlist/[uuid]';
 import github_callback from '../api/github/callback';
@@ -128,6 +129,10 @@ app.get('/api/og/profileinfo/:address', (req, res) => {
 
 app.get('/api/email/verifywaitlist/:uuid', (req, res) => {
   return tf(verifyEmailWaitList)({ ...req, query: req.params }, res);
+});
+
+app.get('/api/email/unsubscribe/:unsubscribeToken', (req, res) => {
+  return tf(unsubscribeToken)({ ...req, query: req.params }, res);
 });
 
 app.post('/api/log', tf(log));

--- a/src/pages/colinks/UnsubscribeEmailPage.tsx
+++ b/src/pages/colinks/UnsubscribeEmailPage.tsx
@@ -47,7 +47,7 @@ export const UnsubscribeEmailPage = () => {
             <Flex column css={{ gap: '$md' }}>
               {unsubscribeMessage && (
                 <>
-                  <Text h2>You&lsquo;ve been Unsubscribed</Text>
+                  <Text h2>You&lsquo;ve been unsubscribed</Text>
                   <Panel nested>
                     <Text>{unsubscribeMessage}</Text>
                   </Panel>

--- a/src/pages/colinks/UnsubscribeEmailPage.tsx
+++ b/src/pages/colinks/UnsubscribeEmailPage.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useState } from 'react';
+
+import { WizardInstructions } from 'features/colinks/wizard/WizardInstructions';
+import { fullScreenStyles } from 'features/colinks/wizard/WizardSteps';
+import { useNavigate } from 'react-router';
+import { useParams } from 'react-router-dom';
+
+import { LoadingModal } from '../../components';
+import { useAuthStateMachine } from '../../features/auth/RequireAuth';
+import { coLinksPaths } from '../../routes/paths';
+import { Button, Flex, Panel, Text } from '../../ui';
+
+export const UnsubscribeEmailPage = () => {
+  useAuthStateMachine(false);
+  const { unsubscribeToken } = useParams();
+  const navigate = useNavigate();
+
+  const [unsubscribeMessage, setUnsubscribeMessage] = useState<
+    string | undefined
+  >();
+
+  useEffect(() => {
+    try {
+      fetch('/api/email/unsubscribe/' + unsubscribeToken).then(res => {
+        res.json().then(res => {
+          setUnsubscribeMessage(res.message);
+        });
+      });
+    } catch (e) {
+      if (e instanceof Error) {
+        setUnsubscribeMessage(e.message ?? 'unknown error');
+      } else {
+        setUnsubscribeMessage('Invalid token or network error');
+      }
+    }
+  }, []);
+
+  if (!unsubscribeMessage) {
+    return <LoadingModal visible={true} note="unsubscribe-email" />;
+  }
+
+  return (
+    <>
+      <Flex css={{ flexGrow: 1, height: '100vh', width: '100vw' }}>
+        <Flex column css={{ height: '100vh', width: '100%' }}>
+          <WizardInstructions>
+            <Flex column css={{ gap: '$md' }}>
+              {unsubscribeMessage && (
+                <>
+                  <Text h2>You&lsquo;ve been Unsubscribed</Text>
+                  <Panel nested>
+                    <Text>{unsubscribeMessage}</Text>
+                  </Panel>
+                  <Button
+                    color="cta"
+                    onClick={() => {
+                      navigate(coLinksPaths.home, {
+                        replace: true,
+                      });
+                    }}
+                  >
+                    Continue to CoLinks
+                  </Button>
+                  <Button
+                    color="secondary"
+                    onClick={() => {
+                      navigate(coLinksPaths.account, {
+                        replace: true,
+                      });
+                    }}
+                  >
+                    View Email Settings
+                  </Button>
+                </>
+              )}
+            </Flex>
+          </WizardInstructions>
+        </Flex>
+        <Flex
+          css={{
+            ...fullScreenStyles,
+            background:
+              'radial-gradient(circle, rgb(18 19 21) 0%, #BC5B31 58%, #FDE9C4 83%, #462A2C 100%)',
+          }}
+        />
+        <Flex
+          css={{
+            ...fullScreenStyles,
+            animationDirection: 'alternate',
+            backgroundImage: "url('/imgs/background/colink-verification.jpg')",
+            backgroundPosition: '50% 20% ',
+          }}
+        />
+      </Flex>
+    </>
+  );
+};
+
+export default UnsubscribeEmailPage;

--- a/src/routes/coLinksRoutes.tsx
+++ b/src/routes/coLinksRoutes.tsx
@@ -39,6 +39,7 @@ import { WizardStart } from '../pages/colinks/wizard/WizardStart';
 import CoSoulExplorePage from '../pages/CoSoulExplorePage/CoSoulExplorePage';
 import { InviteCodePage } from '../pages/InviteCodePage';
 import { PostPage } from '../pages/PostPage';
+import UnsubscribeEmailPage from 'pages/colinks/UnsubscribeEmailPage';
 
 import { coLinksPaths } from './paths';
 import { RedirectAfterLogin } from './RedirectAfterLogin';
@@ -166,6 +167,10 @@ export const coLinksRoutes = [
       <Route
         path={coLinksPaths.verify(':uuid')}
         element={<VerifyEmailPage />}
+      />
+      <Route
+        path={coLinksPaths.unsubscribe(':unsubscribeToken')}
+        element={<UnsubscribeEmailPage />}
       />
     </Route>
 

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -83,6 +83,8 @@ export const coLinksPaths = {
   history: (address: string) => `/${address}/history`,
   holdings: (address: string) => `/${address}/holdings`,
   holders: (address: string) => `/${address}/holders`,
+  unsubscribe: (unsubscribeToken: string) =>
+    `/email/unsubscribe/${unsubscribeToken}`,
   // email verification
   verify: (uuid: string) => `/email/verify/${uuid}`,
   verifyWaitList: (uuid: string) => `/email/verifywaitlist/${uuid}`,


### PR DESCRIPTION
## What
Create one click link to unsubscribe from receiving emails:
1- generate a token based on profile Id, email and email type
2- generate a link with the token and send it to post mark
3- adjust postmark template
4- create a landing page for the unsubscribe link

## Why

Allow users to easily unsubscribe from emails

## Screenshots (if appropriate):
![image](https://github.com/coordinape/coordinape/assets/34943689/bf463fb8-021d-49c1-8012-806cb2827867)
![image](https://github.com/coordinape/coordinape/assets/34943689/46e4cf9b-89d3-4092-8a82-24870b0c6fbf)

## Before Merging
The production templates on postmark needs to be updated as well
1- A new layout needs to be updated "CoLinks with one click unsubscribe"
this layout will have the ubsubscribe link at the footer
![image](https://github.com/coordinape/coordinape/assets/34943689/13781ea9-bd37-42c6-8db0-38aa2530ef7f)

2- CoLinks Unread Notifications template needs to use this new layout instead.