### PR TITLE
ui bugfix: md block image

### DIFF
--- a/src/ui/MarkdownPreview/MarkdownPreview.tsx
+++ b/src/ui/MarkdownPreview/MarkdownPreview.tsx
@@ -54,7 +54,7 @@ const StyledMarkdownPreview = styled(ReactMarkdownPreview, {
   img: {
     display: 'block',
     maxHeight: '500px',
-    mb: '$xs',
+    my: '$xs',
   },
   'h1, h2, h3, h4, h5, p, ul, ol': {
     mb: '0 !important',
@@ -167,7 +167,8 @@ export const MarkdownPreview = (
                   <Text
                     onClick={() => setModal(true)}
                     css={{
-                      display: 'inline-block',
+                      display: 'block',
+                      width: 'fit-content',
                       position: 'relative',
                       overflow: 'hidden',
                       '&:hover, &:focus': {


### PR DESCRIPTION
Here's the bug:
![Screenshot 2024-02-06 at 11 02 54 AM](https://github.com/coordinape/coordinape/assets/100873710/d44dce99-bc96-40a6-93ae-1a60cc7eea9d)

fixed to be stacked like this:
![Screenshot 2024-02-06 at 11 05 24 AM](https://github.com/coordinape/coordinape/assets/100873710/6ee50336-2ce7-44a9-8ee0-90cb3b0e4afa)

