### PR TITLE
Batch pGIVE Syncing

### DIFF
--- a/_api/hasura/cron/syncCoSouls.ts
+++ b/_api/hasura/cron/syncCoSouls.ts
@@ -2,7 +2,7 @@
 import { VercelRequest, VercelResponse } from '@vercel/node';
 import { DateTime, Settings } from 'luxon';
 
-import { IS_LOCAL_ENV } from '../../../api-lib/config';
+import { IS_LOCAL_ENV, IS_TEST_ENV } from '../../../api-lib/config';
 import { adminClient } from '../../../api-lib/gql/adminClient';
 import { errorLog } from '../../../api-lib/HttpError';
 import { getCirclesNoPgiveWithDateFilter } from '../../../api-lib/pgives';
@@ -26,7 +26,7 @@ type CoSoul = Awaited<ReturnType<typeof getCoSoulsToUpdate>>[number];
 // This cron ensures that on-chain pgive reflects our local pgive state.
 // This should only process each CoSoul once per month
 async function handler(req: VercelRequest, res: VercelResponse) {
-  if (IS_LOCAL_ENV) {
+  if (IS_LOCAL_ENV && !IS_TEST_ENV) {
     return res.status(200).json({
       message: 'This endpoint is disabled in local environment.',
     });

--- a/api-test/hasura/cron/syncCoSouls.test.ts
+++ b/api-test/hasura/cron/syncCoSouls.test.ts
@@ -1,0 +1,210 @@
+vi.mock('puppeteer-core', () => {
+  return { default: {} };
+});
+import assert from 'assert';
+
+import type { CoSoul } from '@coordinape/contracts/typechain';
+import type { VercelRequest } from '@vercel/node';
+import { vi } from 'vitest';
+
+import handler, * as syncCosouls from '../../../_api/hasura/cron/syncCoSouls';
+import {
+  cosouls_constraint,
+  cosouls_update_column,
+} from '../../../api-lib/gql/__generated__/zeus';
+import { adminClient } from '../../../api-lib/gql/adminClient';
+import * as cosoulApi from '../../../src/features/cosoul/api/cosoul';
+import { Contracts } from '../../../src/features/cosoul/contracts';
+import {
+  provider,
+  restoreSnapshot,
+  takeSnapshot,
+} from '../../../src/utils/testing/provider';
+import { createProfile, createUser } from '../../helpers';
+
+let contract: CoSoul;
+let snapshotId: string;
+let mainAccount: string;
+let secondAccount: string;
+let mainTokenId: number | undefined;
+let secondTokenId: number | undefined;
+let accounts: string[];
+let user: any;
+let user2: any;
+let mainTx: Awaited<ReturnType<typeof contract.mint>>;
+let secondTx: Awaited<ReturnType<typeof contract.mint>>;
+
+const req = {
+  headers: { verification_key: process.env.HASURA_EVENT_SECRET },
+} as unknown as VercelRequest;
+
+const res: any = { status: vi.fn(() => res), json: vi.fn() };
+
+describe('syncCoSouls cron', () => {
+  beforeEach(async () => {
+    vi.spyOn(syncCosouls, 'isHistoricalPGiveFinished').mockResolvedValue(true);
+    vi.spyOn(cosoulApi, 'setOnChainPGIVE');
+    vi.spyOn(cosoulApi, 'setBatchOnChainPGIVE');
+
+    snapshotId = await takeSnapshot();
+
+    accounts = await provider().listAccounts();
+
+    mainAccount = accounts[0];
+    const mainProfile = await createProfile(adminClient, {
+      address: mainAccount,
+    });
+    user = await createUser(adminClient, { profile_id: mainProfile.id });
+
+    contract = (await Contracts.fromProvider(provider())).cosoul;
+
+    mainTx = await contract.mint();
+    mainTokenId = await cosoulApi.getTokenId(mainAccount);
+
+    secondAccount = accounts[1];
+    const secondProfile = await createProfile(adminClient, {
+      address: secondAccount,
+    });
+    user2 = await createUser(adminClient, { profile_id: secondProfile.id });
+
+    secondTx = await cosoulApi.mintCoSoulForAddress(secondAccount);
+    secondTokenId = await cosoulApi.getTokenId(secondAccount);
+
+    await adminClient.mutate(
+      {
+        delete_member_epoch_pgives: [
+          {
+            where: {},
+          },
+          { affected_rows: true },
+        ],
+      },
+      { operationName: 'syncCoSoul__deleteMembersEpochPGive' }
+    );
+
+    await adminClient.mutate(
+      {
+        insert_cosouls: [
+          {
+            objects: [
+              {
+                created_tx_hash: mainTx.hash,
+                token_id: mainTokenId,
+                address: mainAccount,
+                checked_at: null,
+                pgive: 1,
+              },
+              {
+                created_tx_hash: secondTx.hash,
+                token_id: secondTokenId,
+                address: secondAccount,
+                checked_at: null,
+                pgive: 1,
+              },
+            ],
+            on_conflict: {
+              constraint: cosouls_constraint.cosouls_token_id_key,
+              update_columns: [
+                cosouls_update_column.token_id,
+                cosouls_update_column.created_tx_hash,
+                cosouls_update_column.address,
+                cosouls_update_column.checked_at,
+                cosouls_update_column.pgive,
+              ],
+            },
+          },
+          {
+            affected_rows: true,
+          },
+        ],
+      },
+      {
+        operationName: 'syncCoSoulTest__insertCoSoul',
+      }
+    );
+  });
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    await restoreSnapshot(snapshotId);
+  });
+
+  afterAll(async () => {
+    await adminClient.mutate(
+      {
+        delete_cosouls: [
+          {
+            where: {},
+          },
+          // something needs to be returned in the mutation
+          { __typename: true, affected_rows: true },
+        ],
+      },
+      { operationName: 'test__DeleteCosouls' }
+    );
+  });
+
+  test('updates pgive for one user on chain using setOnChainPGIVE', async () => {
+    assert(mainTokenId);
+    await adminClient.mutate(
+      {
+        insert_member_epoch_pgives_one: [
+          {
+            object: {
+              user_id: user.id,
+              epoch_id: 1,
+              pgive: 500,
+              normalized_pgive: 500,
+            },
+          },
+          { id: true },
+        ],
+      },
+      { operationName: 'syncCoSoul__insertMemberEpochPGive' }
+    );
+    await handler(req, res);
+    expect(res.json).toHaveBeenCalled();
+    expect(cosoulApi.setOnChainPGIVE).toHaveBeenCalledWith(mainTokenId, 500);
+    expect(await cosoulApi.getOnChainPGIVE(mainTokenId)).toEqual(500);
+  });
+
+  test('updates pgive for multiple users on chain using setBatchOnChainPGIVE', async () => {
+    assert(mainTokenId);
+    assert(secondTokenId);
+    await adminClient.mutate(
+      {
+        insert_member_epoch_pgives: [
+          {
+            objects: [
+              {
+                user_id: user.id,
+                epoch_id: 1,
+                pgive: 320,
+                normalized_pgive: 320,
+              },
+              {
+                user_id: user2.id,
+                epoch_id: 1,
+                pgive: 330,
+                normalized_pgive: 330,
+              },
+            ],
+          },
+          { affected_rows: true },
+        ],
+      },
+      { operationName: 'syncCoSoul__insertMembersEpochPGive' }
+    );
+
+    await handler(req, res);
+    expect(res.json).toHaveBeenCalled();
+    let payload = '0x00';
+    payload +=
+      cosoulApi.getPayload(320, mainTokenId) +
+      cosoulApi.getPayload(330, secondTokenId);
+    expect(cosoulApi.setBatchOnChainPGIVE).toHaveBeenCalledWith(payload);
+    expect(cosoulApi.setOnChainPGIVE).not.toBeCalled();
+    expect(await cosoulApi.getOnChainPGIVE(mainTokenId)).toEqual(320);
+    expect(await cosoulApi.getOnChainPGIVE(secondTokenId)).toEqual(330);
+  });
+});

--- a/hardhat/test/utils/network.ts
+++ b/hardhat/test/utils/network.ts
@@ -1,4 +1,5 @@
 import { network } from 'hardhat';
+
 import config from '../../hardhat.config';
 
 const { url: jsonRpcUrl, blockNumber } =

--- a/src/features/cosoul/api/cosoul.ts
+++ b/src/features/cosoul/api/cosoul.ts
@@ -11,7 +11,7 @@ export const REP_SLOT = 1;
 export const PGIVE_SYNC_DURATION_DAYS = 30;
 
 type Slot = typeof PGIVE_SLOT | typeof REP_SLOT;
-type CoSoulArgs = { tokenId: number; amount: number };
+export type CoSoulArgs = { tokenId: number; amount: number };
 
 function getCoSoulContract() {
   const chainId = Number(chain.chainId);


### PR DESCRIPTION
## What
Switch cosoul pgive syncer to use batchSetSlot_UfO  instead of  setSlot:
- batch syncing in cron
- Updated existing unit testing.
- added a new unit test for syncCoSouls cron to make sure all changes work together

## Test and Deployment Plan
The changes are tested in the following files:
hardhat/test/01-cosoul/00-cosoul.ts
src/features/cosoul/api/cosoul.test.ts
api-test/hasura/cron/syncCoSouls.test.ts - new file

## How
1 - batchSetSlot_UfO needs bytes array: first byte is pgive slot which is 0
then 8 bytes for each pgive where 4 bytes for pgives amount and four for token id.
I utilized paddedHex and converted to typescript to freely convert the number to hex and add 0x on choice