### PR TITLE
Colinks handle inactive emails

### DIFF
--- a/_api/hasura/cron/bigQuestionEmails.ts
+++ b/_api/hasura/cron/bigQuestionEmails.ts
@@ -3,7 +3,7 @@ import { DateTime } from 'luxon';
 
 import { sendCoLinksBigQuestionEmail } from '../../../api-lib/email/postmark';
 import { adminClient } from '../../../api-lib/gql/adminClient';
-import { errorResponse } from '../../../api-lib/HttpError';
+import { BaseHttpError, errorResponse } from '../../../api-lib/HttpError';
 import { verifyHasuraRequestMiddleware } from '../../../api-lib/validate';
 import { IN_DEVELOPMENT } from '../../../src/config/env';
 
@@ -149,7 +149,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
           });
           return;
         } catch (e) {
-          if (e instanceof Error && e.message.includes('spam complaint')) {
+          if (e instanceof BaseHttpError && e.httpStatus === 406) {
             unverifyUserEmail({
               profileId: profile.id,
               email: profile.emails[0].email,

--- a/_api/hasura/cron/bigQuestionEmails.ts
+++ b/_api/hasura/cron/bigQuestionEmails.ts
@@ -84,7 +84,7 @@ async function getEligibleUsersWithEmails(big_question_id: number) {
   );
 
   // eslint-disable-next-line no-console
-  console.log(`found ${profiles.length} profiles this batch`, [profiles]);
+  console.log(`found ${profiles.length} profiles this batch`, profiles);
   return profiles;
 }
 

--- a/_api/hasura/cron/colinksNotificationEmails.ts
+++ b/_api/hasura/cron/colinksNotificationEmails.ts
@@ -3,7 +3,7 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { sendCoLinksNotificationsEmail } from '../../../api-lib/email/postmark';
 import { order_by } from '../../../api-lib/gql/__generated__/zeus';
 import { adminClient } from '../../../api-lib/gql/adminClient';
-import { errorResponse } from '../../../api-lib/HttpError';
+import { BaseHttpError, errorResponse } from '../../../api-lib/HttpError';
 import { verifyHasuraRequestMiddleware } from '../../../api-lib/validate';
 import { isRejected } from '../../../src/common-lib/epochs';
 import { IN_DEVELOPMENT } from '../../../src/config/env';
@@ -157,7 +157,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
             });
             return;
           } catch (e) {
-            if (e instanceof Error && e.message.includes('spam complaint')) {
+            if (e instanceof BaseHttpError && e.httpStatus === 406) {
               unverifyUserEmail({
                 profileId: profile.id,
                 email: profile.emails[0].email,

--- a/_api/hasura/cron/colinksNotificationEmails.ts
+++ b/_api/hasura/cron/colinksNotificationEmails.ts
@@ -94,7 +94,7 @@ export async function unverifyUserEmail({
         { affected_rows: true, returning: { email: true } },
       ],
     },
-    { operationName: 'bigQuestionEmails__unverifyUserEmail' }
+    { operationName: 'colinksNotificationEmail__unverifyUserEmail' }
   );
 }
 

--- a/_api/hasura/cron/colinksNotificationEmails.ts
+++ b/_api/hasura/cron/colinksNotificationEmails.ts
@@ -91,7 +91,7 @@ export async function unverifyUserEmail({
             verified_at: null,
           },
         },
-        { affected_rows: true, returning: { email: true } },
+        { affected_rows: true },
       ],
     },
     { operationName: 'colinksNotificationEmail__unverifyUserEmail' }

--- a/api-lib/HttpError.ts
+++ b/api-lib/HttpError.ts
@@ -33,7 +33,7 @@ interface HttpError extends Error {
   causeMessage?: string;
 }
 
-class BaseHttpError extends Error implements HttpError {
+export class BaseHttpError extends Error implements HttpError {
   causeMessage?: string;
   constructor(message: string, cause?: any) {
     super(message);


### PR DESCRIPTION
## What
set verified_at to null if the user is rejecting colinks emails

## Test and Deployment Plan
I tried it by throwing an error with 'spam complaint' and the notified email got unverified
