### PR TITLE
one click unsubscribe to epoch notifications emails

### DIFF
--- a/_api/email/unsubscribe/[unsubscribeToken].ts
+++ b/_api/email/unsubscribe/[unsubscribeToken].ts
@@ -49,9 +49,9 @@ export async function unsubscribeEmail(
   const display =
     emailType === 'notification'
       ? 'unread notifications emails'
-      : emailType === 'product'
+      : emailType === 'colinks_happenings' || emailType === 'give_happenings'
         ? 'product emails'
-        : 'transactional emails';
+        : 'circle emails';
   return res.status(200).send({
     message: `Email unsubscribed successfully from ${display}`,
   });
@@ -61,11 +61,9 @@ function getEmailColumn(emailType: EmailType) {
   switch (emailType) {
     case 'notification':
       return { _set: { colinks_notification_emails: false } };
-    case 'product':
+    case 'give_happenings':
       return { _set: { product_emails: false } };
-    case 'transactional':
-      return { _set: { app_emails: false } };
-    case 'colinks_product':
+    case 'colinks_happenings':
       return { _set: { colinks_product_emails: false } };
     default:
       return { _set: { app_emails: false } };

--- a/_api/email/unsubscribe/[unsubscribeToken].ts
+++ b/_api/email/unsubscribe/[unsubscribeToken].ts
@@ -46,24 +46,33 @@ export async function unsubscribeEmail(
     { operationName: 'email_unsubscribtion' }
   );
 
-  const display =
-    emailType === 'notification'
-      ? 'unread notifications emails'
-      : emailType === 'colinks_happenings' || emailType === 'give_happenings'
-        ? 'product emails'
-        : 'circle emails';
+  let display;
+  switch (emailType) {
+    case EmailType.COLINKS_NOTIFICATION:
+      display = 'unread notifications emails';
+      break;
+    case EmailType.COLINKS_HOT_HAPPENINGS:
+      display = 'hot happenings emails';
+      break;
+    case EmailType.GIVE_CIRCLE_HAPPENINGS:
+      display = 'product emails';
+      break;
+    default:
+      display = 'circle emails';
+  }
+
   return res.status(200).send({
     message: `Email unsubscribed successfully from ${display}`,
   });
 }
 
-function getEmailColumn(emailType: EmailType) {
-  switch (emailType) {
-    case 'notification':
+function getEmailColumn(emailType: string) {
+    switch (emailType) {
+    case EmailType.COLINKS_NOTIFICATION:
       return { _set: { colinks_notification_emails: false } };
-    case 'give_happenings':
+    case EmailType.GIVE_CIRCLE_HAPPENINGS:
       return { _set: { product_emails: false } };
-    case 'colinks_happenings':
+    case EmailType.COLINKS_HOT_HAPPENINGS:
       return { _set: { colinks_product_emails: false } };
     default:
       return { _set: { app_emails: false } };

--- a/_api/hasura/cron/epochs.ts
+++ b/_api/hasura/cron/epochs.ts
@@ -75,9 +75,17 @@ async function getEpochsToNotify() {
                 discord_webhook: true,
                 organization: { id: true, name: true, sample: true },
                 users: [
-                  { where: { deleted_at: { _is_null: true } } },
+                  {
+                    where: {
+                      _and: [
+                        { deleted_at: { _is_null: true } },
+                        { profile: { app_emails: { _eq: true } } },
+                      ],
+                    },
+                  },
                   {
                     profile: {
+                      id: true,
                       emails: [
                         {
                           where: {
@@ -139,13 +147,17 @@ async function getEpochsToNotify() {
                 users: [
                   {
                     where: {
-                      non_giver: { _eq: false },
-                      deleted_at: { _is_null: true },
-                      give_token_remaining: { _gt: 0 },
+                      _and: [
+                        { non_giver: { _eq: false } },
+                        { deleted_at: { _is_null: true } },
+                        { give_token_remaining: { _gt: 0 } },
+                        { profile: { app_emails: { _eq: true } } },
+                      ],
                     },
                   },
                   {
                     profile: {
+                      id: true,
                       name: true,
                       emails: [
                         {
@@ -198,13 +210,18 @@ async function getEpochsToNotify() {
                 users: [
                   {
                     where: {
-                      deleted_at: { _is_null: true },
+                      _and: [
+                        { deleted_at: { _is_null: true } },
+                        { profile: { app_emails: { _eq: true } } },
+                      ],
                     },
                   },
                   {
                     id: true,
                     profile: {
+                      id: true,
                       name: true,
+                      app_emails: true,
                       emails: [
                         {
                           where: {
@@ -334,11 +351,11 @@ export async function notifyEpochStart({
         await notifyEpochStatus(message, { telegram: true }, epoch);
 
       const membersData = (epoch.circle?.users || []).reduce<
-        { email: string }[]
+        { email: string; profileId: number }[]
       >((acc, u) => {
         const email: string = u.profile?.emails?.[0]?.email;
         if (email) {
-          acc.push({ email: email });
+          acc.push({ email: email, profileId: u.profile.id });
         }
         return acc;
       }, []);
@@ -397,11 +414,11 @@ export async function notifyEpochEnd({
       }
 
       const membersData = (epoch.circle?.users || []).reduce<
-        { email: string }[]
+        { email: string; profileId: number }[]
       >((acc, u) => {
         const email: string = u.profile?.emails?.[0]?.email;
         if (email) {
-          acc.push({ email: email });
+          acc.push({ email: email, profileId: u.profile.id });
         }
         return acc;
       }, []);
@@ -474,48 +491,51 @@ export async function endEpochHandler(
   // if auto_opt_out is true, set users where `starting_tokens == give_tokens_remaining to non_receiver = true
   // copy user bios to histories
   // reset give_tokens_received = 0, give_token_remaining = starting tokens, epoch_first_visit = 1, bio = null
-  const userUpdateMutations = circle.users.reduce((ops, user) => {
-    const userUserHasAllGive =
-      user.give_token_remaining === user.starting_tokens;
-    if (userUserHasAllGive) usersWithStartingGive.push(user.profile.name);
-    const optOutMutation =
-      !user.non_giver &&
-      !user.non_receiver &&
-      circle.auto_opt_out &&
-      userUserHasAllGive
-        ? { non_receiver: true }
-        : {};
+  const userUpdateMutations = circle.users.reduce(
+    (ops, user) => {
+      const userUserHasAllGive =
+        user.give_token_remaining === user.starting_tokens;
+      if (userUserHasAllGive) usersWithStartingGive.push(user.profile.name);
+      const optOutMutation =
+        !user.non_giver &&
+        !user.non_receiver &&
+        circle.auto_opt_out &&
+        userUserHasAllGive
+          ? { non_receiver: true }
+          : {};
 
-    ops[`u${user.id}_history`] = {
-      insert_histories_one: [
-        {
-          object: {
-            user_id: user.id,
-            bio: user.bio,
-            epoch_id: epoch.id,
-            circle_id: circle_id,
+      ops[`u${user.id}_history`] = {
+        insert_histories_one: [
+          {
+            object: {
+              user_id: user.id,
+              bio: user.bio,
+              epoch_id: epoch.id,
+              circle_id: circle_id,
+            },
           },
-        },
-        { __typename: true },
-      ],
-    };
-    ops[`u${user.id}_userReset`] = {
-      update_users_by_pk: [
-        {
-          pk_columns: { id: user.id },
-          _set: {
-            give_token_received: 0,
-            give_token_remaining: user.starting_tokens,
-            epoch_first_visit: true,
-            bio: null,
-            ...optOutMutation,
+          { __typename: true },
+        ],
+      };
+      ops[`u${user.id}_userReset`] = {
+        update_users_by_pk: [
+          {
+            pk_columns: { id: user.id },
+            _set: {
+              give_token_received: 0,
+              give_token_remaining: user.starting_tokens,
+              epoch_first_visit: true,
+              bio: null,
+              ...optOutMutation,
+            },
           },
-        },
-        { __typename: true },
-      ],
-    };
-    return ops;
-  }, {} as { [aliasKey: string]: ValueTypes['mutation_root'] });
+          { __typename: true },
+        ],
+      };
+      return ops;
+    },
+    {} as { [aliasKey: string]: ValueTypes['mutation_root'] }
+  );
 
   await adminClient.mutate(
     {
@@ -833,12 +853,19 @@ function calculateNumReceived(
   epoch: Pick<EpochsToNotify, 'endEpoch'>['endEpoch'][number]
 ) {
   return (epoch.circle?.users || []).reduce<
-    { email: string; tokenNumReceived: number; notesNumReceived: number }[]
+    {
+      email: string;
+      tokenNumReceived: number;
+      notesNumReceived: number;
+      profileId: number;
+    }[]
   >((acc, u) => {
     const email = u.profile?.emails?.[0]?.email;
-    if (email) {
+    const emailSubscribtion = u.profile?.app_emails;
+    if (email && emailSubscribtion) {
       acc.push({
         email,
+        profileId: u.profile.id,
         tokenNumReceived: epoch.epoch_pending_token_gifts.reduce(
           (count, gift) =>
             count + (gift.recipient_id === u.id && gift.tokens > 0 ? 1 : 0),
@@ -870,6 +897,7 @@ async function emailEpochStatus({
     email: string;
     tokenNumReceived?: number;
     notesNumReceived?: number;
+    profileId: number;
   }>;
 }) {
   try {
@@ -881,29 +909,32 @@ async function emailEpochStatus({
               circle_id: circleId,
               circle_name: circleName,
               epoch_id: epochId,
+              profile_id: memberData.profileId,
               num_give_senders: memberData.tokenNumReceived ?? 0,
               num_notes_received: memberData.notesNumReceived ?? 0,
             });
           })
         : status === 'endingSoon'
-        ? membersData.map(memberData => {
-            return sendEpochEndingSoonEmail({
-              email: memberData.email,
-              circle_id: circleId,
-              circle_name: circleName,
-              epoch_id: epochId,
-            });
-          })
-        : status === 'started'
-        ? membersData.map(memberData => {
-            return sendEpochStartedEmail({
-              email: memberData.email,
-              circle_id: circleId,
-              circle_name: circleName,
-              epoch_id: epochId,
-            });
-          })
-        : []
+          ? membersData.map(memberData => {
+              return sendEpochEndingSoonEmail({
+                email: memberData.email,
+                circle_id: circleId,
+                circle_name: circleName,
+                epoch_id: epochId,
+                profile_id: memberData.profileId,
+              });
+            })
+          : status === 'started'
+            ? membersData.map(memberData => {
+                return sendEpochStartedEmail({
+                  email: memberData.email,
+                  circle_id: circleId,
+                  circle_name: circleName,
+                  epoch_id: epochId,
+                  profile_id: memberData.profileId,
+                });
+              })
+            : []
     );
 
     const errors = responses?.filter(isRejected);

--- a/_api/hasura/cron/epochs.ts
+++ b/_api/hasura/cron/epochs.ts
@@ -861,8 +861,8 @@ function calculateNumReceived(
     }[]
   >((acc, u) => {
     const email = u.profile?.emails?.[0]?.email;
-    const emailSubscribtion = u.profile?.app_emails;
-    if (email && emailSubscribtion) {
+    const emailSubscription = u.profile?.app_emails;
+    if (email && emailSubscription) {
       acc.push({
         email,
         profileId: u.profile.id,

--- a/api-lib/email/postmark.ts
+++ b/api-lib/email/postmark.ts
@@ -144,7 +144,7 @@ export async function sendCoLinksBigQuestionEmail(params: {
   const token = genToken(
     params.profile_id.toString(),
     params.email,
-    'colinks_product'
+    EmailType.COLINKS_HOT_HAPPENINGS
   );
   const input = {
     action_url:

--- a/api-lib/email/postmark.ts
+++ b/api-lib/email/postmark.ts
@@ -238,15 +238,23 @@ export async function sendEpochEndedEmail(params: {
   circle_name: string;
   circle_id: number;
   epoch_id: number;
+  profile_id: number;
   num_give_senders: number;
   num_notes_received: number;
 }) {
+  const token = genToken(
+    params.profile_id.toString(),
+    params.email,
+    'circle_notification'
+  );
+
   const input = {
     circle_name: params.circle_name,
     epoch_id: params.epoch_id,
     num_give_senders: params.num_give_senders,
     num_notes_received: params.num_notes_received,
     action_url: `${webAppURL('give')}/circles/${params.circle_id}/epochs`,
+    unsubscribe_url: webAppURL('give') + '/email/unsubscribe/' + token,
   };
   const res = await sendEmail(
     params.email,
@@ -262,11 +270,19 @@ export async function sendEpochEndingSoonEmail(params: {
   circle_name: string;
   circle_id: number;
   epoch_id: number;
+  profile_id: number;
 }) {
+  const token = genToken(
+    params.profile_id.toString(),
+    params.email,
+    'circle_notification'
+  );
+
   const input = {
     circle_name: params.circle_name,
     epoch_id: params.epoch_id,
     action_url: `${webAppURL('give')}/circles/${params.circle_id}/give`,
+    unsubscribe_url: webAppURL('give') + '/email/unsubscribe/' + token,
   };
   const res = await sendEmail(
     params.email,
@@ -282,11 +298,19 @@ export async function sendEpochStartedEmail(params: {
   circle_name: string;
   circle_id: number;
   epoch_id: number;
+  profile_id: number;
 }) {
+  const token = genToken(
+    params.profile_id.toString(),
+    params.email,
+    'circle_notification'
+  );
+
   const input = {
     circle_name: params.circle_name,
     epoch_id: params.epoch_id,
     action_url: `${webAppURL('give')}/circles/${params.circle_id}/give`,
+    unsubscribe_url: webAppURL('give') + '/email/unsubscribe/' + token,
   };
   const res = await sendEmail(
     params.email,

--- a/api-lib/email/postmark.ts
+++ b/api-lib/email/postmark.ts
@@ -3,7 +3,7 @@ import { coLinksPaths } from '../../src/routes/paths';
 import { POSTMARK_SERVER_TOKEN } from '../config';
 import { adminClient } from '../gql/adminClient';
 
-import { genToken } from './unsubscribe';
+import { EmailType, genToken } from './unsubscribe';
 
 const HELP_URL = 'https://docs.coordinape.com';
 const API_BASE_URL = 'https://api.postmarkapp.com';
@@ -118,7 +118,7 @@ export async function sendCoLinksNotificationsEmail(params: {
   const token = genToken(
     params.profile_id.toString(),
     params.email,
-    'notification'
+    EmailType.COLINKS_NOTIFICATION
   );
   const input = {
     action_url: webAppURL('colinks') + coLinksPaths.notifications,
@@ -245,7 +245,7 @@ export async function sendEpochEndedEmail(params: {
   const token = genToken(
     params.profile_id.toString(),
     params.email,
-    'circle_notification'
+    EmailType.CIRCLE_NOTIFICATION
   );
 
   const input = {
@@ -275,7 +275,7 @@ export async function sendEpochEndingSoonEmail(params: {
   const token = genToken(
     params.profile_id.toString(),
     params.email,
-    'circle_notification'
+    EmailType.CIRCLE_NOTIFICATION
   );
 
   const input = {
@@ -303,7 +303,7 @@ export async function sendEpochStartedEmail(params: {
   const token = genToken(
     params.profile_id.toString(),
     params.email,
-    'circle_notification'
+    EmailType.CIRCLE_NOTIFICATION
   );
 
   const input = {

--- a/api-lib/email/unsubscribe.ts
+++ b/api-lib/email/unsubscribe.ts
@@ -4,8 +4,8 @@ import { HMAC_SECRET } from '../config';
 import { UnauthorizedError } from '../HttpError';
 
 export enum EmailType {
-  GIVE_CIRCLE_HAPPENINGS = 'give_happenings',
-  COLINKS_HOT_HAPPENINGS = 'colinks_happenings',
+  GIVE_CIRCLE_HAPPENINGS = 'give_circle_product',
+  COLINKS_HOT_HAPPENINGS = 'colinks_product',
   CIRCLE_NOTIFICATION = 'circle_notification',
   COLINKS_NOTIFICATION = 'notification', // for colinks notifications. remainded this way to not affect old links
 }
@@ -61,7 +61,7 @@ export function decodeToken(encodedString: string): {
   if (token !== generatedToken) {
     throw new UnauthorizedError('Invalid unsubscribe token');
   }
-  return { profileId, email, emailType };
+  return { profileId, email, emailType: emailType as EmailType };
 }
 
 function genHmac(profileId: string, email: string, emailType: string): string {

--- a/api-lib/email/unsubscribe.ts
+++ b/api-lib/email/unsubscribe.ts
@@ -3,18 +3,18 @@ import { createHmac } from 'crypto';
 import { HMAC_SECRET } from '../config';
 import { UnauthorizedError } from '../HttpError';
 
-export type EmailType =
-  | 'product'
-  | 'transactional'
-  | 'notification'
-  | 'colinks_product';
+type EmailType =
+  | 'give_happenings'
+  | 'colinks_happenings'
+  | 'circle_notification'
+  | 'notification'; // for colinks notifications. remainded this way to not affect old links
 
 export function isEmailType(emailType: string): emailType is EmailType {
   return [
-    'product',
-    'transactional',
+    'give_happenings',
+    'colinks_happenings',
+    'circle_notification',
     'notification',
-    'colinks_product',
   ].includes(emailType);
 }
 
@@ -31,7 +31,6 @@ export function genToken(
     emailType,
     token,
   });
-
   return params.toString();
 }
 

--- a/api-lib/email/unsubscribe.ts
+++ b/api-lib/email/unsubscribe.ts
@@ -3,18 +3,19 @@ import { createHmac } from 'crypto';
 import { HMAC_SECRET } from '../config';
 import { UnauthorizedError } from '../HttpError';
 
-type EmailType =
-  | 'give_happenings'
-  | 'colinks_happenings'
-  | 'circle_notification'
-  | 'notification'; // for colinks notifications. remainded this way to not affect old links
+export enum EmailType {
+  GIVE_CIRCLE_HAPPENINGS = 'give_happenings',
+  COLINKS_HOT_HAPPENINGS = 'colinks_happenings',
+  CIRCLE_NOTIFICATION = 'circle_notification',
+  COLINKS_NOTIFICATION = 'notification', // for colinks notifications. remainded this way to not affect old links
+}
 
-export function isEmailType(emailType: string): emailType is EmailType {
+export function isEmailType(emailType: EmailType): emailType is EmailType {
   return [
-    'give_happenings',
-    'colinks_happenings',
-    'circle_notification',
-    'notification',
+    EmailType.CIRCLE_NOTIFICATION,
+    EmailType.COLINKS_NOTIFICATION,
+    EmailType.COLINKS_HOT_HAPPENINGS,
+    EmailType.GIVE_CIRCLE_HAPPENINGS,
   ].includes(emailType);
 }
 
@@ -45,7 +46,13 @@ export function decodeToken(encodedString: string): {
   const token = params.get('token');
   const emailType = params.get('emailType');
 
-  if (!profileId || !email || !token || !emailType || !isEmailType(emailType)) {
+  if (
+    !profileId ||
+    !email ||
+    !token ||
+    !emailType ||
+    !isEmailType(emailType as EmailType)
+  ) {
     throw new UnauthorizedError('Invalid unsubscribe token');
   }
 

--- a/api-test/email/unsubscribe.test.ts
+++ b/api-test/email/unsubscribe.test.ts
@@ -16,7 +16,7 @@ describe('unsubscribe tokens', () => {
   beforeEach(() => {
     profileId = '123';
     email = 'jugo@naranja.es';
-    emailType = 'product';
+    emailType = 'colinks_happenings';
     token = genToken(profileId, email, emailType);
   });
 

--- a/api-test/email/unsubscribe.test.ts
+++ b/api-test/email/unsubscribe.test.ts
@@ -16,7 +16,7 @@ describe('unsubscribe tokens', () => {
   beforeEach(() => {
     profileId = '123';
     email = 'jugo@naranja.es';
-    emailType = 'colinks_happenings';
+    emailType = 'colinks_product';
     token = genToken(profileId, email, emailType);
   });
 

--- a/api-test/hasura/cron/epochs_emails_stubbed.test.ts
+++ b/api-test/hasura/cron/epochs_emails_stubbed.test.ts
@@ -8,8 +8,6 @@ import {
   notifyEpochEnd,
   notifyEpochStart,
 } from '../../../_api/hasura/cron/epochs';
-import { insertActivity } from '../../../api-lib/event_triggers/activity/mutations';
-import { adminClient } from '../../../api-lib/gql/adminClient';
 import {
   sendEpochEndedEmail,
   sendEpochEndingSoonEmail,
@@ -87,8 +85,20 @@ const mockCircle = {
       name: 'mock Org',
     },
     users: [
-      { profile: { name: 'bob', emails: [{ email: 'bob@test.com' }] } },
-      { profile: { name: 'alice', emails: [{ email: 'alice@test.com' }] } },
+      {
+        profile: {
+          app_emails: true,
+          name: 'bob',
+          emails: [{ email: 'bob@test.com' }],
+        },
+      },
+      {
+        profile: {
+          app_emails: true,
+          name: 'alice',
+          emails: [{ email: 'alice@test.com' }],
+        },
+      },
     ],
   },
   notifyEndEpochs: {
@@ -98,8 +108,20 @@ const mockCircle = {
     name: 'circle with ending epoch',
     organization: { name: 'mock Org' },
     users: [
-      { profile: { name: 'bob', emails: [{ email: 'bob@test.com' }] } },
-      { profile: { name: 'alice', emails: [{ email: 'alice@test.com' }] } },
+      {
+        profile: {
+          app_emails: true,
+          name: 'bob',
+          emails: [{ email: 'bob@test.com' }],
+        },
+      },
+      {
+        profile: {
+          app_emails: true,
+          name: 'alice',
+          emails: [{ email: 'alice@test.com' }],
+        },
+      },
     ],
   },
   endEpoch: {
@@ -119,6 +141,7 @@ const mockCircle = {
         starting_tokens: 100 * (1 + i),
         give_token_remaining: i > 1 ? 0 : 100 * (1 + i),
         profile: {
+          app_emails: i < 5 ? true : false,
           name: 'person ' + i,
           emails: [i < 6 ? { email: `person${i}@test.com` } : {}],
         },
@@ -205,7 +228,7 @@ describe('send email notifications to circle members with verified emails', () =
     });
     const result = await endEpoch(input);
     expect(result).toEqual([]);
-    expect(sendEpochEndedEmail).toBeCalledTimes(6); //number of users with emails
+    expect(sendEpochEndedEmail).toBeCalledTimes(5); //number of users with app_emails set to true
     expect(sendEpochEndedEmail).nthCalledWith(1, {
       circle_id: 1,
       circle_name: 'circle with epoch that has ended',

--- a/src/pages/UnsubscribeEmailPage/UnsubscribeEmailPage.tsx
+++ b/src/pages/UnsubscribeEmailPage/UnsubscribeEmailPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 
+import { useIsCoLinksSite } from 'features/colinks/useIsCoLinksSite';
 import { WizardInstructions } from 'features/colinks/wizard/WizardInstructions';
 import { fullScreenStyles } from 'features/colinks/wizard/WizardSteps';
 import { useNavigate } from 'react-router';
@@ -7,13 +8,14 @@ import { useParams } from 'react-router-dom';
 
 import { LoadingModal } from '../../components';
 import { useAuthStateMachine } from '../../features/auth/RequireWeb3Auth';
-import { coLinksPaths } from '../../routes/paths';
+import { coLinksPaths, givePaths } from '../../routes/paths';
 import { Button, Flex, Panel, Text } from '../../ui';
 
 export const UnsubscribeEmailPage = () => {
   useAuthStateMachine(false);
   const { unsubscribeToken } = useParams();
   const navigate = useNavigate();
+  const isCoLinks = useIsCoLinksSite();
 
   const [unsubscribeMessage, setUnsubscribeMessage] = useState<
     string | undefined
@@ -54,19 +56,33 @@ export const UnsubscribeEmailPage = () => {
                   <Button
                     color="cta"
                     onClick={() => {
-                      navigate(coLinksPaths.home, {
-                        replace: true,
-                      });
+                      if (isCoLinks) {
+                        navigate(coLinksPaths.home, {
+                          replace: true,
+                        });
+                      } else {
+                        navigate(givePaths.home, {
+                          replace: true,
+                        });
+                      }
                     }}
                   >
-                    Continue to CoLinks
+                    {isCoLinks
+                      ? 'Continue to CoLinks'
+                      : 'Continue to Coordinape'}
                   </Button>
                   <Button
                     color="secondary"
                     onClick={() => {
-                      navigate(coLinksPaths.account, {
-                        replace: true,
-                      });
+                      if (isCoLinks) {
+                        navigate(coLinksPaths.account, {
+                          replace: true,
+                        });
+                      } else {
+                        navigate(givePaths.account, {
+                          replace: true,
+                        });
+                      }
                     }}
                   >
                     View Email Settings

--- a/src/routes/coLinksRoutes.tsx
+++ b/src/routes/coLinksRoutes.tsx
@@ -41,7 +41,7 @@ import { WizardStart } from '../pages/colinks/wizard/WizardStart';
 import CoSoulExplorePage from '../pages/CoSoulExplorePage/CoSoulExplorePage';
 import { InviteCodePage } from '../pages/InviteCodePage';
 import { PostPage } from '../pages/PostPage';
-import UnsubscribeEmailPage from 'pages/colinks/UnsubscribeEmailPage';
+import UnsubscribeEmailPage from 'pages/UnsubscribeEmailPage/UnsubscribeEmailPage';
 
 import { coLinksPaths } from './paths';
 import { RedirectAfterLogin } from './RedirectAfterLogin';

--- a/src/routes/giveRoutes.tsx
+++ b/src/routes/giveRoutes.tsx
@@ -31,6 +31,7 @@ import ProfilePage from '../pages/ProfilePage';
 import VaultsPage from '../pages/VaultsPage';
 import { VaultTransactions } from '../pages/VaultsPage/VaultTransactions';
 import VerifyEmailPage from '../pages/VerifyEmailPage';
+import UnsubscribeEmailPage from 'pages/UnsubscribeEmailPage/UnsubscribeEmailPage';
 
 import {
   NotReady,
@@ -194,6 +195,10 @@ export const giveRoutes = [
     >
       <Route path={givePaths.join(':token')} element={<JoinPage />} />
       <Route path={givePaths.verify(':uuid')} element={<VerifyEmailPage />} />
+      <Route
+        path={givePaths.unsubscribe(':unsubscribeToken')}
+        element={<UnsubscribeEmailPage />}
+      />
       <Route
         path="*"
         element={

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -143,6 +143,8 @@ export const givePaths = {
 
   // email verification
   verify: (uuid: string) => `/email/verify/${uuid}`,
+  unsubscribe: (unsubscribeToken: string) =>
+    `/email/unsubscribe/${unsubscribeToken}`,
 };
 
 export const isCircleSpecificPath = (location: Location) =>


### PR DESCRIPTION
## What
add one click unsubscribe to epoch notifications emails
1- for notifyEndEpochs and notifyStartEpochs: the users query is filtered by app_emails flag value
2- for endEpoch the users are filtered after fetching because the full list of users is required for other calculations
3- updated the emailType except for the already in use type 'notification' which is used for colinks emails
4- updated postmark functions and template

## Test and Deployment Plan
Tested  unsubsribe link for all epochs type and for colinks notifications

## Screenshots (if appropriate):
![image](https://github.com/coordinape/coordinape/assets/34943689/30fab380-8b87-457a-8b8c-d3024b46a4d6)
![image](https://github.com/coordinape/coordinape/assets/34943689/af256f01-9387-49e7-9d96-9250e4a21c6f)


### After Merge
On postmark, layout: "Basic with one click unsubscribe" with alias basic-one-click-unsubscribe should be copied to production server and used for Epoch Ended, Epoch Ending Soon and Epoch Started templates