### PR TITLE
Wrap useNotificationCount query and favicon changing into sub component so it doesn't cause full app re-renders on every refetch.

### DIFF
--- a/src/features/activities/useInfiniteActivities.tsx
+++ b/src/features/activities/useInfiniteActivities.tsx
@@ -120,6 +120,7 @@ export const useInfiniteActivities = (
       refetchOnWindowFocus: true,
       refetchInterval: overrideRefetchInterval ?? 10000,
       onSettled: () => onSettled && onSettled(),
+      notifyOnChangeProps: 'tracked',
     }
   );
 };

--- a/src/features/colinks/CoLinksContext.tsx
+++ b/src/features/colinks/CoLinksContext.tsx
@@ -6,15 +6,14 @@ import { useLocation } from 'react-router-dom';
 
 import { LoadingModal } from '../../components';
 import CopyCodeTextField from '../../components/CopyCodeTextField';
-import { webAppURL } from '../../config/webAppURL';
 import useConnectedAddress from '../../hooks/useConnectedAddress';
 import { coLinksPaths } from '../../routes/paths';
 import { Button, Flex, Modal, Text } from '../../ui';
 import { useAuthStore } from '../auth';
 import { useLogout } from '../auth/useLogout';
 import { getCoLinksContract } from '../cosoul/contracts';
-import { useNotificationCount } from '../notifications/useNotificationCount';
 
+import { FaviconNotificationBadge } from './FaviconNotificationBadge';
 import { useCoLinksNavQuery } from './useCoLinksNavQuery';
 import { TOS_UPDATED_AT } from './wizard/WizardTerms';
 
@@ -91,21 +90,6 @@ const CoLinksProvider: React.FC<CoLinksProviderProps> = ({ children }) => {
     }
   }, [data]);
 
-  const { count: notificationCount } = useNotificationCount();
-  useEffect(() => {
-    let link = document.querySelector("link[rel~='icon']") as HTMLLinkElement;
-    if (!link) {
-      link = document.createElement('link');
-      link.rel = 'icon';
-      document.getElementsByTagName('head')[0].appendChild(link);
-    }
-    if (notificationCount !== undefined && notificationCount > 0) {
-      link.href = webAppURL('colinks') + '/imgs/logo/colinks-favicon-noti.png';
-    } else {
-      link.href = webAppURL('colinks') + '/imgs/logo/colinks-favicon.png';
-    }
-  }, [notificationCount]);
-
   // TODO: handle these cases
   // if (!chainId) {
   //   return <Text>Not connected</Text>;
@@ -137,6 +121,7 @@ const CoLinksProvider: React.FC<CoLinksProviderProps> = ({ children }) => {
         setShowConnectWallet,
       }}
     >
+      <FaviconNotificationBadge />
       {children}
       {showConnectWallet && (
         <ConnectWalletModal onClose={() => setShowConnectWallet(false)} />

--- a/src/features/colinks/CoLinksNav.tsx
+++ b/src/features/colinks/CoLinksNav.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { useContext, useEffect, useState } from 'react';
+import { memo, useContext, useEffect, useState } from 'react';
 
 import { CoLogoMark } from 'features/nav/CoLogoMark';
 import { client } from 'lib/gql/client';
@@ -367,7 +367,7 @@ const NavItem = ({
   );
 };
 
-const Count = () => {
+const Count = memo(function Count() {
   const { count } = useNotificationCount();
 
   return count ? (
@@ -388,4 +388,4 @@ const Count = () => {
       {count}
     </Text>
   ) : null;
-};
+});

--- a/src/features/colinks/FaviconNotificationBadge.tsx
+++ b/src/features/colinks/FaviconNotificationBadge.tsx
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+
+import { webAppURL } from '../../config/webAppURL';
+import { useNotificationCount } from '../notifications/useNotificationCount';
+
+export const FaviconNotificationBadge = () => {
+  const { count: notificationCount } = useNotificationCount();
+  useEffect(() => {
+    let link = document.querySelector("link[rel~='icon']") as HTMLLinkElement;
+    if (!link) {
+      link = document.createElement('link');
+      link.rel = 'icon';
+      document.getElementsByTagName('head')[0].appendChild(link);
+    }
+    if (notificationCount !== undefined && notificationCount > 0) {
+      link.href = webAppURL('colinks') + '/imgs/logo/colinks-favicon-noti.png';
+    } else {
+      link.href = webAppURL('colinks') + '/imgs/logo/colinks-favicon.png';
+    }
+  }, [notificationCount]);
+
+  return null;
+};


### PR DESCRIPTION
Fixes two whole page re-render bugs

1. useNotificationCount in the Provider causes everything nested in the provider (whole app) to rerender. Fixed by wrapping in Component

See
https://www.developerway.com/posts/why-custom-react-hooks-could-destroy-your-app-performance
for a description of the issue and why this resolves it

2. Fix activity list re-rendering on new data fetching, and changes it to only re-render when new data is fetched via `notifyOnChangeProps` 