### PR TITLE
UI Bugfix: wrong modal style for loading indicator

### DIFF
--- a/src/ui/Modal.tsx
+++ b/src/ui/Modal.tsx
@@ -190,6 +190,7 @@ export const Modal = ({
           }}
           lightbox={lightbox}
           cmdk={cmdk}
+          loader={loader}
           onPointerDownOutside={event => {
             event.preventDefault();
           }}


### PR DESCRIPTION
bug:
![Screenshot 2024-02-06 at 11 16 59 AM](https://github.com/coordinape/coordinape/assets/100873710/84f78cc6-78dc-4fc9-9e0e-310befd6ec6a)

pass loader prop into dialog.content