### PR TITLE
add notifications for others replies

### DIFF
--- a/api-lib/gql/__generated__/zeus/const.ts
+++ b/api-lib/gql/__generated__/zeus/const.ts
@@ -7827,6 +7827,8 @@ export const AllTypesProps: Record<string, any> = {
     reaction_id: 'bigint_comparison_exp',
     reply: 'replies_bool_exp',
     reply_id: 'Int_comparison_exp',
+    second_actor_profile_id: 'bigint_comparison_exp',
+    second_actor_public_profile: 'profiles_public_bool_exp',
   },
   notifications_constraint: true,
   notifications_inc_input: {
@@ -7834,6 +7836,7 @@ export const AllTypesProps: Record<string, any> = {
     invite_joined_id: 'bigint',
     profile_id: 'bigint',
     reaction_id: 'bigint',
+    second_actor_profile_id: 'bigint',
   },
   notifications_insert_input: {
     actor_profile_id: 'bigint',
@@ -7851,6 +7854,8 @@ export const AllTypesProps: Record<string, any> = {
     reaction: 'reactions_obj_rel_insert_input',
     reaction_id: 'bigint',
     reply: 'replies_obj_rel_insert_input',
+    second_actor_profile_id: 'bigint',
+    second_actor_public_profile: 'profiles_public_obj_rel_insert_input',
   },
   notifications_on_conflict: {
     constraint: 'notifications_constraint',
@@ -7878,6 +7883,8 @@ export const AllTypesProps: Record<string, any> = {
     reaction_id: 'order_by',
     reply: 'replies_order_by',
     reply_id: 'order_by',
+    second_actor_profile_id: 'order_by',
+    second_actor_public_profile: 'profiles_public_order_by',
   },
   notifications_pk_columns_input: {},
   notifications_select_column: true,
@@ -7888,6 +7895,7 @@ export const AllTypesProps: Record<string, any> = {
     link_tx_hash: 'citext',
     profile_id: 'bigint',
     reaction_id: 'bigint',
+    second_actor_profile_id: 'bigint',
   },
   notifications_stream_cursor_input: {
     initial_value: 'notifications_stream_cursor_value_input',
@@ -7900,6 +7908,7 @@ export const AllTypesProps: Record<string, any> = {
     link_tx_hash: 'citext',
     profile_id: 'bigint',
     reaction_id: 'bigint',
+    second_actor_profile_id: 'bigint',
   },
   notifications_update_column: true,
   notifications_updates: {
@@ -18823,6 +18832,8 @@ export const ReturnTypes: Record<string, any> = {
     reaction_id: 'bigint',
     reply: 'replies',
     reply_id: 'Int',
+    second_actor_profile_id: 'bigint',
+    second_actor_public_profile: 'profiles_public',
   },
   notifications_aggregate: {
     aggregate: 'notifications_aggregate_fields',
@@ -18851,6 +18862,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'Float',
     reaction_id: 'Float',
     reply_id: 'Float',
+    second_actor_profile_id: 'Float',
   },
   notifications_max_fields: {
     actor_profile_id: 'bigint',
@@ -18864,6 +18876,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'bigint',
     reaction_id: 'bigint',
     reply_id: 'Int',
+    second_actor_profile_id: 'bigint',
   },
   notifications_min_fields: {
     actor_profile_id: 'bigint',
@@ -18877,6 +18890,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'bigint',
     reaction_id: 'bigint',
     reply_id: 'Int',
+    second_actor_profile_id: 'bigint',
   },
   notifications_mutation_response: {
     affected_rows: 'Int',
@@ -18892,6 +18906,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'Float',
     reaction_id: 'Float',
     reply_id: 'Float',
+    second_actor_profile_id: 'Float',
   },
   notifications_stddev_pop_fields: {
     actor_profile_id: 'Float',
@@ -18903,6 +18918,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'Float',
     reaction_id: 'Float',
     reply_id: 'Float',
+    second_actor_profile_id: 'Float',
   },
   notifications_stddev_samp_fields: {
     actor_profile_id: 'Float',
@@ -18914,6 +18930,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'Float',
     reaction_id: 'Float',
     reply_id: 'Float',
+    second_actor_profile_id: 'Float',
   },
   notifications_sum_fields: {
     actor_profile_id: 'bigint',
@@ -18925,6 +18942,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'bigint',
     reaction_id: 'bigint',
     reply_id: 'Int',
+    second_actor_profile_id: 'bigint',
   },
   notifications_var_pop_fields: {
     actor_profile_id: 'Float',
@@ -18936,6 +18954,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'Float',
     reaction_id: 'Float',
     reply_id: 'Float',
+    second_actor_profile_id: 'Float',
   },
   notifications_var_samp_fields: {
     actor_profile_id: 'Float',
@@ -18947,6 +18966,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'Float',
     reaction_id: 'Float',
     reply_id: 'Float',
+    second_actor_profile_id: 'Float',
   },
   notifications_variance_fields: {
     actor_profile_id: 'Float',
@@ -18958,6 +18978,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'Float',
     reaction_id: 'Float',
     reply_id: 'Float',
+    second_actor_profile_id: 'Float',
   },
   org_members: {
     created_at: 'timestamp',

--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -20519,6 +20519,9 @@ export type ValueTypes = {
     /** An object relationship */
     reply?: ValueTypes['replies'];
     reply_id?: boolean | `@${string}`;
+    second_actor_profile_id?: boolean | `@${string}`;
+    /** An object relationship */
+    second_actor_public_profile?: ValueTypes['profiles_public'];
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregated selection of "notifications" */
@@ -20562,6 +20565,7 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     reaction_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
+    second_actor_profile_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** Boolean expression to filter rows from the table "notifications". All fields are combined with a logical 'AND'. */
@@ -20595,6 +20599,14 @@ export type ValueTypes = {
     reaction_id?: ValueTypes['bigint_comparison_exp'] | undefined | null;
     reply?: ValueTypes['replies_bool_exp'] | undefined | null;
     reply_id?: ValueTypes['Int_comparison_exp'] | undefined | null;
+    second_actor_profile_id?:
+      | ValueTypes['bigint_comparison_exp']
+      | undefined
+      | null;
+    second_actor_public_profile?:
+      | ValueTypes['profiles_public_bool_exp']
+      | undefined
+      | null;
   };
   /** unique or primary key constraints on table "notifications" */
   ['notifications_constraint']: notifications_constraint;
@@ -20609,6 +20621,7 @@ export type ValueTypes = {
     profile_id?: ValueTypes['bigint'] | undefined | null;
     reaction_id?: ValueTypes['bigint'] | undefined | null;
     reply_id?: number | undefined | null;
+    second_actor_profile_id?: ValueTypes['bigint'] | undefined | null;
   };
   /** input type for inserting data into table "notifications" */
   ['notifications_insert_input']: {
@@ -20644,6 +20657,11 @@ export type ValueTypes = {
     reaction_id?: ValueTypes['bigint'] | undefined | null;
     reply?: ValueTypes['replies_obj_rel_insert_input'] | undefined | null;
     reply_id?: number | undefined | null;
+    second_actor_profile_id?: ValueTypes['bigint'] | undefined | null;
+    second_actor_public_profile?:
+      | ValueTypes['profiles_public_obj_rel_insert_input']
+      | undefined
+      | null;
   };
   /** aggregate max on columns */
   ['notifications_max_fields']: AliasType<{
@@ -20658,6 +20676,7 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     reaction_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
+    second_actor_profile_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregate min on columns */
@@ -20673,6 +20692,7 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     reaction_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
+    second_actor_profile_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** response of any mutation on the table "notifications" */
@@ -20717,6 +20737,11 @@ export type ValueTypes = {
     reaction_id?: ValueTypes['order_by'] | undefined | null;
     reply?: ValueTypes['replies_order_by'] | undefined | null;
     reply_id?: ValueTypes['order_by'] | undefined | null;
+    second_actor_profile_id?: ValueTypes['order_by'] | undefined | null;
+    second_actor_public_profile?:
+      | ValueTypes['profiles_public_order_by']
+      | undefined
+      | null;
   };
   /** primary key columns input for table: notifications */
   ['notifications_pk_columns_input']: {
@@ -20737,6 +20762,7 @@ export type ValueTypes = {
     profile_id?: ValueTypes['bigint'] | undefined | null;
     reaction_id?: ValueTypes['bigint'] | undefined | null;
     reply_id?: number | undefined | null;
+    second_actor_profile_id?: ValueTypes['bigint'] | undefined | null;
   };
   /** aggregate stddev on columns */
   ['notifications_stddev_fields']: AliasType<{
@@ -20749,6 +20775,7 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     reaction_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
+    second_actor_profile_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregate stddev_pop on columns */
@@ -20762,6 +20789,7 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     reaction_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
+    second_actor_profile_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregate stddev_samp on columns */
@@ -20775,6 +20803,7 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     reaction_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
+    second_actor_profile_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** Streaming cursor of the table "notifications" */
@@ -20797,6 +20826,7 @@ export type ValueTypes = {
     profile_id?: ValueTypes['bigint'] | undefined | null;
     reaction_id?: ValueTypes['bigint'] | undefined | null;
     reply_id?: number | undefined | null;
+    second_actor_profile_id?: ValueTypes['bigint'] | undefined | null;
   };
   /** aggregate sum on columns */
   ['notifications_sum_fields']: AliasType<{
@@ -20809,6 +20839,7 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     reaction_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
+    second_actor_profile_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** update columns of table "notifications" */
@@ -20832,6 +20863,7 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     reaction_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
+    second_actor_profile_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregate var_samp on columns */
@@ -20845,6 +20877,7 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     reaction_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
+    second_actor_profile_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregate variance on columns */
@@ -20858,6 +20891,7 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     reaction_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
+    second_actor_profile_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   ['numeric']: unknown;
@@ -48284,6 +48318,9 @@ export type ModelTypes = {
     /** An object relationship */
     reply?: GraphQLTypes['replies'] | undefined;
     reply_id?: number | undefined;
+    second_actor_profile_id?: GraphQLTypes['bigint'] | undefined;
+    /** An object relationship */
+    second_actor_public_profile?: GraphQLTypes['profiles_public'] | undefined;
   };
   /** aggregated selection of "notifications" */
   ['notifications_aggregate']: {
@@ -48315,6 +48352,7 @@ export type ModelTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    second_actor_profile_id?: number | undefined;
   };
   /** Boolean expression to filter rows from the table "notifications". All fields are combined with a logical 'AND'. */
   ['notifications_bool_exp']: GraphQLTypes['notifications_bool_exp'];
@@ -48337,6 +48375,7 @@ export type ModelTypes = {
     profile_id?: GraphQLTypes['bigint'] | undefined;
     reaction_id?: GraphQLTypes['bigint'] | undefined;
     reply_id?: number | undefined;
+    second_actor_profile_id?: GraphQLTypes['bigint'] | undefined;
   };
   /** aggregate min on columns */
   ['notifications_min_fields']: {
@@ -48351,6 +48390,7 @@ export type ModelTypes = {
     profile_id?: GraphQLTypes['bigint'] | undefined;
     reaction_id?: GraphQLTypes['bigint'] | undefined;
     reply_id?: number | undefined;
+    second_actor_profile_id?: GraphQLTypes['bigint'] | undefined;
   };
   /** response of any mutation on the table "notifications" */
   ['notifications_mutation_response']: {
@@ -48380,6 +48420,7 @@ export type ModelTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    second_actor_profile_id?: number | undefined;
   };
   /** aggregate stddev_pop on columns */
   ['notifications_stddev_pop_fields']: {
@@ -48392,6 +48433,7 @@ export type ModelTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    second_actor_profile_id?: number | undefined;
   };
   /** aggregate stddev_samp on columns */
   ['notifications_stddev_samp_fields']: {
@@ -48404,6 +48446,7 @@ export type ModelTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    second_actor_profile_id?: number | undefined;
   };
   /** Streaming cursor of the table "notifications" */
   ['notifications_stream_cursor_input']: GraphQLTypes['notifications_stream_cursor_input'];
@@ -48420,6 +48463,7 @@ export type ModelTypes = {
     profile_id?: GraphQLTypes['bigint'] | undefined;
     reaction_id?: GraphQLTypes['bigint'] | undefined;
     reply_id?: number | undefined;
+    second_actor_profile_id?: GraphQLTypes['bigint'] | undefined;
   };
   /** update columns of table "notifications" */
   ['notifications_update_column']: GraphQLTypes['notifications_update_column'];
@@ -48435,6 +48479,7 @@ export type ModelTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    second_actor_profile_id?: number | undefined;
   };
   /** aggregate var_samp on columns */
   ['notifications_var_samp_fields']: {
@@ -48447,6 +48492,7 @@ export type ModelTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    second_actor_profile_id?: number | undefined;
   };
   /** aggregate variance on columns */
   ['notifications_variance_fields']: {
@@ -48459,6 +48505,7 @@ export type ModelTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    second_actor_profile_id?: number | undefined;
   };
   ['numeric']: any;
   /** Boolean expression to compare columns of type "numeric". All fields are combined with logical 'AND'. */
@@ -69018,6 +69065,9 @@ export type GraphQLTypes = {
     /** An object relationship */
     reply?: GraphQLTypes['replies'] | undefined;
     reply_id?: number | undefined;
+    second_actor_profile_id?: GraphQLTypes['bigint'] | undefined;
+    /** An object relationship */
+    second_actor_public_profile?: GraphQLTypes['profiles_public'] | undefined;
   };
   /** aggregated selection of "notifications" */
   ['notifications_aggregate']: {
@@ -69052,6 +69102,7 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    second_actor_profile_id?: number | undefined;
   };
   /** Boolean expression to filter rows from the table "notifications". All fields are combined with a logical 'AND'. */
   ['notifications_bool_exp']: {
@@ -69080,6 +69131,10 @@ export type GraphQLTypes = {
     reaction_id?: GraphQLTypes['bigint_comparison_exp'] | undefined;
     reply?: GraphQLTypes['replies_bool_exp'] | undefined;
     reply_id?: GraphQLTypes['Int_comparison_exp'] | undefined;
+    second_actor_profile_id?: GraphQLTypes['bigint_comparison_exp'] | undefined;
+    second_actor_public_profile?:
+      | GraphQLTypes['profiles_public_bool_exp']
+      | undefined;
   };
   /** unique or primary key constraints on table "notifications" */
   ['notifications_constraint']: notifications_constraint;
@@ -69094,6 +69149,7 @@ export type GraphQLTypes = {
     profile_id?: GraphQLTypes['bigint'] | undefined;
     reaction_id?: GraphQLTypes['bigint'] | undefined;
     reply_id?: number | undefined;
+    second_actor_profile_id?: GraphQLTypes['bigint'] | undefined;
   };
   /** input type for inserting data into table "notifications" */
   ['notifications_insert_input']: {
@@ -69123,6 +69179,10 @@ export type GraphQLTypes = {
     reaction_id?: GraphQLTypes['bigint'] | undefined;
     reply?: GraphQLTypes['replies_obj_rel_insert_input'] | undefined;
     reply_id?: number | undefined;
+    second_actor_profile_id?: GraphQLTypes['bigint'] | undefined;
+    second_actor_public_profile?:
+      | GraphQLTypes['profiles_public_obj_rel_insert_input']
+      | undefined;
   };
   /** aggregate max on columns */
   ['notifications_max_fields']: {
@@ -69138,6 +69198,7 @@ export type GraphQLTypes = {
     profile_id?: GraphQLTypes['bigint'] | undefined;
     reaction_id?: GraphQLTypes['bigint'] | undefined;
     reply_id?: number | undefined;
+    second_actor_profile_id?: GraphQLTypes['bigint'] | undefined;
   };
   /** aggregate min on columns */
   ['notifications_min_fields']: {
@@ -69153,6 +69214,7 @@ export type GraphQLTypes = {
     profile_id?: GraphQLTypes['bigint'] | undefined;
     reaction_id?: GraphQLTypes['bigint'] | undefined;
     reply_id?: number | undefined;
+    second_actor_profile_id?: GraphQLTypes['bigint'] | undefined;
   };
   /** response of any mutation on the table "notifications" */
   ['notifications_mutation_response']: {
@@ -69192,6 +69254,10 @@ export type GraphQLTypes = {
     reaction_id?: GraphQLTypes['order_by'] | undefined;
     reply?: GraphQLTypes['replies_order_by'] | undefined;
     reply_id?: GraphQLTypes['order_by'] | undefined;
+    second_actor_profile_id?: GraphQLTypes['order_by'] | undefined;
+    second_actor_public_profile?:
+      | GraphQLTypes['profiles_public_order_by']
+      | undefined;
   };
   /** primary key columns input for table: notifications */
   ['notifications_pk_columns_input']: {
@@ -69212,6 +69278,7 @@ export type GraphQLTypes = {
     profile_id?: GraphQLTypes['bigint'] | undefined;
     reaction_id?: GraphQLTypes['bigint'] | undefined;
     reply_id?: number | undefined;
+    second_actor_profile_id?: GraphQLTypes['bigint'] | undefined;
   };
   /** aggregate stddev on columns */
   ['notifications_stddev_fields']: {
@@ -69225,6 +69292,7 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    second_actor_profile_id?: number | undefined;
   };
   /** aggregate stddev_pop on columns */
   ['notifications_stddev_pop_fields']: {
@@ -69238,6 +69306,7 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    second_actor_profile_id?: number | undefined;
   };
   /** aggregate stddev_samp on columns */
   ['notifications_stddev_samp_fields']: {
@@ -69251,6 +69320,7 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    second_actor_profile_id?: number | undefined;
   };
   /** Streaming cursor of the table "notifications" */
   ['notifications_stream_cursor_input']: {
@@ -69272,6 +69342,7 @@ export type GraphQLTypes = {
     profile_id?: GraphQLTypes['bigint'] | undefined;
     reaction_id?: GraphQLTypes['bigint'] | undefined;
     reply_id?: number | undefined;
+    second_actor_profile_id?: GraphQLTypes['bigint'] | undefined;
   };
   /** aggregate sum on columns */
   ['notifications_sum_fields']: {
@@ -69285,6 +69356,7 @@ export type GraphQLTypes = {
     profile_id?: GraphQLTypes['bigint'] | undefined;
     reaction_id?: GraphQLTypes['bigint'] | undefined;
     reply_id?: number | undefined;
+    second_actor_profile_id?: GraphQLTypes['bigint'] | undefined;
   };
   /** update columns of table "notifications" */
   ['notifications_update_column']: notifications_update_column;
@@ -69308,6 +69380,7 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    second_actor_profile_id?: number | undefined;
   };
   /** aggregate var_samp on columns */
   ['notifications_var_samp_fields']: {
@@ -69321,6 +69394,7 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    second_actor_profile_id?: number | undefined;
   };
   /** aggregate variance on columns */
   ['notifications_variance_fields']: {
@@ -69334,6 +69408,7 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    second_actor_profile_id?: number | undefined;
   };
   ['numeric']: any;
   /** Boolean expression to compare columns of type "numeric". All fields are combined with logical 'AND'. */
@@ -80581,6 +80656,7 @@ export const enum notifications_select_column {
   profile_id = 'profile_id',
   reaction_id = 'reaction_id',
   reply_id = 'reply_id',
+  second_actor_profile_id = 'second_actor_profile_id',
 }
 /** update columns of table "notifications" */
 export const enum notifications_update_column {
@@ -80595,6 +80671,7 @@ export const enum notifications_update_column {
   profile_id = 'profile_id',
   reaction_id = 'reaction_id',
   reply_id = 'reply_id',
+  second_actor_profile_id = 'second_actor_profile_id',
 }
 /** column ordering options */
 export const enum order_by {

--- a/hasura/metadata/databases/default/tables/public_notifications.yaml
+++ b/hasura/metadata/databases/default/tables/public_notifications.yaml
@@ -59,6 +59,15 @@ object_relationships:
   - name: reply
     using:
       foreign_key_constraint_on: reply_id
+  - name: second_actor_public_profile
+    using:
+      manual_configuration:
+        column_mapping:
+          second_actor_profile_id: id
+        insertion_order: null
+        remote_table:
+          name: profiles_public
+          schema: public
 select_permissions:
   - role: user
     permission:

--- a/hasura/migrations/default/1713188205470_alter_table_public_notifications_add_column_second_actor_profile_id/down.sql
+++ b/hasura/migrations/default/1713188205470_alter_table_public_notifications_add_column_second_actor_profile_id/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."notifications" add column "second_actor_profile_id";

--- a/hasura/migrations/default/1713188205470_alter_table_public_notifications_add_column_second_actor_profile_id/up.sql
+++ b/hasura/migrations/default/1713188205470_alter_table_public_notifications_add_column_second_actor_profile_id/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."notifications" add column "second_actor_profile_id" int8
+ null;

--- a/hasura/schema/admin/schema.graphql
+++ b/hasura/schema/admin/schema.graphql
@@ -29255,6 +29255,12 @@ type notifications {
   """
   reply: replies
   reply_id: Int
+  second_actor_profile_id: bigint
+
+  """
+  An object relationship
+  """
+  second_actor_public_profile: profiles_public
 }
 
 """
@@ -29295,6 +29301,7 @@ type notifications_avg_fields {
   profile_id: Float
   reaction_id: Float
   reply_id: Float
+  second_actor_profile_id: Float
 }
 
 """
@@ -29324,6 +29331,8 @@ input notifications_bool_exp {
   reaction_id: bigint_comparison_exp
   reply: replies_bool_exp
   reply_id: Int_comparison_exp
+  second_actor_profile_id: bigint_comparison_exp
+  second_actor_public_profile: profiles_public_bool_exp
 }
 
 """
@@ -29349,6 +29358,7 @@ input notifications_inc_input {
   profile_id: bigint
   reaction_id: bigint
   reply_id: Int
+  second_actor_profile_id: bigint
 }
 
 """
@@ -29375,6 +29385,8 @@ input notifications_insert_input {
   reaction_id: bigint
   reply: replies_obj_rel_insert_input
   reply_id: Int
+  second_actor_profile_id: bigint
+  second_actor_public_profile: profiles_public_obj_rel_insert_input
 }
 
 """
@@ -29392,6 +29404,7 @@ type notifications_max_fields {
   profile_id: bigint
   reaction_id: bigint
   reply_id: Int
+  second_actor_profile_id: bigint
 }
 
 """
@@ -29409,6 +29422,7 @@ type notifications_min_fields {
   profile_id: bigint
   reaction_id: bigint
   reply_id: Int
+  second_actor_profile_id: bigint
 }
 
 """
@@ -29459,6 +29473,8 @@ input notifications_order_by {
   reaction_id: order_by
   reply: replies_order_by
   reply_id: order_by
+  second_actor_profile_id: order_by
+  second_actor_public_profile: profiles_public_order_by
 }
 
 """
@@ -29526,6 +29542,11 @@ enum notifications_select_column {
   column name
   """
   reply_id
+
+  """
+  column name
+  """
+  second_actor_profile_id
 }
 
 """
@@ -29543,6 +29564,7 @@ input notifications_set_input {
   profile_id: bigint
   reaction_id: bigint
   reply_id: Int
+  second_actor_profile_id: bigint
 }
 
 """
@@ -29558,6 +29580,7 @@ type notifications_stddev_fields {
   profile_id: Float
   reaction_id: Float
   reply_id: Float
+  second_actor_profile_id: Float
 }
 
 """
@@ -29573,6 +29596,7 @@ type notifications_stddev_pop_fields {
   profile_id: Float
   reaction_id: Float
   reply_id: Float
+  second_actor_profile_id: Float
 }
 
 """
@@ -29588,6 +29612,7 @@ type notifications_stddev_samp_fields {
   profile_id: Float
   reaction_id: Float
   reply_id: Float
+  second_actor_profile_id: Float
 }
 
 """
@@ -29620,6 +29645,7 @@ input notifications_stream_cursor_value_input {
   profile_id: bigint
   reaction_id: bigint
   reply_id: Int
+  second_actor_profile_id: bigint
 }
 
 """
@@ -29635,6 +29661,7 @@ type notifications_sum_fields {
   profile_id: bigint
   reaction_id: bigint
   reply_id: Int
+  second_actor_profile_id: bigint
 }
 
 """
@@ -29695,6 +29722,11 @@ enum notifications_update_column {
   column name
   """
   reply_id
+
+  """
+  column name
+  """
+  second_actor_profile_id
 }
 
 input notifications_updates {
@@ -29727,6 +29759,7 @@ type notifications_var_pop_fields {
   profile_id: Float
   reaction_id: Float
   reply_id: Float
+  second_actor_profile_id: Float
 }
 
 """
@@ -29742,6 +29775,7 @@ type notifications_var_samp_fields {
   profile_id: Float
   reaction_id: Float
   reply_id: Float
+  second_actor_profile_id: Float
 }
 
 """
@@ -29757,6 +29791,7 @@ type notifications_variance_fields {
   profile_id: Float
   reaction_id: Float
   reply_id: Float
+  second_actor_profile_id: Float
 }
 
 scalar numeric

--- a/hasura/schema/user/schema.graphql
+++ b/hasura/schema/user/schema.graphql
@@ -12841,6 +12841,11 @@ type notifications {
   """
   reply: replies
   reply_id: Int
+
+  """
+  An object relationship
+  """
+  second_actor_public_profile: profiles_public
 }
 
 """
@@ -12906,6 +12911,7 @@ input notifications_bool_exp {
   reaction_id: bigint_comparison_exp
   reply: replies_bool_exp
   reply_id: Int_comparison_exp
+  second_actor_public_profile: profiles_public_bool_exp
 }
 
 """
@@ -12960,6 +12966,7 @@ input notifications_order_by {
   reaction_id: order_by
   reply: replies_order_by
   reply_id: order_by
+  second_actor_public_profile: profiles_public_order_by
 }
 
 """

--- a/src/lib/gql/__generated__/zeus/const.ts
+++ b/src/lib/gql/__generated__/zeus/const.ts
@@ -4182,6 +4182,7 @@ export const AllTypesProps: Record<string, any> = {
     reaction_id: 'bigint_comparison_exp',
     reply: 'replies_bool_exp',
     reply_id: 'Int_comparison_exp',
+    second_actor_public_profile: 'profiles_public_bool_exp',
   },
   notifications_order_by: {
     actor_profile_public: 'profiles_public_order_by',
@@ -4202,6 +4203,7 @@ export const AllTypesProps: Record<string, any> = {
     reaction_id: 'order_by',
     reply: 'replies_order_by',
     reply_id: 'order_by',
+    second_actor_public_profile: 'profiles_public_order_by',
   },
   notifications_select_column: true,
   notifications_stream_cursor_input: {
@@ -10014,6 +10016,7 @@ export const ReturnTypes: Record<string, any> = {
     reaction_id: 'bigint',
     reply: 'replies',
     reply_id: 'Int',
+    second_actor_public_profile: 'profiles_public',
   },
   notifications_aggregate: {
     aggregate: 'notifications_aggregate_fields',

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -9608,6 +9608,8 @@ export type ValueTypes = {
     /** An object relationship */
     reply?: ValueTypes['replies'];
     reply_id?: boolean | `@${string}`;
+    /** An object relationship */
+    second_actor_public_profile?: ValueTypes['profiles_public'];
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregated selection of "notifications" */
@@ -9680,6 +9682,10 @@ export type ValueTypes = {
     reaction_id?: ValueTypes['bigint_comparison_exp'] | undefined | null;
     reply?: ValueTypes['replies_bool_exp'] | undefined | null;
     reply_id?: ValueTypes['Int_comparison_exp'] | undefined | null;
+    second_actor_public_profile?:
+      | ValueTypes['profiles_public_bool_exp']
+      | undefined
+      | null;
   };
   /** aggregate max on columns */
   ['notifications_max_fields']: AliasType<{
@@ -9733,6 +9739,10 @@ export type ValueTypes = {
     reaction_id?: ValueTypes['order_by'] | undefined | null;
     reply?: ValueTypes['replies_order_by'] | undefined | null;
     reply_id?: ValueTypes['order_by'] | undefined | null;
+    second_actor_public_profile?:
+      | ValueTypes['profiles_public_order_by']
+      | undefined
+      | null;
   };
   /** select columns of table "notifications" */
   ['notifications_select_column']: notifications_select_column;
@@ -23634,6 +23644,8 @@ export type ModelTypes = {
     /** An object relationship */
     reply?: GraphQLTypes['replies'] | undefined;
     reply_id?: number | undefined;
+    /** An object relationship */
+    second_actor_public_profile?: GraphQLTypes['profiles_public'] | undefined;
   };
   /** aggregated selection of "notifications" */
   ['notifications_aggregate']: {
@@ -33354,6 +33366,8 @@ export type GraphQLTypes = {
     /** An object relationship */
     reply?: GraphQLTypes['replies'] | undefined;
     reply_id?: number | undefined;
+    /** An object relationship */
+    second_actor_public_profile?: GraphQLTypes['profiles_public'] | undefined;
   };
   /** aggregated selection of "notifications" */
   ['notifications_aggregate']: {
@@ -33412,6 +33426,9 @@ export type GraphQLTypes = {
     reaction_id?: GraphQLTypes['bigint_comparison_exp'] | undefined;
     reply?: GraphQLTypes['replies_bool_exp'] | undefined;
     reply_id?: GraphQLTypes['Int_comparison_exp'] | undefined;
+    second_actor_public_profile?:
+      | GraphQLTypes['profiles_public_bool_exp']
+      | undefined;
   };
   /** aggregate max on columns */
   ['notifications_max_fields']: {
@@ -33461,6 +33478,9 @@ export type GraphQLTypes = {
     reaction_id?: GraphQLTypes['order_by'] | undefined;
     reply?: GraphQLTypes['replies_order_by'] | undefined;
     reply_id?: GraphQLTypes['order_by'] | undefined;
+    second_actor_public_profile?:
+      | GraphQLTypes['profiles_public_order_by']
+      | undefined;
   };
   /** select columns of table "notifications" */
   ['notifications_select_column']: notifications_select_column;

--- a/src/pages/colinks/NotificationsPage.tsx
+++ b/src/pages/colinks/NotificationsPage.tsx
@@ -57,6 +57,12 @@ const fetchNotifications = async () => {
             address: true,
             id: true,
           },
+          second_actor_public_profile: {
+            avatar: true,
+            name: true,
+            address: true,
+            id: true,
+          },
           reaction: {
             reaction: true,
             profile_id: true,
@@ -131,6 +137,9 @@ const fetchNotifications = async () => {
 type Notification = Awaited<ReturnType<typeof fetchNotifications>>[number];
 
 export type Actor = NonNullable<Notification['actor_profile_public']>;
+export type SecondActor = NonNullable<
+  Notification['second_actor_public_profile']
+>;
 export type Profile = NonNullable<Notification['profile']>;
 export type LinkTx = NonNullable<Notification['link_tx']>;
 export type Reply = NonNullable<Notification['reply']>;
@@ -223,7 +232,11 @@ export const NotificationsPage = () => {
             }
             if (n.reply) {
               content = (
-                <Reply reply={n.reply} actor={n.actor_profile_public} />
+                <Reply
+                  reply={n.reply}
+                  actor={n.actor_profile_public}
+                  secondActor={n.second_actor_public_profile}
+                />
               );
             } else if (n.mention_reply) {
               content = (
@@ -331,7 +344,15 @@ export const MentionReply = ({
     </NotificationItem>
   );
 };
-export const Reply = ({ reply, actor }: { reply: Reply; actor?: Actor }) => {
+export const Reply = ({
+  reply,
+  actor,
+  secondActor,
+}: {
+  reply: Reply;
+  actor?: Actor;
+  secondActor?: SecondActor;
+}) => {
   return (
     <NotificationItem>
       <Flex key={reply.id} css={{ alignItems: 'flex-start', gap: '$sm' }}>
@@ -367,7 +388,31 @@ export const Reply = ({ reply, actor }: { reply: Reply; actor?: Actor }) => {
                 textDecoration: 'none',
               }}
             >
-              <Text size="small">replied to your post</Text>
+              {secondActor?.id ? (
+                secondActor.id === actor?.id ? (
+                  <Text size="small">replied to their post </Text>
+                ) : (
+                  <Text size="small" css={{ whiteSpace: 'pre' }}>
+                    replied to a post by{' '}
+                    <Link
+                      as={NavLink}
+                      css={{
+                        display: 'inline',
+                        alignItems: 'center',
+                        gap: '$xs',
+                        mr: '$xs',
+                      }}
+                      to={coLinksPaths.profile(actor?.address ?? 'FIXME')}
+                    >
+                      <Text inline semibold size="small">
+                        {secondActor?.name}
+                      </Text>
+                    </Link>
+                  </Text>
+                )
+              ) : (
+                <Text size="small">replied to your post</Text>
+              )}
               <Text size="xs" color="neutral" css={{ pl: '$sm' }}>
                 {DateTime.fromISO(reply.created_at).toLocal().toRelative()}
               </Text>


### PR DESCRIPTION
## What
when a user replies to a post you have replied to before you will receive a notification

## Test and Deployment Plan
Create a post by a user and comment on it with two other users and then comment by the post creator, each user will receive a different notification as per by the screenshots

## Screenshots (if appropriate):

![image](https://github.com/coordinape/coordinape/assets/34943689/6d2ad182-1ad3-4234-aa44-e3617884cd75)
![image](https://github.com/coordinape/coordinape/assets/34943689/53a1b9b5-f316-4ae5-b3e2-abcb8e7809dd)
![image](https://github.com/coordinape/coordinape/assets/34943689/bbbb8c14-09da-4c9b-90d3-4f6ec1f10b46)

## How
by the reply id I fetched all the users that has replied to this post before.
excluded users that are mentioned to that reply because they are getting different notifications