### PR TITLE
validate against neynar, fake webapp url, force content type

### DIFF
--- a/_api/frames/getFramePostInfo.tsx
+++ b/_api/frames/getFramePostInfo.tsx
@@ -2,6 +2,8 @@
 import { VercelRequest } from '@vercel/node';
 
 import { findOrCreateProfileByFid } from '../../api-lib/neynar/findOrCreateProfileByFid.ts';
+import { validateFrame } from '../../api-lib/neynar.ts';
+import { IN_DEVELOPMENT } from '../../src/config/env.ts';
 
 import { FrameMessage } from './FrameMessage.ts';
 
@@ -15,11 +17,15 @@ export async function getFramePostInfo(req: VercelRequest) {
   console.log(messageBytes);
   console.log(untrustedData);
 
-  // TODO: validation here when !LOCAL ? don't just use untrustedData
   const frameMessage: FrameMessage = untrustedData;
   const profile = await findOrCreateProfileByFid(frameMessage.fid);
 
-  // are we X or Y or rando ?
+  if (!IN_DEVELOPMENT) {
+    const validated = await validateFrame(messageBytes);
+    if (!validated.valid) {
+      throw new Error('frame validation failed');
+    }
+  }
 
   return {
     message: frameMessage,

--- a/_api/frames/router.tsx
+++ b/_api/frames/router.tsx
@@ -177,6 +177,7 @@ const addFrame = (frame: Frame) => {
           'Cache-Control',
           'no-store, no-cache, must-revalidate, max-age=0'
         );
+        res.setHeader('Content-Type', 'text/html');
         RenderFrameMeta({ frame, res, params });
       }
     );
@@ -249,6 +250,7 @@ const addFrame = (frame: Frame) => {
       );
       res.setHeader('Pragma', 'no-cache');
       res.setHeader('Expires', '0');
+      res.setHeader('Content-Type', 'image/png');
       Readable.fromWeb(ir.body as ReadableStream<any>).pipe(res);
     }
   );

--- a/src/config/webAppURL.ts
+++ b/src/config/webAppURL.ts
@@ -10,8 +10,13 @@ const GIVE_STAGING_URL = 'https://app.costaging.co';
 export const GIVE_LOCAL_URL = 'http://app.co.local:3000';
 export const COLINKS_LOCAL_URL = 'http://colinks.co.local:3000';
 
+// set this to force webAppURL to return a specific URL, like when you are using ngrok to do testing
+const FORCE_WEB_URL = process.env.FORCE_WEB_URL;
+
 export const webAppURL = (app: 'colinks' | 'give' | 'cosoul') => {
-  if (IN_PRODUCTION) {
+  if (FORCE_WEB_URL) {
+    return FORCE_WEB_URL;
+  } else if (IN_PRODUCTION) {
     switch (app) {
       case 'colinks':
         return COLINKS_PRODUCTION_URL;


### PR DESCRIPTION
## What

* Adds frame validation for !IN_DEVELOPMENT. Tested w/ the warpcast frame debugger.
* Added ability  in local dev to force a web app url for testing w/ ngrok
* Forced image/png content type for img return. This fixes an error in the warpcast debugger about missing content type. 

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How
