### PR TITLE
add notifications for others replies

### DIFF
--- a/src/pages/colinks/NotificationsPage.tsx
+++ b/src/pages/colinks/NotificationsPage.tsx
@@ -82,6 +82,14 @@ const fetchNotifications = async () => {
             created_at: true,
             reply: true,
             activity_id: true,
+            activity: {
+              actor_profile_public: {
+                id: true,
+                name: true,
+                avatar: true,
+                address: true,
+              },
+            },
           },
           invited_profile_public: {
             avatar: true,
@@ -224,7 +232,12 @@ export const NotificationsPage = () => {
             }
             if (n.reply) {
               content = (
-                <Reply reply={n.reply} actor={n.actor_profile_public} />
+                <Reply
+                  reply={n.reply}
+                  actor={n.actor_profile_public}
+                  threadCreator={n.reply.activity.actor_profile_public}
+                  profileId={profileId}
+                />
               );
             } else if (n.mention_reply) {
               content = (
@@ -332,7 +345,17 @@ export const MentionReply = ({
     </NotificationItem>
   );
 };
-export const Reply = ({ reply, actor }: { reply: Reply; actor?: Actor }) => {
+export const Reply = ({
+  reply,
+  actor,
+  threadCreator,
+  profileId,
+}: {
+  reply: Reply;
+  actor?: Actor;
+  threadCreator?: Actor;
+  profileId: number;
+}) => {
   return (
     <NotificationItem>
       <Flex key={reply.id} css={{ alignItems: 'flex-start', gap: '$sm' }}>
@@ -368,7 +391,33 @@ export const Reply = ({ reply, actor }: { reply: Reply; actor?: Actor }) => {
                 textDecoration: 'none',
               }}
             >
-              <Text size="small">replied to your post</Text>
+              {threadCreator?.id !== profileId ? (
+                threadCreator?.id === actor?.id ? (
+                  <Text size="small">replied to their post </Text>
+                ) : (
+                  <Text size="small" css={{ whiteSpace: 'pre' }}>
+                    replied to a post by{' '}
+                    <Link
+                      as={NavLink}
+                      css={{
+                        display: 'inline',
+                        alignItems: 'center',
+                        gap: '$xs',
+                        mr: '$xs',
+                      }}
+                      to={coLinksPaths.profile(
+                        threadCreator?.address ?? 'FIXME'
+                      )}
+                    >
+                      <Text inline semibold size="small">
+                        {threadCreator?.name}
+                      </Text>
+                    </Link>
+                  </Text>
+                )
+              ) : (
+                <Text size="small">replied to your post</Text>
+              )}
               <Text size="xs" color="neutral" css={{ pl: '$sm' }}>
                 {DateTime.fromISO(reply.created_at).toLocal().toRelative()}
               </Text>


### PR DESCRIPTION
## What
#replaces #2860 
when a user replies to a post you have replied to before you will receive a notification

## Test and Deployment Plan

Create a post by a user and comment on it with two other users and then comment by the post creator, each user will receive a different notification as per by the screenshots

## Screenshots (if appropriate):
Commenter 1
![image](https://github.com/coordinape/coordinape/assets/34943689/8fb4c747-2df0-42c0-ace2-05ac84e50c0c)

Thread owner
![image](https://github.com/coordinape/coordinape/assets/34943689/45c5bf9b-7052-40b9-b6bf-55f7379186e1)

Commenter 2


## How
1- When a user reply to a post, get all other replies to that post and their posters.
2- notify other replies posters.