### PR TITLE
fix subscription cancellation decoding function

### DIFF
--- a/api-lib/email/unsubscribe.ts
+++ b/api-lib/email/unsubscribe.ts
@@ -43,9 +43,8 @@ export function decodeToken(encodedString: string): {
   const params = new URLSearchParams(encodedString);
   const profileId = params.get('profileId');
   const email = decodeURIComponent(params.get('email') || '');
-  const token = params.get('token');
+  const token = params.get('token')?.split('?')[0];
   const emailType = params.get('emailType');
-
   if (
     !profileId ||
     !email ||
@@ -53,12 +52,14 @@ export function decodeToken(encodedString: string): {
     !emailType ||
     !isEmailType(emailType as EmailType)
   ) {
+    console.error(params);
     throw new UnauthorizedError('Invalid unsubscribe token');
   }
 
   const generatedToken = genHmac(profileId, email, emailType);
 
   if (token !== generatedToken) {
+    console.error(params);
     throw new UnauthorizedError('Invalid unsubscribe token');
   }
   return { profileId, email, emailType: emailType as EmailType };

--- a/src/pages/UnsubscribeEmailPage/UnsubscribeEmailPage.tsx
+++ b/src/pages/UnsubscribeEmailPage/UnsubscribeEmailPage.tsx
@@ -31,6 +31,7 @@ export const UnsubscribeEmailPage = () => {
     } catch (e) {
       if (e instanceof Error) {
         setUnsubscribeMessage(e.message ?? 'unknown error');
+        console.error(e);
       } else {
         setUnsubscribeMessage('Invalid token or network error');
       }
@@ -49,7 +50,10 @@ export const UnsubscribeEmailPage = () => {
             <Flex column css={{ gap: '$md' }}>
               {unsubscribeMessage && (
                 <>
-                  <Text h2>You&lsquo;ve been unsubscribed</Text>
+                  {!unsubscribeMessage.includes('Invalid') && (
+                    <Text h2>You&lsquo;ve been unsubscribed</Text>
+                  )}
+
                   <Panel nested>
                     <Text>{unsubscribeMessage}</Text>
                   </Panel>


### PR DESCRIPTION
##what
fix unsubscribe decode function for production
removed successful cancelling header on errors

## Why
unsubscribe token is getting extra parameters on production

## Test and Deployment Plan
tested old unsubscribe links to unsubscribe locally and on staging

## How
split token on "?" 