### PR TITLE
UI Bug: "first to add" button position

### DIFF
--- a/src/components/ComboBox.tsx
+++ b/src/components/ComboBox.tsx
@@ -138,6 +138,11 @@ export const ComboBox = ({
         height: 'auto',
         background: 'transparent !important',
         borderRadius: '0 !important',
+        '&.firstToAdd': {
+          position: 'absolute',
+          bottom: '-$xl',
+          width: '100%',
+        },
       }),
     },
 
@@ -161,7 +166,9 @@ export const ComboBox = ({
             maxHeight: '200px',
           }),
       ...(giveSkillSelector && {
-        p: '$md',
+        pt: '$md',
+        px: '$md',
+        pb: '$2xl',
       }),
     },
 
@@ -174,6 +181,9 @@ export const ComboBox = ({
           pt: 0,
         },
       },
+      ...(giveSkillSelector && {
+        position: 'relative',
+      }),
     },
 
     '[cmdk-group]': {

--- a/src/components/SkillComboBox/SkillComboBox.tsx
+++ b/src/components/SkillComboBox/SkillComboBox.tsx
@@ -258,6 +258,7 @@ const AddItem = ({
 
   return (
     <Command.Item
+      className="firstToAdd"
       color={'cta'}
       key={search}
       value={search}
@@ -267,16 +268,7 @@ const AddItem = ({
         css={{ justifyContent: 'space-between', width: '100%', gap: '$lg' }}
       >
         <Text>Be the First to Add</Text>
-        <Text
-          tag
-          color={'complete'}
-          semibold
-          size={'medium'}
-          css={{
-            background: 'transparent',
-            border: '1px solid $tagSuccessBackground',
-          }}
-        >
+        <Text tag color={'complete'} semibold size={'medium'}>
           {search}
         </Text>
       </Flex>


### PR DESCRIPTION
Not sure why this "be the first to add" is appearing above the list, but we can pin it to the bottom with css.  

buggy prod:
![Screenshot 2024-03-06 at 3 04 18 PM](https://github.com/coordinape/coordinape/assets/100873710/e03791bf-c4a1-49b6-b03f-f75b36ca1810)


absolute pin:
![Screenshot 2024-03-06 at 3 00 40 PM](https://github.com/coordinape/coordinape/assets/100873710/5925cead-637e-4301-9aca-3cbb891dd51e)

Hopefully this will work in prod