### PR TITLE
add replies_reactions table

### DIFF
--- a/_api/hasura/event_triggers/eventManager.ts
+++ b/_api/hasura/event_triggers/eventManager.ts
@@ -13,6 +13,7 @@ import createNotificationColinksGives from '../../../api-lib/event_triggers/crea
 import createNotificationPosts from '../../../api-lib/event_triggers/createNotificationPosts';
 import createNotificationReactions from '../../../api-lib/event_triggers/createNotificationReactions';
 import createNotificationReplies from '../../../api-lib/event_triggers/createNotificationReplies';
+import createNotificationReplyReactions from '../../../api-lib/event_triggers/createNotificationReplyReactions';
 import createReactionInteractionEvent from '../../../api-lib/event_triggers/createReactionInteractionEvent';
 import createReplyInteractionEvent from '../../../api-lib/event_triggers/createReplyInteractionEvent';
 import createVouchedUser from '../../../api-lib/event_triggers/createVouchedUser';
@@ -61,6 +62,7 @@ const HANDLERS: HandlerDict = {
   createNotificationColinksGives,
   createNotificationReactions,
   createNotificationReplies,
+  createNotificationReplyReactions,
   createNotificationPosts,
   createNomineeDiscord,
   userAddedDiscordBot,

--- a/api-lib/event_triggers/createNotificationReplyReactions.ts
+++ b/api-lib/event_triggers/createNotificationReplyReactions.ts
@@ -75,7 +75,7 @@ const handleInsert = async (
   );
 
   res.status(200).json({
-    message: `reactions notification recorded`,
+    message: `reply reaction notification recorded`,
   });
 };
 

--- a/api-lib/event_triggers/createNotificationReplyReactions.ts
+++ b/api-lib/event_triggers/createNotificationReplyReactions.ts
@@ -1,0 +1,113 @@
+import assert from 'assert';
+
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+import { adminClient } from '../gql/adminClient';
+import { errorResponse } from '../HttpError';
+import { EventTriggerPayload } from '../types';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  try {
+    const {
+      event,
+    }: EventTriggerPayload<'replies_reactions', 'INSERT' | 'DELETE'> = req.body;
+
+    if (event.data?.new) {
+      return await handleInsert(event.data.new, res);
+    } else if (event.data?.old) {
+      return await handleDelete(event.data.old, res);
+    }
+  } catch (e) {
+    return errorResponse(res, e);
+  }
+}
+
+const handleInsert = async (
+  newRow: EventTriggerPayload<
+    'replies_reactions',
+    'INSERT'
+  >['event']['data']['new'],
+  res: VercelResponse
+) => {
+  const { profile_id, created_at, id, reply_id } = newRow;
+  const { replies_by_pk } = await adminClient.query(
+    {
+      replies_by_pk: [
+        {
+          id: reply_id,
+        },
+        {
+          profile_id: true,
+        },
+      ],
+    },
+    {
+      operationName: 'getReplyForReactionNotification',
+    }
+  );
+
+  assert(replies_by_pk);
+
+  if (replies_by_pk.profile_id === profile_id) {
+    return res.status(200).json({
+      message: `no notification for reactions you send yourself`,
+    });
+  }
+  await adminClient.mutate(
+    {
+      insert_notifications_one: [
+        {
+          object: {
+            profile_id: replies_by_pk.profile_id,
+            actor_profile_id: profile_id,
+            created_at: created_at,
+            reply_reaction_id: id,
+          },
+        },
+        {
+          __typename: true,
+        },
+      ],
+    },
+    {
+      operationName: 'insert_replyreactionNotification',
+    }
+  );
+
+  res.status(200).json({
+    message: `reactions notification recorded`,
+  });
+};
+
+const handleDelete = async (
+  newRow: EventTriggerPayload<
+    'replies_reactions',
+    'DELETE'
+  >['event']['data']['old'],
+  res: VercelResponse
+) => {
+  const { id } = newRow;
+  await adminClient.mutate(
+    {
+      delete_notifications: [
+        {
+          where: {
+            reaction_id: {
+              _eq: id,
+            },
+          },
+        },
+        {
+          __typename: true,
+        },
+      ],
+    },
+    {
+      operationName: 'delete_replyreactionNotification',
+    }
+  );
+
+  res.status(200).json({
+    message: `reply reaction notification deleted`,
+  });
+};

--- a/api-lib/gql/__generated__/zeus/const.ts
+++ b/api-lib/gql/__generated__/zeus/const.ts
@@ -7952,6 +7952,8 @@ export const AllTypesProps: Record<string, any> = {
     reaction_id: 'bigint_comparison_exp',
     reply: 'replies_bool_exp',
     reply_id: 'Int_comparison_exp',
+    reply_reaction: 'replies_reactions_bool_exp',
+    reply_reaction_id: 'bigint_comparison_exp',
   },
   notifications_constraint: true,
   notifications_inc_input: {
@@ -7959,6 +7961,7 @@ export const AllTypesProps: Record<string, any> = {
     invite_joined_id: 'bigint',
     profile_id: 'bigint',
     reaction_id: 'bigint',
+    reply_reaction_id: 'bigint',
   },
   notifications_insert_input: {
     actor_profile_id: 'bigint',
@@ -7976,6 +7979,8 @@ export const AllTypesProps: Record<string, any> = {
     reaction: 'reactions_obj_rel_insert_input',
     reaction_id: 'bigint',
     reply: 'replies_obj_rel_insert_input',
+    reply_reaction: 'replies_reactions_obj_rel_insert_input',
+    reply_reaction_id: 'bigint',
   },
   notifications_on_conflict: {
     constraint: 'notifications_constraint',
@@ -8003,6 +8008,8 @@ export const AllTypesProps: Record<string, any> = {
     reaction_id: 'order_by',
     reply: 'replies_order_by',
     reply_id: 'order_by',
+    reply_reaction: 'replies_reactions_order_by',
+    reply_reaction_id: 'order_by',
   },
   notifications_pk_columns_input: {},
   notifications_select_column: true,
@@ -8013,6 +8020,7 @@ export const AllTypesProps: Record<string, any> = {
     link_tx_hash: 'citext',
     profile_id: 'bigint',
     reaction_id: 'bigint',
+    reply_reaction_id: 'bigint',
   },
   notifications_stream_cursor_input: {
     initial_value: 'notifications_stream_cursor_value_input',
@@ -8025,6 +8033,7 @@ export const AllTypesProps: Record<string, any> = {
     link_tx_hash: 'citext',
     profile_id: 'bigint',
     reaction_id: 'bigint',
+    reply_reaction_id: 'bigint',
   },
   notifications_update_column: true,
   notifications_updates: {
@@ -11246,6 +11255,7 @@ export const AllTypesProps: Record<string, any> = {
     on_conflict: 'replies_reactions_on_conflict',
   },
   replies_reactions_avg_order_by: {
+    activity_id: 'order_by',
     id: 'order_by',
     profile_id: 'order_by',
     reply_id: 'order_by',
@@ -11254,6 +11264,8 @@ export const AllTypesProps: Record<string, any> = {
     _and: 'replies_reactions_bool_exp',
     _not: 'replies_reactions_bool_exp',
     _or: 'replies_reactions_bool_exp',
+    activity: 'activities_bool_exp',
+    activity_id: 'Int_comparison_exp',
     created_at: 'timestamptz_comparison_exp',
     id: 'bigint_comparison_exp',
     profile: 'profiles_bool_exp',
@@ -11269,6 +11281,7 @@ export const AllTypesProps: Record<string, any> = {
     id: 'bigint',
   },
   replies_reactions_insert_input: {
+    activity: 'activities_obj_rel_insert_input',
     created_at: 'timestamptz',
     id: 'bigint',
     profile: 'profiles_obj_rel_insert_input',
@@ -11277,6 +11290,7 @@ export const AllTypesProps: Record<string, any> = {
     updated_at: 'timestamptz',
   },
   replies_reactions_max_order_by: {
+    activity_id: 'order_by',
     created_at: 'order_by',
     id: 'order_by',
     profile_id: 'order_by',
@@ -11285,6 +11299,7 @@ export const AllTypesProps: Record<string, any> = {
     updated_at: 'order_by',
   },
   replies_reactions_min_order_by: {
+    activity_id: 'order_by',
     created_at: 'order_by',
     id: 'order_by',
     profile_id: 'order_by',
@@ -11292,12 +11307,18 @@ export const AllTypesProps: Record<string, any> = {
     reply_id: 'order_by',
     updated_at: 'order_by',
   },
+  replies_reactions_obj_rel_insert_input: {
+    data: 'replies_reactions_insert_input',
+    on_conflict: 'replies_reactions_on_conflict',
+  },
   replies_reactions_on_conflict: {
     constraint: 'replies_reactions_constraint',
     update_columns: 'replies_reactions_update_column',
     where: 'replies_reactions_bool_exp',
   },
   replies_reactions_order_by: {
+    activity: 'activities_order_by',
+    activity_id: 'order_by',
     created_at: 'order_by',
     id: 'order_by',
     profile: 'profiles_order_by',
@@ -11318,16 +11339,19 @@ export const AllTypesProps: Record<string, any> = {
     updated_at: 'timestamptz',
   },
   replies_reactions_stddev_order_by: {
+    activity_id: 'order_by',
     id: 'order_by',
     profile_id: 'order_by',
     reply_id: 'order_by',
   },
   replies_reactions_stddev_pop_order_by: {
+    activity_id: 'order_by',
     id: 'order_by',
     profile_id: 'order_by',
     reply_id: 'order_by',
   },
   replies_reactions_stddev_samp_order_by: {
+    activity_id: 'order_by',
     id: 'order_by',
     profile_id: 'order_by',
     reply_id: 'order_by',
@@ -11342,6 +11366,7 @@ export const AllTypesProps: Record<string, any> = {
     updated_at: 'timestamptz',
   },
   replies_reactions_sum_order_by: {
+    activity_id: 'order_by',
     id: 'order_by',
     profile_id: 'order_by',
     reply_id: 'order_by',
@@ -11353,16 +11378,19 @@ export const AllTypesProps: Record<string, any> = {
     where: 'replies_reactions_bool_exp',
   },
   replies_reactions_var_pop_order_by: {
+    activity_id: 'order_by',
     id: 'order_by',
     profile_id: 'order_by',
     reply_id: 'order_by',
   },
   replies_reactions_var_samp_order_by: {
+    activity_id: 'order_by',
     id: 'order_by',
     profile_id: 'order_by',
     reply_id: 'order_by',
   },
   replies_reactions_variance_order_by: {
+    activity_id: 'order_by',
     id: 'order_by',
     profile_id: 'order_by',
     reply_id: 'order_by',
@@ -19434,6 +19462,8 @@ export const ReturnTypes: Record<string, any> = {
     reaction_id: 'bigint',
     reply: 'replies',
     reply_id: 'Int',
+    reply_reaction: 'replies_reactions',
+    reply_reaction_id: 'bigint',
   },
   notifications_aggregate: {
     aggregate: 'notifications_aggregate_fields',
@@ -19462,6 +19492,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'Float',
     reaction_id: 'Float',
     reply_id: 'Float',
+    reply_reaction_id: 'Float',
   },
   notifications_max_fields: {
     actor_profile_id: 'bigint',
@@ -19475,6 +19506,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'bigint',
     reaction_id: 'bigint',
     reply_id: 'Int',
+    reply_reaction_id: 'bigint',
   },
   notifications_min_fields: {
     actor_profile_id: 'bigint',
@@ -19488,6 +19520,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'bigint',
     reaction_id: 'bigint',
     reply_id: 'Int',
+    reply_reaction_id: 'bigint',
   },
   notifications_mutation_response: {
     affected_rows: 'Int',
@@ -19503,6 +19536,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'Float',
     reaction_id: 'Float',
     reply_id: 'Float',
+    reply_reaction_id: 'Float',
   },
   notifications_stddev_pop_fields: {
     actor_profile_id: 'Float',
@@ -19514,6 +19548,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'Float',
     reaction_id: 'Float',
     reply_id: 'Float',
+    reply_reaction_id: 'Float',
   },
   notifications_stddev_samp_fields: {
     actor_profile_id: 'Float',
@@ -19525,6 +19560,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'Float',
     reaction_id: 'Float',
     reply_id: 'Float',
+    reply_reaction_id: 'Float',
   },
   notifications_sum_fields: {
     actor_profile_id: 'bigint',
@@ -19536,6 +19572,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'bigint',
     reaction_id: 'bigint',
     reply_id: 'Int',
+    reply_reaction_id: 'bigint',
   },
   notifications_var_pop_fields: {
     actor_profile_id: 'Float',
@@ -19547,6 +19584,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'Float',
     reaction_id: 'Float',
     reply_id: 'Float',
+    reply_reaction_id: 'Float',
   },
   notifications_var_samp_fields: {
     actor_profile_id: 'Float',
@@ -19558,6 +19596,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'Float',
     reaction_id: 'Float',
     reply_id: 'Float',
+    reply_reaction_id: 'Float',
   },
   notifications_variance_fields: {
     actor_profile_id: 'Float',
@@ -19569,6 +19608,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'Float',
     reaction_id: 'Float',
     reply_id: 'Float',
+    reply_reaction_id: 'Float',
   },
   org_members: {
     created_at: 'timestamp',
@@ -21453,6 +21493,8 @@ export const ReturnTypes: Record<string, any> = {
     returning: 'replies',
   },
   replies_reactions: {
+    activity: 'activities',
+    activity_id: 'Int',
     created_at: 'timestamptz',
     id: 'bigint',
     profile: 'profiles',
@@ -21481,11 +21523,13 @@ export const ReturnTypes: Record<string, any> = {
     variance: 'replies_reactions_variance_fields',
   },
   replies_reactions_avg_fields: {
+    activity_id: 'Float',
     id: 'Float',
     profile_id: 'Float',
     reply_id: 'Float',
   },
   replies_reactions_max_fields: {
+    activity_id: 'Int',
     created_at: 'timestamptz',
     id: 'bigint',
     profile_id: 'Int',
@@ -21494,6 +21538,7 @@ export const ReturnTypes: Record<string, any> = {
     updated_at: 'timestamptz',
   },
   replies_reactions_min_fields: {
+    activity_id: 'Int',
     created_at: 'timestamptz',
     id: 'bigint',
     profile_id: 'Int',
@@ -21506,36 +21551,43 @@ export const ReturnTypes: Record<string, any> = {
     returning: 'replies_reactions',
   },
   replies_reactions_stddev_fields: {
+    activity_id: 'Float',
     id: 'Float',
     profile_id: 'Float',
     reply_id: 'Float',
   },
   replies_reactions_stddev_pop_fields: {
+    activity_id: 'Float',
     id: 'Float',
     profile_id: 'Float',
     reply_id: 'Float',
   },
   replies_reactions_stddev_samp_fields: {
+    activity_id: 'Float',
     id: 'Float',
     profile_id: 'Float',
     reply_id: 'Float',
   },
   replies_reactions_sum_fields: {
+    activity_id: 'Int',
     id: 'bigint',
     profile_id: 'Int',
     reply_id: 'Int',
   },
   replies_reactions_var_pop_fields: {
+    activity_id: 'Float',
     id: 'Float',
     profile_id: 'Float',
     reply_id: 'Float',
   },
   replies_reactions_var_samp_fields: {
+    activity_id: 'Float',
     id: 'Float',
     profile_id: 'Float',
     reply_id: 'Float',
   },
   replies_reactions_variance_fields: {
+    activity_id: 'Float',
     id: 'Float',
     profile_id: 'Float',
     reply_id: 'Float',

--- a/api-lib/gql/__generated__/zeus/const.ts
+++ b/api-lib/gql/__generated__/zeus/const.ts
@@ -5885,6 +5885,12 @@ export const AllTypesProps: Record<string, any> = {
     delete_replies_by_pk: {
       id: 'bigint',
     },
+    delete_replies_reactions: {
+      where: 'replies_reactions_bool_exp',
+    },
+    delete_replies_reactions_by_pk: {
+      id: 'bigint',
+    },
     delete_reputation_scores: {
       where: 'reputation_scores_bool_exp',
     },
@@ -6371,6 +6377,14 @@ export const AllTypesProps: Record<string, any> = {
     insert_replies_one: {
       object: 'replies_insert_input',
       on_conflict: 'replies_on_conflict',
+    },
+    insert_replies_reactions: {
+      objects: 'replies_reactions_insert_input',
+      on_conflict: 'replies_reactions_on_conflict',
+    },
+    insert_replies_reactions_one: {
+      object: 'replies_reactions_insert_input',
+      on_conflict: 'replies_reactions_on_conflict',
     },
     insert_reputation_scores: {
       objects: 'reputation_scores_insert_input',
@@ -7223,6 +7237,19 @@ export const AllTypesProps: Record<string, any> = {
     },
     update_replies_many: {
       updates: 'replies_updates',
+    },
+    update_replies_reactions: {
+      _inc: 'replies_reactions_inc_input',
+      _set: 'replies_reactions_set_input',
+      where: 'replies_reactions_bool_exp',
+    },
+    update_replies_reactions_by_pk: {
+      _inc: 'replies_reactions_inc_input',
+      _set: 'replies_reactions_set_input',
+      pk_columns: 'replies_reactions_pk_columns_input',
+    },
+    update_replies_reactions_many: {
+      updates: 'replies_reactions_updates',
     },
     update_reputation_scores: {
       _inc: 'reputation_scores_inc_input',
@@ -10652,6 +10679,19 @@ export const AllTypesProps: Record<string, any> = {
     replies_by_pk: {
       id: 'bigint',
     },
+    replies_reactions: {
+      distinct_on: 'replies_reactions_select_column',
+      order_by: 'replies_reactions_order_by',
+      where: 'replies_reactions_bool_exp',
+    },
+    replies_reactions_aggregate: {
+      distinct_on: 'replies_reactions_select_column',
+      order_by: 'replies_reactions_order_by',
+      where: 'replies_reactions_bool_exp',
+    },
+    replies_reactions_by_pk: {
+      id: 'bigint',
+    },
     reputation_scores: {
       distinct_on: 'reputation_scores_select_column',
       order_by: 'reputation_scores_order_by',
@@ -11158,6 +11198,77 @@ export const AllTypesProps: Record<string, any> = {
   },
   replies_pk_columns_input: {
     id: 'bigint',
+  },
+  replies_reactions_aggregate_fields: {
+    count: {
+      columns: 'replies_reactions_select_column',
+    },
+  },
+  replies_reactions_bool_exp: {
+    _and: 'replies_reactions_bool_exp',
+    _not: 'replies_reactions_bool_exp',
+    _or: 'replies_reactions_bool_exp',
+    created_at: 'timestamptz_comparison_exp',
+    id: 'bigint_comparison_exp',
+    profile: 'profiles_bool_exp',
+    profile_id: 'Int_comparison_exp',
+    profile_public: 'profiles_public_bool_exp',
+    reaction: 'String_comparison_exp',
+    reply: 'replies_bool_exp',
+    reply_id: 'Int_comparison_exp',
+    updated_at: 'timestamptz_comparison_exp',
+  },
+  replies_reactions_constraint: true,
+  replies_reactions_inc_input: {
+    id: 'bigint',
+  },
+  replies_reactions_insert_input: {
+    created_at: 'timestamptz',
+    id: 'bigint',
+    profile: 'profiles_obj_rel_insert_input',
+    profile_public: 'profiles_public_obj_rel_insert_input',
+    reply: 'replies_obj_rel_insert_input',
+    updated_at: 'timestamptz',
+  },
+  replies_reactions_on_conflict: {
+    constraint: 'replies_reactions_constraint',
+    update_columns: 'replies_reactions_update_column',
+    where: 'replies_reactions_bool_exp',
+  },
+  replies_reactions_order_by: {
+    created_at: 'order_by',
+    id: 'order_by',
+    profile: 'profiles_order_by',
+    profile_id: 'order_by',
+    profile_public: 'profiles_public_order_by',
+    reaction: 'order_by',
+    reply: 'replies_order_by',
+    reply_id: 'order_by',
+    updated_at: 'order_by',
+  },
+  replies_reactions_pk_columns_input: {
+    id: 'bigint',
+  },
+  replies_reactions_select_column: true,
+  replies_reactions_set_input: {
+    created_at: 'timestamptz',
+    id: 'bigint',
+    updated_at: 'timestamptz',
+  },
+  replies_reactions_stream_cursor_input: {
+    initial_value: 'replies_reactions_stream_cursor_value_input',
+    ordering: 'cursor_ordering',
+  },
+  replies_reactions_stream_cursor_value_input: {
+    created_at: 'timestamptz',
+    id: 'bigint',
+    updated_at: 'timestamptz',
+  },
+  replies_reactions_update_column: true,
+  replies_reactions_updates: {
+    _inc: 'replies_reactions_inc_input',
+    _set: 'replies_reactions_set_input',
+    where: 'replies_reactions_bool_exp',
   },
   replies_select_column: true,
   replies_set_input: {
@@ -12359,6 +12470,23 @@ export const AllTypesProps: Record<string, any> = {
     },
     replies_by_pk: {
       id: 'bigint',
+    },
+    replies_reactions: {
+      distinct_on: 'replies_reactions_select_column',
+      order_by: 'replies_reactions_order_by',
+      where: 'replies_reactions_bool_exp',
+    },
+    replies_reactions_aggregate: {
+      distinct_on: 'replies_reactions_select_column',
+      order_by: 'replies_reactions_order_by',
+      where: 'replies_reactions_bool_exp',
+    },
+    replies_reactions_by_pk: {
+      id: 'bigint',
+    },
+    replies_reactions_stream: {
+      cursor: 'replies_reactions_stream_cursor_input',
+      where: 'replies_reactions_bool_exp',
     },
     replies_stream: {
       cursor: 'replies_stream_cursor_input',
@@ -18393,6 +18521,8 @@ export const ReturnTypes: Record<string, any> = {
     delete_reactions_by_pk: 'reactions',
     delete_replies: 'replies_mutation_response',
     delete_replies_by_pk: 'replies',
+    delete_replies_reactions: 'replies_reactions_mutation_response',
+    delete_replies_reactions_by_pk: 'replies_reactions',
     delete_reputation_scores: 'reputation_scores_mutation_response',
     delete_reputation_scores_by_pk: 'reputation_scores',
     delete_skills: 'skills_mutation_response',
@@ -18532,6 +18662,8 @@ export const ReturnTypes: Record<string, any> = {
     insert_reactions_one: 'reactions',
     insert_replies: 'replies_mutation_response',
     insert_replies_one: 'replies',
+    insert_replies_reactions: 'replies_reactions_mutation_response',
+    insert_replies_reactions_one: 'replies_reactions',
     insert_reputation_scores: 'reputation_scores_mutation_response',
     insert_reputation_scores_one: 'reputation_scores',
     insert_skills: 'skills_mutation_response',
@@ -18746,6 +18878,9 @@ export const ReturnTypes: Record<string, any> = {
     update_replies: 'replies_mutation_response',
     update_replies_by_pk: 'replies',
     update_replies_many: 'replies_mutation_response',
+    update_replies_reactions: 'replies_reactions_mutation_response',
+    update_replies_reactions_by_pk: 'replies_reactions',
+    update_replies_reactions_many: 'replies_reactions_mutation_response',
     update_reputation_scores: 'reputation_scores_mutation_response',
     update_reputation_scores_by_pk: 'reputation_scores',
     update_reputation_scores_many: 'reputation_scores_mutation_response',
@@ -21011,6 +21146,9 @@ export const ReturnTypes: Record<string, any> = {
     replies: 'replies',
     replies_aggregate: 'replies_aggregate',
     replies_by_pk: 'replies',
+    replies_reactions: 'replies_reactions',
+    replies_reactions_aggregate: 'replies_reactions_aggregate',
+    replies_reactions_by_pk: 'replies_reactions',
     reputation_scores: 'reputation_scores',
     reputation_scores_aggregate: 'reputation_scores_aggregate',
     reputation_scores_by_pk: 'reputation_scores',
@@ -21214,6 +21352,94 @@ export const ReturnTypes: Record<string, any> = {
   replies_mutation_response: {
     affected_rows: 'Int',
     returning: 'replies',
+  },
+  replies_reactions: {
+    created_at: 'timestamptz',
+    id: 'bigint',
+    profile: 'profiles',
+    profile_id: 'Int',
+    profile_public: 'profiles_public',
+    reaction: 'String',
+    reply: 'replies',
+    reply_id: 'Int',
+    updated_at: 'timestamptz',
+  },
+  replies_reactions_aggregate: {
+    aggregate: 'replies_reactions_aggregate_fields',
+    nodes: 'replies_reactions',
+  },
+  replies_reactions_aggregate_fields: {
+    avg: 'replies_reactions_avg_fields',
+    count: 'Int',
+    max: 'replies_reactions_max_fields',
+    min: 'replies_reactions_min_fields',
+    stddev: 'replies_reactions_stddev_fields',
+    stddev_pop: 'replies_reactions_stddev_pop_fields',
+    stddev_samp: 'replies_reactions_stddev_samp_fields',
+    sum: 'replies_reactions_sum_fields',
+    var_pop: 'replies_reactions_var_pop_fields',
+    var_samp: 'replies_reactions_var_samp_fields',
+    variance: 'replies_reactions_variance_fields',
+  },
+  replies_reactions_avg_fields: {
+    id: 'Float',
+    profile_id: 'Float',
+    reply_id: 'Float',
+  },
+  replies_reactions_max_fields: {
+    created_at: 'timestamptz',
+    id: 'bigint',
+    profile_id: 'Int',
+    reaction: 'String',
+    reply_id: 'Int',
+    updated_at: 'timestamptz',
+  },
+  replies_reactions_min_fields: {
+    created_at: 'timestamptz',
+    id: 'bigint',
+    profile_id: 'Int',
+    reaction: 'String',
+    reply_id: 'Int',
+    updated_at: 'timestamptz',
+  },
+  replies_reactions_mutation_response: {
+    affected_rows: 'Int',
+    returning: 'replies_reactions',
+  },
+  replies_reactions_stddev_fields: {
+    id: 'Float',
+    profile_id: 'Float',
+    reply_id: 'Float',
+  },
+  replies_reactions_stddev_pop_fields: {
+    id: 'Float',
+    profile_id: 'Float',
+    reply_id: 'Float',
+  },
+  replies_reactions_stddev_samp_fields: {
+    id: 'Float',
+    profile_id: 'Float',
+    reply_id: 'Float',
+  },
+  replies_reactions_sum_fields: {
+    id: 'bigint',
+    profile_id: 'Int',
+    reply_id: 'Int',
+  },
+  replies_reactions_var_pop_fields: {
+    id: 'Float',
+    profile_id: 'Float',
+    reply_id: 'Float',
+  },
+  replies_reactions_var_samp_fields: {
+    id: 'Float',
+    profile_id: 'Float',
+    reply_id: 'Float',
+  },
+  replies_reactions_variance_fields: {
+    id: 'Float',
+    profile_id: 'Float',
+    reply_id: 'Float',
   },
   replies_stddev_fields: {
     activity_actor_id: 'Float',
@@ -21777,6 +22003,10 @@ export const ReturnTypes: Record<string, any> = {
     replies: 'replies',
     replies_aggregate: 'replies_aggregate',
     replies_by_pk: 'replies',
+    replies_reactions: 'replies_reactions',
+    replies_reactions_aggregate: 'replies_reactions_aggregate',
+    replies_reactions_by_pk: 'replies_reactions',
+    replies_reactions_stream: 'replies_reactions',
     replies_stream: 'replies',
     reputation_scores: 'reputation_scores',
     reputation_scores_aggregate: 'reputation_scores_aggregate',

--- a/api-lib/gql/__generated__/zeus/const.ts
+++ b/api-lib/gql/__generated__/zeus/const.ts
@@ -11086,6 +11086,18 @@ export const AllTypesProps: Record<string, any> = {
     id: 'order_by',
     profile_id: 'order_by',
   },
+  replies: {
+    reactions: {
+      distinct_on: 'replies_reactions_select_column',
+      order_by: 'replies_reactions_order_by',
+      where: 'replies_reactions_bool_exp',
+    },
+    reactions_aggregate: {
+      distinct_on: 'replies_reactions_select_column',
+      order_by: 'replies_reactions_order_by',
+      where: 'replies_reactions_bool_exp',
+    },
+  },
   replies_aggregate_bool_exp: {
     count: 'replies_aggregate_bool_exp_count',
   },
@@ -11136,6 +11148,8 @@ export const AllTypesProps: Record<string, any> = {
     profile: 'profiles_bool_exp',
     profile_id: 'Int_comparison_exp',
     profile_public: 'profiles_public_bool_exp',
+    reactions: 'replies_reactions_bool_exp',
+    reactions_aggregate: 'replies_reactions_aggregate_bool_exp',
     reply: 'String_comparison_exp',
     updated_at: 'timestamptz_comparison_exp',
   },
@@ -11151,6 +11165,7 @@ export const AllTypesProps: Record<string, any> = {
     private_stream_visibility: 'private_stream_visibility_obj_rel_insert_input',
     profile: 'profiles_obj_rel_insert_input',
     profile_public: 'profiles_public_obj_rel_insert_input',
+    reactions: 'replies_reactions_arr_rel_insert_input',
     updated_at: 'timestamptz',
   },
   replies_max_order_by: {
@@ -11193,16 +11208,47 @@ export const AllTypesProps: Record<string, any> = {
     profile: 'profiles_order_by',
     profile_id: 'order_by',
     profile_public: 'profiles_public_order_by',
+    reactions_aggregate: 'replies_reactions_aggregate_order_by',
     reply: 'order_by',
     updated_at: 'order_by',
   },
   replies_pk_columns_input: {
     id: 'bigint',
   },
+  replies_reactions_aggregate_bool_exp: {
+    count: 'replies_reactions_aggregate_bool_exp_count',
+  },
+  replies_reactions_aggregate_bool_exp_count: {
+    arguments: 'replies_reactions_select_column',
+    filter: 'replies_reactions_bool_exp',
+    predicate: 'Int_comparison_exp',
+  },
   replies_reactions_aggregate_fields: {
     count: {
       columns: 'replies_reactions_select_column',
     },
+  },
+  replies_reactions_aggregate_order_by: {
+    avg: 'replies_reactions_avg_order_by',
+    count: 'order_by',
+    max: 'replies_reactions_max_order_by',
+    min: 'replies_reactions_min_order_by',
+    stddev: 'replies_reactions_stddev_order_by',
+    stddev_pop: 'replies_reactions_stddev_pop_order_by',
+    stddev_samp: 'replies_reactions_stddev_samp_order_by',
+    sum: 'replies_reactions_sum_order_by',
+    var_pop: 'replies_reactions_var_pop_order_by',
+    var_samp: 'replies_reactions_var_samp_order_by',
+    variance: 'replies_reactions_variance_order_by',
+  },
+  replies_reactions_arr_rel_insert_input: {
+    data: 'replies_reactions_insert_input',
+    on_conflict: 'replies_reactions_on_conflict',
+  },
+  replies_reactions_avg_order_by: {
+    id: 'order_by',
+    profile_id: 'order_by',
+    reply_id: 'order_by',
   },
   replies_reactions_bool_exp: {
     _and: 'replies_reactions_bool_exp',
@@ -11230,6 +11276,22 @@ export const AllTypesProps: Record<string, any> = {
     reply: 'replies_obj_rel_insert_input',
     updated_at: 'timestamptz',
   },
+  replies_reactions_max_order_by: {
+    created_at: 'order_by',
+    id: 'order_by',
+    profile_id: 'order_by',
+    reaction: 'order_by',
+    reply_id: 'order_by',
+    updated_at: 'order_by',
+  },
+  replies_reactions_min_order_by: {
+    created_at: 'order_by',
+    id: 'order_by',
+    profile_id: 'order_by',
+    reaction: 'order_by',
+    reply_id: 'order_by',
+    updated_at: 'order_by',
+  },
   replies_reactions_on_conflict: {
     constraint: 'replies_reactions_constraint',
     update_columns: 'replies_reactions_update_column',
@@ -11255,6 +11317,21 @@ export const AllTypesProps: Record<string, any> = {
     id: 'bigint',
     updated_at: 'timestamptz',
   },
+  replies_reactions_stddev_order_by: {
+    id: 'order_by',
+    profile_id: 'order_by',
+    reply_id: 'order_by',
+  },
+  replies_reactions_stddev_pop_order_by: {
+    id: 'order_by',
+    profile_id: 'order_by',
+    reply_id: 'order_by',
+  },
+  replies_reactions_stddev_samp_order_by: {
+    id: 'order_by',
+    profile_id: 'order_by',
+    reply_id: 'order_by',
+  },
   replies_reactions_stream_cursor_input: {
     initial_value: 'replies_reactions_stream_cursor_value_input',
     ordering: 'cursor_ordering',
@@ -11264,11 +11341,31 @@ export const AllTypesProps: Record<string, any> = {
     id: 'bigint',
     updated_at: 'timestamptz',
   },
+  replies_reactions_sum_order_by: {
+    id: 'order_by',
+    profile_id: 'order_by',
+    reply_id: 'order_by',
+  },
   replies_reactions_update_column: true,
   replies_reactions_updates: {
     _inc: 'replies_reactions_inc_input',
     _set: 'replies_reactions_set_input',
     where: 'replies_reactions_bool_exp',
+  },
+  replies_reactions_var_pop_order_by: {
+    id: 'order_by',
+    profile_id: 'order_by',
+    reply_id: 'order_by',
+  },
+  replies_reactions_var_samp_order_by: {
+    id: 'order_by',
+    profile_id: 'order_by',
+    reply_id: 'order_by',
+  },
+  replies_reactions_variance_order_by: {
+    id: 'order_by',
+    profile_id: 'order_by',
+    reply_id: 'order_by',
   },
   replies_select_column: true,
   replies_set_input: {
@@ -21303,6 +21400,8 @@ export const ReturnTypes: Record<string, any> = {
     profile: 'profiles',
     profile_id: 'Int',
     profile_public: 'profiles_public',
+    reactions: 'replies_reactions',
+    reactions_aggregate: 'replies_reactions_aggregate',
     reply: 'String',
     updated_at: 'timestamptz',
   },

--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -31125,6 +31125,52 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     /** An object relationship */
     profile_public?: ValueTypes['profiles_public'];
+    reactions?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['replies_reactions_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['replies_reactions_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ValueTypes['replies_reactions_bool_exp'] | undefined | null;
+      },
+      ValueTypes['replies_reactions'],
+    ];
+    reactions_aggregate?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['replies_reactions_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['replies_reactions_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ValueTypes['replies_reactions_bool_exp'] | undefined | null;
+      },
+      ValueTypes['replies_reactions_aggregate'],
+    ];
     reply?: boolean | `@${string}`;
     updated_at?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
@@ -31218,6 +31264,11 @@ export type ValueTypes = {
     profile?: ValueTypes['profiles_bool_exp'] | undefined | null;
     profile_id?: ValueTypes['Int_comparison_exp'] | undefined | null;
     profile_public?: ValueTypes['profiles_public_bool_exp'] | undefined | null;
+    reactions?: ValueTypes['replies_reactions_bool_exp'] | undefined | null;
+    reactions_aggregate?:
+      | ValueTypes['replies_reactions_aggregate_bool_exp']
+      | undefined
+      | null;
     reply?: ValueTypes['String_comparison_exp'] | undefined | null;
     updated_at?: ValueTypes['timestamptz_comparison_exp'] | undefined | null;
   };
@@ -31246,6 +31297,10 @@ export type ValueTypes = {
     profile_id?: number | undefined | null;
     profile_public?:
       | ValueTypes['profiles_public_obj_rel_insert_input']
+      | undefined
+      | null;
+    reactions?:
+      | ValueTypes['replies_reactions_arr_rel_insert_input']
       | undefined
       | null;
     reply?: string | undefined | null;
@@ -31332,6 +31387,10 @@ export type ValueTypes = {
     profile?: ValueTypes['profiles_order_by'] | undefined | null;
     profile_id?: ValueTypes['order_by'] | undefined | null;
     profile_public?: ValueTypes['profiles_public_order_by'] | undefined | null;
+    reactions_aggregate?:
+      | ValueTypes['replies_reactions_aggregate_order_by']
+      | undefined
+      | null;
     reply?: ValueTypes['order_by'] | undefined | null;
     updated_at?: ValueTypes['order_by'] | undefined | null;
   };
@@ -31361,6 +31420,21 @@ export type ValueTypes = {
     nodes?: ValueTypes['replies_reactions'];
     __typename?: boolean | `@${string}`;
   }>;
+  ['replies_reactions_aggregate_bool_exp']: {
+    count?:
+      | ValueTypes['replies_reactions_aggregate_bool_exp_count']
+      | undefined
+      | null;
+  };
+  ['replies_reactions_aggregate_bool_exp_count']: {
+    arguments?:
+      | Array<ValueTypes['replies_reactions_select_column']>
+      | undefined
+      | null;
+    distinct?: boolean | undefined | null;
+    filter?: ValueTypes['replies_reactions_bool_exp'] | undefined | null;
+    predicate: ValueTypes['Int_comparison_exp'];
+  };
   /** aggregate fields of "replies_reactions" */
   ['replies_reactions_aggregate_fields']: AliasType<{
     avg?: ValueTypes['replies_reactions_avg_fields'];
@@ -31385,6 +31459,44 @@ export type ValueTypes = {
     variance?: ValueTypes['replies_reactions_variance_fields'];
     __typename?: boolean | `@${string}`;
   }>;
+  /** order by aggregate values of table "replies_reactions" */
+  ['replies_reactions_aggregate_order_by']: {
+    avg?: ValueTypes['replies_reactions_avg_order_by'] | undefined | null;
+    count?: ValueTypes['order_by'] | undefined | null;
+    max?: ValueTypes['replies_reactions_max_order_by'] | undefined | null;
+    min?: ValueTypes['replies_reactions_min_order_by'] | undefined | null;
+    stddev?: ValueTypes['replies_reactions_stddev_order_by'] | undefined | null;
+    stddev_pop?:
+      | ValueTypes['replies_reactions_stddev_pop_order_by']
+      | undefined
+      | null;
+    stddev_samp?:
+      | ValueTypes['replies_reactions_stddev_samp_order_by']
+      | undefined
+      | null;
+    sum?: ValueTypes['replies_reactions_sum_order_by'] | undefined | null;
+    var_pop?:
+      | ValueTypes['replies_reactions_var_pop_order_by']
+      | undefined
+      | null;
+    var_samp?:
+      | ValueTypes['replies_reactions_var_samp_order_by']
+      | undefined
+      | null;
+    variance?:
+      | ValueTypes['replies_reactions_variance_order_by']
+      | undefined
+      | null;
+  };
+  /** input type for inserting array relation for remote table "replies_reactions" */
+  ['replies_reactions_arr_rel_insert_input']: {
+    data: Array<ValueTypes['replies_reactions_insert_input']>;
+    /** upsert condition */
+    on_conflict?:
+      | ValueTypes['replies_reactions_on_conflict']
+      | undefined
+      | null;
+  };
   /** aggregate avg on columns */
   ['replies_reactions_avg_fields']: AliasType<{
     id?: boolean | `@${string}`;
@@ -31392,6 +31504,12 @@ export type ValueTypes = {
     reply_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
+  /** order by avg() on columns of table "replies_reactions" */
+  ['replies_reactions_avg_order_by']: {
+    id?: ValueTypes['order_by'] | undefined | null;
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+    reply_id?: ValueTypes['order_by'] | undefined | null;
+  };
   /** Boolean expression to filter rows from the table "replies_reactions". All fields are combined with a logical 'AND'. */
   ['replies_reactions_bool_exp']: {
     _and?: Array<ValueTypes['replies_reactions_bool_exp']> | undefined | null;
@@ -31440,6 +31558,15 @@ export type ValueTypes = {
     updated_at?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
+  /** order by max() on columns of table "replies_reactions" */
+  ['replies_reactions_max_order_by']: {
+    created_at?: ValueTypes['order_by'] | undefined | null;
+    id?: ValueTypes['order_by'] | undefined | null;
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+    reaction?: ValueTypes['order_by'] | undefined | null;
+    reply_id?: ValueTypes['order_by'] | undefined | null;
+    updated_at?: ValueTypes['order_by'] | undefined | null;
+  };
   /** aggregate min on columns */
   ['replies_reactions_min_fields']: AliasType<{
     created_at?: boolean | `@${string}`;
@@ -31450,6 +31577,15 @@ export type ValueTypes = {
     updated_at?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
+  /** order by min() on columns of table "replies_reactions" */
+  ['replies_reactions_min_order_by']: {
+    created_at?: ValueTypes['order_by'] | undefined | null;
+    id?: ValueTypes['order_by'] | undefined | null;
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+    reaction?: ValueTypes['order_by'] | undefined | null;
+    reply_id?: ValueTypes['order_by'] | undefined | null;
+    updated_at?: ValueTypes['order_by'] | undefined | null;
+  };
   /** response of any mutation on the table "replies_reactions" */
   ['replies_reactions_mutation_response']: AliasType<{
     /** number of rows affected by the mutation */
@@ -31498,6 +31634,12 @@ export type ValueTypes = {
     reply_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
+  /** order by stddev() on columns of table "replies_reactions" */
+  ['replies_reactions_stddev_order_by']: {
+    id?: ValueTypes['order_by'] | undefined | null;
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+    reply_id?: ValueTypes['order_by'] | undefined | null;
+  };
   /** aggregate stddev_pop on columns */
   ['replies_reactions_stddev_pop_fields']: AliasType<{
     id?: boolean | `@${string}`;
@@ -31505,6 +31647,12 @@ export type ValueTypes = {
     reply_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
+  /** order by stddev_pop() on columns of table "replies_reactions" */
+  ['replies_reactions_stddev_pop_order_by']: {
+    id?: ValueTypes['order_by'] | undefined | null;
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+    reply_id?: ValueTypes['order_by'] | undefined | null;
+  };
   /** aggregate stddev_samp on columns */
   ['replies_reactions_stddev_samp_fields']: AliasType<{
     id?: boolean | `@${string}`;
@@ -31512,6 +31660,12 @@ export type ValueTypes = {
     reply_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
+  /** order by stddev_samp() on columns of table "replies_reactions" */
+  ['replies_reactions_stddev_samp_order_by']: {
+    id?: ValueTypes['order_by'] | undefined | null;
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+    reply_id?: ValueTypes['order_by'] | undefined | null;
+  };
   /** Streaming cursor of the table "replies_reactions" */
   ['replies_reactions_stream_cursor_input']: {
     /** Stream column input with initial value */
@@ -31535,6 +31689,12 @@ export type ValueTypes = {
     reply_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
+  /** order by sum() on columns of table "replies_reactions" */
+  ['replies_reactions_sum_order_by']: {
+    id?: ValueTypes['order_by'] | undefined | null;
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+    reply_id?: ValueTypes['order_by'] | undefined | null;
+  };
   /** update columns of table "replies_reactions" */
   ['replies_reactions_update_column']: replies_reactions_update_column;
   ['replies_reactions_updates']: {
@@ -31552,6 +31712,12 @@ export type ValueTypes = {
     reply_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
+  /** order by var_pop() on columns of table "replies_reactions" */
+  ['replies_reactions_var_pop_order_by']: {
+    id?: ValueTypes['order_by'] | undefined | null;
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+    reply_id?: ValueTypes['order_by'] | undefined | null;
+  };
   /** aggregate var_samp on columns */
   ['replies_reactions_var_samp_fields']: AliasType<{
     id?: boolean | `@${string}`;
@@ -31559,6 +31725,12 @@ export type ValueTypes = {
     reply_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
+  /** order by var_samp() on columns of table "replies_reactions" */
+  ['replies_reactions_var_samp_order_by']: {
+    id?: ValueTypes['order_by'] | undefined | null;
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+    reply_id?: ValueTypes['order_by'] | undefined | null;
+  };
   /** aggregate variance on columns */
   ['replies_reactions_variance_fields']: AliasType<{
     id?: boolean | `@${string}`;
@@ -31566,6 +31738,12 @@ export type ValueTypes = {
     reply_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
+  /** order by variance() on columns of table "replies_reactions" */
+  ['replies_reactions_variance_order_by']: {
+    id?: ValueTypes['order_by'] | undefined | null;
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+    reply_id?: ValueTypes['order_by'] | undefined | null;
+  };
   /** select columns of table "replies" */
   ['replies_select_column']: replies_select_column;
   /** input type for updating data in table "replies" */
@@ -52915,6 +53093,10 @@ export type ModelTypes = {
     profile_id: number;
     /** An object relationship */
     profile_public?: GraphQLTypes['profiles_public'] | undefined;
+    /** An array relationship */
+    reactions: Array<GraphQLTypes['replies_reactions']>;
+    /** An aggregate relationship */
+    reactions_aggregate: GraphQLTypes['replies_reactions_aggregate'];
     reply: string;
     updated_at: GraphQLTypes['timestamptz'];
   };
@@ -53021,6 +53203,8 @@ export type ModelTypes = {
     aggregate?: GraphQLTypes['replies_reactions_aggregate_fields'] | undefined;
     nodes: Array<GraphQLTypes['replies_reactions']>;
   };
+  ['replies_reactions_aggregate_bool_exp']: GraphQLTypes['replies_reactions_aggregate_bool_exp'];
+  ['replies_reactions_aggregate_bool_exp_count']: GraphQLTypes['replies_reactions_aggregate_bool_exp_count'];
   /** aggregate fields of "replies_reactions" */
   ['replies_reactions_aggregate_fields']: {
     avg?: GraphQLTypes['replies_reactions_avg_fields'] | undefined;
@@ -53039,12 +53223,18 @@ export type ModelTypes = {
     var_samp?: GraphQLTypes['replies_reactions_var_samp_fields'] | undefined;
     variance?: GraphQLTypes['replies_reactions_variance_fields'] | undefined;
   };
+  /** order by aggregate values of table "replies_reactions" */
+  ['replies_reactions_aggregate_order_by']: GraphQLTypes['replies_reactions_aggregate_order_by'];
+  /** input type for inserting array relation for remote table "replies_reactions" */
+  ['replies_reactions_arr_rel_insert_input']: GraphQLTypes['replies_reactions_arr_rel_insert_input'];
   /** aggregate avg on columns */
   ['replies_reactions_avg_fields']: {
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
+  /** order by avg() on columns of table "replies_reactions" */
+  ['replies_reactions_avg_order_by']: GraphQLTypes['replies_reactions_avg_order_by'];
   /** Boolean expression to filter rows from the table "replies_reactions". All fields are combined with a logical 'AND'. */
   ['replies_reactions_bool_exp']: GraphQLTypes['replies_reactions_bool_exp'];
   /** unique or primary key constraints on table "replies_reactions" */
@@ -53062,6 +53252,8 @@ export type ModelTypes = {
     reply_id?: number | undefined;
     updated_at?: GraphQLTypes['timestamptz'] | undefined;
   };
+  /** order by max() on columns of table "replies_reactions" */
+  ['replies_reactions_max_order_by']: GraphQLTypes['replies_reactions_max_order_by'];
   /** aggregate min on columns */
   ['replies_reactions_min_fields']: {
     created_at?: GraphQLTypes['timestamptz'] | undefined;
@@ -53071,6 +53263,8 @@ export type ModelTypes = {
     reply_id?: number | undefined;
     updated_at?: GraphQLTypes['timestamptz'] | undefined;
   };
+  /** order by min() on columns of table "replies_reactions" */
+  ['replies_reactions_min_order_by']: GraphQLTypes['replies_reactions_min_order_by'];
   /** response of any mutation on the table "replies_reactions" */
   ['replies_reactions_mutation_response']: {
     /** number of rows affected by the mutation */
@@ -53094,18 +53288,24 @@ export type ModelTypes = {
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
+  /** order by stddev() on columns of table "replies_reactions" */
+  ['replies_reactions_stddev_order_by']: GraphQLTypes['replies_reactions_stddev_order_by'];
   /** aggregate stddev_pop on columns */
   ['replies_reactions_stddev_pop_fields']: {
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
+  /** order by stddev_pop() on columns of table "replies_reactions" */
+  ['replies_reactions_stddev_pop_order_by']: GraphQLTypes['replies_reactions_stddev_pop_order_by'];
   /** aggregate stddev_samp on columns */
   ['replies_reactions_stddev_samp_fields']: {
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
+  /** order by stddev_samp() on columns of table "replies_reactions" */
+  ['replies_reactions_stddev_samp_order_by']: GraphQLTypes['replies_reactions_stddev_samp_order_by'];
   /** Streaming cursor of the table "replies_reactions" */
   ['replies_reactions_stream_cursor_input']: GraphQLTypes['replies_reactions_stream_cursor_input'];
   /** Initial value of the column from where the streaming should start */
@@ -53116,6 +53316,8 @@ export type ModelTypes = {
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
+  /** order by sum() on columns of table "replies_reactions" */
+  ['replies_reactions_sum_order_by']: GraphQLTypes['replies_reactions_sum_order_by'];
   /** update columns of table "replies_reactions" */
   ['replies_reactions_update_column']: GraphQLTypes['replies_reactions_update_column'];
   ['replies_reactions_updates']: GraphQLTypes['replies_reactions_updates'];
@@ -53125,18 +53327,24 @@ export type ModelTypes = {
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
+  /** order by var_pop() on columns of table "replies_reactions" */
+  ['replies_reactions_var_pop_order_by']: GraphQLTypes['replies_reactions_var_pop_order_by'];
   /** aggregate var_samp on columns */
   ['replies_reactions_var_samp_fields']: {
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
+  /** order by var_samp() on columns of table "replies_reactions" */
+  ['replies_reactions_var_samp_order_by']: GraphQLTypes['replies_reactions_var_samp_order_by'];
   /** aggregate variance on columns */
   ['replies_reactions_variance_fields']: {
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
+  /** order by variance() on columns of table "replies_reactions" */
+  ['replies_reactions_variance_order_by']: GraphQLTypes['replies_reactions_variance_order_by'];
   /** select columns of table "replies" */
   ['replies_select_column']: GraphQLTypes['replies_select_column'];
   /** input type for updating data in table "replies" */
@@ -76599,6 +76807,10 @@ export type GraphQLTypes = {
     profile_id: number;
     /** An object relationship */
     profile_public?: GraphQLTypes['profiles_public'] | undefined;
+    /** An array relationship */
+    reactions: Array<GraphQLTypes['replies_reactions']>;
+    /** An aggregate relationship */
+    reactions_aggregate: GraphQLTypes['replies_reactions_aggregate'];
     reply: string;
     updated_at: GraphQLTypes['timestamptz'];
   };
@@ -76684,6 +76896,10 @@ export type GraphQLTypes = {
     profile?: GraphQLTypes['profiles_bool_exp'] | undefined;
     profile_id?: GraphQLTypes['Int_comparison_exp'] | undefined;
     profile_public?: GraphQLTypes['profiles_public_bool_exp'] | undefined;
+    reactions?: GraphQLTypes['replies_reactions_bool_exp'] | undefined;
+    reactions_aggregate?:
+      | GraphQLTypes['replies_reactions_aggregate_bool_exp']
+      | undefined;
     reply?: GraphQLTypes['String_comparison_exp'] | undefined;
     updated_at?: GraphQLTypes['timestamptz_comparison_exp'] | undefined;
   };
@@ -76711,6 +76927,9 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     profile_public?:
       | GraphQLTypes['profiles_public_obj_rel_insert_input']
+      | undefined;
+    reactions?:
+      | GraphQLTypes['replies_reactions_arr_rel_insert_input']
       | undefined;
     reply?: string | undefined;
     updated_at?: GraphQLTypes['timestamptz'] | undefined;
@@ -76795,6 +77014,9 @@ export type GraphQLTypes = {
     profile?: GraphQLTypes['profiles_order_by'] | undefined;
     profile_id?: GraphQLTypes['order_by'] | undefined;
     profile_public?: GraphQLTypes['profiles_public_order_by'] | undefined;
+    reactions_aggregate?:
+      | GraphQLTypes['replies_reactions_aggregate_order_by']
+      | undefined;
     reply?: GraphQLTypes['order_by'] | undefined;
     updated_at?: GraphQLTypes['order_by'] | undefined;
   };
@@ -76824,6 +77046,19 @@ export type GraphQLTypes = {
     aggregate?: GraphQLTypes['replies_reactions_aggregate_fields'] | undefined;
     nodes: Array<GraphQLTypes['replies_reactions']>;
   };
+  ['replies_reactions_aggregate_bool_exp']: {
+    count?:
+      | GraphQLTypes['replies_reactions_aggregate_bool_exp_count']
+      | undefined;
+  };
+  ['replies_reactions_aggregate_bool_exp_count']: {
+    arguments?:
+      | Array<GraphQLTypes['replies_reactions_select_column']>
+      | undefined;
+    distinct?: boolean | undefined;
+    filter?: GraphQLTypes['replies_reactions_bool_exp'] | undefined;
+    predicate: GraphQLTypes['Int_comparison_exp'];
+  };
   /** aggregate fields of "replies_reactions" */
   ['replies_reactions_aggregate_fields']: {
     __typename: 'replies_reactions_aggregate_fields';
@@ -76843,12 +77078,42 @@ export type GraphQLTypes = {
     var_samp?: GraphQLTypes['replies_reactions_var_samp_fields'] | undefined;
     variance?: GraphQLTypes['replies_reactions_variance_fields'] | undefined;
   };
+  /** order by aggregate values of table "replies_reactions" */
+  ['replies_reactions_aggregate_order_by']: {
+    avg?: GraphQLTypes['replies_reactions_avg_order_by'] | undefined;
+    count?: GraphQLTypes['order_by'] | undefined;
+    max?: GraphQLTypes['replies_reactions_max_order_by'] | undefined;
+    min?: GraphQLTypes['replies_reactions_min_order_by'] | undefined;
+    stddev?: GraphQLTypes['replies_reactions_stddev_order_by'] | undefined;
+    stddev_pop?:
+      | GraphQLTypes['replies_reactions_stddev_pop_order_by']
+      | undefined;
+    stddev_samp?:
+      | GraphQLTypes['replies_reactions_stddev_samp_order_by']
+      | undefined;
+    sum?: GraphQLTypes['replies_reactions_sum_order_by'] | undefined;
+    var_pop?: GraphQLTypes['replies_reactions_var_pop_order_by'] | undefined;
+    var_samp?: GraphQLTypes['replies_reactions_var_samp_order_by'] | undefined;
+    variance?: GraphQLTypes['replies_reactions_variance_order_by'] | undefined;
+  };
+  /** input type for inserting array relation for remote table "replies_reactions" */
+  ['replies_reactions_arr_rel_insert_input']: {
+    data: Array<GraphQLTypes['replies_reactions_insert_input']>;
+    /** upsert condition */
+    on_conflict?: GraphQLTypes['replies_reactions_on_conflict'] | undefined;
+  };
   /** aggregate avg on columns */
   ['replies_reactions_avg_fields']: {
     __typename: 'replies_reactions_avg_fields';
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
+  };
+  /** order by avg() on columns of table "replies_reactions" */
+  ['replies_reactions_avg_order_by']: {
+    id?: GraphQLTypes['order_by'] | undefined;
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+    reply_id?: GraphQLTypes['order_by'] | undefined;
   };
   /** Boolean expression to filter rows from the table "replies_reactions". All fields are combined with a logical 'AND'. */
   ['replies_reactions_bool_exp']: {
@@ -76897,6 +77162,15 @@ export type GraphQLTypes = {
     reply_id?: number | undefined;
     updated_at?: GraphQLTypes['timestamptz'] | undefined;
   };
+  /** order by max() on columns of table "replies_reactions" */
+  ['replies_reactions_max_order_by']: {
+    created_at?: GraphQLTypes['order_by'] | undefined;
+    id?: GraphQLTypes['order_by'] | undefined;
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+    reaction?: GraphQLTypes['order_by'] | undefined;
+    reply_id?: GraphQLTypes['order_by'] | undefined;
+    updated_at?: GraphQLTypes['order_by'] | undefined;
+  };
   /** aggregate min on columns */
   ['replies_reactions_min_fields']: {
     __typename: 'replies_reactions_min_fields';
@@ -76906,6 +77180,15 @@ export type GraphQLTypes = {
     reaction?: string | undefined;
     reply_id?: number | undefined;
     updated_at?: GraphQLTypes['timestamptz'] | undefined;
+  };
+  /** order by min() on columns of table "replies_reactions" */
+  ['replies_reactions_min_order_by']: {
+    created_at?: GraphQLTypes['order_by'] | undefined;
+    id?: GraphQLTypes['order_by'] | undefined;
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+    reaction?: GraphQLTypes['order_by'] | undefined;
+    reply_id?: GraphQLTypes['order_by'] | undefined;
+    updated_at?: GraphQLTypes['order_by'] | undefined;
   };
   /** response of any mutation on the table "replies_reactions" */
   ['replies_reactions_mutation_response']: {
@@ -76955,6 +77238,12 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
+  /** order by stddev() on columns of table "replies_reactions" */
+  ['replies_reactions_stddev_order_by']: {
+    id?: GraphQLTypes['order_by'] | undefined;
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+    reply_id?: GraphQLTypes['order_by'] | undefined;
+  };
   /** aggregate stddev_pop on columns */
   ['replies_reactions_stddev_pop_fields']: {
     __typename: 'replies_reactions_stddev_pop_fields';
@@ -76962,12 +77251,24 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
+  /** order by stddev_pop() on columns of table "replies_reactions" */
+  ['replies_reactions_stddev_pop_order_by']: {
+    id?: GraphQLTypes['order_by'] | undefined;
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+    reply_id?: GraphQLTypes['order_by'] | undefined;
+  };
   /** aggregate stddev_samp on columns */
   ['replies_reactions_stddev_samp_fields']: {
     __typename: 'replies_reactions_stddev_samp_fields';
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
+  };
+  /** order by stddev_samp() on columns of table "replies_reactions" */
+  ['replies_reactions_stddev_samp_order_by']: {
+    id?: GraphQLTypes['order_by'] | undefined;
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+    reply_id?: GraphQLTypes['order_by'] | undefined;
   };
   /** Streaming cursor of the table "replies_reactions" */
   ['replies_reactions_stream_cursor_input']: {
@@ -76992,6 +77293,12 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
+  /** order by sum() on columns of table "replies_reactions" */
+  ['replies_reactions_sum_order_by']: {
+    id?: GraphQLTypes['order_by'] | undefined;
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+    reply_id?: GraphQLTypes['order_by'] | undefined;
+  };
   /** update columns of table "replies_reactions" */
   ['replies_reactions_update_column']: replies_reactions_update_column;
   ['replies_reactions_updates']: {
@@ -77009,6 +77316,12 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
+  /** order by var_pop() on columns of table "replies_reactions" */
+  ['replies_reactions_var_pop_order_by']: {
+    id?: GraphQLTypes['order_by'] | undefined;
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+    reply_id?: GraphQLTypes['order_by'] | undefined;
+  };
   /** aggregate var_samp on columns */
   ['replies_reactions_var_samp_fields']: {
     __typename: 'replies_reactions_var_samp_fields';
@@ -77016,12 +77329,24 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
+  /** order by var_samp() on columns of table "replies_reactions" */
+  ['replies_reactions_var_samp_order_by']: {
+    id?: GraphQLTypes['order_by'] | undefined;
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+    reply_id?: GraphQLTypes['order_by'] | undefined;
+  };
   /** aggregate variance on columns */
   ['replies_reactions_variance_fields']: {
     __typename: 'replies_reactions_variance_fields';
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
+  };
+  /** order by variance() on columns of table "replies_reactions" */
+  ['replies_reactions_variance_order_by']: {
+    id?: GraphQLTypes['order_by'] | undefined;
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+    reply_id?: GraphQLTypes['order_by'] | undefined;
   };
   /** select columns of table "replies" */
   ['replies_select_column']: replies_select_column;

--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -15729,6 +15729,17 @@ export type ValueTypes = {
       { id: ValueTypes['bigint'] },
       ValueTypes['replies'],
     ];
+    delete_replies_reactions?: [
+      {
+        /** filter the rows which have to be deleted */
+        where: ValueTypes['replies_reactions_bool_exp'];
+      },
+      ValueTypes['replies_reactions_mutation_response'],
+    ];
+    delete_replies_reactions_by_pk?: [
+      { id: ValueTypes['bigint'] },
+      ValueTypes['replies_reactions'],
+    ];
     delete_reputation_scores?: [
       {
         /** filter the rows which have to be deleted */
@@ -16968,6 +16979,30 @@ export type ValueTypes = {
         on_conflict?: ValueTypes['replies_on_conflict'] | undefined | null;
       },
       ValueTypes['replies'],
+    ];
+    insert_replies_reactions?: [
+      {
+        /** the rows to be inserted */
+        objects: Array<
+          ValueTypes['replies_reactions_insert_input']
+        > /** upsert condition */;
+        on_conflict?:
+          | ValueTypes['replies_reactions_on_conflict']
+          | undefined
+          | null;
+      },
+      ValueTypes['replies_reactions_mutation_response'],
+    ];
+    insert_replies_reactions_one?: [
+      {
+        /** the row to be inserted */
+        object: ValueTypes['replies_reactions_insert_input'] /** upsert condition */;
+        on_conflict?:
+          | ValueTypes['replies_reactions_on_conflict']
+          | undefined
+          | null;
+      },
+      ValueTypes['replies_reactions'],
     ];
     insert_reputation_scores?: [
       {
@@ -19201,6 +19236,40 @@ export type ValueTypes = {
         updates: Array<ValueTypes['replies_updates']>;
       },
       ValueTypes['replies_mutation_response'],
+    ];
+    update_replies_reactions?: [
+      {
+        /** increments the numeric columns with given value of the filtered values */
+        _inc?:
+          | ValueTypes['replies_reactions_inc_input']
+          | undefined
+          | null /** sets the columns of the filtered rows to the given values */;
+        _set?:
+          | ValueTypes['replies_reactions_set_input']
+          | undefined
+          | null /** filter the rows which have to be updated */;
+        where: ValueTypes['replies_reactions_bool_exp'];
+      },
+      ValueTypes['replies_reactions_mutation_response'],
+    ];
+    update_replies_reactions_by_pk?: [
+      {
+        /** increments the numeric columns with given value of the filtered values */
+        _inc?:
+          | ValueTypes['replies_reactions_inc_input']
+          | undefined
+          | null /** sets the columns of the filtered rows to the given values */;
+        _set?: ValueTypes['replies_reactions_set_input'] | undefined | null;
+        pk_columns: ValueTypes['replies_reactions_pk_columns_input'];
+      },
+      ValueTypes['replies_reactions'],
+    ];
+    update_replies_reactions_many?: [
+      {
+        /** updates to execute, in order */
+        updates: Array<ValueTypes['replies_reactions_updates']>;
+      },
+      ValueTypes['replies_reactions_mutation_response'],
     ];
     update_reputation_scores?: [
       {
@@ -29719,6 +29788,56 @@ export type ValueTypes = {
       ValueTypes['replies_aggregate'],
     ];
     replies_by_pk?: [{ id: ValueTypes['bigint'] }, ValueTypes['replies']];
+    replies_reactions?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['replies_reactions_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['replies_reactions_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ValueTypes['replies_reactions_bool_exp'] | undefined | null;
+      },
+      ValueTypes['replies_reactions'],
+    ];
+    replies_reactions_aggregate?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['replies_reactions_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['replies_reactions_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ValueTypes['replies_reactions_bool_exp'] | undefined | null;
+      },
+      ValueTypes['replies_reactions_aggregate'],
+    ];
+    replies_reactions_by_pk?: [
+      { id: ValueTypes['bigint'] },
+      ValueTypes['replies_reactions'],
+    ];
     reputation_scores?: [
       {
         /** distinct select on columns */
@@ -31220,6 +31339,233 @@ export type ValueTypes = {
   ['replies_pk_columns_input']: {
     id: ValueTypes['bigint'];
   };
+  /** columns and relationships of "replies_reactions" */
+  ['replies_reactions']: AliasType<{
+    created_at?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    /** An object relationship */
+    profile?: ValueTypes['profiles'];
+    profile_id?: boolean | `@${string}`;
+    /** An object relationship */
+    profile_public?: ValueTypes['profiles_public'];
+    reaction?: boolean | `@${string}`;
+    /** An object relationship */
+    reply?: ValueTypes['replies'];
+    reply_id?: boolean | `@${string}`;
+    updated_at?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregated selection of "replies_reactions" */
+  ['replies_reactions_aggregate']: AliasType<{
+    aggregate?: ValueTypes['replies_reactions_aggregate_fields'];
+    nodes?: ValueTypes['replies_reactions'];
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate fields of "replies_reactions" */
+  ['replies_reactions_aggregate_fields']: AliasType<{
+    avg?: ValueTypes['replies_reactions_avg_fields'];
+    count?: [
+      {
+        columns?:
+          | Array<ValueTypes['replies_reactions_select_column']>
+          | undefined
+          | null;
+        distinct?: boolean | undefined | null;
+      },
+      boolean | `@${string}`,
+    ];
+    max?: ValueTypes['replies_reactions_max_fields'];
+    min?: ValueTypes['replies_reactions_min_fields'];
+    stddev?: ValueTypes['replies_reactions_stddev_fields'];
+    stddev_pop?: ValueTypes['replies_reactions_stddev_pop_fields'];
+    stddev_samp?: ValueTypes['replies_reactions_stddev_samp_fields'];
+    sum?: ValueTypes['replies_reactions_sum_fields'];
+    var_pop?: ValueTypes['replies_reactions_var_pop_fields'];
+    var_samp?: ValueTypes['replies_reactions_var_samp_fields'];
+    variance?: ValueTypes['replies_reactions_variance_fields'];
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate avg on columns */
+  ['replies_reactions_avg_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    profile_id?: boolean | `@${string}`;
+    reply_id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** Boolean expression to filter rows from the table "replies_reactions". All fields are combined with a logical 'AND'. */
+  ['replies_reactions_bool_exp']: {
+    _and?: Array<ValueTypes['replies_reactions_bool_exp']> | undefined | null;
+    _not?: ValueTypes['replies_reactions_bool_exp'] | undefined | null;
+    _or?: Array<ValueTypes['replies_reactions_bool_exp']> | undefined | null;
+    created_at?: ValueTypes['timestamptz_comparison_exp'] | undefined | null;
+    id?: ValueTypes['bigint_comparison_exp'] | undefined | null;
+    profile?: ValueTypes['profiles_bool_exp'] | undefined | null;
+    profile_id?: ValueTypes['Int_comparison_exp'] | undefined | null;
+    profile_public?: ValueTypes['profiles_public_bool_exp'] | undefined | null;
+    reaction?: ValueTypes['String_comparison_exp'] | undefined | null;
+    reply?: ValueTypes['replies_bool_exp'] | undefined | null;
+    reply_id?: ValueTypes['Int_comparison_exp'] | undefined | null;
+    updated_at?: ValueTypes['timestamptz_comparison_exp'] | undefined | null;
+  };
+  /** unique or primary key constraints on table "replies_reactions" */
+  ['replies_reactions_constraint']: replies_reactions_constraint;
+  /** input type for incrementing numeric columns in table "replies_reactions" */
+  ['replies_reactions_inc_input']: {
+    id?: ValueTypes['bigint'] | undefined | null;
+    profile_id?: number | undefined | null;
+    reply_id?: number | undefined | null;
+  };
+  /** input type for inserting data into table "replies_reactions" */
+  ['replies_reactions_insert_input']: {
+    created_at?: ValueTypes['timestamptz'] | undefined | null;
+    id?: ValueTypes['bigint'] | undefined | null;
+    profile?: ValueTypes['profiles_obj_rel_insert_input'] | undefined | null;
+    profile_id?: number | undefined | null;
+    profile_public?:
+      | ValueTypes['profiles_public_obj_rel_insert_input']
+      | undefined
+      | null;
+    reaction?: string | undefined | null;
+    reply?: ValueTypes['replies_obj_rel_insert_input'] | undefined | null;
+    reply_id?: number | undefined | null;
+    updated_at?: ValueTypes['timestamptz'] | undefined | null;
+  };
+  /** aggregate max on columns */
+  ['replies_reactions_max_fields']: AliasType<{
+    created_at?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    profile_id?: boolean | `@${string}`;
+    reaction?: boolean | `@${string}`;
+    reply_id?: boolean | `@${string}`;
+    updated_at?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate min on columns */
+  ['replies_reactions_min_fields']: AliasType<{
+    created_at?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    profile_id?: boolean | `@${string}`;
+    reaction?: boolean | `@${string}`;
+    reply_id?: boolean | `@${string}`;
+    updated_at?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** response of any mutation on the table "replies_reactions" */
+  ['replies_reactions_mutation_response']: AliasType<{
+    /** number of rows affected by the mutation */
+    affected_rows?: boolean | `@${string}`;
+    /** data from the rows affected by the mutation */
+    returning?: ValueTypes['replies_reactions'];
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** on_conflict condition type for table "replies_reactions" */
+  ['replies_reactions_on_conflict']: {
+    constraint: ValueTypes['replies_reactions_constraint'];
+    update_columns: Array<ValueTypes['replies_reactions_update_column']>;
+    where?: ValueTypes['replies_reactions_bool_exp'] | undefined | null;
+  };
+  /** Ordering options when selecting data from "replies_reactions". */
+  ['replies_reactions_order_by']: {
+    created_at?: ValueTypes['order_by'] | undefined | null;
+    id?: ValueTypes['order_by'] | undefined | null;
+    profile?: ValueTypes['profiles_order_by'] | undefined | null;
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+    profile_public?: ValueTypes['profiles_public_order_by'] | undefined | null;
+    reaction?: ValueTypes['order_by'] | undefined | null;
+    reply?: ValueTypes['replies_order_by'] | undefined | null;
+    reply_id?: ValueTypes['order_by'] | undefined | null;
+    updated_at?: ValueTypes['order_by'] | undefined | null;
+  };
+  /** primary key columns input for table: replies_reactions */
+  ['replies_reactions_pk_columns_input']: {
+    id: ValueTypes['bigint'];
+  };
+  /** select columns of table "replies_reactions" */
+  ['replies_reactions_select_column']: replies_reactions_select_column;
+  /** input type for updating data in table "replies_reactions" */
+  ['replies_reactions_set_input']: {
+    created_at?: ValueTypes['timestamptz'] | undefined | null;
+    id?: ValueTypes['bigint'] | undefined | null;
+    profile_id?: number | undefined | null;
+    reaction?: string | undefined | null;
+    reply_id?: number | undefined | null;
+    updated_at?: ValueTypes['timestamptz'] | undefined | null;
+  };
+  /** aggregate stddev on columns */
+  ['replies_reactions_stddev_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    profile_id?: boolean | `@${string}`;
+    reply_id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate stddev_pop on columns */
+  ['replies_reactions_stddev_pop_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    profile_id?: boolean | `@${string}`;
+    reply_id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate stddev_samp on columns */
+  ['replies_reactions_stddev_samp_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    profile_id?: boolean | `@${string}`;
+    reply_id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** Streaming cursor of the table "replies_reactions" */
+  ['replies_reactions_stream_cursor_input']: {
+    /** Stream column input with initial value */
+    initial_value: ValueTypes['replies_reactions_stream_cursor_value_input'];
+    /** cursor ordering */
+    ordering?: ValueTypes['cursor_ordering'] | undefined | null;
+  };
+  /** Initial value of the column from where the streaming should start */
+  ['replies_reactions_stream_cursor_value_input']: {
+    created_at?: ValueTypes['timestamptz'] | undefined | null;
+    id?: ValueTypes['bigint'] | undefined | null;
+    profile_id?: number | undefined | null;
+    reaction?: string | undefined | null;
+    reply_id?: number | undefined | null;
+    updated_at?: ValueTypes['timestamptz'] | undefined | null;
+  };
+  /** aggregate sum on columns */
+  ['replies_reactions_sum_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    profile_id?: boolean | `@${string}`;
+    reply_id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** update columns of table "replies_reactions" */
+  ['replies_reactions_update_column']: replies_reactions_update_column;
+  ['replies_reactions_updates']: {
+    /** increments the numeric columns with given value of the filtered values */
+    _inc?: ValueTypes['replies_reactions_inc_input'] | undefined | null;
+    /** sets the columns of the filtered rows to the given values */
+    _set?: ValueTypes['replies_reactions_set_input'] | undefined | null;
+    /** filter the rows which have to be updated */
+    where: ValueTypes['replies_reactions_bool_exp'];
+  };
+  /** aggregate var_pop on columns */
+  ['replies_reactions_var_pop_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    profile_id?: boolean | `@${string}`;
+    reply_id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate var_samp on columns */
+  ['replies_reactions_var_samp_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    profile_id?: boolean | `@${string}`;
+    reply_id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate variance on columns */
+  ['replies_reactions_variance_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    profile_id?: boolean | `@${string}`;
+    reply_id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
   /** select columns of table "replies" */
   ['replies_select_column']: replies_select_column;
   /** input type for updating data in table "replies" */
@@ -35662,6 +36008,67 @@ export type ValueTypes = {
       ValueTypes['replies_aggregate'],
     ];
     replies_by_pk?: [{ id: ValueTypes['bigint'] }, ValueTypes['replies']];
+    replies_reactions?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['replies_reactions_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['replies_reactions_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ValueTypes['replies_reactions_bool_exp'] | undefined | null;
+      },
+      ValueTypes['replies_reactions'],
+    ];
+    replies_reactions_aggregate?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['replies_reactions_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['replies_reactions_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ValueTypes['replies_reactions_bool_exp'] | undefined | null;
+      },
+      ValueTypes['replies_reactions_aggregate'],
+    ];
+    replies_reactions_by_pk?: [
+      { id: ValueTypes['bigint'] },
+      ValueTypes['replies_reactions'],
+    ];
+    replies_reactions_stream?: [
+      {
+        /** maximum number of rows returned in a single batch */
+        batch_size: number /** cursor to stream the results returned by the query */;
+        cursor: Array<
+          ValueTypes['replies_reactions_stream_cursor_input'] | undefined | null
+        > /** filter the rows returned */;
+        where?: ValueTypes['replies_reactions_bool_exp'] | undefined | null;
+      },
+      ValueTypes['replies_reactions'],
+    ];
     replies_stream?: [
       {
         /** maximum number of rows returned in a single batch */
@@ -47480,6 +47887,14 @@ export type ModelTypes = {
     delete_replies?: GraphQLTypes['replies_mutation_response'] | undefined;
     /** delete single row from the table: "replies" */
     delete_replies_by_pk?: GraphQLTypes['replies'] | undefined;
+    /** delete data from the table: "replies_reactions" */
+    delete_replies_reactions?:
+      | GraphQLTypes['replies_reactions_mutation_response']
+      | undefined;
+    /** delete single row from the table: "replies_reactions" */
+    delete_replies_reactions_by_pk?:
+      | GraphQLTypes['replies_reactions']
+      | undefined;
     /** delete data from the table: "reputation_scores" */
     delete_reputation_scores?:
       | GraphQLTypes['reputation_scores_mutation_response']
@@ -47874,6 +48289,14 @@ export type ModelTypes = {
     insert_replies?: GraphQLTypes['replies_mutation_response'] | undefined;
     /** insert a single row into the table: "replies" */
     insert_replies_one?: GraphQLTypes['replies'] | undefined;
+    /** insert data into the table: "replies_reactions" */
+    insert_replies_reactions?:
+      | GraphQLTypes['replies_reactions_mutation_response']
+      | undefined;
+    /** insert a single row into the table: "replies_reactions" */
+    insert_replies_reactions_one?:
+      | GraphQLTypes['replies_reactions']
+      | undefined;
     /** insert data into the table: "reputation_scores" */
     insert_reputation_scores?:
       | GraphQLTypes['reputation_scores_mutation_response']
@@ -48521,6 +48944,18 @@ export type ModelTypes = {
     /** update multiples rows of table: "replies" */
     update_replies_many?:
       | Array<GraphQLTypes['replies_mutation_response'] | undefined>
+      | undefined;
+    /** update data of the table: "replies_reactions" */
+    update_replies_reactions?:
+      | GraphQLTypes['replies_reactions_mutation_response']
+      | undefined;
+    /** update single row of the table: "replies_reactions" */
+    update_replies_reactions_by_pk?:
+      | GraphQLTypes['replies_reactions']
+      | undefined;
+    /** update multiples rows of table: "replies_reactions" */
+    update_replies_reactions_many?:
+      | Array<GraphQLTypes['replies_reactions_mutation_response'] | undefined>
       | undefined;
     /** update data of the table: "reputation_scores" */
     update_reputation_scores?:
@@ -52187,6 +52622,12 @@ export type ModelTypes = {
     replies_aggregate: GraphQLTypes['replies_aggregate'];
     /** fetch data from the table: "replies" using primary key columns */
     replies_by_pk?: GraphQLTypes['replies'] | undefined;
+    /** fetch data from the table: "replies_reactions" */
+    replies_reactions: Array<GraphQLTypes['replies_reactions']>;
+    /** fetch aggregated fields from the table: "replies_reactions" */
+    replies_reactions_aggregate: GraphQLTypes['replies_reactions_aggregate'];
+    /** fetch data from the table: "replies_reactions" using primary key columns */
+    replies_reactions_by_pk?: GraphQLTypes['replies_reactions'] | undefined;
     /** fetch data from the table: "reputation_scores" */
     reputation_scores: Array<GraphQLTypes['reputation_scores']>;
     /** fetch aggregated fields from the table: "reputation_scores" */
@@ -52560,6 +53001,142 @@ export type ModelTypes = {
   ['replies_order_by']: GraphQLTypes['replies_order_by'];
   /** primary key columns input for table: replies */
   ['replies_pk_columns_input']: GraphQLTypes['replies_pk_columns_input'];
+  /** columns and relationships of "replies_reactions" */
+  ['replies_reactions']: {
+    created_at: GraphQLTypes['timestamptz'];
+    id: GraphQLTypes['bigint'];
+    /** An object relationship */
+    profile?: GraphQLTypes['profiles'] | undefined;
+    profile_id: number;
+    /** An object relationship */
+    profile_public?: GraphQLTypes['profiles_public'] | undefined;
+    reaction: string;
+    /** An object relationship */
+    reply?: GraphQLTypes['replies'] | undefined;
+    reply_id: number;
+    updated_at: GraphQLTypes['timestamptz'];
+  };
+  /** aggregated selection of "replies_reactions" */
+  ['replies_reactions_aggregate']: {
+    aggregate?: GraphQLTypes['replies_reactions_aggregate_fields'] | undefined;
+    nodes: Array<GraphQLTypes['replies_reactions']>;
+  };
+  /** aggregate fields of "replies_reactions" */
+  ['replies_reactions_aggregate_fields']: {
+    avg?: GraphQLTypes['replies_reactions_avg_fields'] | undefined;
+    count: number;
+    max?: GraphQLTypes['replies_reactions_max_fields'] | undefined;
+    min?: GraphQLTypes['replies_reactions_min_fields'] | undefined;
+    stddev?: GraphQLTypes['replies_reactions_stddev_fields'] | undefined;
+    stddev_pop?:
+      | GraphQLTypes['replies_reactions_stddev_pop_fields']
+      | undefined;
+    stddev_samp?:
+      | GraphQLTypes['replies_reactions_stddev_samp_fields']
+      | undefined;
+    sum?: GraphQLTypes['replies_reactions_sum_fields'] | undefined;
+    var_pop?: GraphQLTypes['replies_reactions_var_pop_fields'] | undefined;
+    var_samp?: GraphQLTypes['replies_reactions_var_samp_fields'] | undefined;
+    variance?: GraphQLTypes['replies_reactions_variance_fields'] | undefined;
+  };
+  /** aggregate avg on columns */
+  ['replies_reactions_avg_fields']: {
+    id?: number | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
+  };
+  /** Boolean expression to filter rows from the table "replies_reactions". All fields are combined with a logical 'AND'. */
+  ['replies_reactions_bool_exp']: GraphQLTypes['replies_reactions_bool_exp'];
+  /** unique or primary key constraints on table "replies_reactions" */
+  ['replies_reactions_constraint']: GraphQLTypes['replies_reactions_constraint'];
+  /** input type for incrementing numeric columns in table "replies_reactions" */
+  ['replies_reactions_inc_input']: GraphQLTypes['replies_reactions_inc_input'];
+  /** input type for inserting data into table "replies_reactions" */
+  ['replies_reactions_insert_input']: GraphQLTypes['replies_reactions_insert_input'];
+  /** aggregate max on columns */
+  ['replies_reactions_max_fields']: {
+    created_at?: GraphQLTypes['timestamptz'] | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    profile_id?: number | undefined;
+    reaction?: string | undefined;
+    reply_id?: number | undefined;
+    updated_at?: GraphQLTypes['timestamptz'] | undefined;
+  };
+  /** aggregate min on columns */
+  ['replies_reactions_min_fields']: {
+    created_at?: GraphQLTypes['timestamptz'] | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    profile_id?: number | undefined;
+    reaction?: string | undefined;
+    reply_id?: number | undefined;
+    updated_at?: GraphQLTypes['timestamptz'] | undefined;
+  };
+  /** response of any mutation on the table "replies_reactions" */
+  ['replies_reactions_mutation_response']: {
+    /** number of rows affected by the mutation */
+    affected_rows: number;
+    /** data from the rows affected by the mutation */
+    returning: Array<GraphQLTypes['replies_reactions']>;
+  };
+  /** on_conflict condition type for table "replies_reactions" */
+  ['replies_reactions_on_conflict']: GraphQLTypes['replies_reactions_on_conflict'];
+  /** Ordering options when selecting data from "replies_reactions". */
+  ['replies_reactions_order_by']: GraphQLTypes['replies_reactions_order_by'];
+  /** primary key columns input for table: replies_reactions */
+  ['replies_reactions_pk_columns_input']: GraphQLTypes['replies_reactions_pk_columns_input'];
+  /** select columns of table "replies_reactions" */
+  ['replies_reactions_select_column']: GraphQLTypes['replies_reactions_select_column'];
+  /** input type for updating data in table "replies_reactions" */
+  ['replies_reactions_set_input']: GraphQLTypes['replies_reactions_set_input'];
+  /** aggregate stddev on columns */
+  ['replies_reactions_stddev_fields']: {
+    id?: number | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
+  };
+  /** aggregate stddev_pop on columns */
+  ['replies_reactions_stddev_pop_fields']: {
+    id?: number | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
+  };
+  /** aggregate stddev_samp on columns */
+  ['replies_reactions_stddev_samp_fields']: {
+    id?: number | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
+  };
+  /** Streaming cursor of the table "replies_reactions" */
+  ['replies_reactions_stream_cursor_input']: GraphQLTypes['replies_reactions_stream_cursor_input'];
+  /** Initial value of the column from where the streaming should start */
+  ['replies_reactions_stream_cursor_value_input']: GraphQLTypes['replies_reactions_stream_cursor_value_input'];
+  /** aggregate sum on columns */
+  ['replies_reactions_sum_fields']: {
+    id?: GraphQLTypes['bigint'] | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
+  };
+  /** update columns of table "replies_reactions" */
+  ['replies_reactions_update_column']: GraphQLTypes['replies_reactions_update_column'];
+  ['replies_reactions_updates']: GraphQLTypes['replies_reactions_updates'];
+  /** aggregate var_pop on columns */
+  ['replies_reactions_var_pop_fields']: {
+    id?: number | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
+  };
+  /** aggregate var_samp on columns */
+  ['replies_reactions_var_samp_fields']: {
+    id?: number | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
+  };
+  /** aggregate variance on columns */
+  ['replies_reactions_variance_fields']: {
+    id?: number | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
+  };
   /** select columns of table "replies" */
   ['replies_select_column']: GraphQLTypes['replies_select_column'];
   /** input type for updating data in table "replies" */
@@ -53533,6 +54110,14 @@ export type ModelTypes = {
     replies_aggregate: GraphQLTypes['replies_aggregate'];
     /** fetch data from the table: "replies" using primary key columns */
     replies_by_pk?: GraphQLTypes['replies'] | undefined;
+    /** fetch data from the table: "replies_reactions" */
+    replies_reactions: Array<GraphQLTypes['replies_reactions']>;
+    /** fetch aggregated fields from the table: "replies_reactions" */
+    replies_reactions_aggregate: GraphQLTypes['replies_reactions_aggregate'];
+    /** fetch data from the table: "replies_reactions" using primary key columns */
+    replies_reactions_by_pk?: GraphQLTypes['replies_reactions'] | undefined;
+    /** fetch data from the table in a streaming manner: "replies_reactions" */
+    replies_reactions_stream: Array<GraphQLTypes['replies_reactions']>;
     /** fetch data from the table in a streaming manner: "replies" */
     replies_stream: Array<GraphQLTypes['replies']>;
     /** fetch data from the table: "reputation_scores" */
@@ -68092,6 +68677,14 @@ export type GraphQLTypes = {
     delete_replies?: GraphQLTypes['replies_mutation_response'] | undefined;
     /** delete single row from the table: "replies" */
     delete_replies_by_pk?: GraphQLTypes['replies'] | undefined;
+    /** delete data from the table: "replies_reactions" */
+    delete_replies_reactions?:
+      | GraphQLTypes['replies_reactions_mutation_response']
+      | undefined;
+    /** delete single row from the table: "replies_reactions" */
+    delete_replies_reactions_by_pk?:
+      | GraphQLTypes['replies_reactions']
+      | undefined;
     /** delete data from the table: "reputation_scores" */
     delete_reputation_scores?:
       | GraphQLTypes['reputation_scores_mutation_response']
@@ -68486,6 +69079,14 @@ export type GraphQLTypes = {
     insert_replies?: GraphQLTypes['replies_mutation_response'] | undefined;
     /** insert a single row into the table: "replies" */
     insert_replies_one?: GraphQLTypes['replies'] | undefined;
+    /** insert data into the table: "replies_reactions" */
+    insert_replies_reactions?:
+      | GraphQLTypes['replies_reactions_mutation_response']
+      | undefined;
+    /** insert a single row into the table: "replies_reactions" */
+    insert_replies_reactions_one?:
+      | GraphQLTypes['replies_reactions']
+      | undefined;
     /** insert data into the table: "reputation_scores" */
     insert_reputation_scores?:
       | GraphQLTypes['reputation_scores_mutation_response']
@@ -69133,6 +69734,18 @@ export type GraphQLTypes = {
     /** update multiples rows of table: "replies" */
     update_replies_many?:
       | Array<GraphQLTypes['replies_mutation_response'] | undefined>
+      | undefined;
+    /** update data of the table: "replies_reactions" */
+    update_replies_reactions?:
+      | GraphQLTypes['replies_reactions_mutation_response']
+      | undefined;
+    /** update single row of the table: "replies_reactions" */
+    update_replies_reactions_by_pk?:
+      | GraphQLTypes['replies_reactions']
+      | undefined;
+    /** update multiples rows of table: "replies_reactions" */
+    update_replies_reactions_many?:
+      | Array<GraphQLTypes['replies_reactions_mutation_response'] | undefined>
       | undefined;
     /** update data of the table: "reputation_scores" */
     update_reputation_scores?:
@@ -75534,6 +76147,12 @@ export type GraphQLTypes = {
     replies_aggregate: GraphQLTypes['replies_aggregate'];
     /** fetch data from the table: "replies" using primary key columns */
     replies_by_pk?: GraphQLTypes['replies'] | undefined;
+    /** fetch data from the table: "replies_reactions" */
+    replies_reactions: Array<GraphQLTypes['replies_reactions']>;
+    /** fetch aggregated fields from the table: "replies_reactions" */
+    replies_reactions_aggregate: GraphQLTypes['replies_reactions_aggregate'];
+    /** fetch data from the table: "replies_reactions" using primary key columns */
+    replies_reactions_by_pk?: GraphQLTypes['replies_reactions'] | undefined;
     /** fetch data from the table: "reputation_scores" */
     reputation_scores: Array<GraphQLTypes['reputation_scores']>;
     /** fetch aggregated fields from the table: "reputation_scores" */
@@ -76182,6 +76801,227 @@ export type GraphQLTypes = {
   /** primary key columns input for table: replies */
   ['replies_pk_columns_input']: {
     id: GraphQLTypes['bigint'];
+  };
+  /** columns and relationships of "replies_reactions" */
+  ['replies_reactions']: {
+    __typename: 'replies_reactions';
+    created_at: GraphQLTypes['timestamptz'];
+    id: GraphQLTypes['bigint'];
+    /** An object relationship */
+    profile?: GraphQLTypes['profiles'] | undefined;
+    profile_id: number;
+    /** An object relationship */
+    profile_public?: GraphQLTypes['profiles_public'] | undefined;
+    reaction: string;
+    /** An object relationship */
+    reply?: GraphQLTypes['replies'] | undefined;
+    reply_id: number;
+    updated_at: GraphQLTypes['timestamptz'];
+  };
+  /** aggregated selection of "replies_reactions" */
+  ['replies_reactions_aggregate']: {
+    __typename: 'replies_reactions_aggregate';
+    aggregate?: GraphQLTypes['replies_reactions_aggregate_fields'] | undefined;
+    nodes: Array<GraphQLTypes['replies_reactions']>;
+  };
+  /** aggregate fields of "replies_reactions" */
+  ['replies_reactions_aggregate_fields']: {
+    __typename: 'replies_reactions_aggregate_fields';
+    avg?: GraphQLTypes['replies_reactions_avg_fields'] | undefined;
+    count: number;
+    max?: GraphQLTypes['replies_reactions_max_fields'] | undefined;
+    min?: GraphQLTypes['replies_reactions_min_fields'] | undefined;
+    stddev?: GraphQLTypes['replies_reactions_stddev_fields'] | undefined;
+    stddev_pop?:
+      | GraphQLTypes['replies_reactions_stddev_pop_fields']
+      | undefined;
+    stddev_samp?:
+      | GraphQLTypes['replies_reactions_stddev_samp_fields']
+      | undefined;
+    sum?: GraphQLTypes['replies_reactions_sum_fields'] | undefined;
+    var_pop?: GraphQLTypes['replies_reactions_var_pop_fields'] | undefined;
+    var_samp?: GraphQLTypes['replies_reactions_var_samp_fields'] | undefined;
+    variance?: GraphQLTypes['replies_reactions_variance_fields'] | undefined;
+  };
+  /** aggregate avg on columns */
+  ['replies_reactions_avg_fields']: {
+    __typename: 'replies_reactions_avg_fields';
+    id?: number | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
+  };
+  /** Boolean expression to filter rows from the table "replies_reactions". All fields are combined with a logical 'AND'. */
+  ['replies_reactions_bool_exp']: {
+    _and?: Array<GraphQLTypes['replies_reactions_bool_exp']> | undefined;
+    _not?: GraphQLTypes['replies_reactions_bool_exp'] | undefined;
+    _or?: Array<GraphQLTypes['replies_reactions_bool_exp']> | undefined;
+    created_at?: GraphQLTypes['timestamptz_comparison_exp'] | undefined;
+    id?: GraphQLTypes['bigint_comparison_exp'] | undefined;
+    profile?: GraphQLTypes['profiles_bool_exp'] | undefined;
+    profile_id?: GraphQLTypes['Int_comparison_exp'] | undefined;
+    profile_public?: GraphQLTypes['profiles_public_bool_exp'] | undefined;
+    reaction?: GraphQLTypes['String_comparison_exp'] | undefined;
+    reply?: GraphQLTypes['replies_bool_exp'] | undefined;
+    reply_id?: GraphQLTypes['Int_comparison_exp'] | undefined;
+    updated_at?: GraphQLTypes['timestamptz_comparison_exp'] | undefined;
+  };
+  /** unique or primary key constraints on table "replies_reactions" */
+  ['replies_reactions_constraint']: replies_reactions_constraint;
+  /** input type for incrementing numeric columns in table "replies_reactions" */
+  ['replies_reactions_inc_input']: {
+    id?: GraphQLTypes['bigint'] | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
+  };
+  /** input type for inserting data into table "replies_reactions" */
+  ['replies_reactions_insert_input']: {
+    created_at?: GraphQLTypes['timestamptz'] | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    profile?: GraphQLTypes['profiles_obj_rel_insert_input'] | undefined;
+    profile_id?: number | undefined;
+    profile_public?:
+      | GraphQLTypes['profiles_public_obj_rel_insert_input']
+      | undefined;
+    reaction?: string | undefined;
+    reply?: GraphQLTypes['replies_obj_rel_insert_input'] | undefined;
+    reply_id?: number | undefined;
+    updated_at?: GraphQLTypes['timestamptz'] | undefined;
+  };
+  /** aggregate max on columns */
+  ['replies_reactions_max_fields']: {
+    __typename: 'replies_reactions_max_fields';
+    created_at?: GraphQLTypes['timestamptz'] | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    profile_id?: number | undefined;
+    reaction?: string | undefined;
+    reply_id?: number | undefined;
+    updated_at?: GraphQLTypes['timestamptz'] | undefined;
+  };
+  /** aggregate min on columns */
+  ['replies_reactions_min_fields']: {
+    __typename: 'replies_reactions_min_fields';
+    created_at?: GraphQLTypes['timestamptz'] | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    profile_id?: number | undefined;
+    reaction?: string | undefined;
+    reply_id?: number | undefined;
+    updated_at?: GraphQLTypes['timestamptz'] | undefined;
+  };
+  /** response of any mutation on the table "replies_reactions" */
+  ['replies_reactions_mutation_response']: {
+    __typename: 'replies_reactions_mutation_response';
+    /** number of rows affected by the mutation */
+    affected_rows: number;
+    /** data from the rows affected by the mutation */
+    returning: Array<GraphQLTypes['replies_reactions']>;
+  };
+  /** on_conflict condition type for table "replies_reactions" */
+  ['replies_reactions_on_conflict']: {
+    constraint: GraphQLTypes['replies_reactions_constraint'];
+    update_columns: Array<GraphQLTypes['replies_reactions_update_column']>;
+    where?: GraphQLTypes['replies_reactions_bool_exp'] | undefined;
+  };
+  /** Ordering options when selecting data from "replies_reactions". */
+  ['replies_reactions_order_by']: {
+    created_at?: GraphQLTypes['order_by'] | undefined;
+    id?: GraphQLTypes['order_by'] | undefined;
+    profile?: GraphQLTypes['profiles_order_by'] | undefined;
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+    profile_public?: GraphQLTypes['profiles_public_order_by'] | undefined;
+    reaction?: GraphQLTypes['order_by'] | undefined;
+    reply?: GraphQLTypes['replies_order_by'] | undefined;
+    reply_id?: GraphQLTypes['order_by'] | undefined;
+    updated_at?: GraphQLTypes['order_by'] | undefined;
+  };
+  /** primary key columns input for table: replies_reactions */
+  ['replies_reactions_pk_columns_input']: {
+    id: GraphQLTypes['bigint'];
+  };
+  /** select columns of table "replies_reactions" */
+  ['replies_reactions_select_column']: replies_reactions_select_column;
+  /** input type for updating data in table "replies_reactions" */
+  ['replies_reactions_set_input']: {
+    created_at?: GraphQLTypes['timestamptz'] | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    profile_id?: number | undefined;
+    reaction?: string | undefined;
+    reply_id?: number | undefined;
+    updated_at?: GraphQLTypes['timestamptz'] | undefined;
+  };
+  /** aggregate stddev on columns */
+  ['replies_reactions_stddev_fields']: {
+    __typename: 'replies_reactions_stddev_fields';
+    id?: number | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
+  };
+  /** aggregate stddev_pop on columns */
+  ['replies_reactions_stddev_pop_fields']: {
+    __typename: 'replies_reactions_stddev_pop_fields';
+    id?: number | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
+  };
+  /** aggregate stddev_samp on columns */
+  ['replies_reactions_stddev_samp_fields']: {
+    __typename: 'replies_reactions_stddev_samp_fields';
+    id?: number | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
+  };
+  /** Streaming cursor of the table "replies_reactions" */
+  ['replies_reactions_stream_cursor_input']: {
+    /** Stream column input with initial value */
+    initial_value: GraphQLTypes['replies_reactions_stream_cursor_value_input'];
+    /** cursor ordering */
+    ordering?: GraphQLTypes['cursor_ordering'] | undefined;
+  };
+  /** Initial value of the column from where the streaming should start */
+  ['replies_reactions_stream_cursor_value_input']: {
+    created_at?: GraphQLTypes['timestamptz'] | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    profile_id?: number | undefined;
+    reaction?: string | undefined;
+    reply_id?: number | undefined;
+    updated_at?: GraphQLTypes['timestamptz'] | undefined;
+  };
+  /** aggregate sum on columns */
+  ['replies_reactions_sum_fields']: {
+    __typename: 'replies_reactions_sum_fields';
+    id?: GraphQLTypes['bigint'] | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
+  };
+  /** update columns of table "replies_reactions" */
+  ['replies_reactions_update_column']: replies_reactions_update_column;
+  ['replies_reactions_updates']: {
+    /** increments the numeric columns with given value of the filtered values */
+    _inc?: GraphQLTypes['replies_reactions_inc_input'] | undefined;
+    /** sets the columns of the filtered rows to the given values */
+    _set?: GraphQLTypes['replies_reactions_set_input'] | undefined;
+    /** filter the rows which have to be updated */
+    where: GraphQLTypes['replies_reactions_bool_exp'];
+  };
+  /** aggregate var_pop on columns */
+  ['replies_reactions_var_pop_fields']: {
+    __typename: 'replies_reactions_var_pop_fields';
+    id?: number | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
+  };
+  /** aggregate var_samp on columns */
+  ['replies_reactions_var_samp_fields']: {
+    __typename: 'replies_reactions_var_samp_fields';
+    id?: number | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
+  };
+  /** aggregate variance on columns */
+  ['replies_reactions_variance_fields']: {
+    __typename: 'replies_reactions_variance_fields';
+    id?: number | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
   };
   /** select columns of table "replies" */
   ['replies_select_column']: replies_select_column;
@@ -77468,6 +78308,14 @@ export type GraphQLTypes = {
     replies_aggregate: GraphQLTypes['replies_aggregate'];
     /** fetch data from the table: "replies" using primary key columns */
     replies_by_pk?: GraphQLTypes['replies'] | undefined;
+    /** fetch data from the table: "replies_reactions" */
+    replies_reactions: Array<GraphQLTypes['replies_reactions']>;
+    /** fetch aggregated fields from the table: "replies_reactions" */
+    replies_reactions_aggregate: GraphQLTypes['replies_reactions_aggregate'];
+    /** fetch data from the table: "replies_reactions" using primary key columns */
+    replies_reactions_by_pk?: GraphQLTypes['replies_reactions'] | undefined;
+    /** fetch data from the table in a streaming manner: "replies_reactions" */
+    replies_reactions_stream: Array<GraphQLTypes['replies_reactions']>;
     /** fetch data from the table in a streaming manner: "replies" */
     replies_stream: Array<GraphQLTypes['replies']>;
     /** fetch data from the table: "reputation_scores" */
@@ -82599,6 +83447,29 @@ export const enum reactions_update_column {
 /** unique or primary key constraints on table "replies" */
 export const enum replies_constraint {
   replies_pkey = 'replies_pkey',
+}
+/** unique or primary key constraints on table "replies_reactions" */
+export const enum replies_reactions_constraint {
+  replies_reactions_pkey = 'replies_reactions_pkey',
+  replies_reactions_profile_id_reply_id_reaction_key = 'replies_reactions_profile_id_reply_id_reaction_key',
+}
+/** select columns of table "replies_reactions" */
+export const enum replies_reactions_select_column {
+  created_at = 'created_at',
+  id = 'id',
+  profile_id = 'profile_id',
+  reaction = 'reaction',
+  reply_id = 'reply_id',
+  updated_at = 'updated_at',
+}
+/** update columns of table "replies_reactions" */
+export const enum replies_reactions_update_column {
+  created_at = 'created_at',
+  id = 'id',
+  profile_id = 'profile_id',
+  reaction = 'reaction',
+  reply_id = 'reply_id',
+  updated_at = 'updated_at',
 }
 /** select columns of table "replies" */
 export const enum replies_select_column {

--- a/api-lib/gql/__generated__/zeus/index.ts
+++ b/api-lib/gql/__generated__/zeus/index.ts
@@ -20995,6 +20995,9 @@ export type ValueTypes = {
     /** An object relationship */
     reply?: ValueTypes['replies'];
     reply_id?: boolean | `@${string}`;
+    /** An object relationship */
+    reply_reaction?: ValueTypes['replies_reactions'];
+    reply_reaction_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregated selection of "notifications" */
@@ -21038,6 +21041,7 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     reaction_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
+    reply_reaction_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** Boolean expression to filter rows from the table "notifications". All fields are combined with a logical 'AND'. */
@@ -21071,6 +21075,11 @@ export type ValueTypes = {
     reaction_id?: ValueTypes['bigint_comparison_exp'] | undefined | null;
     reply?: ValueTypes['replies_bool_exp'] | undefined | null;
     reply_id?: ValueTypes['Int_comparison_exp'] | undefined | null;
+    reply_reaction?:
+      | ValueTypes['replies_reactions_bool_exp']
+      | undefined
+      | null;
+    reply_reaction_id?: ValueTypes['bigint_comparison_exp'] | undefined | null;
   };
   /** unique or primary key constraints on table "notifications" */
   ['notifications_constraint']: notifications_constraint;
@@ -21085,6 +21094,7 @@ export type ValueTypes = {
     profile_id?: ValueTypes['bigint'] | undefined | null;
     reaction_id?: ValueTypes['bigint'] | undefined | null;
     reply_id?: number | undefined | null;
+    reply_reaction_id?: ValueTypes['bigint'] | undefined | null;
   };
   /** input type for inserting data into table "notifications" */
   ['notifications_insert_input']: {
@@ -21120,6 +21130,11 @@ export type ValueTypes = {
     reaction_id?: ValueTypes['bigint'] | undefined | null;
     reply?: ValueTypes['replies_obj_rel_insert_input'] | undefined | null;
     reply_id?: number | undefined | null;
+    reply_reaction?:
+      | ValueTypes['replies_reactions_obj_rel_insert_input']
+      | undefined
+      | null;
+    reply_reaction_id?: ValueTypes['bigint'] | undefined | null;
   };
   /** aggregate max on columns */
   ['notifications_max_fields']: AliasType<{
@@ -21134,6 +21149,7 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     reaction_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
+    reply_reaction_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregate min on columns */
@@ -21149,6 +21165,7 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     reaction_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
+    reply_reaction_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** response of any mutation on the table "notifications" */
@@ -21193,6 +21210,11 @@ export type ValueTypes = {
     reaction_id?: ValueTypes['order_by'] | undefined | null;
     reply?: ValueTypes['replies_order_by'] | undefined | null;
     reply_id?: ValueTypes['order_by'] | undefined | null;
+    reply_reaction?:
+      | ValueTypes['replies_reactions_order_by']
+      | undefined
+      | null;
+    reply_reaction_id?: ValueTypes['order_by'] | undefined | null;
   };
   /** primary key columns input for table: notifications */
   ['notifications_pk_columns_input']: {
@@ -21213,6 +21235,7 @@ export type ValueTypes = {
     profile_id?: ValueTypes['bigint'] | undefined | null;
     reaction_id?: ValueTypes['bigint'] | undefined | null;
     reply_id?: number | undefined | null;
+    reply_reaction_id?: ValueTypes['bigint'] | undefined | null;
   };
   /** aggregate stddev on columns */
   ['notifications_stddev_fields']: AliasType<{
@@ -21225,6 +21248,7 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     reaction_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
+    reply_reaction_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregate stddev_pop on columns */
@@ -21238,6 +21262,7 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     reaction_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
+    reply_reaction_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregate stddev_samp on columns */
@@ -21251,6 +21276,7 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     reaction_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
+    reply_reaction_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** Streaming cursor of the table "notifications" */
@@ -21273,6 +21299,7 @@ export type ValueTypes = {
     profile_id?: ValueTypes['bigint'] | undefined | null;
     reaction_id?: ValueTypes['bigint'] | undefined | null;
     reply_id?: number | undefined | null;
+    reply_reaction_id?: ValueTypes['bigint'] | undefined | null;
   };
   /** aggregate sum on columns */
   ['notifications_sum_fields']: AliasType<{
@@ -21285,6 +21312,7 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     reaction_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
+    reply_reaction_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** update columns of table "notifications" */
@@ -21308,6 +21336,7 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     reaction_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
+    reply_reaction_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregate var_samp on columns */
@@ -21321,6 +21350,7 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     reaction_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
+    reply_reaction_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregate variance on columns */
@@ -21334,6 +21364,7 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     reaction_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
+    reply_reaction_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   ['numeric']: unknown;
@@ -31400,6 +31431,9 @@ export type ValueTypes = {
   };
   /** columns and relationships of "replies_reactions" */
   ['replies_reactions']: AliasType<{
+    /** An object relationship */
+    activity?: ValueTypes['activities'];
+    activity_id?: boolean | `@${string}`;
     created_at?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
     /** An object relationship */
@@ -31499,6 +31533,7 @@ export type ValueTypes = {
   };
   /** aggregate avg on columns */
   ['replies_reactions_avg_fields']: AliasType<{
+    activity_id?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
     profile_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
@@ -31506,6 +31541,7 @@ export type ValueTypes = {
   }>;
   /** order by avg() on columns of table "replies_reactions" */
   ['replies_reactions_avg_order_by']: {
+    activity_id?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
     profile_id?: ValueTypes['order_by'] | undefined | null;
     reply_id?: ValueTypes['order_by'] | undefined | null;
@@ -31515,6 +31551,8 @@ export type ValueTypes = {
     _and?: Array<ValueTypes['replies_reactions_bool_exp']> | undefined | null;
     _not?: ValueTypes['replies_reactions_bool_exp'] | undefined | null;
     _or?: Array<ValueTypes['replies_reactions_bool_exp']> | undefined | null;
+    activity?: ValueTypes['activities_bool_exp'] | undefined | null;
+    activity_id?: ValueTypes['Int_comparison_exp'] | undefined | null;
     created_at?: ValueTypes['timestamptz_comparison_exp'] | undefined | null;
     id?: ValueTypes['bigint_comparison_exp'] | undefined | null;
     profile?: ValueTypes['profiles_bool_exp'] | undefined | null;
@@ -31529,12 +31567,15 @@ export type ValueTypes = {
   ['replies_reactions_constraint']: replies_reactions_constraint;
   /** input type for incrementing numeric columns in table "replies_reactions" */
   ['replies_reactions_inc_input']: {
+    activity_id?: number | undefined | null;
     id?: ValueTypes['bigint'] | undefined | null;
     profile_id?: number | undefined | null;
     reply_id?: number | undefined | null;
   };
   /** input type for inserting data into table "replies_reactions" */
   ['replies_reactions_insert_input']: {
+    activity?: ValueTypes['activities_obj_rel_insert_input'] | undefined | null;
+    activity_id?: number | undefined | null;
     created_at?: ValueTypes['timestamptz'] | undefined | null;
     id?: ValueTypes['bigint'] | undefined | null;
     profile?: ValueTypes['profiles_obj_rel_insert_input'] | undefined | null;
@@ -31550,6 +31591,7 @@ export type ValueTypes = {
   };
   /** aggregate max on columns */
   ['replies_reactions_max_fields']: AliasType<{
+    activity_id?: boolean | `@${string}`;
     created_at?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
     profile_id?: boolean | `@${string}`;
@@ -31560,6 +31602,7 @@ export type ValueTypes = {
   }>;
   /** order by max() on columns of table "replies_reactions" */
   ['replies_reactions_max_order_by']: {
+    activity_id?: ValueTypes['order_by'] | undefined | null;
     created_at?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
     profile_id?: ValueTypes['order_by'] | undefined | null;
@@ -31569,6 +31612,7 @@ export type ValueTypes = {
   };
   /** aggregate min on columns */
   ['replies_reactions_min_fields']: AliasType<{
+    activity_id?: boolean | `@${string}`;
     created_at?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
     profile_id?: boolean | `@${string}`;
@@ -31579,6 +31623,7 @@ export type ValueTypes = {
   }>;
   /** order by min() on columns of table "replies_reactions" */
   ['replies_reactions_min_order_by']: {
+    activity_id?: ValueTypes['order_by'] | undefined | null;
     created_at?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
     profile_id?: ValueTypes['order_by'] | undefined | null;
@@ -31594,6 +31639,15 @@ export type ValueTypes = {
     returning?: ValueTypes['replies_reactions'];
     __typename?: boolean | `@${string}`;
   }>;
+  /** input type for inserting object relation for remote table "replies_reactions" */
+  ['replies_reactions_obj_rel_insert_input']: {
+    data: ValueTypes['replies_reactions_insert_input'];
+    /** upsert condition */
+    on_conflict?:
+      | ValueTypes['replies_reactions_on_conflict']
+      | undefined
+      | null;
+  };
   /** on_conflict condition type for table "replies_reactions" */
   ['replies_reactions_on_conflict']: {
     constraint: ValueTypes['replies_reactions_constraint'];
@@ -31602,6 +31656,8 @@ export type ValueTypes = {
   };
   /** Ordering options when selecting data from "replies_reactions". */
   ['replies_reactions_order_by']: {
+    activity?: ValueTypes['activities_order_by'] | undefined | null;
+    activity_id?: ValueTypes['order_by'] | undefined | null;
     created_at?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
     profile?: ValueTypes['profiles_order_by'] | undefined | null;
@@ -31620,6 +31676,7 @@ export type ValueTypes = {
   ['replies_reactions_select_column']: replies_reactions_select_column;
   /** input type for updating data in table "replies_reactions" */
   ['replies_reactions_set_input']: {
+    activity_id?: number | undefined | null;
     created_at?: ValueTypes['timestamptz'] | undefined | null;
     id?: ValueTypes['bigint'] | undefined | null;
     profile_id?: number | undefined | null;
@@ -31629,6 +31686,7 @@ export type ValueTypes = {
   };
   /** aggregate stddev on columns */
   ['replies_reactions_stddev_fields']: AliasType<{
+    activity_id?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
     profile_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
@@ -31636,12 +31694,14 @@ export type ValueTypes = {
   }>;
   /** order by stddev() on columns of table "replies_reactions" */
   ['replies_reactions_stddev_order_by']: {
+    activity_id?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
     profile_id?: ValueTypes['order_by'] | undefined | null;
     reply_id?: ValueTypes['order_by'] | undefined | null;
   };
   /** aggregate stddev_pop on columns */
   ['replies_reactions_stddev_pop_fields']: AliasType<{
+    activity_id?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
     profile_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
@@ -31649,12 +31709,14 @@ export type ValueTypes = {
   }>;
   /** order by stddev_pop() on columns of table "replies_reactions" */
   ['replies_reactions_stddev_pop_order_by']: {
+    activity_id?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
     profile_id?: ValueTypes['order_by'] | undefined | null;
     reply_id?: ValueTypes['order_by'] | undefined | null;
   };
   /** aggregate stddev_samp on columns */
   ['replies_reactions_stddev_samp_fields']: AliasType<{
+    activity_id?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
     profile_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
@@ -31662,6 +31724,7 @@ export type ValueTypes = {
   }>;
   /** order by stddev_samp() on columns of table "replies_reactions" */
   ['replies_reactions_stddev_samp_order_by']: {
+    activity_id?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
     profile_id?: ValueTypes['order_by'] | undefined | null;
     reply_id?: ValueTypes['order_by'] | undefined | null;
@@ -31675,6 +31738,7 @@ export type ValueTypes = {
   };
   /** Initial value of the column from where the streaming should start */
   ['replies_reactions_stream_cursor_value_input']: {
+    activity_id?: number | undefined | null;
     created_at?: ValueTypes['timestamptz'] | undefined | null;
     id?: ValueTypes['bigint'] | undefined | null;
     profile_id?: number | undefined | null;
@@ -31684,6 +31748,7 @@ export type ValueTypes = {
   };
   /** aggregate sum on columns */
   ['replies_reactions_sum_fields']: AliasType<{
+    activity_id?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
     profile_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
@@ -31691,6 +31756,7 @@ export type ValueTypes = {
   }>;
   /** order by sum() on columns of table "replies_reactions" */
   ['replies_reactions_sum_order_by']: {
+    activity_id?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
     profile_id?: ValueTypes['order_by'] | undefined | null;
     reply_id?: ValueTypes['order_by'] | undefined | null;
@@ -31707,6 +31773,7 @@ export type ValueTypes = {
   };
   /** aggregate var_pop on columns */
   ['replies_reactions_var_pop_fields']: AliasType<{
+    activity_id?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
     profile_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
@@ -31714,12 +31781,14 @@ export type ValueTypes = {
   }>;
   /** order by var_pop() on columns of table "replies_reactions" */
   ['replies_reactions_var_pop_order_by']: {
+    activity_id?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
     profile_id?: ValueTypes['order_by'] | undefined | null;
     reply_id?: ValueTypes['order_by'] | undefined | null;
   };
   /** aggregate var_samp on columns */
   ['replies_reactions_var_samp_fields']: AliasType<{
+    activity_id?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
     profile_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
@@ -31727,12 +31796,14 @@ export type ValueTypes = {
   }>;
   /** order by var_samp() on columns of table "replies_reactions" */
   ['replies_reactions_var_samp_order_by']: {
+    activity_id?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
     profile_id?: ValueTypes['order_by'] | undefined | null;
     reply_id?: ValueTypes['order_by'] | undefined | null;
   };
   /** aggregate variance on columns */
   ['replies_reactions_variance_fields']: AliasType<{
+    activity_id?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
     profile_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
@@ -31740,6 +31811,7 @@ export type ValueTypes = {
   }>;
   /** order by variance() on columns of table "replies_reactions" */
   ['replies_reactions_variance_order_by']: {
+    activity_id?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
     profile_id?: ValueTypes['order_by'] | undefined | null;
     reply_id?: ValueTypes['order_by'] | undefined | null;
@@ -49938,6 +50010,9 @@ export type ModelTypes = {
     /** An object relationship */
     reply?: GraphQLTypes['replies'] | undefined;
     reply_id?: number | undefined;
+    /** An object relationship */
+    reply_reaction?: GraphQLTypes['replies_reactions'] | undefined;
+    reply_reaction_id?: GraphQLTypes['bigint'] | undefined;
   };
   /** aggregated selection of "notifications" */
   ['notifications_aggregate']: {
@@ -49969,6 +50044,7 @@ export type ModelTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: number | undefined;
   };
   /** Boolean expression to filter rows from the table "notifications". All fields are combined with a logical 'AND'. */
   ['notifications_bool_exp']: GraphQLTypes['notifications_bool_exp'];
@@ -49991,6 +50067,7 @@ export type ModelTypes = {
     profile_id?: GraphQLTypes['bigint'] | undefined;
     reaction_id?: GraphQLTypes['bigint'] | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: GraphQLTypes['bigint'] | undefined;
   };
   /** aggregate min on columns */
   ['notifications_min_fields']: {
@@ -50005,6 +50082,7 @@ export type ModelTypes = {
     profile_id?: GraphQLTypes['bigint'] | undefined;
     reaction_id?: GraphQLTypes['bigint'] | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: GraphQLTypes['bigint'] | undefined;
   };
   /** response of any mutation on the table "notifications" */
   ['notifications_mutation_response']: {
@@ -50034,6 +50112,7 @@ export type ModelTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: number | undefined;
   };
   /** aggregate stddev_pop on columns */
   ['notifications_stddev_pop_fields']: {
@@ -50046,6 +50125,7 @@ export type ModelTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: number | undefined;
   };
   /** aggregate stddev_samp on columns */
   ['notifications_stddev_samp_fields']: {
@@ -50058,6 +50138,7 @@ export type ModelTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: number | undefined;
   };
   /** Streaming cursor of the table "notifications" */
   ['notifications_stream_cursor_input']: GraphQLTypes['notifications_stream_cursor_input'];
@@ -50074,6 +50155,7 @@ export type ModelTypes = {
     profile_id?: GraphQLTypes['bigint'] | undefined;
     reaction_id?: GraphQLTypes['bigint'] | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: GraphQLTypes['bigint'] | undefined;
   };
   /** update columns of table "notifications" */
   ['notifications_update_column']: GraphQLTypes['notifications_update_column'];
@@ -50089,6 +50171,7 @@ export type ModelTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: number | undefined;
   };
   /** aggregate var_samp on columns */
   ['notifications_var_samp_fields']: {
@@ -50101,6 +50184,7 @@ export type ModelTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: number | undefined;
   };
   /** aggregate variance on columns */
   ['notifications_variance_fields']: {
@@ -50113,6 +50197,7 @@ export type ModelTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: number | undefined;
   };
   ['numeric']: any;
   /** Boolean expression to compare columns of type "numeric". All fields are combined with logical 'AND'. */
@@ -53185,6 +53270,9 @@ export type ModelTypes = {
   ['replies_pk_columns_input']: GraphQLTypes['replies_pk_columns_input'];
   /** columns and relationships of "replies_reactions" */
   ['replies_reactions']: {
+    /** An object relationship */
+    activity?: GraphQLTypes['activities'] | undefined;
+    activity_id: number;
     created_at: GraphQLTypes['timestamptz'];
     id: GraphQLTypes['bigint'];
     /** An object relationship */
@@ -53229,6 +53317,7 @@ export type ModelTypes = {
   ['replies_reactions_arr_rel_insert_input']: GraphQLTypes['replies_reactions_arr_rel_insert_input'];
   /** aggregate avg on columns */
   ['replies_reactions_avg_fields']: {
+    activity_id?: number | undefined;
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
@@ -53245,6 +53334,7 @@ export type ModelTypes = {
   ['replies_reactions_insert_input']: GraphQLTypes['replies_reactions_insert_input'];
   /** aggregate max on columns */
   ['replies_reactions_max_fields']: {
+    activity_id?: number | undefined;
     created_at?: GraphQLTypes['timestamptz'] | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
     profile_id?: number | undefined;
@@ -53256,6 +53346,7 @@ export type ModelTypes = {
   ['replies_reactions_max_order_by']: GraphQLTypes['replies_reactions_max_order_by'];
   /** aggregate min on columns */
   ['replies_reactions_min_fields']: {
+    activity_id?: number | undefined;
     created_at?: GraphQLTypes['timestamptz'] | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
     profile_id?: number | undefined;
@@ -53272,6 +53363,8 @@ export type ModelTypes = {
     /** data from the rows affected by the mutation */
     returning: Array<GraphQLTypes['replies_reactions']>;
   };
+  /** input type for inserting object relation for remote table "replies_reactions" */
+  ['replies_reactions_obj_rel_insert_input']: GraphQLTypes['replies_reactions_obj_rel_insert_input'];
   /** on_conflict condition type for table "replies_reactions" */
   ['replies_reactions_on_conflict']: GraphQLTypes['replies_reactions_on_conflict'];
   /** Ordering options when selecting data from "replies_reactions". */
@@ -53284,6 +53377,7 @@ export type ModelTypes = {
   ['replies_reactions_set_input']: GraphQLTypes['replies_reactions_set_input'];
   /** aggregate stddev on columns */
   ['replies_reactions_stddev_fields']: {
+    activity_id?: number | undefined;
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
@@ -53292,6 +53386,7 @@ export type ModelTypes = {
   ['replies_reactions_stddev_order_by']: GraphQLTypes['replies_reactions_stddev_order_by'];
   /** aggregate stddev_pop on columns */
   ['replies_reactions_stddev_pop_fields']: {
+    activity_id?: number | undefined;
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
@@ -53300,6 +53395,7 @@ export type ModelTypes = {
   ['replies_reactions_stddev_pop_order_by']: GraphQLTypes['replies_reactions_stddev_pop_order_by'];
   /** aggregate stddev_samp on columns */
   ['replies_reactions_stddev_samp_fields']: {
+    activity_id?: number | undefined;
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
@@ -53312,6 +53408,7 @@ export type ModelTypes = {
   ['replies_reactions_stream_cursor_value_input']: GraphQLTypes['replies_reactions_stream_cursor_value_input'];
   /** aggregate sum on columns */
   ['replies_reactions_sum_fields']: {
+    activity_id?: number | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
@@ -53323,6 +53420,7 @@ export type ModelTypes = {
   ['replies_reactions_updates']: GraphQLTypes['replies_reactions_updates'];
   /** aggregate var_pop on columns */
   ['replies_reactions_var_pop_fields']: {
+    activity_id?: number | undefined;
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
@@ -53331,6 +53429,7 @@ export type ModelTypes = {
   ['replies_reactions_var_pop_order_by']: GraphQLTypes['replies_reactions_var_pop_order_by'];
   /** aggregate var_samp on columns */
   ['replies_reactions_var_samp_fields']: {
+    activity_id?: number | undefined;
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
@@ -53339,6 +53438,7 @@ export type ModelTypes = {
   ['replies_reactions_var_samp_order_by']: GraphQLTypes['replies_reactions_var_samp_order_by'];
   /** aggregate variance on columns */
   ['replies_reactions_variance_fields']: {
+    activity_id?: number | undefined;
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
@@ -71308,6 +71408,9 @@ export type GraphQLTypes = {
     /** An object relationship */
     reply?: GraphQLTypes['replies'] | undefined;
     reply_id?: number | undefined;
+    /** An object relationship */
+    reply_reaction?: GraphQLTypes['replies_reactions'] | undefined;
+    reply_reaction_id?: GraphQLTypes['bigint'] | undefined;
   };
   /** aggregated selection of "notifications" */
   ['notifications_aggregate']: {
@@ -71342,6 +71445,7 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: number | undefined;
   };
   /** Boolean expression to filter rows from the table "notifications". All fields are combined with a logical 'AND'. */
   ['notifications_bool_exp']: {
@@ -71370,6 +71474,8 @@ export type GraphQLTypes = {
     reaction_id?: GraphQLTypes['bigint_comparison_exp'] | undefined;
     reply?: GraphQLTypes['replies_bool_exp'] | undefined;
     reply_id?: GraphQLTypes['Int_comparison_exp'] | undefined;
+    reply_reaction?: GraphQLTypes['replies_reactions_bool_exp'] | undefined;
+    reply_reaction_id?: GraphQLTypes['bigint_comparison_exp'] | undefined;
   };
   /** unique or primary key constraints on table "notifications" */
   ['notifications_constraint']: notifications_constraint;
@@ -71384,6 +71490,7 @@ export type GraphQLTypes = {
     profile_id?: GraphQLTypes['bigint'] | undefined;
     reaction_id?: GraphQLTypes['bigint'] | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: GraphQLTypes['bigint'] | undefined;
   };
   /** input type for inserting data into table "notifications" */
   ['notifications_insert_input']: {
@@ -71413,6 +71520,10 @@ export type GraphQLTypes = {
     reaction_id?: GraphQLTypes['bigint'] | undefined;
     reply?: GraphQLTypes['replies_obj_rel_insert_input'] | undefined;
     reply_id?: number | undefined;
+    reply_reaction?:
+      | GraphQLTypes['replies_reactions_obj_rel_insert_input']
+      | undefined;
+    reply_reaction_id?: GraphQLTypes['bigint'] | undefined;
   };
   /** aggregate max on columns */
   ['notifications_max_fields']: {
@@ -71428,6 +71539,7 @@ export type GraphQLTypes = {
     profile_id?: GraphQLTypes['bigint'] | undefined;
     reaction_id?: GraphQLTypes['bigint'] | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: GraphQLTypes['bigint'] | undefined;
   };
   /** aggregate min on columns */
   ['notifications_min_fields']: {
@@ -71443,6 +71555,7 @@ export type GraphQLTypes = {
     profile_id?: GraphQLTypes['bigint'] | undefined;
     reaction_id?: GraphQLTypes['bigint'] | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: GraphQLTypes['bigint'] | undefined;
   };
   /** response of any mutation on the table "notifications" */
   ['notifications_mutation_response']: {
@@ -71482,6 +71595,8 @@ export type GraphQLTypes = {
     reaction_id?: GraphQLTypes['order_by'] | undefined;
     reply?: GraphQLTypes['replies_order_by'] | undefined;
     reply_id?: GraphQLTypes['order_by'] | undefined;
+    reply_reaction?: GraphQLTypes['replies_reactions_order_by'] | undefined;
+    reply_reaction_id?: GraphQLTypes['order_by'] | undefined;
   };
   /** primary key columns input for table: notifications */
   ['notifications_pk_columns_input']: {
@@ -71502,6 +71617,7 @@ export type GraphQLTypes = {
     profile_id?: GraphQLTypes['bigint'] | undefined;
     reaction_id?: GraphQLTypes['bigint'] | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: GraphQLTypes['bigint'] | undefined;
   };
   /** aggregate stddev on columns */
   ['notifications_stddev_fields']: {
@@ -71515,6 +71631,7 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: number | undefined;
   };
   /** aggregate stddev_pop on columns */
   ['notifications_stddev_pop_fields']: {
@@ -71528,6 +71645,7 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: number | undefined;
   };
   /** aggregate stddev_samp on columns */
   ['notifications_stddev_samp_fields']: {
@@ -71541,6 +71659,7 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: number | undefined;
   };
   /** Streaming cursor of the table "notifications" */
   ['notifications_stream_cursor_input']: {
@@ -71562,6 +71681,7 @@ export type GraphQLTypes = {
     profile_id?: GraphQLTypes['bigint'] | undefined;
     reaction_id?: GraphQLTypes['bigint'] | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: GraphQLTypes['bigint'] | undefined;
   };
   /** aggregate sum on columns */
   ['notifications_sum_fields']: {
@@ -71575,6 +71695,7 @@ export type GraphQLTypes = {
     profile_id?: GraphQLTypes['bigint'] | undefined;
     reaction_id?: GraphQLTypes['bigint'] | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: GraphQLTypes['bigint'] | undefined;
   };
   /** update columns of table "notifications" */
   ['notifications_update_column']: notifications_update_column;
@@ -71598,6 +71719,7 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: number | undefined;
   };
   /** aggregate var_samp on columns */
   ['notifications_var_samp_fields']: {
@@ -71611,6 +71733,7 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: number | undefined;
   };
   /** aggregate variance on columns */
   ['notifications_variance_fields']: {
@@ -71624,6 +71747,7 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: number | undefined;
   };
   ['numeric']: any;
   /** Boolean expression to compare columns of type "numeric". All fields are combined with logical 'AND'. */
@@ -77027,6 +77151,9 @@ export type GraphQLTypes = {
   /** columns and relationships of "replies_reactions" */
   ['replies_reactions']: {
     __typename: 'replies_reactions';
+    /** An object relationship */
+    activity?: GraphQLTypes['activities'] | undefined;
+    activity_id: number;
     created_at: GraphQLTypes['timestamptz'];
     id: GraphQLTypes['bigint'];
     /** An object relationship */
@@ -77105,12 +77232,14 @@ export type GraphQLTypes = {
   /** aggregate avg on columns */
   ['replies_reactions_avg_fields']: {
     __typename: 'replies_reactions_avg_fields';
+    activity_id?: number | undefined;
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
   /** order by avg() on columns of table "replies_reactions" */
   ['replies_reactions_avg_order_by']: {
+    activity_id?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
     profile_id?: GraphQLTypes['order_by'] | undefined;
     reply_id?: GraphQLTypes['order_by'] | undefined;
@@ -77120,6 +77249,8 @@ export type GraphQLTypes = {
     _and?: Array<GraphQLTypes['replies_reactions_bool_exp']> | undefined;
     _not?: GraphQLTypes['replies_reactions_bool_exp'] | undefined;
     _or?: Array<GraphQLTypes['replies_reactions_bool_exp']> | undefined;
+    activity?: GraphQLTypes['activities_bool_exp'] | undefined;
+    activity_id?: GraphQLTypes['Int_comparison_exp'] | undefined;
     created_at?: GraphQLTypes['timestamptz_comparison_exp'] | undefined;
     id?: GraphQLTypes['bigint_comparison_exp'] | undefined;
     profile?: GraphQLTypes['profiles_bool_exp'] | undefined;
@@ -77134,12 +77265,15 @@ export type GraphQLTypes = {
   ['replies_reactions_constraint']: replies_reactions_constraint;
   /** input type for incrementing numeric columns in table "replies_reactions" */
   ['replies_reactions_inc_input']: {
+    activity_id?: number | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
   /** input type for inserting data into table "replies_reactions" */
   ['replies_reactions_insert_input']: {
+    activity?: GraphQLTypes['activities_obj_rel_insert_input'] | undefined;
+    activity_id?: number | undefined;
     created_at?: GraphQLTypes['timestamptz'] | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
     profile?: GraphQLTypes['profiles_obj_rel_insert_input'] | undefined;
@@ -77155,6 +77289,7 @@ export type GraphQLTypes = {
   /** aggregate max on columns */
   ['replies_reactions_max_fields']: {
     __typename: 'replies_reactions_max_fields';
+    activity_id?: number | undefined;
     created_at?: GraphQLTypes['timestamptz'] | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
     profile_id?: number | undefined;
@@ -77164,6 +77299,7 @@ export type GraphQLTypes = {
   };
   /** order by max() on columns of table "replies_reactions" */
   ['replies_reactions_max_order_by']: {
+    activity_id?: GraphQLTypes['order_by'] | undefined;
     created_at?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
     profile_id?: GraphQLTypes['order_by'] | undefined;
@@ -77174,6 +77310,7 @@ export type GraphQLTypes = {
   /** aggregate min on columns */
   ['replies_reactions_min_fields']: {
     __typename: 'replies_reactions_min_fields';
+    activity_id?: number | undefined;
     created_at?: GraphQLTypes['timestamptz'] | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
     profile_id?: number | undefined;
@@ -77183,6 +77320,7 @@ export type GraphQLTypes = {
   };
   /** order by min() on columns of table "replies_reactions" */
   ['replies_reactions_min_order_by']: {
+    activity_id?: GraphQLTypes['order_by'] | undefined;
     created_at?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
     profile_id?: GraphQLTypes['order_by'] | undefined;
@@ -77198,6 +77336,12 @@ export type GraphQLTypes = {
     /** data from the rows affected by the mutation */
     returning: Array<GraphQLTypes['replies_reactions']>;
   };
+  /** input type for inserting object relation for remote table "replies_reactions" */
+  ['replies_reactions_obj_rel_insert_input']: {
+    data: GraphQLTypes['replies_reactions_insert_input'];
+    /** upsert condition */
+    on_conflict?: GraphQLTypes['replies_reactions_on_conflict'] | undefined;
+  };
   /** on_conflict condition type for table "replies_reactions" */
   ['replies_reactions_on_conflict']: {
     constraint: GraphQLTypes['replies_reactions_constraint'];
@@ -77206,6 +77350,8 @@ export type GraphQLTypes = {
   };
   /** Ordering options when selecting data from "replies_reactions". */
   ['replies_reactions_order_by']: {
+    activity?: GraphQLTypes['activities_order_by'] | undefined;
+    activity_id?: GraphQLTypes['order_by'] | undefined;
     created_at?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
     profile?: GraphQLTypes['profiles_order_by'] | undefined;
@@ -77224,6 +77370,7 @@ export type GraphQLTypes = {
   ['replies_reactions_select_column']: replies_reactions_select_column;
   /** input type for updating data in table "replies_reactions" */
   ['replies_reactions_set_input']: {
+    activity_id?: number | undefined;
     created_at?: GraphQLTypes['timestamptz'] | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
     profile_id?: number | undefined;
@@ -77234,12 +77381,14 @@ export type GraphQLTypes = {
   /** aggregate stddev on columns */
   ['replies_reactions_stddev_fields']: {
     __typename: 'replies_reactions_stddev_fields';
+    activity_id?: number | undefined;
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
   /** order by stddev() on columns of table "replies_reactions" */
   ['replies_reactions_stddev_order_by']: {
+    activity_id?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
     profile_id?: GraphQLTypes['order_by'] | undefined;
     reply_id?: GraphQLTypes['order_by'] | undefined;
@@ -77247,12 +77396,14 @@ export type GraphQLTypes = {
   /** aggregate stddev_pop on columns */
   ['replies_reactions_stddev_pop_fields']: {
     __typename: 'replies_reactions_stddev_pop_fields';
+    activity_id?: number | undefined;
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
   /** order by stddev_pop() on columns of table "replies_reactions" */
   ['replies_reactions_stddev_pop_order_by']: {
+    activity_id?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
     profile_id?: GraphQLTypes['order_by'] | undefined;
     reply_id?: GraphQLTypes['order_by'] | undefined;
@@ -77260,12 +77411,14 @@ export type GraphQLTypes = {
   /** aggregate stddev_samp on columns */
   ['replies_reactions_stddev_samp_fields']: {
     __typename: 'replies_reactions_stddev_samp_fields';
+    activity_id?: number | undefined;
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
   /** order by stddev_samp() on columns of table "replies_reactions" */
   ['replies_reactions_stddev_samp_order_by']: {
+    activity_id?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
     profile_id?: GraphQLTypes['order_by'] | undefined;
     reply_id?: GraphQLTypes['order_by'] | undefined;
@@ -77279,6 +77432,7 @@ export type GraphQLTypes = {
   };
   /** Initial value of the column from where the streaming should start */
   ['replies_reactions_stream_cursor_value_input']: {
+    activity_id?: number | undefined;
     created_at?: GraphQLTypes['timestamptz'] | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
     profile_id?: number | undefined;
@@ -77289,12 +77443,14 @@ export type GraphQLTypes = {
   /** aggregate sum on columns */
   ['replies_reactions_sum_fields']: {
     __typename: 'replies_reactions_sum_fields';
+    activity_id?: number | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
   /** order by sum() on columns of table "replies_reactions" */
   ['replies_reactions_sum_order_by']: {
+    activity_id?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
     profile_id?: GraphQLTypes['order_by'] | undefined;
     reply_id?: GraphQLTypes['order_by'] | undefined;
@@ -77312,12 +77468,14 @@ export type GraphQLTypes = {
   /** aggregate var_pop on columns */
   ['replies_reactions_var_pop_fields']: {
     __typename: 'replies_reactions_var_pop_fields';
+    activity_id?: number | undefined;
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
   /** order by var_pop() on columns of table "replies_reactions" */
   ['replies_reactions_var_pop_order_by']: {
+    activity_id?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
     profile_id?: GraphQLTypes['order_by'] | undefined;
     reply_id?: GraphQLTypes['order_by'] | undefined;
@@ -77325,12 +77483,14 @@ export type GraphQLTypes = {
   /** aggregate var_samp on columns */
   ['replies_reactions_var_samp_fields']: {
     __typename: 'replies_reactions_var_samp_fields';
+    activity_id?: number | undefined;
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
   /** order by var_samp() on columns of table "replies_reactions" */
   ['replies_reactions_var_samp_order_by']: {
+    activity_id?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
     profile_id?: GraphQLTypes['order_by'] | undefined;
     reply_id?: GraphQLTypes['order_by'] | undefined;
@@ -77338,12 +77498,14 @@ export type GraphQLTypes = {
   /** aggregate variance on columns */
   ['replies_reactions_variance_fields']: {
     __typename: 'replies_reactions_variance_fields';
+    activity_id?: number | undefined;
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
   /** order by variance() on columns of table "replies_reactions" */
   ['replies_reactions_variance_order_by']: {
+    activity_id?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
     profile_id?: GraphQLTypes['order_by'] | undefined;
     reply_id?: GraphQLTypes['order_by'] | undefined;
@@ -83316,6 +83478,7 @@ export const enum notifications_select_column {
   profile_id = 'profile_id',
   reaction_id = 'reaction_id',
   reply_id = 'reply_id',
+  reply_reaction_id = 'reply_reaction_id',
 }
 /** update columns of table "notifications" */
 export const enum notifications_update_column {
@@ -83330,6 +83493,7 @@ export const enum notifications_update_column {
   profile_id = 'profile_id',
   reaction_id = 'reaction_id',
   reply_id = 'reply_id',
+  reply_reaction_id = 'reply_reaction_id',
 }
 /** column ordering options */
 export const enum order_by {
@@ -83780,6 +83944,7 @@ export const enum replies_reactions_constraint {
 }
 /** select columns of table "replies_reactions" */
 export const enum replies_reactions_select_column {
+  activity_id = 'activity_id',
   created_at = 'created_at',
   id = 'id',
   profile_id = 'profile_id',
@@ -83789,6 +83954,7 @@ export const enum replies_reactions_select_column {
 }
 /** update columns of table "replies_reactions" */
 export const enum replies_reactions_update_column {
+  activity_id = 'activity_id',
   created_at = 'created_at',
   id = 'id',
   profile_id = 'profile_id',

--- a/hasura/metadata/databases/default/tables/public_notifications.yaml
+++ b/hasura/metadata/databases/default/tables/public_notifications.yaml
@@ -59,6 +59,15 @@ object_relationships:
   - name: reply
     using:
       foreign_key_constraint_on: reply_id
+  - name: reply_reaction
+    using:
+      manual_configuration:
+        column_mapping:
+          reply_reaction_id: id
+        insertion_order: null
+        remote_table:
+          name: replies_reactions
+          schema: public
 select_permissions:
   - role: user
     permission:
@@ -72,6 +81,7 @@ select_permissions:
         - profile_id
         - reaction_id
         - reply_id
+        - reply_reaction_id
       filter:
         profile_id:
           _eq: X-Hasura-User-Id

--- a/hasura/metadata/databases/default/tables/public_replies.yaml
+++ b/hasura/metadata/databases/default/tables/public_replies.yaml
@@ -26,6 +26,16 @@ object_relationships:
         remote_table:
           name: profiles_public
           schema: public
+array_relationships:
+  - name: reactions
+    using:
+      manual_configuration:
+        column_mapping:
+          id: reply_id
+        insertion_order: null
+        remote_table:
+          name: replies_reactions
+          schema: public
 insert_permissions:
   - role: user
     permission:

--- a/hasura/metadata/databases/default/tables/public_replies_reactions.yaml
+++ b/hasura/metadata/databases/default/tables/public_replies_reactions.yaml
@@ -1,0 +1,120 @@
+table:
+  name: replies_reactions
+  schema: public
+object_relationships:
+  - name: activity
+    using:
+      manual_configuration:
+        column_mapping:
+          activity_id: id
+        insertion_order: null
+        remote_table:
+          name: activities
+          schema: public
+  - name: profile
+    using:
+      manual_configuration:
+        column_mapping:
+          profile_id: id
+        insertion_order: null
+        remote_table:
+          name: profiles
+          schema: public
+  - name: profile_public
+    using:
+      manual_configuration:
+        column_mapping:
+          profile_id: id
+        insertion_order: null
+        remote_table:
+          name: profiles_public
+          schema: public
+  - name: reply
+    using:
+      manual_configuration:
+        column_mapping:
+          reply_id: id
+        insertion_order: null
+        remote_table:
+          name: replies
+          schema: public
+insert_permissions:
+  - role: user
+    permission:
+      check:
+        _and:
+          - reply:
+              _and:
+                - deleted_at:
+                    _is_null: true
+                - _not:
+                    profile_public:
+                      mutes:
+                        profile_id:
+                          _eq: X-Hasura-User-Id
+          - activity:
+              _or:
+                - private_stream_visibility:
+                    profile_id:
+                      _eq: X-Hasura-User-Id
+                - big_question_id:
+                    _is_null: false
+      set:
+        profile_id: x-hasura-User-Id
+      columns:
+        - activity_id
+        - reaction
+        - reply_id
+select_permissions:
+  - role: user
+    permission:
+      columns:
+        - activity_id
+        - created_at
+        - id
+        - profile_id
+        - reaction
+        - reply_id
+        - updated_at
+      filter:
+        _and:
+          - reply:
+              _and:
+                - deleted_at:
+                    _is_null: true
+                - _not:
+                    profile_public:
+                      mutes:
+                        profile_id:
+                          _eq: X-Hasura-User-Id
+          - activity:
+              _or:
+                - private_stream_visibility:
+                    profile_id:
+                      _eq: X-Hasura-User-Id
+                - big_question_id:
+                    _is_null: false
+      limit: 100
+      allow_aggregations: true
+delete_permissions:
+  - role: user
+    permission:
+      filter:
+        profile_id:
+          _eq: X-Hasura-User-Id
+event_triggers:
+  - name: createNotificationReplyReactions
+    definition:
+      delete:
+        columns: '*'
+      enable_manual: false
+      insert:
+        columns: '*'
+    retry_conf:
+      interval_sec: 10
+      num_retries: 0
+      timeout_sec: 60
+    webhook: '{{HASURA_API_BASE_URL}}/event_triggers/eventManager?event=createNotificationReplyReactions'
+    headers:
+      - name: verification_key
+        value_from_env: HASURA_EVENT_SECRET

--- a/hasura/metadata/databases/default/tables/tables.yaml
+++ b/hasura/metadata/databases/default/tables/tables.yaml
@@ -57,6 +57,7 @@
 - "!include public_profiles_public.yaml"
 - "!include public_reactions.yaml"
 - "!include public_replies.yaml"
+- "!include public_replies_reactions.yaml"
 - "!include public_reputation_scores.yaml"
 - "!include public_shared_nfts.yaml"
 - "!include public_skills.yaml"

--- a/hasura/migrations/default/1717308575449_create_table_public_replies_reactions/down.sql
+++ b/hasura/migrations/default/1717308575449_create_table_public_replies_reactions/down.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "public"."replies_reactions" DROP CONSTRAINT "replies_reactions_profile_id_reply_id_reaction_key";
+ALTER TABLE "public"."replies_reactions" drop constraint "replies_reactions_reply_id_fkey";
+ALTER TABLE "public"."replies_reactions" drop constraint "replies_reactions_activity_id_fkey";
+DROP INDEX IF EXISTS "public"."replies_reactions_index_profile_id";
+DROP INDEX IF EXISTS "public"."replies_reactions_index_reply_id";
+DROP INDEX IF EXISTS "public"."replies_reactions_index_activity_id";
+DROP TABLE "public"."replies_reactions";

--- a/hasura/migrations/default/1717308575449_create_table_public_replies_reactions/down.sql
+++ b/hasura/migrations/default/1717308575449_create_table_public_replies_reactions/down.sql
@@ -1,6 +1,6 @@
 ALTER TABLE "public"."replies_reactions" DROP CONSTRAINT "replies_reactions_profile_id_reply_id_reaction_key";
-ALTER TABLE "public"."replies_reactions" drop constraint "replies_reactions_reply_id_fkey";
-ALTER TABLE "public"."replies_reactions" drop constraint "replies_reactions_activity_id_fkey";
+ALTER TABLE "public"."replies_reactions" DROP CONSTRAINT "replies_reactions_reply_id_fkey";
+ALTER TABLE "public"."replies_reactions" DROP CONSTRAINT "replies_reactions_activity_id_fkey";
 DROP INDEX IF EXISTS "public"."replies_reactions_index_profile_id";
 DROP INDEX IF EXISTS "public"."replies_reactions_index_reply_id";
 DROP INDEX IF EXISTS "public"."replies_reactions_index_activity_id";

--- a/hasura/migrations/default/1717308575449_create_table_public_replies_reactions/up.sql
+++ b/hasura/migrations/default/1717308575449_create_table_public_replies_reactions/up.sql
@@ -1,0 +1,41 @@
+CREATE TABLE "public"."replies_reactions" ("id" bigserial NOT NULL, "created_at" timestamptz NOT NULL DEFAULT now(), "updated_at" timestamptz NOT NULL DEFAULT now(), "reply_id" integer NOT NULL, "activity_id" integer NOT NULL, "profile_id" integer NOT NULL, "reaction" text NOT NULL, PRIMARY KEY ("id") , UNIQUE ("id"));
+CREATE OR REPLACE FUNCTION "public"."set_current_timestamp_updated_at"()
+RETURNS TRIGGER AS $$
+DECLARE
+  _new record;
+BEGIN
+  _new := NEW;
+  _new."updated_at" = NOW();
+  RETURN _new;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER "set_public_replies_reactions_updated_at"
+BEFORE UPDATE ON "public"."replies_reactions"
+FOR EACH ROW
+EXECUTE PROCEDURE "public"."set_current_timestamp_updated_at"();
+COMMENT ON TRIGGER "set_public_replies_reactions_updated_at" ON "public"."replies_reactions" 
+IS 'trigger to set value of column "updated_at" to current timestamp on row update';
+
+CREATE  INDEX "replies_reactions_index_profile_id" on
+  "public"."replies_reactions" using btree ("profile_id");
+
+CREATE  INDEX "replies_reactions_index_reply_id" on
+  "public"."replies_reactions" using btree ("reply_id");
+
+CREATE  INDEX "replies_reactions_index_activity_id" on
+  "public"."replies_reactions" using btree ("activity_id");
+
+ALTER TABLE "public"."replies_reactions"
+  ADD CONSTRAINT "replies_reactions_reply_id_fkey"
+  FOREIGN KEY ("reply_id")
+  REFERENCES "public"."replies"
+  ("id") ON UPDATE CASCADE ON DELETE CASCADE;
+
+ALTER TABLE "public"."replies_reactions"
+  ADD CONSTRAINT "replies_reactions_activity_id_fkey"
+  FOREIGN KEY ("activity_id")
+  REFERENCES "public"."activities"
+  ("id") ON UPDATE CASCADE ON DELETE CASCADE;
+
+ALTER TABLE "public"."replies_reactions"
+  ADD CONSTRAINT "replies_reactions_profile_id_reply_id_reaction_key" UNIQUE ("profile_id", "reply_id", "reaction");

--- a/hasura/migrations/default/1717844615993_alter_table_public_notifications_add_column_reply_reaction_id/down.sql
+++ b/hasura/migrations/default/1717844615993_alter_table_public_notifications_add_column_reply_reaction_id/down.sql
@@ -1,0 +1,4 @@
+alter table "public"."notifications" drop constraint "notifications_check";
+alter table "public"."notifications" add constraint "notifications_check" check (CHECK (reply_id IS NOT NULL OR invite_joined_id IS NOT NULL OR link_tx_hash IS NOT NULL OR reaction_id IS NOT NULL OR mention_reply_id IS NOT NULL OR mention_post_id IS NOT NULL OR colinks_give_id IS NOT NULL));
+alter table "public"."notifications" drop constraint "notifications_reply_reaction_id_fkey";
+alter table "public"."notifications" drop column "reply_reaction_id";

--- a/hasura/migrations/default/1717844615993_alter_table_public_notifications_add_column_reply_reaction_id/up.sql
+++ b/hasura/migrations/default/1717844615993_alter_table_public_notifications_add_column_reply_reaction_id/up.sql
@@ -1,0 +1,11 @@
+alter table "public"."notifications" add column "reply_reaction_id" bigint
+ null;
+
+alter table "public"."notifications"
+  add constraint "notifications_reply_reaction_id_fkey"
+  foreign key ("reply_reaction_id")
+  references "public"."replies_reactions"
+  ("id") on update cascade on delete cascade;
+
+alter table "public"."notifications" drop constraint "notifications_check";
+alter table "public"."notifications" add constraint "notifications_check" check (reply_id IS NOT NULL OR invite_joined_id IS NOT NULL OR link_tx_hash IS NOT NULL OR reaction_id IS NOT NULL OR mention_reply_id IS NOT NULL OR mention_post_id IS NOT NULL OR colinks_give_id IS NOT NULL OR reply_reaction_id IS NOT NULL);

--- a/hasura/schema/admin/schema.graphql
+++ b/hasura/schema/admin/schema.graphql
@@ -29920,6 +29920,12 @@ type notifications {
   """
   reply: replies
   reply_id: Int
+
+  """
+  An object relationship
+  """
+  reply_reaction: replies_reactions
+  reply_reaction_id: bigint
 }
 
 """
@@ -29960,6 +29966,7 @@ type notifications_avg_fields {
   profile_id: Float
   reaction_id: Float
   reply_id: Float
+  reply_reaction_id: Float
 }
 
 """
@@ -29989,6 +29996,8 @@ input notifications_bool_exp {
   reaction_id: bigint_comparison_exp
   reply: replies_bool_exp
   reply_id: Int_comparison_exp
+  reply_reaction: replies_reactions_bool_exp
+  reply_reaction_id: bigint_comparison_exp
 }
 
 """
@@ -30014,6 +30023,7 @@ input notifications_inc_input {
   profile_id: bigint
   reaction_id: bigint
   reply_id: Int
+  reply_reaction_id: bigint
 }
 
 """
@@ -30040,6 +30050,8 @@ input notifications_insert_input {
   reaction_id: bigint
   reply: replies_obj_rel_insert_input
   reply_id: Int
+  reply_reaction: replies_reactions_obj_rel_insert_input
+  reply_reaction_id: bigint
 }
 
 """
@@ -30057,6 +30069,7 @@ type notifications_max_fields {
   profile_id: bigint
   reaction_id: bigint
   reply_id: Int
+  reply_reaction_id: bigint
 }
 
 """
@@ -30074,6 +30087,7 @@ type notifications_min_fields {
   profile_id: bigint
   reaction_id: bigint
   reply_id: Int
+  reply_reaction_id: bigint
 }
 
 """
@@ -30124,6 +30138,8 @@ input notifications_order_by {
   reaction_id: order_by
   reply: replies_order_by
   reply_id: order_by
+  reply_reaction: replies_reactions_order_by
+  reply_reaction_id: order_by
 }
 
 """
@@ -30191,6 +30207,11 @@ enum notifications_select_column {
   column name
   """
   reply_id
+
+  """
+  column name
+  """
+  reply_reaction_id
 }
 
 """
@@ -30208,6 +30229,7 @@ input notifications_set_input {
   profile_id: bigint
   reaction_id: bigint
   reply_id: Int
+  reply_reaction_id: bigint
 }
 
 """
@@ -30223,6 +30245,7 @@ type notifications_stddev_fields {
   profile_id: Float
   reaction_id: Float
   reply_id: Float
+  reply_reaction_id: Float
 }
 
 """
@@ -30238,6 +30261,7 @@ type notifications_stddev_pop_fields {
   profile_id: Float
   reaction_id: Float
   reply_id: Float
+  reply_reaction_id: Float
 }
 
 """
@@ -30253,6 +30277,7 @@ type notifications_stddev_samp_fields {
   profile_id: Float
   reaction_id: Float
   reply_id: Float
+  reply_reaction_id: Float
 }
 
 """
@@ -30285,6 +30310,7 @@ input notifications_stream_cursor_value_input {
   profile_id: bigint
   reaction_id: bigint
   reply_id: Int
+  reply_reaction_id: bigint
 }
 
 """
@@ -30300,6 +30326,7 @@ type notifications_sum_fields {
   profile_id: bigint
   reaction_id: bigint
   reply_id: Int
+  reply_reaction_id: bigint
 }
 
 """
@@ -30360,6 +30387,11 @@ enum notifications_update_column {
   column name
   """
   reply_id
+
+  """
+  column name
+  """
+  reply_reaction_id
 }
 
 input notifications_updates {
@@ -30392,6 +30424,7 @@ type notifications_var_pop_fields {
   profile_id: Float
   reaction_id: Float
   reply_id: Float
+  reply_reaction_id: Float
 }
 
 """
@@ -30407,6 +30440,7 @@ type notifications_var_samp_fields {
   profile_id: Float
   reaction_id: Float
   reply_id: Float
+  reply_reaction_id: Float
 }
 
 """
@@ -30422,6 +30456,7 @@ type notifications_variance_fields {
   profile_id: Float
   reaction_id: Float
   reply_id: Float
+  reply_reaction_id: Float
 }
 
 scalar numeric
@@ -44665,6 +44700,11 @@ input replies_pk_columns_input {
 columns and relationships of "replies_reactions"
 """
 type replies_reactions {
+  """
+  An object relationship
+  """
+  activity: activities
+  activity_id: Int!
   created_at: timestamptz!
   id: bigint!
 
@@ -44757,6 +44797,7 @@ input replies_reactions_arr_rel_insert_input {
 aggregate avg on columns
 """
 type replies_reactions_avg_fields {
+  activity_id: Float
   id: Float
   profile_id: Float
   reply_id: Float
@@ -44766,6 +44807,7 @@ type replies_reactions_avg_fields {
 order by avg() on columns of table "replies_reactions"
 """
 input replies_reactions_avg_order_by {
+  activity_id: order_by
   id: order_by
   profile_id: order_by
   reply_id: order_by
@@ -44778,6 +44820,8 @@ input replies_reactions_bool_exp {
   _and: [replies_reactions_bool_exp!]
   _not: replies_reactions_bool_exp
   _or: [replies_reactions_bool_exp!]
+  activity: activities_bool_exp
+  activity_id: Int_comparison_exp
   created_at: timestamptz_comparison_exp
   id: bigint_comparison_exp
   profile: profiles_bool_exp
@@ -44808,6 +44852,7 @@ enum replies_reactions_constraint {
 input type for incrementing numeric columns in table "replies_reactions"
 """
 input replies_reactions_inc_input {
+  activity_id: Int
   id: bigint
   profile_id: Int
   reply_id: Int
@@ -44817,6 +44862,8 @@ input replies_reactions_inc_input {
 input type for inserting data into table "replies_reactions"
 """
 input replies_reactions_insert_input {
+  activity: activities_obj_rel_insert_input
+  activity_id: Int
   created_at: timestamptz
   id: bigint
   profile: profiles_obj_rel_insert_input
@@ -44832,6 +44879,7 @@ input replies_reactions_insert_input {
 aggregate max on columns
 """
 type replies_reactions_max_fields {
+  activity_id: Int
   created_at: timestamptz
   id: bigint
   profile_id: Int
@@ -44844,6 +44892,7 @@ type replies_reactions_max_fields {
 order by max() on columns of table "replies_reactions"
 """
 input replies_reactions_max_order_by {
+  activity_id: order_by
   created_at: order_by
   id: order_by
   profile_id: order_by
@@ -44856,6 +44905,7 @@ input replies_reactions_max_order_by {
 aggregate min on columns
 """
 type replies_reactions_min_fields {
+  activity_id: Int
   created_at: timestamptz
   id: bigint
   profile_id: Int
@@ -44868,6 +44918,7 @@ type replies_reactions_min_fields {
 order by min() on columns of table "replies_reactions"
 """
 input replies_reactions_min_order_by {
+  activity_id: order_by
   created_at: order_by
   id: order_by
   profile_id: order_by
@@ -44892,6 +44943,18 @@ type replies_reactions_mutation_response {
 }
 
 """
+input type for inserting object relation for remote table "replies_reactions"
+"""
+input replies_reactions_obj_rel_insert_input {
+  data: replies_reactions_insert_input!
+
+  """
+  upsert condition
+  """
+  on_conflict: replies_reactions_on_conflict
+}
+
+"""
 on_conflict condition type for table "replies_reactions"
 """
 input replies_reactions_on_conflict {
@@ -44904,6 +44967,8 @@ input replies_reactions_on_conflict {
 Ordering options when selecting data from "replies_reactions".
 """
 input replies_reactions_order_by {
+  activity: activities_order_by
+  activity_id: order_by
   created_at: order_by
   id: order_by
   profile: profiles_order_by
@@ -44926,6 +44991,11 @@ input replies_reactions_pk_columns_input {
 select columns of table "replies_reactions"
 """
 enum replies_reactions_select_column {
+  """
+  column name
+  """
+  activity_id
+
   """
   column name
   """
@@ -44961,6 +45031,7 @@ enum replies_reactions_select_column {
 input type for updating data in table "replies_reactions"
 """
 input replies_reactions_set_input {
+  activity_id: Int
   created_at: timestamptz
   id: bigint
   profile_id: Int
@@ -44973,6 +45044,7 @@ input replies_reactions_set_input {
 aggregate stddev on columns
 """
 type replies_reactions_stddev_fields {
+  activity_id: Float
   id: Float
   profile_id: Float
   reply_id: Float
@@ -44982,6 +45054,7 @@ type replies_reactions_stddev_fields {
 order by stddev() on columns of table "replies_reactions"
 """
 input replies_reactions_stddev_order_by {
+  activity_id: order_by
   id: order_by
   profile_id: order_by
   reply_id: order_by
@@ -44991,6 +45064,7 @@ input replies_reactions_stddev_order_by {
 aggregate stddev_pop on columns
 """
 type replies_reactions_stddev_pop_fields {
+  activity_id: Float
   id: Float
   profile_id: Float
   reply_id: Float
@@ -45000,6 +45074,7 @@ type replies_reactions_stddev_pop_fields {
 order by stddev_pop() on columns of table "replies_reactions"
 """
 input replies_reactions_stddev_pop_order_by {
+  activity_id: order_by
   id: order_by
   profile_id: order_by
   reply_id: order_by
@@ -45009,6 +45084,7 @@ input replies_reactions_stddev_pop_order_by {
 aggregate stddev_samp on columns
 """
 type replies_reactions_stddev_samp_fields {
+  activity_id: Float
   id: Float
   profile_id: Float
   reply_id: Float
@@ -45018,6 +45094,7 @@ type replies_reactions_stddev_samp_fields {
 order by stddev_samp() on columns of table "replies_reactions"
 """
 input replies_reactions_stddev_samp_order_by {
+  activity_id: order_by
   id: order_by
   profile_id: order_by
   reply_id: order_by
@@ -45042,6 +45119,7 @@ input replies_reactions_stream_cursor_input {
 Initial value of the column from where the streaming should start
 """
 input replies_reactions_stream_cursor_value_input {
+  activity_id: Int
   created_at: timestamptz
   id: bigint
   profile_id: Int
@@ -45054,6 +45132,7 @@ input replies_reactions_stream_cursor_value_input {
 aggregate sum on columns
 """
 type replies_reactions_sum_fields {
+  activity_id: Int
   id: bigint
   profile_id: Int
   reply_id: Int
@@ -45063,6 +45142,7 @@ type replies_reactions_sum_fields {
 order by sum() on columns of table "replies_reactions"
 """
 input replies_reactions_sum_order_by {
+  activity_id: order_by
   id: order_by
   profile_id: order_by
   reply_id: order_by
@@ -45072,6 +45152,11 @@ input replies_reactions_sum_order_by {
 update columns of table "replies_reactions"
 """
 enum replies_reactions_update_column {
+  """
+  column name
+  """
+  activity_id
+
   """
   column name
   """
@@ -45124,6 +45209,7 @@ input replies_reactions_updates {
 aggregate var_pop on columns
 """
 type replies_reactions_var_pop_fields {
+  activity_id: Float
   id: Float
   profile_id: Float
   reply_id: Float
@@ -45133,6 +45219,7 @@ type replies_reactions_var_pop_fields {
 order by var_pop() on columns of table "replies_reactions"
 """
 input replies_reactions_var_pop_order_by {
+  activity_id: order_by
   id: order_by
   profile_id: order_by
   reply_id: order_by
@@ -45142,6 +45229,7 @@ input replies_reactions_var_pop_order_by {
 aggregate var_samp on columns
 """
 type replies_reactions_var_samp_fields {
+  activity_id: Float
   id: Float
   profile_id: Float
   reply_id: Float
@@ -45151,6 +45239,7 @@ type replies_reactions_var_samp_fields {
 order by var_samp() on columns of table "replies_reactions"
 """
 input replies_reactions_var_samp_order_by {
+  activity_id: order_by
   id: order_by
   profile_id: order_by
   reply_id: order_by
@@ -45160,6 +45249,7 @@ input replies_reactions_var_samp_order_by {
 aggregate variance on columns
 """
 type replies_reactions_variance_fields {
+  activity_id: Float
   id: Float
   profile_id: Float
   reply_id: Float
@@ -45169,6 +45259,7 @@ type replies_reactions_variance_fields {
 order by variance() on columns of table "replies_reactions"
 """
 input replies_reactions_variance_order_by {
+  activity_id: order_by
   id: order_by
   profile_id: order_by
   reply_id: order_by

--- a/hasura/schema/admin/schema.graphql
+++ b/hasura/schema/admin/schema.graphql
@@ -44332,6 +44332,66 @@ type replies {
   An object relationship
   """
   profile_public: profiles_public
+
+  """
+  An array relationship
+  """
+  reactions(
+    """
+    distinct select on columns
+    """
+    distinct_on: [replies_reactions_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [replies_reactions_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: replies_reactions_bool_exp
+  ): [replies_reactions!]!
+
+  """
+  An aggregate relationship
+  """
+  reactions_aggregate(
+    """
+    distinct select on columns
+    """
+    distinct_on: [replies_reactions_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [replies_reactions_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: replies_reactions_bool_exp
+  ): replies_reactions_aggregate!
   reply: String!
   updated_at: timestamptz!
 }
@@ -44438,6 +44498,8 @@ input replies_bool_exp {
   profile: profiles_bool_exp
   profile_id: Int_comparison_exp
   profile_public: profiles_public_bool_exp
+  reactions: replies_reactions_bool_exp
+  reactions_aggregate: replies_reactions_aggregate_bool_exp
   reply: String_comparison_exp
   updated_at: timestamptz_comparison_exp
 }
@@ -44476,6 +44538,7 @@ input replies_insert_input {
   profile: profiles_obj_rel_insert_input
   profile_id: Int
   profile_public: profiles_public_obj_rel_insert_input
+  reactions: replies_reactions_arr_rel_insert_input
   reply: String
   updated_at: timestamptz
 }
@@ -44586,6 +44649,7 @@ input replies_order_by {
   profile: profiles_order_by
   profile_id: order_by
   profile_public: profiles_public_order_by
+  reactions_aggregate: replies_reactions_aggregate_order_by
   reply: order_by
   updated_at: order_by
 }
@@ -44632,6 +44696,17 @@ type replies_reactions_aggregate {
   nodes: [replies_reactions!]!
 }
 
+input replies_reactions_aggregate_bool_exp {
+  count: replies_reactions_aggregate_bool_exp_count
+}
+
+input replies_reactions_aggregate_bool_exp_count {
+  arguments: [replies_reactions_select_column!]
+  distinct: Boolean
+  filter: replies_reactions_bool_exp
+  predicate: Int_comparison_exp!
+}
+
 """
 aggregate fields of "replies_reactions"
 """
@@ -44650,12 +44725,50 @@ type replies_reactions_aggregate_fields {
 }
 
 """
+order by aggregate values of table "replies_reactions"
+"""
+input replies_reactions_aggregate_order_by {
+  avg: replies_reactions_avg_order_by
+  count: order_by
+  max: replies_reactions_max_order_by
+  min: replies_reactions_min_order_by
+  stddev: replies_reactions_stddev_order_by
+  stddev_pop: replies_reactions_stddev_pop_order_by
+  stddev_samp: replies_reactions_stddev_samp_order_by
+  sum: replies_reactions_sum_order_by
+  var_pop: replies_reactions_var_pop_order_by
+  var_samp: replies_reactions_var_samp_order_by
+  variance: replies_reactions_variance_order_by
+}
+
+"""
+input type for inserting array relation for remote table "replies_reactions"
+"""
+input replies_reactions_arr_rel_insert_input {
+  data: [replies_reactions_insert_input!]!
+
+  """
+  upsert condition
+  """
+  on_conflict: replies_reactions_on_conflict
+}
+
+"""
 aggregate avg on columns
 """
 type replies_reactions_avg_fields {
   id: Float
   profile_id: Float
   reply_id: Float
+}
+
+"""
+order by avg() on columns of table "replies_reactions"
+"""
+input replies_reactions_avg_order_by {
+  id: order_by
+  profile_id: order_by
+  reply_id: order_by
 }
 
 """
@@ -44728,6 +44841,18 @@ type replies_reactions_max_fields {
 }
 
 """
+order by max() on columns of table "replies_reactions"
+"""
+input replies_reactions_max_order_by {
+  created_at: order_by
+  id: order_by
+  profile_id: order_by
+  reaction: order_by
+  reply_id: order_by
+  updated_at: order_by
+}
+
+"""
 aggregate min on columns
 """
 type replies_reactions_min_fields {
@@ -44737,6 +44862,18 @@ type replies_reactions_min_fields {
   reaction: String
   reply_id: Int
   updated_at: timestamptz
+}
+
+"""
+order by min() on columns of table "replies_reactions"
+"""
+input replies_reactions_min_order_by {
+  created_at: order_by
+  id: order_by
+  profile_id: order_by
+  reaction: order_by
+  reply_id: order_by
+  updated_at: order_by
 }
 
 """
@@ -44842,6 +44979,15 @@ type replies_reactions_stddev_fields {
 }
 
 """
+order by stddev() on columns of table "replies_reactions"
+"""
+input replies_reactions_stddev_order_by {
+  id: order_by
+  profile_id: order_by
+  reply_id: order_by
+}
+
+"""
 aggregate stddev_pop on columns
 """
 type replies_reactions_stddev_pop_fields {
@@ -44851,12 +44997,30 @@ type replies_reactions_stddev_pop_fields {
 }
 
 """
+order by stddev_pop() on columns of table "replies_reactions"
+"""
+input replies_reactions_stddev_pop_order_by {
+  id: order_by
+  profile_id: order_by
+  reply_id: order_by
+}
+
+"""
 aggregate stddev_samp on columns
 """
 type replies_reactions_stddev_samp_fields {
   id: Float
   profile_id: Float
   reply_id: Float
+}
+
+"""
+order by stddev_samp() on columns of table "replies_reactions"
+"""
+input replies_reactions_stddev_samp_order_by {
+  id: order_by
+  profile_id: order_by
+  reply_id: order_by
 }
 
 """
@@ -44893,6 +45057,15 @@ type replies_reactions_sum_fields {
   id: bigint
   profile_id: Int
   reply_id: Int
+}
+
+"""
+order by sum() on columns of table "replies_reactions"
+"""
+input replies_reactions_sum_order_by {
+  id: order_by
+  profile_id: order_by
+  reply_id: order_by
 }
 
 """
@@ -44957,6 +45130,15 @@ type replies_reactions_var_pop_fields {
 }
 
 """
+order by var_pop() on columns of table "replies_reactions"
+"""
+input replies_reactions_var_pop_order_by {
+  id: order_by
+  profile_id: order_by
+  reply_id: order_by
+}
+
+"""
 aggregate var_samp on columns
 """
 type replies_reactions_var_samp_fields {
@@ -44966,12 +45148,30 @@ type replies_reactions_var_samp_fields {
 }
 
 """
+order by var_samp() on columns of table "replies_reactions"
+"""
+input replies_reactions_var_samp_order_by {
+  id: order_by
+  profile_id: order_by
+  reply_id: order_by
+}
+
+"""
 aggregate variance on columns
 """
 type replies_reactions_variance_fields {
   id: Float
   profile_id: Float
   reply_id: Float
+}
+
+"""
+order by variance() on columns of table "replies_reactions"
+"""
+input replies_reactions_variance_order_by {
+  id: order_by
+  profile_id: order_by
+  reply_id: order_by
 }
 
 """

--- a/hasura/schema/admin/schema.graphql
+++ b/hasura/schema/admin/schema.graphql
@@ -22508,6 +22508,21 @@ type mutation_root {
   delete_replies_by_pk(id: bigint!): replies
 
   """
+  delete data from the table: "replies_reactions"
+  """
+  delete_replies_reactions(
+    """
+    filter the rows which have to be deleted
+    """
+    where: replies_reactions_bool_exp!
+  ): replies_reactions_mutation_response
+
+  """
+  delete single row from the table: "replies_reactions"
+  """
+  delete_replies_reactions_by_pk(id: bigint!): replies_reactions
+
+  """
   delete data from the table: "reputation_scores"
   """
   delete_reputation_scores(
@@ -24235,6 +24250,36 @@ type mutation_root {
     """
     on_conflict: replies_on_conflict
   ): replies
+
+  """
+  insert data into the table: "replies_reactions"
+  """
+  insert_replies_reactions(
+    """
+    the rows to be inserted
+    """
+    objects: [replies_reactions_insert_input!]!
+
+    """
+    upsert condition
+    """
+    on_conflict: replies_reactions_on_conflict
+  ): replies_reactions_mutation_response
+
+  """
+  insert a single row into the table: "replies_reactions"
+  """
+  insert_replies_reactions_one(
+    """
+    the row to be inserted
+    """
+    object: replies_reactions_insert_input!
+
+    """
+    upsert condition
+    """
+    on_conflict: replies_reactions_on_conflict
+  ): replies_reactions
 
   """
   insert data into the table: "reputation_scores"
@@ -27197,6 +27242,52 @@ type mutation_root {
     """
     updates: [replies_updates!]!
   ): [replies_mutation_response]
+
+  """
+  update data of the table: "replies_reactions"
+  """
+  update_replies_reactions(
+    """
+    increments the numeric columns with given value of the filtered values
+    """
+    _inc: replies_reactions_inc_input
+
+    """
+    sets the columns of the filtered rows to the given values
+    """
+    _set: replies_reactions_set_input
+
+    """
+    filter the rows which have to be updated
+    """
+    where: replies_reactions_bool_exp!
+  ): replies_reactions_mutation_response
+
+  """
+  update single row of the table: "replies_reactions"
+  """
+  update_replies_reactions_by_pk(
+    """
+    increments the numeric columns with given value of the filtered values
+    """
+    _inc: replies_reactions_inc_input
+
+    """
+    sets the columns of the filtered rows to the given values
+    """
+    _set: replies_reactions_set_input
+    pk_columns: replies_reactions_pk_columns_input!
+  ): replies_reactions
+
+  """
+  update multiples rows of table: "replies_reactions"
+  """
+  update_replies_reactions_many(
+    """
+    updates to execute, in order
+    """
+    updates: [replies_reactions_updates!]!
+  ): [replies_reactions_mutation_response]
 
   """
   update data of the table: "reputation_scores"
@@ -42358,6 +42449,71 @@ type query_root {
   replies_by_pk(id: bigint!): replies
 
   """
+  fetch data from the table: "replies_reactions"
+  """
+  replies_reactions(
+    """
+    distinct select on columns
+    """
+    distinct_on: [replies_reactions_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [replies_reactions_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: replies_reactions_bool_exp
+  ): [replies_reactions!]!
+
+  """
+  fetch aggregated fields from the table: "replies_reactions"
+  """
+  replies_reactions_aggregate(
+    """
+    distinct select on columns
+    """
+    distinct_on: [replies_reactions_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [replies_reactions_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: replies_reactions_bool_exp
+  ): replies_reactions_aggregate!
+
+  """
+  fetch data from the table: "replies_reactions" using primary key columns
+  """
+  replies_reactions_by_pk(id: bigint!): replies_reactions
+
+  """
   fetch data from the table: "reputation_scores"
   """
   reputation_scores(
@@ -44439,6 +44595,383 @@ primary key columns input for table: replies
 """
 input replies_pk_columns_input {
   id: bigint!
+}
+
+"""
+columns and relationships of "replies_reactions"
+"""
+type replies_reactions {
+  created_at: timestamptz!
+  id: bigint!
+
+  """
+  An object relationship
+  """
+  profile: profiles
+  profile_id: Int!
+
+  """
+  An object relationship
+  """
+  profile_public: profiles_public
+  reaction: String!
+
+  """
+  An object relationship
+  """
+  reply: replies
+  reply_id: Int!
+  updated_at: timestamptz!
+}
+
+"""
+aggregated selection of "replies_reactions"
+"""
+type replies_reactions_aggregate {
+  aggregate: replies_reactions_aggregate_fields
+  nodes: [replies_reactions!]!
+}
+
+"""
+aggregate fields of "replies_reactions"
+"""
+type replies_reactions_aggregate_fields {
+  avg: replies_reactions_avg_fields
+  count(columns: [replies_reactions_select_column!], distinct: Boolean): Int!
+  max: replies_reactions_max_fields
+  min: replies_reactions_min_fields
+  stddev: replies_reactions_stddev_fields
+  stddev_pop: replies_reactions_stddev_pop_fields
+  stddev_samp: replies_reactions_stddev_samp_fields
+  sum: replies_reactions_sum_fields
+  var_pop: replies_reactions_var_pop_fields
+  var_samp: replies_reactions_var_samp_fields
+  variance: replies_reactions_variance_fields
+}
+
+"""
+aggregate avg on columns
+"""
+type replies_reactions_avg_fields {
+  id: Float
+  profile_id: Float
+  reply_id: Float
+}
+
+"""
+Boolean expression to filter rows from the table "replies_reactions". All fields are combined with a logical 'AND'.
+"""
+input replies_reactions_bool_exp {
+  _and: [replies_reactions_bool_exp!]
+  _not: replies_reactions_bool_exp
+  _or: [replies_reactions_bool_exp!]
+  created_at: timestamptz_comparison_exp
+  id: bigint_comparison_exp
+  profile: profiles_bool_exp
+  profile_id: Int_comparison_exp
+  profile_public: profiles_public_bool_exp
+  reaction: String_comparison_exp
+  reply: replies_bool_exp
+  reply_id: Int_comparison_exp
+  updated_at: timestamptz_comparison_exp
+}
+
+"""
+unique or primary key constraints on table "replies_reactions"
+"""
+enum replies_reactions_constraint {
+  """
+  unique or primary key constraint on columns "id"
+  """
+  replies_reactions_pkey
+
+  """
+  unique or primary key constraint on columns "reply_id", "profile_id", "reaction"
+  """
+  replies_reactions_profile_id_reply_id_reaction_key
+}
+
+"""
+input type for incrementing numeric columns in table "replies_reactions"
+"""
+input replies_reactions_inc_input {
+  id: bigint
+  profile_id: Int
+  reply_id: Int
+}
+
+"""
+input type for inserting data into table "replies_reactions"
+"""
+input replies_reactions_insert_input {
+  created_at: timestamptz
+  id: bigint
+  profile: profiles_obj_rel_insert_input
+  profile_id: Int
+  profile_public: profiles_public_obj_rel_insert_input
+  reaction: String
+  reply: replies_obj_rel_insert_input
+  reply_id: Int
+  updated_at: timestamptz
+}
+
+"""
+aggregate max on columns
+"""
+type replies_reactions_max_fields {
+  created_at: timestamptz
+  id: bigint
+  profile_id: Int
+  reaction: String
+  reply_id: Int
+  updated_at: timestamptz
+}
+
+"""
+aggregate min on columns
+"""
+type replies_reactions_min_fields {
+  created_at: timestamptz
+  id: bigint
+  profile_id: Int
+  reaction: String
+  reply_id: Int
+  updated_at: timestamptz
+}
+
+"""
+response of any mutation on the table "replies_reactions"
+"""
+type replies_reactions_mutation_response {
+  """
+  number of rows affected by the mutation
+  """
+  affected_rows: Int!
+
+  """
+  data from the rows affected by the mutation
+  """
+  returning: [replies_reactions!]!
+}
+
+"""
+on_conflict condition type for table "replies_reactions"
+"""
+input replies_reactions_on_conflict {
+  constraint: replies_reactions_constraint!
+  update_columns: [replies_reactions_update_column!]! = []
+  where: replies_reactions_bool_exp
+}
+
+"""
+Ordering options when selecting data from "replies_reactions".
+"""
+input replies_reactions_order_by {
+  created_at: order_by
+  id: order_by
+  profile: profiles_order_by
+  profile_id: order_by
+  profile_public: profiles_public_order_by
+  reaction: order_by
+  reply: replies_order_by
+  reply_id: order_by
+  updated_at: order_by
+}
+
+"""
+primary key columns input for table: replies_reactions
+"""
+input replies_reactions_pk_columns_input {
+  id: bigint!
+}
+
+"""
+select columns of table "replies_reactions"
+"""
+enum replies_reactions_select_column {
+  """
+  column name
+  """
+  created_at
+
+  """
+  column name
+  """
+  id
+
+  """
+  column name
+  """
+  profile_id
+
+  """
+  column name
+  """
+  reaction
+
+  """
+  column name
+  """
+  reply_id
+
+  """
+  column name
+  """
+  updated_at
+}
+
+"""
+input type for updating data in table "replies_reactions"
+"""
+input replies_reactions_set_input {
+  created_at: timestamptz
+  id: bigint
+  profile_id: Int
+  reaction: String
+  reply_id: Int
+  updated_at: timestamptz
+}
+
+"""
+aggregate stddev on columns
+"""
+type replies_reactions_stddev_fields {
+  id: Float
+  profile_id: Float
+  reply_id: Float
+}
+
+"""
+aggregate stddev_pop on columns
+"""
+type replies_reactions_stddev_pop_fields {
+  id: Float
+  profile_id: Float
+  reply_id: Float
+}
+
+"""
+aggregate stddev_samp on columns
+"""
+type replies_reactions_stddev_samp_fields {
+  id: Float
+  profile_id: Float
+  reply_id: Float
+}
+
+"""
+Streaming cursor of the table "replies_reactions"
+"""
+input replies_reactions_stream_cursor_input {
+  """
+  Stream column input with initial value
+  """
+  initial_value: replies_reactions_stream_cursor_value_input!
+
+  """
+  cursor ordering
+  """
+  ordering: cursor_ordering
+}
+
+"""
+Initial value of the column from where the streaming should start
+"""
+input replies_reactions_stream_cursor_value_input {
+  created_at: timestamptz
+  id: bigint
+  profile_id: Int
+  reaction: String
+  reply_id: Int
+  updated_at: timestamptz
+}
+
+"""
+aggregate sum on columns
+"""
+type replies_reactions_sum_fields {
+  id: bigint
+  profile_id: Int
+  reply_id: Int
+}
+
+"""
+update columns of table "replies_reactions"
+"""
+enum replies_reactions_update_column {
+  """
+  column name
+  """
+  created_at
+
+  """
+  column name
+  """
+  id
+
+  """
+  column name
+  """
+  profile_id
+
+  """
+  column name
+  """
+  reaction
+
+  """
+  column name
+  """
+  reply_id
+
+  """
+  column name
+  """
+  updated_at
+}
+
+input replies_reactions_updates {
+  """
+  increments the numeric columns with given value of the filtered values
+  """
+  _inc: replies_reactions_inc_input
+
+  """
+  sets the columns of the filtered rows to the given values
+  """
+  _set: replies_reactions_set_input
+
+  """
+  filter the rows which have to be updated
+  """
+  where: replies_reactions_bool_exp!
+}
+
+"""
+aggregate var_pop on columns
+"""
+type replies_reactions_var_pop_fields {
+  id: Float
+  profile_id: Float
+  reply_id: Float
+}
+
+"""
+aggregate var_samp on columns
+"""
+type replies_reactions_var_samp_fields {
+  id: Float
+  profile_id: Float
+  reply_id: Float
+}
+
+"""
+aggregate variance on columns
+"""
+type replies_reactions_variance_fields {
+  id: Float
+  profile_id: Float
+  reply_id: Float
 }
 
 """
@@ -50762,6 +51295,91 @@ type subscription_root {
   fetch data from the table: "replies" using primary key columns
   """
   replies_by_pk(id: bigint!): replies
+
+  """
+  fetch data from the table: "replies_reactions"
+  """
+  replies_reactions(
+    """
+    distinct select on columns
+    """
+    distinct_on: [replies_reactions_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [replies_reactions_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: replies_reactions_bool_exp
+  ): [replies_reactions!]!
+
+  """
+  fetch aggregated fields from the table: "replies_reactions"
+  """
+  replies_reactions_aggregate(
+    """
+    distinct select on columns
+    """
+    distinct_on: [replies_reactions_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [replies_reactions_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: replies_reactions_bool_exp
+  ): replies_reactions_aggregate!
+
+  """
+  fetch data from the table: "replies_reactions" using primary key columns
+  """
+  replies_reactions_by_pk(id: bigint!): replies_reactions
+
+  """
+  fetch data from the table in a streaming manner: "replies_reactions"
+  """
+  replies_reactions_stream(
+    """
+    maximum number of rows returned in a single batch
+    """
+    batch_size: Int!
+
+    """
+    cursor to stream the results returned by the query
+    """
+    cursor: [replies_reactions_stream_cursor_input]!
+
+    """
+    filter the rows returned
+    """
+    where: replies_reactions_bool_exp
+  ): [replies_reactions!]!
 
   """
   fetch data from the table in a streaming manner: "replies"

--- a/hasura/schema/user/schema.graphql
+++ b/hasura/schema/user/schema.graphql
@@ -10714,6 +10714,21 @@ type mutation_root {
   delete_reactions_by_pk(id: bigint!): reactions
 
   """
+  delete data from the table: "replies_reactions"
+  """
+  delete_replies_reactions(
+    """
+    filter the rows which have to be deleted
+    """
+    where: replies_reactions_bool_exp!
+  ): replies_reactions_mutation_response
+
+  """
+  delete single row from the table: "replies_reactions"
+  """
+  delete_replies_reactions_by_pk(id: bigint!): replies_reactions
+
+  """
   delete data from the table: "twitter_accounts"
   """
   delete_twitter_accounts(
@@ -11159,6 +11174,36 @@ type mutation_root {
     """
     on_conflict: replies_on_conflict
   ): replies
+
+  """
+  insert data into the table: "replies_reactions"
+  """
+  insert_replies_reactions(
+    """
+    the rows to be inserted
+    """
+    objects: [replies_reactions_insert_input!]!
+
+    """
+    upsert condition
+    """
+    on_conflict: replies_reactions_on_conflict
+  ): replies_reactions_mutation_response
+
+  """
+  insert a single row into the table: "replies_reactions"
+  """
+  insert_replies_reactions_one(
+    """
+    the row to be inserted
+    """
+    object: replies_reactions_insert_input!
+
+    """
+    upsert condition
+    """
+    on_conflict: replies_reactions_on_conflict
+  ): replies_reactions
 
   """
   insert data into the table: "skills"
@@ -19472,6 +19517,71 @@ type query_root {
   replies_by_pk(id: bigint!): replies
 
   """
+  fetch data from the table: "replies_reactions"
+  """
+  replies_reactions(
+    """
+    distinct select on columns
+    """
+    distinct_on: [replies_reactions_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [replies_reactions_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: replies_reactions_bool_exp
+  ): [replies_reactions!]!
+
+  """
+  fetch aggregated fields from the table: "replies_reactions"
+  """
+  replies_reactions_aggregate(
+    """
+    distinct select on columns
+    """
+    distinct_on: [replies_reactions_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [replies_reactions_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: replies_reactions_bool_exp
+  ): replies_reactions_aggregate!
+
+  """
+  fetch data from the table: "replies_reactions" using primary key columns
+  """
+  replies_reactions_by_pk(id: bigint!): replies_reactions
+
+  """
   fetch data from the table: "reputation_scores"
   """
   reputation_scores(
@@ -20843,6 +20953,18 @@ type replies_mutation_response {
 }
 
 """
+input type for inserting object relation for remote table "replies"
+"""
+input replies_obj_rel_insert_input {
+  data: replies_insert_input!
+
+  """
+  upsert condition
+  """
+  on_conflict: replies_on_conflict
+}
+
+"""
 on_conflict condition type for table "replies"
 """
 input replies_on_conflict {
@@ -20874,6 +20996,307 @@ primary key columns input for table: replies
 """
 input replies_pk_columns_input {
   id: bigint!
+}
+
+"""
+columns and relationships of "replies_reactions"
+"""
+type replies_reactions {
+  created_at: timestamptz!
+  id: bigint!
+
+  """
+  An object relationship
+  """
+  profile: profiles
+  profile_id: Int!
+
+  """
+  An object relationship
+  """
+  profile_public: profiles_public
+  reaction: String!
+
+  """
+  An object relationship
+  """
+  reply: replies
+  reply_id: Int!
+  updated_at: timestamptz!
+}
+
+"""
+aggregated selection of "replies_reactions"
+"""
+type replies_reactions_aggregate {
+  aggregate: replies_reactions_aggregate_fields
+  nodes: [replies_reactions!]!
+}
+
+"""
+aggregate fields of "replies_reactions"
+"""
+type replies_reactions_aggregate_fields {
+  avg: replies_reactions_avg_fields
+  count(columns: [replies_reactions_select_column!], distinct: Boolean): Int!
+  max: replies_reactions_max_fields
+  min: replies_reactions_min_fields
+  stddev: replies_reactions_stddev_fields
+  stddev_pop: replies_reactions_stddev_pop_fields
+  stddev_samp: replies_reactions_stddev_samp_fields
+  sum: replies_reactions_sum_fields
+  var_pop: replies_reactions_var_pop_fields
+  var_samp: replies_reactions_var_samp_fields
+  variance: replies_reactions_variance_fields
+}
+
+"""
+aggregate avg on columns
+"""
+type replies_reactions_avg_fields {
+  id: Float
+  profile_id: Float
+  reply_id: Float
+}
+
+"""
+Boolean expression to filter rows from the table "replies_reactions". All fields are combined with a logical 'AND'.
+"""
+input replies_reactions_bool_exp {
+  _and: [replies_reactions_bool_exp!]
+  _not: replies_reactions_bool_exp
+  _or: [replies_reactions_bool_exp!]
+  created_at: timestamptz_comparison_exp
+  id: bigint_comparison_exp
+  profile: profiles_bool_exp
+  profile_id: Int_comparison_exp
+  profile_public: profiles_public_bool_exp
+  reaction: String_comparison_exp
+  reply: replies_bool_exp
+  reply_id: Int_comparison_exp
+  updated_at: timestamptz_comparison_exp
+}
+
+"""
+unique or primary key constraints on table "replies_reactions"
+"""
+enum replies_reactions_constraint {
+  """
+  unique or primary key constraint on columns "id"
+  """
+  replies_reactions_pkey
+
+  """
+  unique or primary key constraint on columns "reply_id", "profile_id", "reaction"
+  """
+  replies_reactions_profile_id_reply_id_reaction_key
+}
+
+"""
+input type for inserting data into table "replies_reactions"
+"""
+input replies_reactions_insert_input {
+  reaction: String
+  reply: replies_obj_rel_insert_input
+  reply_id: Int
+}
+
+"""
+aggregate max on columns
+"""
+type replies_reactions_max_fields {
+  created_at: timestamptz
+  id: bigint
+  profile_id: Int
+  reaction: String
+  reply_id: Int
+  updated_at: timestamptz
+}
+
+"""
+aggregate min on columns
+"""
+type replies_reactions_min_fields {
+  created_at: timestamptz
+  id: bigint
+  profile_id: Int
+  reaction: String
+  reply_id: Int
+  updated_at: timestamptz
+}
+
+"""
+response of any mutation on the table "replies_reactions"
+"""
+type replies_reactions_mutation_response {
+  """
+  number of rows affected by the mutation
+  """
+  affected_rows: Int!
+
+  """
+  data from the rows affected by the mutation
+  """
+  returning: [replies_reactions!]!
+}
+
+"""
+on_conflict condition type for table "replies_reactions"
+"""
+input replies_reactions_on_conflict {
+  constraint: replies_reactions_constraint!
+  update_columns: [replies_reactions_update_column!]! = []
+  where: replies_reactions_bool_exp
+}
+
+"""
+Ordering options when selecting data from "replies_reactions".
+"""
+input replies_reactions_order_by {
+  created_at: order_by
+  id: order_by
+  profile: profiles_order_by
+  profile_id: order_by
+  profile_public: profiles_public_order_by
+  reaction: order_by
+  reply: replies_order_by
+  reply_id: order_by
+  updated_at: order_by
+}
+
+"""
+select columns of table "replies_reactions"
+"""
+enum replies_reactions_select_column {
+  """
+  column name
+  """
+  created_at
+
+  """
+  column name
+  """
+  id
+
+  """
+  column name
+  """
+  profile_id
+
+  """
+  column name
+  """
+  reaction
+
+  """
+  column name
+  """
+  reply_id
+
+  """
+  column name
+  """
+  updated_at
+}
+
+"""
+aggregate stddev on columns
+"""
+type replies_reactions_stddev_fields {
+  id: Float
+  profile_id: Float
+  reply_id: Float
+}
+
+"""
+aggregate stddev_pop on columns
+"""
+type replies_reactions_stddev_pop_fields {
+  id: Float
+  profile_id: Float
+  reply_id: Float
+}
+
+"""
+aggregate stddev_samp on columns
+"""
+type replies_reactions_stddev_samp_fields {
+  id: Float
+  profile_id: Float
+  reply_id: Float
+}
+
+"""
+Streaming cursor of the table "replies_reactions"
+"""
+input replies_reactions_stream_cursor_input {
+  """
+  Stream column input with initial value
+  """
+  initial_value: replies_reactions_stream_cursor_value_input!
+
+  """
+  cursor ordering
+  """
+  ordering: cursor_ordering
+}
+
+"""
+Initial value of the column from where the streaming should start
+"""
+input replies_reactions_stream_cursor_value_input {
+  created_at: timestamptz
+  id: bigint
+  profile_id: Int
+  reaction: String
+  reply_id: Int
+  updated_at: timestamptz
+}
+
+"""
+aggregate sum on columns
+"""
+type replies_reactions_sum_fields {
+  id: bigint
+  profile_id: Int
+  reply_id: Int
+}
+
+"""
+placeholder for update columns of table "replies_reactions" (current role has no relevant permissions)
+"""
+enum replies_reactions_update_column {
+  """
+  placeholder (do not use)
+  """
+  _PLACEHOLDER
+}
+
+"""
+aggregate var_pop on columns
+"""
+type replies_reactions_var_pop_fields {
+  id: Float
+  profile_id: Float
+  reply_id: Float
+}
+
+"""
+aggregate var_samp on columns
+"""
+type replies_reactions_var_samp_fields {
+  id: Float
+  profile_id: Float
+  reply_id: Float
+}
+
+"""
+aggregate variance on columns
+"""
+type replies_reactions_variance_fields {
+  id: Float
+  profile_id: Float
+  reply_id: Float
 }
 
 """
@@ -24610,6 +25033,91 @@ type subscription_root {
   fetch data from the table: "replies" using primary key columns
   """
   replies_by_pk(id: bigint!): replies
+
+  """
+  fetch data from the table: "replies_reactions"
+  """
+  replies_reactions(
+    """
+    distinct select on columns
+    """
+    distinct_on: [replies_reactions_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [replies_reactions_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: replies_reactions_bool_exp
+  ): [replies_reactions!]!
+
+  """
+  fetch aggregated fields from the table: "replies_reactions"
+  """
+  replies_reactions_aggregate(
+    """
+    distinct select on columns
+    """
+    distinct_on: [replies_reactions_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [replies_reactions_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: replies_reactions_bool_exp
+  ): replies_reactions_aggregate!
+
+  """
+  fetch data from the table: "replies_reactions" using primary key columns
+  """
+  replies_reactions_by_pk(id: bigint!): replies_reactions
+
+  """
+  fetch data from the table in a streaming manner: "replies_reactions"
+  """
+  replies_reactions_stream(
+    """
+    maximum number of rows returned in a single batch
+    """
+    batch_size: Int!
+
+    """
+    cursor to stream the results returned by the query
+    """
+    cursor: [replies_reactions_stream_cursor_input]!
+
+    """
+    filter the rows returned
+    """
+    where: replies_reactions_bool_exp
+  ): [replies_reactions!]!
 
   """
   fetch data from the table in a streaming manner: "replies"

--- a/hasura/schema/user/schema.graphql
+++ b/hasura/schema/user/schema.graphql
@@ -20764,6 +20764,66 @@ type replies {
   An object relationship
   """
   profile_public: profiles_public
+
+  """
+  An array relationship
+  """
+  reactions(
+    """
+    distinct select on columns
+    """
+    distinct_on: [replies_reactions_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [replies_reactions_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: replies_reactions_bool_exp
+  ): [replies_reactions!]!
+
+  """
+  An aggregate relationship
+  """
+  reactions_aggregate(
+    """
+    distinct select on columns
+    """
+    distinct_on: [replies_reactions_select_column!]
+
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [replies_reactions_order_by!]
+
+    """
+    filter the rows returned
+    """
+    where: replies_reactions_bool_exp
+  ): replies_reactions_aggregate!
   reply: String!
   updated_at: timestamptz!
 }
@@ -20858,6 +20918,8 @@ input replies_bool_exp {
   profile: profiles_bool_exp
   profile_id: Int_comparison_exp
   profile_public: profiles_public_bool_exp
+  reactions: replies_reactions_bool_exp
+  reactions_aggregate: replies_reactions_aggregate_bool_exp
   reply: String_comparison_exp
   updated_at: timestamptz_comparison_exp
 }
@@ -20878,6 +20940,7 @@ input type for inserting data into table "replies"
 input replies_insert_input {
   activity_actor_id: Int
   activity_id: Int
+  reactions: replies_reactions_arr_rel_insert_input
   reply: String
 }
 
@@ -20987,6 +21050,7 @@ input replies_order_by {
   profile: profiles_order_by
   profile_id: order_by
   profile_public: profiles_public_order_by
+  reactions_aggregate: replies_reactions_aggregate_order_by
   reply: order_by
   updated_at: order_by
 }
@@ -21033,6 +21097,17 @@ type replies_reactions_aggregate {
   nodes: [replies_reactions!]!
 }
 
+input replies_reactions_aggregate_bool_exp {
+  count: replies_reactions_aggregate_bool_exp_count
+}
+
+input replies_reactions_aggregate_bool_exp_count {
+  arguments: [replies_reactions_select_column!]
+  distinct: Boolean
+  filter: replies_reactions_bool_exp
+  predicate: Int_comparison_exp!
+}
+
 """
 aggregate fields of "replies_reactions"
 """
@@ -21051,12 +21126,50 @@ type replies_reactions_aggregate_fields {
 }
 
 """
+order by aggregate values of table "replies_reactions"
+"""
+input replies_reactions_aggregate_order_by {
+  avg: replies_reactions_avg_order_by
+  count: order_by
+  max: replies_reactions_max_order_by
+  min: replies_reactions_min_order_by
+  stddev: replies_reactions_stddev_order_by
+  stddev_pop: replies_reactions_stddev_pop_order_by
+  stddev_samp: replies_reactions_stddev_samp_order_by
+  sum: replies_reactions_sum_order_by
+  var_pop: replies_reactions_var_pop_order_by
+  var_samp: replies_reactions_var_samp_order_by
+  variance: replies_reactions_variance_order_by
+}
+
+"""
+input type for inserting array relation for remote table "replies_reactions"
+"""
+input replies_reactions_arr_rel_insert_input {
+  data: [replies_reactions_insert_input!]!
+
+  """
+  upsert condition
+  """
+  on_conflict: replies_reactions_on_conflict
+}
+
+"""
 aggregate avg on columns
 """
 type replies_reactions_avg_fields {
   id: Float
   profile_id: Float
   reply_id: Float
+}
+
+"""
+order by avg() on columns of table "replies_reactions"
+"""
+input replies_reactions_avg_order_by {
+  id: order_by
+  profile_id: order_by
+  reply_id: order_by
 }
 
 """
@@ -21114,6 +21227,18 @@ type replies_reactions_max_fields {
 }
 
 """
+order by max() on columns of table "replies_reactions"
+"""
+input replies_reactions_max_order_by {
+  created_at: order_by
+  id: order_by
+  profile_id: order_by
+  reaction: order_by
+  reply_id: order_by
+  updated_at: order_by
+}
+
+"""
 aggregate min on columns
 """
 type replies_reactions_min_fields {
@@ -21123,6 +21248,18 @@ type replies_reactions_min_fields {
   reaction: String
   reply_id: Int
   updated_at: timestamptz
+}
+
+"""
+order by min() on columns of table "replies_reactions"
+"""
+input replies_reactions_min_order_by {
+  created_at: order_by
+  id: order_by
+  profile_id: order_by
+  reaction: order_by
+  reply_id: order_by
+  updated_at: order_by
 }
 
 """
@@ -21209,6 +21346,15 @@ type replies_reactions_stddev_fields {
 }
 
 """
+order by stddev() on columns of table "replies_reactions"
+"""
+input replies_reactions_stddev_order_by {
+  id: order_by
+  profile_id: order_by
+  reply_id: order_by
+}
+
+"""
 aggregate stddev_pop on columns
 """
 type replies_reactions_stddev_pop_fields {
@@ -21218,12 +21364,30 @@ type replies_reactions_stddev_pop_fields {
 }
 
 """
+order by stddev_pop() on columns of table "replies_reactions"
+"""
+input replies_reactions_stddev_pop_order_by {
+  id: order_by
+  profile_id: order_by
+  reply_id: order_by
+}
+
+"""
 aggregate stddev_samp on columns
 """
 type replies_reactions_stddev_samp_fields {
   id: Float
   profile_id: Float
   reply_id: Float
+}
+
+"""
+order by stddev_samp() on columns of table "replies_reactions"
+"""
+input replies_reactions_stddev_samp_order_by {
+  id: order_by
+  profile_id: order_by
+  reply_id: order_by
 }
 
 """
@@ -21263,6 +21427,15 @@ type replies_reactions_sum_fields {
 }
 
 """
+order by sum() on columns of table "replies_reactions"
+"""
+input replies_reactions_sum_order_by {
+  id: order_by
+  profile_id: order_by
+  reply_id: order_by
+}
+
+"""
 placeholder for update columns of table "replies_reactions" (current role has no relevant permissions)
 """
 enum replies_reactions_update_column {
@@ -21282,6 +21455,15 @@ type replies_reactions_var_pop_fields {
 }
 
 """
+order by var_pop() on columns of table "replies_reactions"
+"""
+input replies_reactions_var_pop_order_by {
+  id: order_by
+  profile_id: order_by
+  reply_id: order_by
+}
+
+"""
 aggregate var_samp on columns
 """
 type replies_reactions_var_samp_fields {
@@ -21291,12 +21473,30 @@ type replies_reactions_var_samp_fields {
 }
 
 """
+order by var_samp() on columns of table "replies_reactions"
+"""
+input replies_reactions_var_samp_order_by {
+  id: order_by
+  profile_id: order_by
+  reply_id: order_by
+}
+
+"""
 aggregate variance on columns
 """
 type replies_reactions_variance_fields {
   id: Float
   profile_id: Float
   reply_id: Float
+}
+
+"""
+order by variance() on columns of table "replies_reactions"
+"""
+input replies_reactions_variance_order_by {
+  id: order_by
+  profile_id: order_by
+  reply_id: order_by
 }
 
 """

--- a/hasura/schema/user/schema.graphql
+++ b/hasura/schema/user/schema.graphql
@@ -12899,6 +12899,12 @@ type notifications {
   """
   reply: replies
   reply_id: Int
+
+  """
+  An object relationship
+  """
+  reply_reaction: replies_reactions
+  reply_reaction_id: bigint
 }
 
 """
@@ -12937,6 +12943,7 @@ type notifications_avg_fields {
   profile_id: Float
   reaction_id: Float
   reply_id: Float
+  reply_reaction_id: Float
 }
 
 """
@@ -12964,6 +12971,8 @@ input notifications_bool_exp {
   reaction_id: bigint_comparison_exp
   reply: replies_bool_exp
   reply_id: Int_comparison_exp
+  reply_reaction: replies_reactions_bool_exp
+  reply_reaction_id: bigint_comparison_exp
 }
 
 """
@@ -12979,6 +12988,7 @@ type notifications_max_fields {
   profile_id: bigint
   reaction_id: bigint
   reply_id: Int
+  reply_reaction_id: bigint
 }
 
 """
@@ -12994,6 +13004,7 @@ type notifications_min_fields {
   profile_id: bigint
   reaction_id: bigint
   reply_id: Int
+  reply_reaction_id: bigint
 }
 
 """
@@ -13018,6 +13029,8 @@ input notifications_order_by {
   reaction_id: order_by
   reply: replies_order_by
   reply_id: order_by
+  reply_reaction: replies_reactions_order_by
+  reply_reaction_id: order_by
 }
 
 """
@@ -13068,6 +13081,11 @@ enum notifications_select_column {
   column name
   """
   reply_id
+
+  """
+  column name
+  """
+  reply_reaction_id
 }
 
 """
@@ -13081,6 +13099,7 @@ type notifications_stddev_fields {
   profile_id: Float
   reaction_id: Float
   reply_id: Float
+  reply_reaction_id: Float
 }
 
 """
@@ -13094,6 +13113,7 @@ type notifications_stddev_pop_fields {
   profile_id: Float
   reaction_id: Float
   reply_id: Float
+  reply_reaction_id: Float
 }
 
 """
@@ -13107,6 +13127,7 @@ type notifications_stddev_samp_fields {
   profile_id: Float
   reaction_id: Float
   reply_id: Float
+  reply_reaction_id: Float
 }
 
 """
@@ -13137,6 +13158,7 @@ input notifications_stream_cursor_value_input {
   profile_id: bigint
   reaction_id: bigint
   reply_id: Int
+  reply_reaction_id: bigint
 }
 
 """
@@ -13150,6 +13172,7 @@ type notifications_sum_fields {
   profile_id: bigint
   reaction_id: bigint
   reply_id: Int
+  reply_reaction_id: bigint
 }
 
 """
@@ -13163,6 +13186,7 @@ type notifications_var_pop_fields {
   profile_id: Float
   reaction_id: Float
   reply_id: Float
+  reply_reaction_id: Float
 }
 
 """
@@ -13176,6 +13200,7 @@ type notifications_var_samp_fields {
   profile_id: Float
   reaction_id: Float
   reply_id: Float
+  reply_reaction_id: Float
 }
 
 """
@@ -13189,6 +13214,7 @@ type notifications_variance_fields {
   profile_id: Float
   reaction_id: Float
   reply_id: Float
+  reply_reaction_id: Float
 }
 
 scalar numeric
@@ -21066,6 +21092,11 @@ input replies_pk_columns_input {
 columns and relationships of "replies_reactions"
 """
 type replies_reactions {
+  """
+  An object relationship
+  """
+  activity: activities
+  activity_id: Int!
   created_at: timestamptz!
   id: bigint!
 
@@ -21158,6 +21189,7 @@ input replies_reactions_arr_rel_insert_input {
 aggregate avg on columns
 """
 type replies_reactions_avg_fields {
+  activity_id: Float
   id: Float
   profile_id: Float
   reply_id: Float
@@ -21167,6 +21199,7 @@ type replies_reactions_avg_fields {
 order by avg() on columns of table "replies_reactions"
 """
 input replies_reactions_avg_order_by {
+  activity_id: order_by
   id: order_by
   profile_id: order_by
   reply_id: order_by
@@ -21179,6 +21212,8 @@ input replies_reactions_bool_exp {
   _and: [replies_reactions_bool_exp!]
   _not: replies_reactions_bool_exp
   _or: [replies_reactions_bool_exp!]
+  activity: activities_bool_exp
+  activity_id: Int_comparison_exp
   created_at: timestamptz_comparison_exp
   id: bigint_comparison_exp
   profile: profiles_bool_exp
@@ -21209,6 +21244,7 @@ enum replies_reactions_constraint {
 input type for inserting data into table "replies_reactions"
 """
 input replies_reactions_insert_input {
+  activity_id: Int
   reaction: String
   reply: replies_obj_rel_insert_input
   reply_id: Int
@@ -21218,6 +21254,7 @@ input replies_reactions_insert_input {
 aggregate max on columns
 """
 type replies_reactions_max_fields {
+  activity_id: Int
   created_at: timestamptz
   id: bigint
   profile_id: Int
@@ -21230,6 +21267,7 @@ type replies_reactions_max_fields {
 order by max() on columns of table "replies_reactions"
 """
 input replies_reactions_max_order_by {
+  activity_id: order_by
   created_at: order_by
   id: order_by
   profile_id: order_by
@@ -21242,6 +21280,7 @@ input replies_reactions_max_order_by {
 aggregate min on columns
 """
 type replies_reactions_min_fields {
+  activity_id: Int
   created_at: timestamptz
   id: bigint
   profile_id: Int
@@ -21254,6 +21293,7 @@ type replies_reactions_min_fields {
 order by min() on columns of table "replies_reactions"
 """
 input replies_reactions_min_order_by {
+  activity_id: order_by
   created_at: order_by
   id: order_by
   profile_id: order_by
@@ -21290,6 +21330,8 @@ input replies_reactions_on_conflict {
 Ordering options when selecting data from "replies_reactions".
 """
 input replies_reactions_order_by {
+  activity: activities_order_by
+  activity_id: order_by
   created_at: order_by
   id: order_by
   profile: profiles_order_by
@@ -21305,6 +21347,11 @@ input replies_reactions_order_by {
 select columns of table "replies_reactions"
 """
 enum replies_reactions_select_column {
+  """
+  column name
+  """
+  activity_id
+
   """
   column name
   """
@@ -21340,6 +21387,7 @@ enum replies_reactions_select_column {
 aggregate stddev on columns
 """
 type replies_reactions_stddev_fields {
+  activity_id: Float
   id: Float
   profile_id: Float
   reply_id: Float
@@ -21349,6 +21397,7 @@ type replies_reactions_stddev_fields {
 order by stddev() on columns of table "replies_reactions"
 """
 input replies_reactions_stddev_order_by {
+  activity_id: order_by
   id: order_by
   profile_id: order_by
   reply_id: order_by
@@ -21358,6 +21407,7 @@ input replies_reactions_stddev_order_by {
 aggregate stddev_pop on columns
 """
 type replies_reactions_stddev_pop_fields {
+  activity_id: Float
   id: Float
   profile_id: Float
   reply_id: Float
@@ -21367,6 +21417,7 @@ type replies_reactions_stddev_pop_fields {
 order by stddev_pop() on columns of table "replies_reactions"
 """
 input replies_reactions_stddev_pop_order_by {
+  activity_id: order_by
   id: order_by
   profile_id: order_by
   reply_id: order_by
@@ -21376,6 +21427,7 @@ input replies_reactions_stddev_pop_order_by {
 aggregate stddev_samp on columns
 """
 type replies_reactions_stddev_samp_fields {
+  activity_id: Float
   id: Float
   profile_id: Float
   reply_id: Float
@@ -21385,6 +21437,7 @@ type replies_reactions_stddev_samp_fields {
 order by stddev_samp() on columns of table "replies_reactions"
 """
 input replies_reactions_stddev_samp_order_by {
+  activity_id: order_by
   id: order_by
   profile_id: order_by
   reply_id: order_by
@@ -21409,6 +21462,7 @@ input replies_reactions_stream_cursor_input {
 Initial value of the column from where the streaming should start
 """
 input replies_reactions_stream_cursor_value_input {
+  activity_id: Int
   created_at: timestamptz
   id: bigint
   profile_id: Int
@@ -21421,6 +21475,7 @@ input replies_reactions_stream_cursor_value_input {
 aggregate sum on columns
 """
 type replies_reactions_sum_fields {
+  activity_id: Int
   id: bigint
   profile_id: Int
   reply_id: Int
@@ -21430,6 +21485,7 @@ type replies_reactions_sum_fields {
 order by sum() on columns of table "replies_reactions"
 """
 input replies_reactions_sum_order_by {
+  activity_id: order_by
   id: order_by
   profile_id: order_by
   reply_id: order_by
@@ -21449,6 +21505,7 @@ enum replies_reactions_update_column {
 aggregate var_pop on columns
 """
 type replies_reactions_var_pop_fields {
+  activity_id: Float
   id: Float
   profile_id: Float
   reply_id: Float
@@ -21458,6 +21515,7 @@ type replies_reactions_var_pop_fields {
 order by var_pop() on columns of table "replies_reactions"
 """
 input replies_reactions_var_pop_order_by {
+  activity_id: order_by
   id: order_by
   profile_id: order_by
   reply_id: order_by
@@ -21467,6 +21525,7 @@ input replies_reactions_var_pop_order_by {
 aggregate var_samp on columns
 """
 type replies_reactions_var_samp_fields {
+  activity_id: Float
   id: Float
   profile_id: Float
   reply_id: Float
@@ -21476,6 +21535,7 @@ type replies_reactions_var_samp_fields {
 order by var_samp() on columns of table "replies_reactions"
 """
 input replies_reactions_var_samp_order_by {
+  activity_id: order_by
   id: order_by
   profile_id: order_by
   reply_id: order_by
@@ -21485,6 +21545,7 @@ input replies_reactions_var_samp_order_by {
 aggregate variance on columns
 """
 type replies_reactions_variance_fields {
+  activity_id: Float
   id: Float
   profile_id: Float
   reply_id: Float
@@ -21494,6 +21555,7 @@ type replies_reactions_variance_fields {
 order by variance() on columns of table "replies_reactions"
 """
 input replies_reactions_variance_order_by {
+  activity_id: order_by
   id: order_by
   profile_id: order_by
   reply_id: order_by

--- a/src/features/activities/replies/RepliesBox.tsx
+++ b/src/features/activities/replies/RepliesBox.tsx
@@ -184,6 +184,7 @@ export const RepliesBox = ({
                     css={{ cursor: 'auto', mt: '0' }}
                   />
                   <ReplyReactionBar
+                    activityId={activityId}
                     replyId={reply.id}
                     reactions={reply.reactions}
                     drawer={false}

--- a/src/features/activities/replies/ReplyReactionBar.tsx
+++ b/src/features/activities/replies/ReplyReactionBar.tsx
@@ -31,10 +31,12 @@ export const ReplyReactionBar = ({
   reactions,
   drawer,
   replyId,
+  activityId,
 }: {
   reactions: Reaction[];
   drawer?: boolean;
   replyId: number;
+  activityId: number;
 }) => {
   const myProfileId = useAuthStore(state => state.profileId);
   const [currentReactions, setCurrentReactions] =
@@ -102,7 +104,11 @@ export const ReplyReactionBar = ({
 
   const addReaction = (reaction: string) => {
     setTimeout(() => {
-      createReplyReaction({ reply_id: replyId, reaction });
+      createReplyReaction({
+        reply_id: replyId,
+        reaction,
+        activity_id: activityId,
+      });
     }, 500);
   };
 

--- a/src/features/activities/replies/ReplyReactionBar.tsx
+++ b/src/features/activities/replies/ReplyReactionBar.tsx
@@ -1,0 +1,162 @@
+import React, { useEffect, useState } from 'react';
+
+import { useAuthStore } from 'features/auth';
+import { useMutation } from 'react-query';
+
+import { FaceSmile } from '../../../icons/__generated';
+import { Flex } from '../../../ui';
+import { ReactionButton } from '../reactions/ReactionButton';
+import { ReactionCounts } from '../reactions/ReactionCounts';
+import {
+  DEFAULT_REACTIONS,
+  ReactionOptions,
+} from '../reactions/ReactionOptions';
+
+import {
+  createReplyReactionMutation,
+  deleteReplyReactionMutation,
+} from './mutations';
+import '../heart.css';
+import { Reply } from './RepliesBox';
+
+type Reaction = Reply['reactions'][number];
+
+type ReactionGroup = {
+  reaction: string;
+  count: number;
+  myReaction?: number;
+};
+
+export const ReplyReactionBar = ({
+  reactions,
+  drawer,
+  replyId,
+}: {
+  reactions: Reaction[];
+  drawer?: boolean;
+  replyId: number;
+}) => {
+  const myProfileId = useAuthStore(state => state.profileId);
+  const [currentReactions, setCurrentReactions] =
+    useState<Reaction[]>(reactions);
+  const [groupedReactions, setGroupedReactions] = useState<{
+    [key: string]: ReactionGroup;
+  }>({});
+  const [myReactions, setMyReactions] = useState<{ [key: string]: number }>({});
+  const [showAddReaction, setShowAddReaction] = useState(false);
+
+  useEffect(() => {
+    // reduce the reactions to counts
+    const reactionGroupsMap = currentReactions.reduce<{
+      [key: string]: ReactionGroup;
+    }>((rgm, reaction) => {
+      const rg = rgm[reaction.reaction] ?? {
+        reaction: reaction.reaction,
+        count: 0,
+      };
+      rg.count++;
+
+      if (reaction.profile?.id === myProfileId) {
+        rg.myReaction = reaction.id;
+      }
+      rgm[reaction.reaction] = rg;
+
+      return rgm;
+    }, {});
+
+    setGroupedReactions(reactionGroupsMap);
+
+    const myReacts: { [key: string]: number } = {};
+    for (const react of Object.keys(reactionGroupsMap)) {
+      const myReact = reactionGroupsMap[react]?.myReaction;
+      if (myReact) {
+        myReacts[react] = myReact;
+      }
+    }
+    setMyReactions(myReacts);
+  }, [currentReactions]);
+
+  const { mutate: createReplyReaction } = useMutation(
+    createReplyReactionMutation,
+    {
+      onSuccess: newReaction => {
+        setCurrentReactions(prevState => [...prevState, newReaction]);
+      },
+      onSettled: () => {
+        setShowAddReaction(false);
+      },
+    }
+  );
+
+  const { mutate: deleteReplyReaction } = useMutation(
+    deleteReplyReactionMutation,
+    {
+      onSuccess: id => {
+        setCurrentReactions(prevState => prevState.filter(r => r.id !== id));
+      },
+      onSettled: () => {
+        setShowAddReaction(false);
+      },
+    }
+  );
+
+  const addReaction = (reaction: string) => {
+    setTimeout(() => {
+      createReplyReaction({ reply_id: replyId, reaction });
+    }, 500);
+  };
+
+  return (
+    <Flex css={{ position: 'relative', overflowY: 'visible', minHeight: 24 }}>
+      {showAddReaction && (
+        <ReactionOptions
+          drawer={drawer}
+          deleteReaction={(id: number) => {
+            deleteReplyReaction(id);
+          }}
+          addReaction={addReaction}
+          setShowAddReaction={setShowAddReaction}
+          myReactions={myReactions}
+        />
+      )}
+      <Flex css={{ alignItems: 'center', gap: '$sm' }}>
+        <ReactionButton
+          className="iconReaction"
+          color="transparent"
+          onClick={() => setShowAddReaction(prev => !prev)}
+          css={{
+            border: 'none',
+            borderRadius: 9999,
+            p: 0,
+            mr: '$xxs',
+            minHeight: 0,
+            backgroundColor: 'transparent',
+            color: '$secondaryText',
+            '&:hover': {
+              color: '$linkHover',
+              background: '$tagCtaBackground',
+            },
+            svg: {
+              marginRight: 0,
+            },
+          }}
+        >
+          <span role="img" aria-label="react">
+            <FaceSmile fa />
+          </span>
+        </ReactionButton>
+        <ReactionCounts
+          addReaction={(r: string) => {
+            addReaction(r);
+          }}
+          deleteReaction={(id: number) => {
+            deleteReplyReaction(id);
+          }}
+          reactionGroups={DEFAULT_REACTIONS.map(
+            react => groupedReactions[react]
+          )}
+        />
+      </Flex>
+    </Flex>
+  );
+};

--- a/src/features/activities/replies/mutations.ts
+++ b/src/features/activities/replies/mutations.ts
@@ -1,0 +1,46 @@
+import assert from 'assert';
+
+import { ValueTypes } from 'lib/gql/__generated__/zeus';
+import { client } from 'lib/gql/client';
+
+export const createReplyReactionMutation = async (
+  object: ValueTypes['replies_reactions_insert_input']
+) => {
+  const { insert_replies_reactions_one } = await client.mutate(
+    {
+      insert_replies_reactions_one: [
+        { object },
+        {
+          id: true,
+          reaction: true,
+          profile: {
+            name: true,
+            id: true,
+          },
+        },
+      ],
+    },
+    {
+      operationName: 'createReplyReaction',
+    }
+  );
+  assert(insert_replies_reactions_one);
+  return insert_replies_reactions_one;
+};
+
+export const deleteReplyReactionMutation = async (id: number) => {
+  await client.mutate(
+    {
+      delete_replies_reactions: [
+        { where: { id: { _eq: id } } },
+        {
+          affected_rows: true,
+        },
+      ],
+    },
+    {
+      operationName: 'deleteReplyReaction',
+    }
+  );
+  return id;
+};

--- a/src/lib/gql/__generated__/zeus/const.ts
+++ b/src/lib/gql/__generated__/zeus/const.ts
@@ -4200,6 +4200,8 @@ export const AllTypesProps: Record<string, any> = {
     reaction_id: 'bigint_comparison_exp',
     reply: 'replies_bool_exp',
     reply_id: 'Int_comparison_exp',
+    reply_reaction: 'replies_reactions_bool_exp',
+    reply_reaction_id: 'bigint_comparison_exp',
   },
   notifications_order_by: {
     actor_profile_public: 'profiles_public_order_by',
@@ -4220,6 +4222,8 @@ export const AllTypesProps: Record<string, any> = {
     reaction_id: 'order_by',
     reply: 'replies_order_by',
     reply_id: 'order_by',
+    reply_reaction: 'replies_reactions_order_by',
+    reply_reaction_id: 'order_by',
   },
   notifications_select_column: true,
   notifications_stream_cursor_input: {
@@ -4232,6 +4236,7 @@ export const AllTypesProps: Record<string, any> = {
     link_tx_hash: 'citext',
     profile_id: 'bigint',
     reaction_id: 'bigint',
+    reply_reaction_id: 'bigint',
   },
   numeric: 'String',
   numeric_comparison_exp: {
@@ -6321,6 +6326,7 @@ export const AllTypesProps: Record<string, any> = {
     on_conflict: 'replies_reactions_on_conflict',
   },
   replies_reactions_avg_order_by: {
+    activity_id: 'order_by',
     id: 'order_by',
     profile_id: 'order_by',
     reply_id: 'order_by',
@@ -6329,6 +6335,8 @@ export const AllTypesProps: Record<string, any> = {
     _and: 'replies_reactions_bool_exp',
     _not: 'replies_reactions_bool_exp',
     _or: 'replies_reactions_bool_exp',
+    activity: 'activities_bool_exp',
+    activity_id: 'Int_comparison_exp',
     created_at: 'timestamptz_comparison_exp',
     id: 'bigint_comparison_exp',
     profile: 'profiles_bool_exp',
@@ -6344,6 +6352,7 @@ export const AllTypesProps: Record<string, any> = {
     reply: 'replies_obj_rel_insert_input',
   },
   replies_reactions_max_order_by: {
+    activity_id: 'order_by',
     created_at: 'order_by',
     id: 'order_by',
     profile_id: 'order_by',
@@ -6352,6 +6361,7 @@ export const AllTypesProps: Record<string, any> = {
     updated_at: 'order_by',
   },
   replies_reactions_min_order_by: {
+    activity_id: 'order_by',
     created_at: 'order_by',
     id: 'order_by',
     profile_id: 'order_by',
@@ -6365,6 +6375,8 @@ export const AllTypesProps: Record<string, any> = {
     where: 'replies_reactions_bool_exp',
   },
   replies_reactions_order_by: {
+    activity: 'activities_order_by',
+    activity_id: 'order_by',
     created_at: 'order_by',
     id: 'order_by',
     profile: 'profiles_order_by',
@@ -6377,16 +6389,19 @@ export const AllTypesProps: Record<string, any> = {
   },
   replies_reactions_select_column: true,
   replies_reactions_stddev_order_by: {
+    activity_id: 'order_by',
     id: 'order_by',
     profile_id: 'order_by',
     reply_id: 'order_by',
   },
   replies_reactions_stddev_pop_order_by: {
+    activity_id: 'order_by',
     id: 'order_by',
     profile_id: 'order_by',
     reply_id: 'order_by',
   },
   replies_reactions_stddev_samp_order_by: {
+    activity_id: 'order_by',
     id: 'order_by',
     profile_id: 'order_by',
     reply_id: 'order_by',
@@ -6401,22 +6416,26 @@ export const AllTypesProps: Record<string, any> = {
     updated_at: 'timestamptz',
   },
   replies_reactions_sum_order_by: {
+    activity_id: 'order_by',
     id: 'order_by',
     profile_id: 'order_by',
     reply_id: 'order_by',
   },
   replies_reactions_update_column: true,
   replies_reactions_var_pop_order_by: {
+    activity_id: 'order_by',
     id: 'order_by',
     profile_id: 'order_by',
     reply_id: 'order_by',
   },
   replies_reactions_var_samp_order_by: {
+    activity_id: 'order_by',
     id: 'order_by',
     profile_id: 'order_by',
     reply_id: 'order_by',
   },
   replies_reactions_variance_order_by: {
+    activity_id: 'order_by',
     id: 'order_by',
     profile_id: 'order_by',
     reply_id: 'order_by',
@@ -10250,6 +10269,8 @@ export const ReturnTypes: Record<string, any> = {
     reaction_id: 'bigint',
     reply: 'replies',
     reply_id: 'Int',
+    reply_reaction: 'replies_reactions',
+    reply_reaction_id: 'bigint',
   },
   notifications_aggregate: {
     aggregate: 'notifications_aggregate_fields',
@@ -10276,6 +10297,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'Float',
     reaction_id: 'Float',
     reply_id: 'Float',
+    reply_reaction_id: 'Float',
   },
   notifications_max_fields: {
     created_at: 'timestamptz',
@@ -10287,6 +10309,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'bigint',
     reaction_id: 'bigint',
     reply_id: 'Int',
+    reply_reaction_id: 'bigint',
   },
   notifications_min_fields: {
     created_at: 'timestamptz',
@@ -10298,6 +10321,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'bigint',
     reaction_id: 'bigint',
     reply_id: 'Int',
+    reply_reaction_id: 'bigint',
   },
   notifications_stddev_fields: {
     id: 'Float',
@@ -10307,6 +10331,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'Float',
     reaction_id: 'Float',
     reply_id: 'Float',
+    reply_reaction_id: 'Float',
   },
   notifications_stddev_pop_fields: {
     id: 'Float',
@@ -10316,6 +10341,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'Float',
     reaction_id: 'Float',
     reply_id: 'Float',
+    reply_reaction_id: 'Float',
   },
   notifications_stddev_samp_fields: {
     id: 'Float',
@@ -10325,6 +10351,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'Float',
     reaction_id: 'Float',
     reply_id: 'Float',
+    reply_reaction_id: 'Float',
   },
   notifications_sum_fields: {
     id: 'Int',
@@ -10334,6 +10361,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'bigint',
     reaction_id: 'bigint',
     reply_id: 'Int',
+    reply_reaction_id: 'bigint',
   },
   notifications_var_pop_fields: {
     id: 'Float',
@@ -10343,6 +10371,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'Float',
     reaction_id: 'Float',
     reply_id: 'Float',
+    reply_reaction_id: 'Float',
   },
   notifications_var_samp_fields: {
     id: 'Float',
@@ -10352,6 +10381,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'Float',
     reaction_id: 'Float',
     reply_id: 'Float',
+    reply_reaction_id: 'Float',
   },
   notifications_variance_fields: {
     id: 'Float',
@@ -10361,6 +10391,7 @@ export const ReturnTypes: Record<string, any> = {
     profile_id: 'Float',
     reaction_id: 'Float',
     reply_id: 'Float',
+    reply_reaction_id: 'Float',
   },
   org_members: {
     created_at: 'timestamp',
@@ -11083,6 +11114,8 @@ export const ReturnTypes: Record<string, any> = {
     returning: 'replies',
   },
   replies_reactions: {
+    activity: 'activities',
+    activity_id: 'Int',
     created_at: 'timestamptz',
     id: 'bigint',
     profile: 'profiles',
@@ -11111,11 +11144,13 @@ export const ReturnTypes: Record<string, any> = {
     variance: 'replies_reactions_variance_fields',
   },
   replies_reactions_avg_fields: {
+    activity_id: 'Float',
     id: 'Float',
     profile_id: 'Float',
     reply_id: 'Float',
   },
   replies_reactions_max_fields: {
+    activity_id: 'Int',
     created_at: 'timestamptz',
     id: 'bigint',
     profile_id: 'Int',
@@ -11124,6 +11159,7 @@ export const ReturnTypes: Record<string, any> = {
     updated_at: 'timestamptz',
   },
   replies_reactions_min_fields: {
+    activity_id: 'Int',
     created_at: 'timestamptz',
     id: 'bigint',
     profile_id: 'Int',
@@ -11136,36 +11172,43 @@ export const ReturnTypes: Record<string, any> = {
     returning: 'replies_reactions',
   },
   replies_reactions_stddev_fields: {
+    activity_id: 'Float',
     id: 'Float',
     profile_id: 'Float',
     reply_id: 'Float',
   },
   replies_reactions_stddev_pop_fields: {
+    activity_id: 'Float',
     id: 'Float',
     profile_id: 'Float',
     reply_id: 'Float',
   },
   replies_reactions_stddev_samp_fields: {
+    activity_id: 'Float',
     id: 'Float',
     profile_id: 'Float',
     reply_id: 'Float',
   },
   replies_reactions_sum_fields: {
+    activity_id: 'Int',
     id: 'bigint',
     profile_id: 'Int',
     reply_id: 'Int',
   },
   replies_reactions_var_pop_fields: {
+    activity_id: 'Float',
     id: 'Float',
     profile_id: 'Float',
     reply_id: 'Float',
   },
   replies_reactions_var_samp_fields: {
+    activity_id: 'Float',
     id: 'Float',
     profile_id: 'Float',
     reply_id: 'Float',
   },
   replies_reactions_variance_fields: {
+    activity_id: 'Float',
     id: 'Float',
     profile_id: 'Float',
     reply_id: 'Float',

--- a/src/lib/gql/__generated__/zeus/const.ts
+++ b/src/lib/gql/__generated__/zeus/const.ts
@@ -6176,6 +6176,18 @@ export const AllTypesProps: Record<string, any> = {
     id: 'order_by',
     profile_id: 'order_by',
   },
+  replies: {
+    reactions: {
+      distinct_on: 'replies_reactions_select_column',
+      order_by: 'replies_reactions_order_by',
+      where: 'replies_reactions_bool_exp',
+    },
+    reactions_aggregate: {
+      distinct_on: 'replies_reactions_select_column',
+      order_by: 'replies_reactions_order_by',
+      where: 'replies_reactions_bool_exp',
+    },
+  },
   replies_aggregate_bool_exp: {
     count: 'replies_aggregate_bool_exp_count',
   },
@@ -6222,11 +6234,15 @@ export const AllTypesProps: Record<string, any> = {
     profile: 'profiles_bool_exp',
     profile_id: 'Int_comparison_exp',
     profile_public: 'profiles_public_bool_exp',
+    reactions: 'replies_reactions_bool_exp',
+    reactions_aggregate: 'replies_reactions_aggregate_bool_exp',
     reply: 'String_comparison_exp',
     updated_at: 'timestamptz_comparison_exp',
   },
   replies_constraint: true,
-  replies_insert_input: {},
+  replies_insert_input: {
+    reactions: 'replies_reactions_arr_rel_insert_input',
+  },
   replies_max_order_by: {
     activity_actor_id: 'order_by',
     activity_id: 'order_by',
@@ -6267,16 +6283,47 @@ export const AllTypesProps: Record<string, any> = {
     profile: 'profiles_order_by',
     profile_id: 'order_by',
     profile_public: 'profiles_public_order_by',
+    reactions_aggregate: 'replies_reactions_aggregate_order_by',
     reply: 'order_by',
     updated_at: 'order_by',
   },
   replies_pk_columns_input: {
     id: 'bigint',
   },
+  replies_reactions_aggregate_bool_exp: {
+    count: 'replies_reactions_aggregate_bool_exp_count',
+  },
+  replies_reactions_aggregate_bool_exp_count: {
+    arguments: 'replies_reactions_select_column',
+    filter: 'replies_reactions_bool_exp',
+    predicate: 'Int_comparison_exp',
+  },
   replies_reactions_aggregate_fields: {
     count: {
       columns: 'replies_reactions_select_column',
     },
+  },
+  replies_reactions_aggregate_order_by: {
+    avg: 'replies_reactions_avg_order_by',
+    count: 'order_by',
+    max: 'replies_reactions_max_order_by',
+    min: 'replies_reactions_min_order_by',
+    stddev: 'replies_reactions_stddev_order_by',
+    stddev_pop: 'replies_reactions_stddev_pop_order_by',
+    stddev_samp: 'replies_reactions_stddev_samp_order_by',
+    sum: 'replies_reactions_sum_order_by',
+    var_pop: 'replies_reactions_var_pop_order_by',
+    var_samp: 'replies_reactions_var_samp_order_by',
+    variance: 'replies_reactions_variance_order_by',
+  },
+  replies_reactions_arr_rel_insert_input: {
+    data: 'replies_reactions_insert_input',
+    on_conflict: 'replies_reactions_on_conflict',
+  },
+  replies_reactions_avg_order_by: {
+    id: 'order_by',
+    profile_id: 'order_by',
+    reply_id: 'order_by',
   },
   replies_reactions_bool_exp: {
     _and: 'replies_reactions_bool_exp',
@@ -6296,6 +6343,22 @@ export const AllTypesProps: Record<string, any> = {
   replies_reactions_insert_input: {
     reply: 'replies_obj_rel_insert_input',
   },
+  replies_reactions_max_order_by: {
+    created_at: 'order_by',
+    id: 'order_by',
+    profile_id: 'order_by',
+    reaction: 'order_by',
+    reply_id: 'order_by',
+    updated_at: 'order_by',
+  },
+  replies_reactions_min_order_by: {
+    created_at: 'order_by',
+    id: 'order_by',
+    profile_id: 'order_by',
+    reaction: 'order_by',
+    reply_id: 'order_by',
+    updated_at: 'order_by',
+  },
   replies_reactions_on_conflict: {
     constraint: 'replies_reactions_constraint',
     update_columns: 'replies_reactions_update_column',
@@ -6313,6 +6376,21 @@ export const AllTypesProps: Record<string, any> = {
     updated_at: 'order_by',
   },
   replies_reactions_select_column: true,
+  replies_reactions_stddev_order_by: {
+    id: 'order_by',
+    profile_id: 'order_by',
+    reply_id: 'order_by',
+  },
+  replies_reactions_stddev_pop_order_by: {
+    id: 'order_by',
+    profile_id: 'order_by',
+    reply_id: 'order_by',
+  },
+  replies_reactions_stddev_samp_order_by: {
+    id: 'order_by',
+    profile_id: 'order_by',
+    reply_id: 'order_by',
+  },
   replies_reactions_stream_cursor_input: {
     initial_value: 'replies_reactions_stream_cursor_value_input',
     ordering: 'cursor_ordering',
@@ -6322,7 +6400,27 @@ export const AllTypesProps: Record<string, any> = {
     id: 'bigint',
     updated_at: 'timestamptz',
   },
+  replies_reactions_sum_order_by: {
+    id: 'order_by',
+    profile_id: 'order_by',
+    reply_id: 'order_by',
+  },
   replies_reactions_update_column: true,
+  replies_reactions_var_pop_order_by: {
+    id: 'order_by',
+    profile_id: 'order_by',
+    reply_id: 'order_by',
+  },
+  replies_reactions_var_samp_order_by: {
+    id: 'order_by',
+    profile_id: 'order_by',
+    reply_id: 'order_by',
+  },
+  replies_reactions_variance_order_by: {
+    id: 'order_by',
+    profile_id: 'order_by',
+    reply_id: 'order_by',
+  },
   replies_select_column: true,
   replies_set_input: {
     deleted_at: 'timestamptz',
@@ -10932,6 +11030,8 @@ export const ReturnTypes: Record<string, any> = {
     profile: 'profiles',
     profile_id: 'Int',
     profile_public: 'profiles_public',
+    reactions: 'replies_reactions',
+    reactions_aggregate: 'replies_reactions_aggregate',
     reply: 'String',
     updated_at: 'timestamptz',
   },

--- a/src/lib/gql/__generated__/zeus/const.ts
+++ b/src/lib/gql/__generated__/zeus/const.ts
@@ -3460,6 +3460,12 @@ export const AllTypesProps: Record<string, any> = {
     delete_reactions_by_pk: {
       id: 'bigint',
     },
+    delete_replies_reactions: {
+      where: 'replies_reactions_bool_exp',
+    },
+    delete_replies_reactions_by_pk: {
+      id: 'bigint',
+    },
     delete_twitter_accounts: {
       where: 'twitter_accounts_bool_exp',
     },
@@ -3584,6 +3590,14 @@ export const AllTypesProps: Record<string, any> = {
     insert_replies_one: {
       object: 'replies_insert_input',
       on_conflict: 'replies_on_conflict',
+    },
+    insert_replies_reactions: {
+      objects: 'replies_reactions_insert_input',
+      on_conflict: 'replies_reactions_on_conflict',
+    },
+    insert_replies_reactions_one: {
+      object: 'replies_reactions_insert_input',
+      on_conflict: 'replies_reactions_on_conflict',
     },
     insert_skills: {
       objects: 'skills_insert_input',
@@ -5878,6 +5892,19 @@ export const AllTypesProps: Record<string, any> = {
     replies_by_pk: {
       id: 'bigint',
     },
+    replies_reactions: {
+      distinct_on: 'replies_reactions_select_column',
+      order_by: 'replies_reactions_order_by',
+      where: 'replies_reactions_bool_exp',
+    },
+    replies_reactions_aggregate: {
+      distinct_on: 'replies_reactions_select_column',
+      order_by: 'replies_reactions_order_by',
+      where: 'replies_reactions_bool_exp',
+    },
+    replies_reactions_by_pk: {
+      id: 'bigint',
+    },
     reputation_scores: {
       distinct_on: 'reputation_scores_select_column',
       order_by: 'reputation_scores_order_by',
@@ -6220,6 +6247,10 @@ export const AllTypesProps: Record<string, any> = {
     reply: 'order_by',
     updated_at: 'order_by',
   },
+  replies_obj_rel_insert_input: {
+    data: 'replies_insert_input',
+    on_conflict: 'replies_on_conflict',
+  },
   replies_on_conflict: {
     constraint: 'replies_constraint',
     update_columns: 'replies_update_column',
@@ -6242,6 +6273,56 @@ export const AllTypesProps: Record<string, any> = {
   replies_pk_columns_input: {
     id: 'bigint',
   },
+  replies_reactions_aggregate_fields: {
+    count: {
+      columns: 'replies_reactions_select_column',
+    },
+  },
+  replies_reactions_bool_exp: {
+    _and: 'replies_reactions_bool_exp',
+    _not: 'replies_reactions_bool_exp',
+    _or: 'replies_reactions_bool_exp',
+    created_at: 'timestamptz_comparison_exp',
+    id: 'bigint_comparison_exp',
+    profile: 'profiles_bool_exp',
+    profile_id: 'Int_comparison_exp',
+    profile_public: 'profiles_public_bool_exp',
+    reaction: 'String_comparison_exp',
+    reply: 'replies_bool_exp',
+    reply_id: 'Int_comparison_exp',
+    updated_at: 'timestamptz_comparison_exp',
+  },
+  replies_reactions_constraint: true,
+  replies_reactions_insert_input: {
+    reply: 'replies_obj_rel_insert_input',
+  },
+  replies_reactions_on_conflict: {
+    constraint: 'replies_reactions_constraint',
+    update_columns: 'replies_reactions_update_column',
+    where: 'replies_reactions_bool_exp',
+  },
+  replies_reactions_order_by: {
+    created_at: 'order_by',
+    id: 'order_by',
+    profile: 'profiles_order_by',
+    profile_id: 'order_by',
+    profile_public: 'profiles_public_order_by',
+    reaction: 'order_by',
+    reply: 'replies_order_by',
+    reply_id: 'order_by',
+    updated_at: 'order_by',
+  },
+  replies_reactions_select_column: true,
+  replies_reactions_stream_cursor_input: {
+    initial_value: 'replies_reactions_stream_cursor_value_input',
+    ordering: 'cursor_ordering',
+  },
+  replies_reactions_stream_cursor_value_input: {
+    created_at: 'timestamptz',
+    id: 'bigint',
+    updated_at: 'timestamptz',
+  },
+  replies_reactions_update_column: true,
   replies_select_column: true,
   replies_set_input: {
     deleted_at: 'timestamptz',
@@ -7026,6 +7107,23 @@ export const AllTypesProps: Record<string, any> = {
     },
     replies_by_pk: {
       id: 'bigint',
+    },
+    replies_reactions: {
+      distinct_on: 'replies_reactions_select_column',
+      order_by: 'replies_reactions_order_by',
+      where: 'replies_reactions_bool_exp',
+    },
+    replies_reactions_aggregate: {
+      distinct_on: 'replies_reactions_select_column',
+      order_by: 'replies_reactions_order_by',
+      where: 'replies_reactions_bool_exp',
+    },
+    replies_reactions_by_pk: {
+      id: 'bigint',
+    },
+    replies_reactions_stream: {
+      cursor: 'replies_reactions_stream_cursor_input',
+      where: 'replies_reactions_bool_exp',
     },
     replies_stream: {
       cursor: 'replies_stream_cursor_input',
@@ -9775,6 +9873,8 @@ export const ReturnTypes: Record<string, any> = {
     delete_profile_skills_by_pk: 'profile_skills',
     delete_reactions: 'reactions_mutation_response',
     delete_reactions_by_pk: 'reactions',
+    delete_replies_reactions: 'replies_reactions_mutation_response',
+    delete_replies_reactions_by_pk: 'replies_reactions',
     delete_twitter_accounts: 'twitter_accounts_mutation_response',
     delete_twitter_accounts_by_pk: 'twitter_accounts',
     endEpoch: 'EpochResponse',
@@ -9813,6 +9913,8 @@ export const ReturnTypes: Record<string, any> = {
     insert_reactions_one: 'reactions',
     insert_replies: 'replies_mutation_response',
     insert_replies_one: 'replies',
+    insert_replies_reactions: 'replies_reactions_mutation_response',
+    insert_replies_reactions_one: 'replies_reactions',
     insert_skills: 'skills_mutation_response',
     insert_skills_one: 'skills',
     linkDiscordCircle: 'LinkDiscordCircleResponse',
@@ -10694,6 +10796,9 @@ export const ReturnTypes: Record<string, any> = {
     replies: 'replies',
     replies_aggregate: 'replies_aggregate',
     replies_by_pk: 'replies',
+    replies_reactions: 'replies_reactions',
+    replies_reactions_aggregate: 'replies_reactions_aggregate',
+    replies_reactions_by_pk: 'replies_reactions',
     reputation_scores: 'reputation_scores',
     reputation_scores_by_pk: 'reputation_scores',
     searchCosouls: 'SearchCosoulsOutput',
@@ -10876,6 +10981,94 @@ export const ReturnTypes: Record<string, any> = {
   replies_mutation_response: {
     affected_rows: 'Int',
     returning: 'replies',
+  },
+  replies_reactions: {
+    created_at: 'timestamptz',
+    id: 'bigint',
+    profile: 'profiles',
+    profile_id: 'Int',
+    profile_public: 'profiles_public',
+    reaction: 'String',
+    reply: 'replies',
+    reply_id: 'Int',
+    updated_at: 'timestamptz',
+  },
+  replies_reactions_aggregate: {
+    aggregate: 'replies_reactions_aggregate_fields',
+    nodes: 'replies_reactions',
+  },
+  replies_reactions_aggregate_fields: {
+    avg: 'replies_reactions_avg_fields',
+    count: 'Int',
+    max: 'replies_reactions_max_fields',
+    min: 'replies_reactions_min_fields',
+    stddev: 'replies_reactions_stddev_fields',
+    stddev_pop: 'replies_reactions_stddev_pop_fields',
+    stddev_samp: 'replies_reactions_stddev_samp_fields',
+    sum: 'replies_reactions_sum_fields',
+    var_pop: 'replies_reactions_var_pop_fields',
+    var_samp: 'replies_reactions_var_samp_fields',
+    variance: 'replies_reactions_variance_fields',
+  },
+  replies_reactions_avg_fields: {
+    id: 'Float',
+    profile_id: 'Float',
+    reply_id: 'Float',
+  },
+  replies_reactions_max_fields: {
+    created_at: 'timestamptz',
+    id: 'bigint',
+    profile_id: 'Int',
+    reaction: 'String',
+    reply_id: 'Int',
+    updated_at: 'timestamptz',
+  },
+  replies_reactions_min_fields: {
+    created_at: 'timestamptz',
+    id: 'bigint',
+    profile_id: 'Int',
+    reaction: 'String',
+    reply_id: 'Int',
+    updated_at: 'timestamptz',
+  },
+  replies_reactions_mutation_response: {
+    affected_rows: 'Int',
+    returning: 'replies_reactions',
+  },
+  replies_reactions_stddev_fields: {
+    id: 'Float',
+    profile_id: 'Float',
+    reply_id: 'Float',
+  },
+  replies_reactions_stddev_pop_fields: {
+    id: 'Float',
+    profile_id: 'Float',
+    reply_id: 'Float',
+  },
+  replies_reactions_stddev_samp_fields: {
+    id: 'Float',
+    profile_id: 'Float',
+    reply_id: 'Float',
+  },
+  replies_reactions_sum_fields: {
+    id: 'bigint',
+    profile_id: 'Int',
+    reply_id: 'Int',
+  },
+  replies_reactions_var_pop_fields: {
+    id: 'Float',
+    profile_id: 'Float',
+    reply_id: 'Float',
+  },
+  replies_reactions_var_samp_fields: {
+    id: 'Float',
+    profile_id: 'Float',
+    reply_id: 'Float',
+  },
+  replies_reactions_variance_fields: {
+    id: 'Float',
+    profile_id: 'Float',
+    reply_id: 'Float',
   },
   replies_stddev_fields: {
     activity_actor_id: 'Float',
@@ -11102,6 +11295,10 @@ export const ReturnTypes: Record<string, any> = {
     replies: 'replies',
     replies_aggregate: 'replies_aggregate',
     replies_by_pk: 'replies',
+    replies_reactions: 'replies_reactions',
+    replies_reactions_aggregate: 'replies_reactions_aggregate',
+    replies_reactions_by_pk: 'replies_reactions',
+    replies_reactions_stream: 'replies_reactions',
     replies_stream: 'replies',
     reputation_scores: 'reputation_scores',
     reputation_scores_by_pk: 'reputation_scores',

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -8131,6 +8131,17 @@ export type ValueTypes = {
       { id: ValueTypes['bigint'] },
       ValueTypes['reactions'],
     ];
+    delete_replies_reactions?: [
+      {
+        /** filter the rows which have to be deleted */
+        where: ValueTypes['replies_reactions_bool_exp'];
+      },
+      ValueTypes['replies_reactions_mutation_response'],
+    ];
+    delete_replies_reactions_by_pk?: [
+      { id: ValueTypes['bigint'] },
+      ValueTypes['replies_reactions'],
+    ];
     delete_twitter_accounts?: [
       {
         /** filter the rows which have to be deleted */
@@ -8466,6 +8477,30 @@ export type ValueTypes = {
         on_conflict?: ValueTypes['replies_on_conflict'] | undefined | null;
       },
       ValueTypes['replies'],
+    ];
+    insert_replies_reactions?: [
+      {
+        /** the rows to be inserted */
+        objects: Array<
+          ValueTypes['replies_reactions_insert_input']
+        > /** upsert condition */;
+        on_conflict?:
+          | ValueTypes['replies_reactions_on_conflict']
+          | undefined
+          | null;
+      },
+      ValueTypes['replies_reactions_mutation_response'],
+    ];
+    insert_replies_reactions_one?: [
+      {
+        /** the row to be inserted */
+        object: ValueTypes['replies_reactions_insert_input'] /** upsert condition */;
+        on_conflict?:
+          | ValueTypes['replies_reactions_on_conflict']
+          | undefined
+          | null;
+      },
+      ValueTypes['replies_reactions'],
     ];
     insert_skills?: [
       {
@@ -14273,6 +14308,56 @@ export type ValueTypes = {
       ValueTypes['replies_aggregate'],
     ];
     replies_by_pk?: [{ id: ValueTypes['bigint'] }, ValueTypes['replies']];
+    replies_reactions?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['replies_reactions_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['replies_reactions_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ValueTypes['replies_reactions_bool_exp'] | undefined | null;
+      },
+      ValueTypes['replies_reactions'],
+    ];
+    replies_reactions_aggregate?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['replies_reactions_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['replies_reactions_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ValueTypes['replies_reactions_bool_exp'] | undefined | null;
+      },
+      ValueTypes['replies_reactions_aggregate'],
+    ];
+    replies_reactions_by_pk?: [
+      { id: ValueTypes['bigint'] },
+      ValueTypes['replies_reactions'],
+    ];
     reputation_scores?: [
       {
         /** distinct select on columns */
@@ -15246,6 +15331,12 @@ export type ValueTypes = {
     returning?: ValueTypes['replies'];
     __typename?: boolean | `@${string}`;
   }>;
+  /** input type for inserting object relation for remote table "replies" */
+  ['replies_obj_rel_insert_input']: {
+    data: ValueTypes['replies_insert_input'];
+    /** upsert condition */
+    on_conflict?: ValueTypes['replies_on_conflict'] | undefined | null;
+  };
   /** on_conflict condition type for table "replies" */
   ['replies_on_conflict']: {
     constraint: ValueTypes['replies_constraint'];
@@ -15274,6 +15365,197 @@ export type ValueTypes = {
   ['replies_pk_columns_input']: {
     id: ValueTypes['bigint'];
   };
+  /** columns and relationships of "replies_reactions" */
+  ['replies_reactions']: AliasType<{
+    created_at?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    /** An object relationship */
+    profile?: ValueTypes['profiles'];
+    profile_id?: boolean | `@${string}`;
+    /** An object relationship */
+    profile_public?: ValueTypes['profiles_public'];
+    reaction?: boolean | `@${string}`;
+    /** An object relationship */
+    reply?: ValueTypes['replies'];
+    reply_id?: boolean | `@${string}`;
+    updated_at?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregated selection of "replies_reactions" */
+  ['replies_reactions_aggregate']: AliasType<{
+    aggregate?: ValueTypes['replies_reactions_aggregate_fields'];
+    nodes?: ValueTypes['replies_reactions'];
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate fields of "replies_reactions" */
+  ['replies_reactions_aggregate_fields']: AliasType<{
+    avg?: ValueTypes['replies_reactions_avg_fields'];
+    count?: [
+      {
+        columns?:
+          | Array<ValueTypes['replies_reactions_select_column']>
+          | undefined
+          | null;
+        distinct?: boolean | undefined | null;
+      },
+      boolean | `@${string}`,
+    ];
+    max?: ValueTypes['replies_reactions_max_fields'];
+    min?: ValueTypes['replies_reactions_min_fields'];
+    stddev?: ValueTypes['replies_reactions_stddev_fields'];
+    stddev_pop?: ValueTypes['replies_reactions_stddev_pop_fields'];
+    stddev_samp?: ValueTypes['replies_reactions_stddev_samp_fields'];
+    sum?: ValueTypes['replies_reactions_sum_fields'];
+    var_pop?: ValueTypes['replies_reactions_var_pop_fields'];
+    var_samp?: ValueTypes['replies_reactions_var_samp_fields'];
+    variance?: ValueTypes['replies_reactions_variance_fields'];
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate avg on columns */
+  ['replies_reactions_avg_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    profile_id?: boolean | `@${string}`;
+    reply_id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** Boolean expression to filter rows from the table "replies_reactions". All fields are combined with a logical 'AND'. */
+  ['replies_reactions_bool_exp']: {
+    _and?: Array<ValueTypes['replies_reactions_bool_exp']> | undefined | null;
+    _not?: ValueTypes['replies_reactions_bool_exp'] | undefined | null;
+    _or?: Array<ValueTypes['replies_reactions_bool_exp']> | undefined | null;
+    created_at?: ValueTypes['timestamptz_comparison_exp'] | undefined | null;
+    id?: ValueTypes['bigint_comparison_exp'] | undefined | null;
+    profile?: ValueTypes['profiles_bool_exp'] | undefined | null;
+    profile_id?: ValueTypes['Int_comparison_exp'] | undefined | null;
+    profile_public?: ValueTypes['profiles_public_bool_exp'] | undefined | null;
+    reaction?: ValueTypes['String_comparison_exp'] | undefined | null;
+    reply?: ValueTypes['replies_bool_exp'] | undefined | null;
+    reply_id?: ValueTypes['Int_comparison_exp'] | undefined | null;
+    updated_at?: ValueTypes['timestamptz_comparison_exp'] | undefined | null;
+  };
+  /** unique or primary key constraints on table "replies_reactions" */
+  ['replies_reactions_constraint']: replies_reactions_constraint;
+  /** input type for inserting data into table "replies_reactions" */
+  ['replies_reactions_insert_input']: {
+    reaction?: string | undefined | null;
+    reply?: ValueTypes['replies_obj_rel_insert_input'] | undefined | null;
+    reply_id?: number | undefined | null;
+  };
+  /** aggregate max on columns */
+  ['replies_reactions_max_fields']: AliasType<{
+    created_at?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    profile_id?: boolean | `@${string}`;
+    reaction?: boolean | `@${string}`;
+    reply_id?: boolean | `@${string}`;
+    updated_at?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate min on columns */
+  ['replies_reactions_min_fields']: AliasType<{
+    created_at?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    profile_id?: boolean | `@${string}`;
+    reaction?: boolean | `@${string}`;
+    reply_id?: boolean | `@${string}`;
+    updated_at?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** response of any mutation on the table "replies_reactions" */
+  ['replies_reactions_mutation_response']: AliasType<{
+    /** number of rows affected by the mutation */
+    affected_rows?: boolean | `@${string}`;
+    /** data from the rows affected by the mutation */
+    returning?: ValueTypes['replies_reactions'];
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** on_conflict condition type for table "replies_reactions" */
+  ['replies_reactions_on_conflict']: {
+    constraint: ValueTypes['replies_reactions_constraint'];
+    update_columns: Array<ValueTypes['replies_reactions_update_column']>;
+    where?: ValueTypes['replies_reactions_bool_exp'] | undefined | null;
+  };
+  /** Ordering options when selecting data from "replies_reactions". */
+  ['replies_reactions_order_by']: {
+    created_at?: ValueTypes['order_by'] | undefined | null;
+    id?: ValueTypes['order_by'] | undefined | null;
+    profile?: ValueTypes['profiles_order_by'] | undefined | null;
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+    profile_public?: ValueTypes['profiles_public_order_by'] | undefined | null;
+    reaction?: ValueTypes['order_by'] | undefined | null;
+    reply?: ValueTypes['replies_order_by'] | undefined | null;
+    reply_id?: ValueTypes['order_by'] | undefined | null;
+    updated_at?: ValueTypes['order_by'] | undefined | null;
+  };
+  /** select columns of table "replies_reactions" */
+  ['replies_reactions_select_column']: replies_reactions_select_column;
+  /** aggregate stddev on columns */
+  ['replies_reactions_stddev_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    profile_id?: boolean | `@${string}`;
+    reply_id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate stddev_pop on columns */
+  ['replies_reactions_stddev_pop_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    profile_id?: boolean | `@${string}`;
+    reply_id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate stddev_samp on columns */
+  ['replies_reactions_stddev_samp_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    profile_id?: boolean | `@${string}`;
+    reply_id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** Streaming cursor of the table "replies_reactions" */
+  ['replies_reactions_stream_cursor_input']: {
+    /** Stream column input with initial value */
+    initial_value: ValueTypes['replies_reactions_stream_cursor_value_input'];
+    /** cursor ordering */
+    ordering?: ValueTypes['cursor_ordering'] | undefined | null;
+  };
+  /** Initial value of the column from where the streaming should start */
+  ['replies_reactions_stream_cursor_value_input']: {
+    created_at?: ValueTypes['timestamptz'] | undefined | null;
+    id?: ValueTypes['bigint'] | undefined | null;
+    profile_id?: number | undefined | null;
+    reaction?: string | undefined | null;
+    reply_id?: number | undefined | null;
+    updated_at?: ValueTypes['timestamptz'] | undefined | null;
+  };
+  /** aggregate sum on columns */
+  ['replies_reactions_sum_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    profile_id?: boolean | `@${string}`;
+    reply_id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** placeholder for update columns of table "replies_reactions" (current role has no relevant permissions) */
+  ['replies_reactions_update_column']: replies_reactions_update_column;
+  /** aggregate var_pop on columns */
+  ['replies_reactions_var_pop_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    profile_id?: boolean | `@${string}`;
+    reply_id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate var_samp on columns */
+  ['replies_reactions_var_samp_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    profile_id?: boolean | `@${string}`;
+    reply_id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate variance on columns */
+  ['replies_reactions_variance_fields']: AliasType<{
+    id?: boolean | `@${string}`;
+    profile_id?: boolean | `@${string}`;
+    reply_id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
   /** select columns of table "replies" */
   ['replies_select_column']: replies_select_column;
   /** input type for updating data in table "replies" */
@@ -17791,6 +18073,67 @@ export type ValueTypes = {
       ValueTypes['replies_aggregate'],
     ];
     replies_by_pk?: [{ id: ValueTypes['bigint'] }, ValueTypes['replies']];
+    replies_reactions?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['replies_reactions_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['replies_reactions_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ValueTypes['replies_reactions_bool_exp'] | undefined | null;
+      },
+      ValueTypes['replies_reactions'],
+    ];
+    replies_reactions_aggregate?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['replies_reactions_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['replies_reactions_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ValueTypes['replies_reactions_bool_exp'] | undefined | null;
+      },
+      ValueTypes['replies_reactions_aggregate'],
+    ];
+    replies_reactions_by_pk?: [
+      { id: ValueTypes['bigint'] },
+      ValueTypes['replies_reactions'],
+    ];
+    replies_reactions_stream?: [
+      {
+        /** maximum number of rows returned in a single batch */
+        batch_size: number /** cursor to stream the results returned by the query */;
+        cursor: Array<
+          ValueTypes['replies_reactions_stream_cursor_input'] | undefined | null
+        > /** filter the rows returned */;
+        where?: ValueTypes['replies_reactions_bool_exp'] | undefined | null;
+      },
+      ValueTypes['replies_reactions'],
+    ];
     replies_stream?: [
       {
         /** maximum number of rows returned in a single batch */
@@ -23183,6 +23526,14 @@ export type ModelTypes = {
     delete_reactions?: GraphQLTypes['reactions_mutation_response'] | undefined;
     /** delete single row from the table: "reactions" */
     delete_reactions_by_pk?: GraphQLTypes['reactions'] | undefined;
+    /** delete data from the table: "replies_reactions" */
+    delete_replies_reactions?:
+      | GraphQLTypes['replies_reactions_mutation_response']
+      | undefined;
+    /** delete single row from the table: "replies_reactions" */
+    delete_replies_reactions_by_pk?:
+      | GraphQLTypes['replies_reactions']
+      | undefined;
     /** delete data from the table: "twitter_accounts" */
     delete_twitter_accounts?:
       | GraphQLTypes['twitter_accounts_mutation_response']
@@ -23283,6 +23634,14 @@ export type ModelTypes = {
     insert_replies?: GraphQLTypes['replies_mutation_response'] | undefined;
     /** insert a single row into the table: "replies" */
     insert_replies_one?: GraphQLTypes['replies'] | undefined;
+    /** insert data into the table: "replies_reactions" */
+    insert_replies_reactions?:
+      | GraphQLTypes['replies_reactions_mutation_response']
+      | undefined;
+    /** insert a single row into the table: "replies_reactions" */
+    insert_replies_reactions_one?:
+      | GraphQLTypes['replies_reactions']
+      | undefined;
     /** insert data into the table: "skills" */
     insert_skills?: GraphQLTypes['skills_mutation_response'] | undefined;
     /** insert a single row into the table: "skills" */
@@ -24970,6 +25329,12 @@ export type ModelTypes = {
     replies_aggregate: GraphQLTypes['replies_aggregate'];
     /** fetch data from the table: "replies" using primary key columns */
     replies_by_pk?: GraphQLTypes['replies'] | undefined;
+    /** fetch data from the table: "replies_reactions" */
+    replies_reactions: Array<GraphQLTypes['replies_reactions']>;
+    /** fetch aggregated fields from the table: "replies_reactions" */
+    replies_reactions_aggregate: GraphQLTypes['replies_reactions_aggregate'];
+    /** fetch data from the table: "replies_reactions" using primary key columns */
+    replies_reactions_by_pk?: GraphQLTypes['replies_reactions'] | undefined;
     /** fetch data from the table: "reputation_scores" */
     reputation_scores: Array<GraphQLTypes['reputation_scores']>;
     /** fetch data from the table: "reputation_scores" using primary key columns */
@@ -25278,12 +25643,143 @@ export type ModelTypes = {
     /** data from the rows affected by the mutation */
     returning: Array<GraphQLTypes['replies']>;
   };
+  /** input type for inserting object relation for remote table "replies" */
+  ['replies_obj_rel_insert_input']: GraphQLTypes['replies_obj_rel_insert_input'];
   /** on_conflict condition type for table "replies" */
   ['replies_on_conflict']: GraphQLTypes['replies_on_conflict'];
   /** Ordering options when selecting data from "replies". */
   ['replies_order_by']: GraphQLTypes['replies_order_by'];
   /** primary key columns input for table: replies */
   ['replies_pk_columns_input']: GraphQLTypes['replies_pk_columns_input'];
+  /** columns and relationships of "replies_reactions" */
+  ['replies_reactions']: {
+    created_at: GraphQLTypes['timestamptz'];
+    id: GraphQLTypes['bigint'];
+    /** An object relationship */
+    profile?: GraphQLTypes['profiles'] | undefined;
+    profile_id: number;
+    /** An object relationship */
+    profile_public?: GraphQLTypes['profiles_public'] | undefined;
+    reaction: string;
+    /** An object relationship */
+    reply?: GraphQLTypes['replies'] | undefined;
+    reply_id: number;
+    updated_at: GraphQLTypes['timestamptz'];
+  };
+  /** aggregated selection of "replies_reactions" */
+  ['replies_reactions_aggregate']: {
+    aggregate?: GraphQLTypes['replies_reactions_aggregate_fields'] | undefined;
+    nodes: Array<GraphQLTypes['replies_reactions']>;
+  };
+  /** aggregate fields of "replies_reactions" */
+  ['replies_reactions_aggregate_fields']: {
+    avg?: GraphQLTypes['replies_reactions_avg_fields'] | undefined;
+    count: number;
+    max?: GraphQLTypes['replies_reactions_max_fields'] | undefined;
+    min?: GraphQLTypes['replies_reactions_min_fields'] | undefined;
+    stddev?: GraphQLTypes['replies_reactions_stddev_fields'] | undefined;
+    stddev_pop?:
+      | GraphQLTypes['replies_reactions_stddev_pop_fields']
+      | undefined;
+    stddev_samp?:
+      | GraphQLTypes['replies_reactions_stddev_samp_fields']
+      | undefined;
+    sum?: GraphQLTypes['replies_reactions_sum_fields'] | undefined;
+    var_pop?: GraphQLTypes['replies_reactions_var_pop_fields'] | undefined;
+    var_samp?: GraphQLTypes['replies_reactions_var_samp_fields'] | undefined;
+    variance?: GraphQLTypes['replies_reactions_variance_fields'] | undefined;
+  };
+  /** aggregate avg on columns */
+  ['replies_reactions_avg_fields']: {
+    id?: number | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
+  };
+  /** Boolean expression to filter rows from the table "replies_reactions". All fields are combined with a logical 'AND'. */
+  ['replies_reactions_bool_exp']: GraphQLTypes['replies_reactions_bool_exp'];
+  /** unique or primary key constraints on table "replies_reactions" */
+  ['replies_reactions_constraint']: GraphQLTypes['replies_reactions_constraint'];
+  /** input type for inserting data into table "replies_reactions" */
+  ['replies_reactions_insert_input']: GraphQLTypes['replies_reactions_insert_input'];
+  /** aggregate max on columns */
+  ['replies_reactions_max_fields']: {
+    created_at?: GraphQLTypes['timestamptz'] | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    profile_id?: number | undefined;
+    reaction?: string | undefined;
+    reply_id?: number | undefined;
+    updated_at?: GraphQLTypes['timestamptz'] | undefined;
+  };
+  /** aggregate min on columns */
+  ['replies_reactions_min_fields']: {
+    created_at?: GraphQLTypes['timestamptz'] | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    profile_id?: number | undefined;
+    reaction?: string | undefined;
+    reply_id?: number | undefined;
+    updated_at?: GraphQLTypes['timestamptz'] | undefined;
+  };
+  /** response of any mutation on the table "replies_reactions" */
+  ['replies_reactions_mutation_response']: {
+    /** number of rows affected by the mutation */
+    affected_rows: number;
+    /** data from the rows affected by the mutation */
+    returning: Array<GraphQLTypes['replies_reactions']>;
+  };
+  /** on_conflict condition type for table "replies_reactions" */
+  ['replies_reactions_on_conflict']: GraphQLTypes['replies_reactions_on_conflict'];
+  /** Ordering options when selecting data from "replies_reactions". */
+  ['replies_reactions_order_by']: GraphQLTypes['replies_reactions_order_by'];
+  /** select columns of table "replies_reactions" */
+  ['replies_reactions_select_column']: GraphQLTypes['replies_reactions_select_column'];
+  /** aggregate stddev on columns */
+  ['replies_reactions_stddev_fields']: {
+    id?: number | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
+  };
+  /** aggregate stddev_pop on columns */
+  ['replies_reactions_stddev_pop_fields']: {
+    id?: number | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
+  };
+  /** aggregate stddev_samp on columns */
+  ['replies_reactions_stddev_samp_fields']: {
+    id?: number | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
+  };
+  /** Streaming cursor of the table "replies_reactions" */
+  ['replies_reactions_stream_cursor_input']: GraphQLTypes['replies_reactions_stream_cursor_input'];
+  /** Initial value of the column from where the streaming should start */
+  ['replies_reactions_stream_cursor_value_input']: GraphQLTypes['replies_reactions_stream_cursor_value_input'];
+  /** aggregate sum on columns */
+  ['replies_reactions_sum_fields']: {
+    id?: GraphQLTypes['bigint'] | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
+  };
+  /** placeholder for update columns of table "replies_reactions" (current role has no relevant permissions) */
+  ['replies_reactions_update_column']: GraphQLTypes['replies_reactions_update_column'];
+  /** aggregate var_pop on columns */
+  ['replies_reactions_var_pop_fields']: {
+    id?: number | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
+  };
+  /** aggregate var_samp on columns */
+  ['replies_reactions_var_samp_fields']: {
+    id?: number | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
+  };
+  /** aggregate variance on columns */
+  ['replies_reactions_variance_fields']: {
+    id?: number | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
+  };
   /** select columns of table "replies" */
   ['replies_select_column']: GraphQLTypes['replies_select_column'];
   /** input type for updating data in table "replies" */
@@ -25758,6 +26254,14 @@ export type ModelTypes = {
     replies_aggregate: GraphQLTypes['replies_aggregate'];
     /** fetch data from the table: "replies" using primary key columns */
     replies_by_pk?: GraphQLTypes['replies'] | undefined;
+    /** fetch data from the table: "replies_reactions" */
+    replies_reactions: Array<GraphQLTypes['replies_reactions']>;
+    /** fetch aggregated fields from the table: "replies_reactions" */
+    replies_reactions_aggregate: GraphQLTypes['replies_reactions_aggregate'];
+    /** fetch data from the table: "replies_reactions" using primary key columns */
+    replies_reactions_by_pk?: GraphQLTypes['replies_reactions'] | undefined;
+    /** fetch data from the table in a streaming manner: "replies_reactions" */
+    replies_reactions_stream: Array<GraphQLTypes['replies_reactions']>;
     /** fetch data from the table in a streaming manner: "replies" */
     replies_stream: Array<GraphQLTypes['replies']>;
     /** fetch data from the table: "reputation_scores" */
@@ -32593,6 +33097,14 @@ export type GraphQLTypes = {
     delete_reactions?: GraphQLTypes['reactions_mutation_response'] | undefined;
     /** delete single row from the table: "reactions" */
     delete_reactions_by_pk?: GraphQLTypes['reactions'] | undefined;
+    /** delete data from the table: "replies_reactions" */
+    delete_replies_reactions?:
+      | GraphQLTypes['replies_reactions_mutation_response']
+      | undefined;
+    /** delete single row from the table: "replies_reactions" */
+    delete_replies_reactions_by_pk?:
+      | GraphQLTypes['replies_reactions']
+      | undefined;
     /** delete data from the table: "twitter_accounts" */
     delete_twitter_accounts?:
       | GraphQLTypes['twitter_accounts_mutation_response']
@@ -32693,6 +33205,14 @@ export type GraphQLTypes = {
     insert_replies?: GraphQLTypes['replies_mutation_response'] | undefined;
     /** insert a single row into the table: "replies" */
     insert_replies_one?: GraphQLTypes['replies'] | undefined;
+    /** insert data into the table: "replies_reactions" */
+    insert_replies_reactions?:
+      | GraphQLTypes['replies_reactions_mutation_response']
+      | undefined;
+    /** insert a single row into the table: "replies_reactions" */
+    insert_replies_reactions_one?:
+      | GraphQLTypes['replies_reactions']
+      | undefined;
     /** insert data into the table: "skills" */
     insert_skills?: GraphQLTypes['skills_mutation_response'] | undefined;
     /** insert a single row into the table: "skills" */
@@ -35941,6 +36461,12 @@ export type GraphQLTypes = {
     replies_aggregate: GraphQLTypes['replies_aggregate'];
     /** fetch data from the table: "replies" using primary key columns */
     replies_by_pk?: GraphQLTypes['replies'] | undefined;
+    /** fetch data from the table: "replies_reactions" */
+    replies_reactions: Array<GraphQLTypes['replies_reactions']>;
+    /** fetch aggregated fields from the table: "replies_reactions" */
+    replies_reactions_aggregate: GraphQLTypes['replies_reactions_aggregate'];
+    /** fetch data from the table: "replies_reactions" using primary key columns */
+    replies_reactions_by_pk?: GraphQLTypes['replies_reactions'] | undefined;
     /** fetch data from the table: "reputation_scores" */
     reputation_scores: Array<GraphQLTypes['reputation_scores']>;
     /** fetch data from the table: "reputation_scores" using primary key columns */
@@ -36441,6 +36967,12 @@ export type GraphQLTypes = {
     /** data from the rows affected by the mutation */
     returning: Array<GraphQLTypes['replies']>;
   };
+  /** input type for inserting object relation for remote table "replies" */
+  ['replies_obj_rel_insert_input']: {
+    data: GraphQLTypes['replies_insert_input'];
+    /** upsert condition */
+    on_conflict?: GraphQLTypes['replies_on_conflict'] | undefined;
+  };
   /** on_conflict condition type for table "replies" */
   ['replies_on_conflict']: {
     constraint: GraphQLTypes['replies_constraint'];
@@ -36467,6 +36999,192 @@ export type GraphQLTypes = {
   /** primary key columns input for table: replies */
   ['replies_pk_columns_input']: {
     id: GraphQLTypes['bigint'];
+  };
+  /** columns and relationships of "replies_reactions" */
+  ['replies_reactions']: {
+    __typename: 'replies_reactions';
+    created_at: GraphQLTypes['timestamptz'];
+    id: GraphQLTypes['bigint'];
+    /** An object relationship */
+    profile?: GraphQLTypes['profiles'] | undefined;
+    profile_id: number;
+    /** An object relationship */
+    profile_public?: GraphQLTypes['profiles_public'] | undefined;
+    reaction: string;
+    /** An object relationship */
+    reply?: GraphQLTypes['replies'] | undefined;
+    reply_id: number;
+    updated_at: GraphQLTypes['timestamptz'];
+  };
+  /** aggregated selection of "replies_reactions" */
+  ['replies_reactions_aggregate']: {
+    __typename: 'replies_reactions_aggregate';
+    aggregate?: GraphQLTypes['replies_reactions_aggregate_fields'] | undefined;
+    nodes: Array<GraphQLTypes['replies_reactions']>;
+  };
+  /** aggregate fields of "replies_reactions" */
+  ['replies_reactions_aggregate_fields']: {
+    __typename: 'replies_reactions_aggregate_fields';
+    avg?: GraphQLTypes['replies_reactions_avg_fields'] | undefined;
+    count: number;
+    max?: GraphQLTypes['replies_reactions_max_fields'] | undefined;
+    min?: GraphQLTypes['replies_reactions_min_fields'] | undefined;
+    stddev?: GraphQLTypes['replies_reactions_stddev_fields'] | undefined;
+    stddev_pop?:
+      | GraphQLTypes['replies_reactions_stddev_pop_fields']
+      | undefined;
+    stddev_samp?:
+      | GraphQLTypes['replies_reactions_stddev_samp_fields']
+      | undefined;
+    sum?: GraphQLTypes['replies_reactions_sum_fields'] | undefined;
+    var_pop?: GraphQLTypes['replies_reactions_var_pop_fields'] | undefined;
+    var_samp?: GraphQLTypes['replies_reactions_var_samp_fields'] | undefined;
+    variance?: GraphQLTypes['replies_reactions_variance_fields'] | undefined;
+  };
+  /** aggregate avg on columns */
+  ['replies_reactions_avg_fields']: {
+    __typename: 'replies_reactions_avg_fields';
+    id?: number | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
+  };
+  /** Boolean expression to filter rows from the table "replies_reactions". All fields are combined with a logical 'AND'. */
+  ['replies_reactions_bool_exp']: {
+    _and?: Array<GraphQLTypes['replies_reactions_bool_exp']> | undefined;
+    _not?: GraphQLTypes['replies_reactions_bool_exp'] | undefined;
+    _or?: Array<GraphQLTypes['replies_reactions_bool_exp']> | undefined;
+    created_at?: GraphQLTypes['timestamptz_comparison_exp'] | undefined;
+    id?: GraphQLTypes['bigint_comparison_exp'] | undefined;
+    profile?: GraphQLTypes['profiles_bool_exp'] | undefined;
+    profile_id?: GraphQLTypes['Int_comparison_exp'] | undefined;
+    profile_public?: GraphQLTypes['profiles_public_bool_exp'] | undefined;
+    reaction?: GraphQLTypes['String_comparison_exp'] | undefined;
+    reply?: GraphQLTypes['replies_bool_exp'] | undefined;
+    reply_id?: GraphQLTypes['Int_comparison_exp'] | undefined;
+    updated_at?: GraphQLTypes['timestamptz_comparison_exp'] | undefined;
+  };
+  /** unique or primary key constraints on table "replies_reactions" */
+  ['replies_reactions_constraint']: replies_reactions_constraint;
+  /** input type for inserting data into table "replies_reactions" */
+  ['replies_reactions_insert_input']: {
+    reaction?: string | undefined;
+    reply?: GraphQLTypes['replies_obj_rel_insert_input'] | undefined;
+    reply_id?: number | undefined;
+  };
+  /** aggregate max on columns */
+  ['replies_reactions_max_fields']: {
+    __typename: 'replies_reactions_max_fields';
+    created_at?: GraphQLTypes['timestamptz'] | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    profile_id?: number | undefined;
+    reaction?: string | undefined;
+    reply_id?: number | undefined;
+    updated_at?: GraphQLTypes['timestamptz'] | undefined;
+  };
+  /** aggregate min on columns */
+  ['replies_reactions_min_fields']: {
+    __typename: 'replies_reactions_min_fields';
+    created_at?: GraphQLTypes['timestamptz'] | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    profile_id?: number | undefined;
+    reaction?: string | undefined;
+    reply_id?: number | undefined;
+    updated_at?: GraphQLTypes['timestamptz'] | undefined;
+  };
+  /** response of any mutation on the table "replies_reactions" */
+  ['replies_reactions_mutation_response']: {
+    __typename: 'replies_reactions_mutation_response';
+    /** number of rows affected by the mutation */
+    affected_rows: number;
+    /** data from the rows affected by the mutation */
+    returning: Array<GraphQLTypes['replies_reactions']>;
+  };
+  /** on_conflict condition type for table "replies_reactions" */
+  ['replies_reactions_on_conflict']: {
+    constraint: GraphQLTypes['replies_reactions_constraint'];
+    update_columns: Array<GraphQLTypes['replies_reactions_update_column']>;
+    where?: GraphQLTypes['replies_reactions_bool_exp'] | undefined;
+  };
+  /** Ordering options when selecting data from "replies_reactions". */
+  ['replies_reactions_order_by']: {
+    created_at?: GraphQLTypes['order_by'] | undefined;
+    id?: GraphQLTypes['order_by'] | undefined;
+    profile?: GraphQLTypes['profiles_order_by'] | undefined;
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+    profile_public?: GraphQLTypes['profiles_public_order_by'] | undefined;
+    reaction?: GraphQLTypes['order_by'] | undefined;
+    reply?: GraphQLTypes['replies_order_by'] | undefined;
+    reply_id?: GraphQLTypes['order_by'] | undefined;
+    updated_at?: GraphQLTypes['order_by'] | undefined;
+  };
+  /** select columns of table "replies_reactions" */
+  ['replies_reactions_select_column']: replies_reactions_select_column;
+  /** aggregate stddev on columns */
+  ['replies_reactions_stddev_fields']: {
+    __typename: 'replies_reactions_stddev_fields';
+    id?: number | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
+  };
+  /** aggregate stddev_pop on columns */
+  ['replies_reactions_stddev_pop_fields']: {
+    __typename: 'replies_reactions_stddev_pop_fields';
+    id?: number | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
+  };
+  /** aggregate stddev_samp on columns */
+  ['replies_reactions_stddev_samp_fields']: {
+    __typename: 'replies_reactions_stddev_samp_fields';
+    id?: number | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
+  };
+  /** Streaming cursor of the table "replies_reactions" */
+  ['replies_reactions_stream_cursor_input']: {
+    /** Stream column input with initial value */
+    initial_value: GraphQLTypes['replies_reactions_stream_cursor_value_input'];
+    /** cursor ordering */
+    ordering?: GraphQLTypes['cursor_ordering'] | undefined;
+  };
+  /** Initial value of the column from where the streaming should start */
+  ['replies_reactions_stream_cursor_value_input']: {
+    created_at?: GraphQLTypes['timestamptz'] | undefined;
+    id?: GraphQLTypes['bigint'] | undefined;
+    profile_id?: number | undefined;
+    reaction?: string | undefined;
+    reply_id?: number | undefined;
+    updated_at?: GraphQLTypes['timestamptz'] | undefined;
+  };
+  /** aggregate sum on columns */
+  ['replies_reactions_sum_fields']: {
+    __typename: 'replies_reactions_sum_fields';
+    id?: GraphQLTypes['bigint'] | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
+  };
+  /** placeholder for update columns of table "replies_reactions" (current role has no relevant permissions) */
+  ['replies_reactions_update_column']: replies_reactions_update_column;
+  /** aggregate var_pop on columns */
+  ['replies_reactions_var_pop_fields']: {
+    __typename: 'replies_reactions_var_pop_fields';
+    id?: number | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
+  };
+  /** aggregate var_samp on columns */
+  ['replies_reactions_var_samp_fields']: {
+    __typename: 'replies_reactions_var_samp_fields';
+    id?: number | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
+  };
+  /** aggregate variance on columns */
+  ['replies_reactions_variance_fields']: {
+    __typename: 'replies_reactions_variance_fields';
+    id?: number | undefined;
+    profile_id?: number | undefined;
+    reply_id?: number | undefined;
   };
   /** select columns of table "replies" */
   ['replies_select_column']: replies_select_column;
@@ -37105,6 +37823,14 @@ export type GraphQLTypes = {
     replies_aggregate: GraphQLTypes['replies_aggregate'];
     /** fetch data from the table: "replies" using primary key columns */
     replies_by_pk?: GraphQLTypes['replies'] | undefined;
+    /** fetch data from the table: "replies_reactions" */
+    replies_reactions: Array<GraphQLTypes['replies_reactions']>;
+    /** fetch aggregated fields from the table: "replies_reactions" */
+    replies_reactions_aggregate: GraphQLTypes['replies_reactions_aggregate'];
+    /** fetch data from the table: "replies_reactions" using primary key columns */
+    replies_reactions_by_pk?: GraphQLTypes['replies_reactions'] | undefined;
+    /** fetch data from the table in a streaming manner: "replies_reactions" */
+    replies_reactions_stream: Array<GraphQLTypes['replies_reactions']>;
     /** fetch data from the table in a streaming manner: "replies" */
     replies_stream: Array<GraphQLTypes['replies']>;
     /** fetch data from the table: "reputation_scores" */
@@ -39493,6 +40219,24 @@ export const enum reactions_update_column {
 /** unique or primary key constraints on table "replies" */
 export const enum replies_constraint {
   replies_pkey = 'replies_pkey',
+}
+/** unique or primary key constraints on table "replies_reactions" */
+export const enum replies_reactions_constraint {
+  replies_reactions_pkey = 'replies_reactions_pkey',
+  replies_reactions_profile_id_reply_id_reaction_key = 'replies_reactions_profile_id_reply_id_reaction_key',
+}
+/** select columns of table "replies_reactions" */
+export const enum replies_reactions_select_column {
+  created_at = 'created_at',
+  id = 'id',
+  profile_id = 'profile_id',
+  reaction = 'reaction',
+  reply_id = 'reply_id',
+  updated_at = 'updated_at',
+}
+/** placeholder for update columns of table "replies_reactions" (current role has no relevant permissions) */
+export const enum replies_reactions_update_column {
+  _PLACEHOLDER = '_PLACEHOLDER',
 }
 /** select columns of table "replies" */
 export const enum replies_select_column {

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -9651,6 +9651,9 @@ export type ValueTypes = {
     /** An object relationship */
     reply?: ValueTypes['replies'];
     reply_id?: boolean | `@${string}`;
+    /** An object relationship */
+    reply_reaction?: ValueTypes['replies_reactions'];
+    reply_reaction_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregated selection of "notifications" */
@@ -9692,6 +9695,7 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     reaction_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
+    reply_reaction_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** Boolean expression to filter rows from the table "notifications". All fields are combined with a logical 'AND'. */
@@ -9723,6 +9727,11 @@ export type ValueTypes = {
     reaction_id?: ValueTypes['bigint_comparison_exp'] | undefined | null;
     reply?: ValueTypes['replies_bool_exp'] | undefined | null;
     reply_id?: ValueTypes['Int_comparison_exp'] | undefined | null;
+    reply_reaction?:
+      | ValueTypes['replies_reactions_bool_exp']
+      | undefined
+      | null;
+    reply_reaction_id?: ValueTypes['bigint_comparison_exp'] | undefined | null;
   };
   /** aggregate max on columns */
   ['notifications_max_fields']: AliasType<{
@@ -9735,6 +9744,7 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     reaction_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
+    reply_reaction_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregate min on columns */
@@ -9748,6 +9758,7 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     reaction_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
+    reply_reaction_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** Ordering options when selecting data from "notifications". */
@@ -9776,6 +9787,11 @@ export type ValueTypes = {
     reaction_id?: ValueTypes['order_by'] | undefined | null;
     reply?: ValueTypes['replies_order_by'] | undefined | null;
     reply_id?: ValueTypes['order_by'] | undefined | null;
+    reply_reaction?:
+      | ValueTypes['replies_reactions_order_by']
+      | undefined
+      | null;
+    reply_reaction_id?: ValueTypes['order_by'] | undefined | null;
   };
   /** select columns of table "notifications" */
   ['notifications_select_column']: notifications_select_column;
@@ -9788,6 +9804,7 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     reaction_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
+    reply_reaction_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregate stddev_pop on columns */
@@ -9799,6 +9816,7 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     reaction_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
+    reply_reaction_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregate stddev_samp on columns */
@@ -9810,6 +9828,7 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     reaction_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
+    reply_reaction_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** Streaming cursor of the table "notifications" */
@@ -9830,6 +9849,7 @@ export type ValueTypes = {
     profile_id?: ValueTypes['bigint'] | undefined | null;
     reaction_id?: ValueTypes['bigint'] | undefined | null;
     reply_id?: number | undefined | null;
+    reply_reaction_id?: ValueTypes['bigint'] | undefined | null;
   };
   /** aggregate sum on columns */
   ['notifications_sum_fields']: AliasType<{
@@ -9840,6 +9860,7 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     reaction_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
+    reply_reaction_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregate var_pop on columns */
@@ -9851,6 +9872,7 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     reaction_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
+    reply_reaction_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregate var_samp on columns */
@@ -9862,6 +9884,7 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     reaction_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
+    reply_reaction_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   /** aggregate variance on columns */
@@ -9873,6 +9896,7 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     reaction_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
+    reply_reaction_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
   ['numeric']: unknown;
@@ -15426,6 +15450,9 @@ export type ValueTypes = {
   };
   /** columns and relationships of "replies_reactions" */
   ['replies_reactions']: AliasType<{
+    /** An object relationship */
+    activity?: ValueTypes['activities'];
+    activity_id?: boolean | `@${string}`;
     created_at?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
     /** An object relationship */
@@ -15525,6 +15552,7 @@ export type ValueTypes = {
   };
   /** aggregate avg on columns */
   ['replies_reactions_avg_fields']: AliasType<{
+    activity_id?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
     profile_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
@@ -15532,6 +15560,7 @@ export type ValueTypes = {
   }>;
   /** order by avg() on columns of table "replies_reactions" */
   ['replies_reactions_avg_order_by']: {
+    activity_id?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
     profile_id?: ValueTypes['order_by'] | undefined | null;
     reply_id?: ValueTypes['order_by'] | undefined | null;
@@ -15541,6 +15570,8 @@ export type ValueTypes = {
     _and?: Array<ValueTypes['replies_reactions_bool_exp']> | undefined | null;
     _not?: ValueTypes['replies_reactions_bool_exp'] | undefined | null;
     _or?: Array<ValueTypes['replies_reactions_bool_exp']> | undefined | null;
+    activity?: ValueTypes['activities_bool_exp'] | undefined | null;
+    activity_id?: ValueTypes['Int_comparison_exp'] | undefined | null;
     created_at?: ValueTypes['timestamptz_comparison_exp'] | undefined | null;
     id?: ValueTypes['bigint_comparison_exp'] | undefined | null;
     profile?: ValueTypes['profiles_bool_exp'] | undefined | null;
@@ -15555,12 +15586,14 @@ export type ValueTypes = {
   ['replies_reactions_constraint']: replies_reactions_constraint;
   /** input type for inserting data into table "replies_reactions" */
   ['replies_reactions_insert_input']: {
+    activity_id?: number | undefined | null;
     reaction?: string | undefined | null;
     reply?: ValueTypes['replies_obj_rel_insert_input'] | undefined | null;
     reply_id?: number | undefined | null;
   };
   /** aggregate max on columns */
   ['replies_reactions_max_fields']: AliasType<{
+    activity_id?: boolean | `@${string}`;
     created_at?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
     profile_id?: boolean | `@${string}`;
@@ -15571,6 +15604,7 @@ export type ValueTypes = {
   }>;
   /** order by max() on columns of table "replies_reactions" */
   ['replies_reactions_max_order_by']: {
+    activity_id?: ValueTypes['order_by'] | undefined | null;
     created_at?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
     profile_id?: ValueTypes['order_by'] | undefined | null;
@@ -15580,6 +15614,7 @@ export type ValueTypes = {
   };
   /** aggregate min on columns */
   ['replies_reactions_min_fields']: AliasType<{
+    activity_id?: boolean | `@${string}`;
     created_at?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
     profile_id?: boolean | `@${string}`;
@@ -15590,6 +15625,7 @@ export type ValueTypes = {
   }>;
   /** order by min() on columns of table "replies_reactions" */
   ['replies_reactions_min_order_by']: {
+    activity_id?: ValueTypes['order_by'] | undefined | null;
     created_at?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
     profile_id?: ValueTypes['order_by'] | undefined | null;
@@ -15613,6 +15649,8 @@ export type ValueTypes = {
   };
   /** Ordering options when selecting data from "replies_reactions". */
   ['replies_reactions_order_by']: {
+    activity?: ValueTypes['activities_order_by'] | undefined | null;
+    activity_id?: ValueTypes['order_by'] | undefined | null;
     created_at?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
     profile?: ValueTypes['profiles_order_by'] | undefined | null;
@@ -15627,6 +15665,7 @@ export type ValueTypes = {
   ['replies_reactions_select_column']: replies_reactions_select_column;
   /** aggregate stddev on columns */
   ['replies_reactions_stddev_fields']: AliasType<{
+    activity_id?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
     profile_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
@@ -15634,12 +15673,14 @@ export type ValueTypes = {
   }>;
   /** order by stddev() on columns of table "replies_reactions" */
   ['replies_reactions_stddev_order_by']: {
+    activity_id?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
     profile_id?: ValueTypes['order_by'] | undefined | null;
     reply_id?: ValueTypes['order_by'] | undefined | null;
   };
   /** aggregate stddev_pop on columns */
   ['replies_reactions_stddev_pop_fields']: AliasType<{
+    activity_id?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
     profile_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
@@ -15647,12 +15688,14 @@ export type ValueTypes = {
   }>;
   /** order by stddev_pop() on columns of table "replies_reactions" */
   ['replies_reactions_stddev_pop_order_by']: {
+    activity_id?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
     profile_id?: ValueTypes['order_by'] | undefined | null;
     reply_id?: ValueTypes['order_by'] | undefined | null;
   };
   /** aggregate stddev_samp on columns */
   ['replies_reactions_stddev_samp_fields']: AliasType<{
+    activity_id?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
     profile_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
@@ -15660,6 +15703,7 @@ export type ValueTypes = {
   }>;
   /** order by stddev_samp() on columns of table "replies_reactions" */
   ['replies_reactions_stddev_samp_order_by']: {
+    activity_id?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
     profile_id?: ValueTypes['order_by'] | undefined | null;
     reply_id?: ValueTypes['order_by'] | undefined | null;
@@ -15673,6 +15717,7 @@ export type ValueTypes = {
   };
   /** Initial value of the column from where the streaming should start */
   ['replies_reactions_stream_cursor_value_input']: {
+    activity_id?: number | undefined | null;
     created_at?: ValueTypes['timestamptz'] | undefined | null;
     id?: ValueTypes['bigint'] | undefined | null;
     profile_id?: number | undefined | null;
@@ -15682,6 +15727,7 @@ export type ValueTypes = {
   };
   /** aggregate sum on columns */
   ['replies_reactions_sum_fields']: AliasType<{
+    activity_id?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
     profile_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
@@ -15689,6 +15735,7 @@ export type ValueTypes = {
   }>;
   /** order by sum() on columns of table "replies_reactions" */
   ['replies_reactions_sum_order_by']: {
+    activity_id?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
     profile_id?: ValueTypes['order_by'] | undefined | null;
     reply_id?: ValueTypes['order_by'] | undefined | null;
@@ -15697,6 +15744,7 @@ export type ValueTypes = {
   ['replies_reactions_update_column']: replies_reactions_update_column;
   /** aggregate var_pop on columns */
   ['replies_reactions_var_pop_fields']: AliasType<{
+    activity_id?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
     profile_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
@@ -15704,12 +15752,14 @@ export type ValueTypes = {
   }>;
   /** order by var_pop() on columns of table "replies_reactions" */
   ['replies_reactions_var_pop_order_by']: {
+    activity_id?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
     profile_id?: ValueTypes['order_by'] | undefined | null;
     reply_id?: ValueTypes['order_by'] | undefined | null;
   };
   /** aggregate var_samp on columns */
   ['replies_reactions_var_samp_fields']: AliasType<{
+    activity_id?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
     profile_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
@@ -15717,12 +15767,14 @@ export type ValueTypes = {
   }>;
   /** order by var_samp() on columns of table "replies_reactions" */
   ['replies_reactions_var_samp_order_by']: {
+    activity_id?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
     profile_id?: ValueTypes['order_by'] | undefined | null;
     reply_id?: ValueTypes['order_by'] | undefined | null;
   };
   /** aggregate variance on columns */
   ['replies_reactions_variance_fields']: AliasType<{
+    activity_id?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
     profile_id?: boolean | `@${string}`;
     reply_id?: boolean | `@${string}`;
@@ -15730,6 +15782,7 @@ export type ValueTypes = {
   }>;
   /** order by variance() on columns of table "replies_reactions" */
   ['replies_reactions_variance_order_by']: {
+    activity_id?: ValueTypes['order_by'] | undefined | null;
     id?: ValueTypes['order_by'] | undefined | null;
     profile_id?: ValueTypes['order_by'] | undefined | null;
     reply_id?: ValueTypes['order_by'] | undefined | null;
@@ -24307,6 +24360,9 @@ export type ModelTypes = {
     /** An object relationship */
     reply?: GraphQLTypes['replies'] | undefined;
     reply_id?: number | undefined;
+    /** An object relationship */
+    reply_reaction?: GraphQLTypes['replies_reactions'] | undefined;
+    reply_reaction_id?: GraphQLTypes['bigint'] | undefined;
   };
   /** aggregated selection of "notifications" */
   ['notifications_aggregate']: {
@@ -24336,6 +24392,7 @@ export type ModelTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: number | undefined;
   };
   /** Boolean expression to filter rows from the table "notifications". All fields are combined with a logical 'AND'. */
   ['notifications_bool_exp']: GraphQLTypes['notifications_bool_exp'];
@@ -24350,6 +24407,7 @@ export type ModelTypes = {
     profile_id?: GraphQLTypes['bigint'] | undefined;
     reaction_id?: GraphQLTypes['bigint'] | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: GraphQLTypes['bigint'] | undefined;
   };
   /** aggregate min on columns */
   ['notifications_min_fields']: {
@@ -24362,6 +24420,7 @@ export type ModelTypes = {
     profile_id?: GraphQLTypes['bigint'] | undefined;
     reaction_id?: GraphQLTypes['bigint'] | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: GraphQLTypes['bigint'] | undefined;
   };
   /** Ordering options when selecting data from "notifications". */
   ['notifications_order_by']: GraphQLTypes['notifications_order_by'];
@@ -24376,6 +24435,7 @@ export type ModelTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: number | undefined;
   };
   /** aggregate stddev_pop on columns */
   ['notifications_stddev_pop_fields']: {
@@ -24386,6 +24446,7 @@ export type ModelTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: number | undefined;
   };
   /** aggregate stddev_samp on columns */
   ['notifications_stddev_samp_fields']: {
@@ -24396,6 +24457,7 @@ export type ModelTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: number | undefined;
   };
   /** Streaming cursor of the table "notifications" */
   ['notifications_stream_cursor_input']: GraphQLTypes['notifications_stream_cursor_input'];
@@ -24410,6 +24472,7 @@ export type ModelTypes = {
     profile_id?: GraphQLTypes['bigint'] | undefined;
     reaction_id?: GraphQLTypes['bigint'] | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: GraphQLTypes['bigint'] | undefined;
   };
   /** aggregate var_pop on columns */
   ['notifications_var_pop_fields']: {
@@ -24420,6 +24483,7 @@ export type ModelTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: number | undefined;
   };
   /** aggregate var_samp on columns */
   ['notifications_var_samp_fields']: {
@@ -24430,6 +24494,7 @@ export type ModelTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: number | undefined;
   };
   /** aggregate variance on columns */
   ['notifications_variance_fields']: {
@@ -24440,6 +24505,7 @@ export type ModelTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: number | undefined;
   };
   ['numeric']: any;
   /** Boolean expression to compare columns of type "numeric". All fields are combined with logical 'AND'. */
@@ -25835,6 +25901,9 @@ export type ModelTypes = {
   ['replies_pk_columns_input']: GraphQLTypes['replies_pk_columns_input'];
   /** columns and relationships of "replies_reactions" */
   ['replies_reactions']: {
+    /** An object relationship */
+    activity?: GraphQLTypes['activities'] | undefined;
+    activity_id: number;
     created_at: GraphQLTypes['timestamptz'];
     id: GraphQLTypes['bigint'];
     /** An object relationship */
@@ -25879,6 +25948,7 @@ export type ModelTypes = {
   ['replies_reactions_arr_rel_insert_input']: GraphQLTypes['replies_reactions_arr_rel_insert_input'];
   /** aggregate avg on columns */
   ['replies_reactions_avg_fields']: {
+    activity_id?: number | undefined;
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
@@ -25893,6 +25963,7 @@ export type ModelTypes = {
   ['replies_reactions_insert_input']: GraphQLTypes['replies_reactions_insert_input'];
   /** aggregate max on columns */
   ['replies_reactions_max_fields']: {
+    activity_id?: number | undefined;
     created_at?: GraphQLTypes['timestamptz'] | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
     profile_id?: number | undefined;
@@ -25904,6 +25975,7 @@ export type ModelTypes = {
   ['replies_reactions_max_order_by']: GraphQLTypes['replies_reactions_max_order_by'];
   /** aggregate min on columns */
   ['replies_reactions_min_fields']: {
+    activity_id?: number | undefined;
     created_at?: GraphQLTypes['timestamptz'] | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
     profile_id?: number | undefined;
@@ -25928,6 +26000,7 @@ export type ModelTypes = {
   ['replies_reactions_select_column']: GraphQLTypes['replies_reactions_select_column'];
   /** aggregate stddev on columns */
   ['replies_reactions_stddev_fields']: {
+    activity_id?: number | undefined;
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
@@ -25936,6 +26009,7 @@ export type ModelTypes = {
   ['replies_reactions_stddev_order_by']: GraphQLTypes['replies_reactions_stddev_order_by'];
   /** aggregate stddev_pop on columns */
   ['replies_reactions_stddev_pop_fields']: {
+    activity_id?: number | undefined;
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
@@ -25944,6 +26018,7 @@ export type ModelTypes = {
   ['replies_reactions_stddev_pop_order_by']: GraphQLTypes['replies_reactions_stddev_pop_order_by'];
   /** aggregate stddev_samp on columns */
   ['replies_reactions_stddev_samp_fields']: {
+    activity_id?: number | undefined;
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
@@ -25956,6 +26031,7 @@ export type ModelTypes = {
   ['replies_reactions_stream_cursor_value_input']: GraphQLTypes['replies_reactions_stream_cursor_value_input'];
   /** aggregate sum on columns */
   ['replies_reactions_sum_fields']: {
+    activity_id?: number | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
@@ -25966,6 +26042,7 @@ export type ModelTypes = {
   ['replies_reactions_update_column']: GraphQLTypes['replies_reactions_update_column'];
   /** aggregate var_pop on columns */
   ['replies_reactions_var_pop_fields']: {
+    activity_id?: number | undefined;
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
@@ -25974,6 +26051,7 @@ export type ModelTypes = {
   ['replies_reactions_var_pop_order_by']: GraphQLTypes['replies_reactions_var_pop_order_by'];
   /** aggregate var_samp on columns */
   ['replies_reactions_var_samp_fields']: {
+    activity_id?: number | undefined;
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
@@ -25982,6 +26060,7 @@ export type ModelTypes = {
   ['replies_reactions_var_samp_order_by']: GraphQLTypes['replies_reactions_var_samp_order_by'];
   /** aggregate variance on columns */
   ['replies_reactions_variance_fields']: {
+    activity_id?: number | undefined;
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
@@ -34237,6 +34316,9 @@ export type GraphQLTypes = {
     /** An object relationship */
     reply?: GraphQLTypes['replies'] | undefined;
     reply_id?: number | undefined;
+    /** An object relationship */
+    reply_reaction?: GraphQLTypes['replies_reactions'] | undefined;
+    reply_reaction_id?: GraphQLTypes['bigint'] | undefined;
   };
   /** aggregated selection of "notifications" */
   ['notifications_aggregate']: {
@@ -34269,6 +34351,7 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: number | undefined;
   };
   /** Boolean expression to filter rows from the table "notifications". All fields are combined with a logical 'AND'. */
   ['notifications_bool_exp']: {
@@ -34295,6 +34378,8 @@ export type GraphQLTypes = {
     reaction_id?: GraphQLTypes['bigint_comparison_exp'] | undefined;
     reply?: GraphQLTypes['replies_bool_exp'] | undefined;
     reply_id?: GraphQLTypes['Int_comparison_exp'] | undefined;
+    reply_reaction?: GraphQLTypes['replies_reactions_bool_exp'] | undefined;
+    reply_reaction_id?: GraphQLTypes['bigint_comparison_exp'] | undefined;
   };
   /** aggregate max on columns */
   ['notifications_max_fields']: {
@@ -34308,6 +34393,7 @@ export type GraphQLTypes = {
     profile_id?: GraphQLTypes['bigint'] | undefined;
     reaction_id?: GraphQLTypes['bigint'] | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: GraphQLTypes['bigint'] | undefined;
   };
   /** aggregate min on columns */
   ['notifications_min_fields']: {
@@ -34321,6 +34407,7 @@ export type GraphQLTypes = {
     profile_id?: GraphQLTypes['bigint'] | undefined;
     reaction_id?: GraphQLTypes['bigint'] | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: GraphQLTypes['bigint'] | undefined;
   };
   /** Ordering options when selecting data from "notifications". */
   ['notifications_order_by']: {
@@ -34344,6 +34431,8 @@ export type GraphQLTypes = {
     reaction_id?: GraphQLTypes['order_by'] | undefined;
     reply?: GraphQLTypes['replies_order_by'] | undefined;
     reply_id?: GraphQLTypes['order_by'] | undefined;
+    reply_reaction?: GraphQLTypes['replies_reactions_order_by'] | undefined;
+    reply_reaction_id?: GraphQLTypes['order_by'] | undefined;
   };
   /** select columns of table "notifications" */
   ['notifications_select_column']: notifications_select_column;
@@ -34357,6 +34446,7 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: number | undefined;
   };
   /** aggregate stddev_pop on columns */
   ['notifications_stddev_pop_fields']: {
@@ -34368,6 +34458,7 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: number | undefined;
   };
   /** aggregate stddev_samp on columns */
   ['notifications_stddev_samp_fields']: {
@@ -34379,6 +34470,7 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: number | undefined;
   };
   /** Streaming cursor of the table "notifications" */
   ['notifications_stream_cursor_input']: {
@@ -34398,6 +34490,7 @@ export type GraphQLTypes = {
     profile_id?: GraphQLTypes['bigint'] | undefined;
     reaction_id?: GraphQLTypes['bigint'] | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: GraphQLTypes['bigint'] | undefined;
   };
   /** aggregate sum on columns */
   ['notifications_sum_fields']: {
@@ -34409,6 +34502,7 @@ export type GraphQLTypes = {
     profile_id?: GraphQLTypes['bigint'] | undefined;
     reaction_id?: GraphQLTypes['bigint'] | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: GraphQLTypes['bigint'] | undefined;
   };
   /** aggregate var_pop on columns */
   ['notifications_var_pop_fields']: {
@@ -34420,6 +34514,7 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: number | undefined;
   };
   /** aggregate var_samp on columns */
   ['notifications_var_samp_fields']: {
@@ -34431,6 +34526,7 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: number | undefined;
   };
   /** aggregate variance on columns */
   ['notifications_variance_fields']: {
@@ -34442,6 +34538,7 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     reaction_id?: number | undefined;
     reply_id?: number | undefined;
+    reply_reaction_id?: number | undefined;
   };
   ['numeric']: any;
   /** Boolean expression to compare columns of type "numeric". All fields are combined with logical 'AND'. */
@@ -37225,6 +37322,9 @@ export type GraphQLTypes = {
   /** columns and relationships of "replies_reactions" */
   ['replies_reactions']: {
     __typename: 'replies_reactions';
+    /** An object relationship */
+    activity?: GraphQLTypes['activities'] | undefined;
+    activity_id: number;
     created_at: GraphQLTypes['timestamptz'];
     id: GraphQLTypes['bigint'];
     /** An object relationship */
@@ -37303,12 +37403,14 @@ export type GraphQLTypes = {
   /** aggregate avg on columns */
   ['replies_reactions_avg_fields']: {
     __typename: 'replies_reactions_avg_fields';
+    activity_id?: number | undefined;
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
   /** order by avg() on columns of table "replies_reactions" */
   ['replies_reactions_avg_order_by']: {
+    activity_id?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
     profile_id?: GraphQLTypes['order_by'] | undefined;
     reply_id?: GraphQLTypes['order_by'] | undefined;
@@ -37318,6 +37420,8 @@ export type GraphQLTypes = {
     _and?: Array<GraphQLTypes['replies_reactions_bool_exp']> | undefined;
     _not?: GraphQLTypes['replies_reactions_bool_exp'] | undefined;
     _or?: Array<GraphQLTypes['replies_reactions_bool_exp']> | undefined;
+    activity?: GraphQLTypes['activities_bool_exp'] | undefined;
+    activity_id?: GraphQLTypes['Int_comparison_exp'] | undefined;
     created_at?: GraphQLTypes['timestamptz_comparison_exp'] | undefined;
     id?: GraphQLTypes['bigint_comparison_exp'] | undefined;
     profile?: GraphQLTypes['profiles_bool_exp'] | undefined;
@@ -37332,6 +37436,7 @@ export type GraphQLTypes = {
   ['replies_reactions_constraint']: replies_reactions_constraint;
   /** input type for inserting data into table "replies_reactions" */
   ['replies_reactions_insert_input']: {
+    activity_id?: number | undefined;
     reaction?: string | undefined;
     reply?: GraphQLTypes['replies_obj_rel_insert_input'] | undefined;
     reply_id?: number | undefined;
@@ -37339,6 +37444,7 @@ export type GraphQLTypes = {
   /** aggregate max on columns */
   ['replies_reactions_max_fields']: {
     __typename: 'replies_reactions_max_fields';
+    activity_id?: number | undefined;
     created_at?: GraphQLTypes['timestamptz'] | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
     profile_id?: number | undefined;
@@ -37348,6 +37454,7 @@ export type GraphQLTypes = {
   };
   /** order by max() on columns of table "replies_reactions" */
   ['replies_reactions_max_order_by']: {
+    activity_id?: GraphQLTypes['order_by'] | undefined;
     created_at?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
     profile_id?: GraphQLTypes['order_by'] | undefined;
@@ -37358,6 +37465,7 @@ export type GraphQLTypes = {
   /** aggregate min on columns */
   ['replies_reactions_min_fields']: {
     __typename: 'replies_reactions_min_fields';
+    activity_id?: number | undefined;
     created_at?: GraphQLTypes['timestamptz'] | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
     profile_id?: number | undefined;
@@ -37367,6 +37475,7 @@ export type GraphQLTypes = {
   };
   /** order by min() on columns of table "replies_reactions" */
   ['replies_reactions_min_order_by']: {
+    activity_id?: GraphQLTypes['order_by'] | undefined;
     created_at?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
     profile_id?: GraphQLTypes['order_by'] | undefined;
@@ -37390,6 +37499,8 @@ export type GraphQLTypes = {
   };
   /** Ordering options when selecting data from "replies_reactions". */
   ['replies_reactions_order_by']: {
+    activity?: GraphQLTypes['activities_order_by'] | undefined;
+    activity_id?: GraphQLTypes['order_by'] | undefined;
     created_at?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
     profile?: GraphQLTypes['profiles_order_by'] | undefined;
@@ -37405,12 +37516,14 @@ export type GraphQLTypes = {
   /** aggregate stddev on columns */
   ['replies_reactions_stddev_fields']: {
     __typename: 'replies_reactions_stddev_fields';
+    activity_id?: number | undefined;
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
   /** order by stddev() on columns of table "replies_reactions" */
   ['replies_reactions_stddev_order_by']: {
+    activity_id?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
     profile_id?: GraphQLTypes['order_by'] | undefined;
     reply_id?: GraphQLTypes['order_by'] | undefined;
@@ -37418,12 +37531,14 @@ export type GraphQLTypes = {
   /** aggregate stddev_pop on columns */
   ['replies_reactions_stddev_pop_fields']: {
     __typename: 'replies_reactions_stddev_pop_fields';
+    activity_id?: number | undefined;
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
   /** order by stddev_pop() on columns of table "replies_reactions" */
   ['replies_reactions_stddev_pop_order_by']: {
+    activity_id?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
     profile_id?: GraphQLTypes['order_by'] | undefined;
     reply_id?: GraphQLTypes['order_by'] | undefined;
@@ -37431,12 +37546,14 @@ export type GraphQLTypes = {
   /** aggregate stddev_samp on columns */
   ['replies_reactions_stddev_samp_fields']: {
     __typename: 'replies_reactions_stddev_samp_fields';
+    activity_id?: number | undefined;
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
   /** order by stddev_samp() on columns of table "replies_reactions" */
   ['replies_reactions_stddev_samp_order_by']: {
+    activity_id?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
     profile_id?: GraphQLTypes['order_by'] | undefined;
     reply_id?: GraphQLTypes['order_by'] | undefined;
@@ -37450,6 +37567,7 @@ export type GraphQLTypes = {
   };
   /** Initial value of the column from where the streaming should start */
   ['replies_reactions_stream_cursor_value_input']: {
+    activity_id?: number | undefined;
     created_at?: GraphQLTypes['timestamptz'] | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
     profile_id?: number | undefined;
@@ -37460,12 +37578,14 @@ export type GraphQLTypes = {
   /** aggregate sum on columns */
   ['replies_reactions_sum_fields']: {
     __typename: 'replies_reactions_sum_fields';
+    activity_id?: number | undefined;
     id?: GraphQLTypes['bigint'] | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
   /** order by sum() on columns of table "replies_reactions" */
   ['replies_reactions_sum_order_by']: {
+    activity_id?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
     profile_id?: GraphQLTypes['order_by'] | undefined;
     reply_id?: GraphQLTypes['order_by'] | undefined;
@@ -37475,12 +37595,14 @@ export type GraphQLTypes = {
   /** aggregate var_pop on columns */
   ['replies_reactions_var_pop_fields']: {
     __typename: 'replies_reactions_var_pop_fields';
+    activity_id?: number | undefined;
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
   /** order by var_pop() on columns of table "replies_reactions" */
   ['replies_reactions_var_pop_order_by']: {
+    activity_id?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
     profile_id?: GraphQLTypes['order_by'] | undefined;
     reply_id?: GraphQLTypes['order_by'] | undefined;
@@ -37488,12 +37610,14 @@ export type GraphQLTypes = {
   /** aggregate var_samp on columns */
   ['replies_reactions_var_samp_fields']: {
     __typename: 'replies_reactions_var_samp_fields';
+    activity_id?: number | undefined;
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
   /** order by var_samp() on columns of table "replies_reactions" */
   ['replies_reactions_var_samp_order_by']: {
+    activity_id?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
     profile_id?: GraphQLTypes['order_by'] | undefined;
     reply_id?: GraphQLTypes['order_by'] | undefined;
@@ -37501,12 +37625,14 @@ export type GraphQLTypes = {
   /** aggregate variance on columns */
   ['replies_reactions_variance_fields']: {
     __typename: 'replies_reactions_variance_fields';
+    activity_id?: number | undefined;
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
   /** order by variance() on columns of table "replies_reactions" */
   ['replies_reactions_variance_order_by']: {
+    activity_id?: GraphQLTypes['order_by'] | undefined;
     id?: GraphQLTypes['order_by'] | undefined;
     profile_id?: GraphQLTypes['order_by'] | undefined;
     reply_id?: GraphQLTypes['order_by'] | undefined;
@@ -40326,6 +40452,7 @@ export const enum notifications_select_column {
   profile_id = 'profile_id',
   reaction_id = 'reaction_id',
   reply_id = 'reply_id',
+  reply_reaction_id = 'reply_reaction_id',
 }
 /** column ordering options */
 export const enum order_by {
@@ -40552,6 +40679,7 @@ export const enum replies_reactions_constraint {
 }
 /** select columns of table "replies_reactions" */
 export const enum replies_reactions_select_column {
+  activity_id = 'activity_id',
   created_at = 'created_at',
   id = 'id',
   profile_id = 'profile_id',

--- a/src/lib/gql/__generated__/zeus/index.ts
+++ b/src/lib/gql/__generated__/zeus/index.ts
@@ -15179,6 +15179,52 @@ export type ValueTypes = {
     profile_id?: boolean | `@${string}`;
     /** An object relationship */
     profile_public?: ValueTypes['profiles_public'];
+    reactions?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['replies_reactions_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['replies_reactions_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ValueTypes['replies_reactions_bool_exp'] | undefined | null;
+      },
+      ValueTypes['replies_reactions'],
+    ];
+    reactions_aggregate?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes['replies_reactions_select_column']>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes['replies_reactions_order_by']>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ValueTypes['replies_reactions_bool_exp'] | undefined | null;
+      },
+      ValueTypes['replies_reactions_aggregate'],
+    ];
     reply?: boolean | `@${string}`;
     updated_at?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
@@ -15266,6 +15312,11 @@ export type ValueTypes = {
     profile?: ValueTypes['profiles_bool_exp'] | undefined | null;
     profile_id?: ValueTypes['Int_comparison_exp'] | undefined | null;
     profile_public?: ValueTypes['profiles_public_bool_exp'] | undefined | null;
+    reactions?: ValueTypes['replies_reactions_bool_exp'] | undefined | null;
+    reactions_aggregate?:
+      | ValueTypes['replies_reactions_aggregate_bool_exp']
+      | undefined
+      | null;
     reply?: ValueTypes['String_comparison_exp'] | undefined | null;
     updated_at?: ValueTypes['timestamptz_comparison_exp'] | undefined | null;
   };
@@ -15275,6 +15326,10 @@ export type ValueTypes = {
   ['replies_insert_input']: {
     activity_actor_id?: number | undefined | null;
     activity_id?: number | undefined | null;
+    reactions?:
+      | ValueTypes['replies_reactions_arr_rel_insert_input']
+      | undefined
+      | null;
     reply?: string | undefined | null;
   };
   /** aggregate max on columns */
@@ -15358,6 +15413,10 @@ export type ValueTypes = {
     profile?: ValueTypes['profiles_order_by'] | undefined | null;
     profile_id?: ValueTypes['order_by'] | undefined | null;
     profile_public?: ValueTypes['profiles_public_order_by'] | undefined | null;
+    reactions_aggregate?:
+      | ValueTypes['replies_reactions_aggregate_order_by']
+      | undefined
+      | null;
     reply?: ValueTypes['order_by'] | undefined | null;
     updated_at?: ValueTypes['order_by'] | undefined | null;
   };
@@ -15387,6 +15446,21 @@ export type ValueTypes = {
     nodes?: ValueTypes['replies_reactions'];
     __typename?: boolean | `@${string}`;
   }>;
+  ['replies_reactions_aggregate_bool_exp']: {
+    count?:
+      | ValueTypes['replies_reactions_aggregate_bool_exp_count']
+      | undefined
+      | null;
+  };
+  ['replies_reactions_aggregate_bool_exp_count']: {
+    arguments?:
+      | Array<ValueTypes['replies_reactions_select_column']>
+      | undefined
+      | null;
+    distinct?: boolean | undefined | null;
+    filter?: ValueTypes['replies_reactions_bool_exp'] | undefined | null;
+    predicate: ValueTypes['Int_comparison_exp'];
+  };
   /** aggregate fields of "replies_reactions" */
   ['replies_reactions_aggregate_fields']: AliasType<{
     avg?: ValueTypes['replies_reactions_avg_fields'];
@@ -15411,6 +15485,44 @@ export type ValueTypes = {
     variance?: ValueTypes['replies_reactions_variance_fields'];
     __typename?: boolean | `@${string}`;
   }>;
+  /** order by aggregate values of table "replies_reactions" */
+  ['replies_reactions_aggregate_order_by']: {
+    avg?: ValueTypes['replies_reactions_avg_order_by'] | undefined | null;
+    count?: ValueTypes['order_by'] | undefined | null;
+    max?: ValueTypes['replies_reactions_max_order_by'] | undefined | null;
+    min?: ValueTypes['replies_reactions_min_order_by'] | undefined | null;
+    stddev?: ValueTypes['replies_reactions_stddev_order_by'] | undefined | null;
+    stddev_pop?:
+      | ValueTypes['replies_reactions_stddev_pop_order_by']
+      | undefined
+      | null;
+    stddev_samp?:
+      | ValueTypes['replies_reactions_stddev_samp_order_by']
+      | undefined
+      | null;
+    sum?: ValueTypes['replies_reactions_sum_order_by'] | undefined | null;
+    var_pop?:
+      | ValueTypes['replies_reactions_var_pop_order_by']
+      | undefined
+      | null;
+    var_samp?:
+      | ValueTypes['replies_reactions_var_samp_order_by']
+      | undefined
+      | null;
+    variance?:
+      | ValueTypes['replies_reactions_variance_order_by']
+      | undefined
+      | null;
+  };
+  /** input type for inserting array relation for remote table "replies_reactions" */
+  ['replies_reactions_arr_rel_insert_input']: {
+    data: Array<ValueTypes['replies_reactions_insert_input']>;
+    /** upsert condition */
+    on_conflict?:
+      | ValueTypes['replies_reactions_on_conflict']
+      | undefined
+      | null;
+  };
   /** aggregate avg on columns */
   ['replies_reactions_avg_fields']: AliasType<{
     id?: boolean | `@${string}`;
@@ -15418,6 +15530,12 @@ export type ValueTypes = {
     reply_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
+  /** order by avg() on columns of table "replies_reactions" */
+  ['replies_reactions_avg_order_by']: {
+    id?: ValueTypes['order_by'] | undefined | null;
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+    reply_id?: ValueTypes['order_by'] | undefined | null;
+  };
   /** Boolean expression to filter rows from the table "replies_reactions". All fields are combined with a logical 'AND'. */
   ['replies_reactions_bool_exp']: {
     _and?: Array<ValueTypes['replies_reactions_bool_exp']> | undefined | null;
@@ -15451,6 +15569,15 @@ export type ValueTypes = {
     updated_at?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
+  /** order by max() on columns of table "replies_reactions" */
+  ['replies_reactions_max_order_by']: {
+    created_at?: ValueTypes['order_by'] | undefined | null;
+    id?: ValueTypes['order_by'] | undefined | null;
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+    reaction?: ValueTypes['order_by'] | undefined | null;
+    reply_id?: ValueTypes['order_by'] | undefined | null;
+    updated_at?: ValueTypes['order_by'] | undefined | null;
+  };
   /** aggregate min on columns */
   ['replies_reactions_min_fields']: AliasType<{
     created_at?: boolean | `@${string}`;
@@ -15461,6 +15588,15 @@ export type ValueTypes = {
     updated_at?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
+  /** order by min() on columns of table "replies_reactions" */
+  ['replies_reactions_min_order_by']: {
+    created_at?: ValueTypes['order_by'] | undefined | null;
+    id?: ValueTypes['order_by'] | undefined | null;
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+    reaction?: ValueTypes['order_by'] | undefined | null;
+    reply_id?: ValueTypes['order_by'] | undefined | null;
+    updated_at?: ValueTypes['order_by'] | undefined | null;
+  };
   /** response of any mutation on the table "replies_reactions" */
   ['replies_reactions_mutation_response']: AliasType<{
     /** number of rows affected by the mutation */
@@ -15496,6 +15632,12 @@ export type ValueTypes = {
     reply_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
+  /** order by stddev() on columns of table "replies_reactions" */
+  ['replies_reactions_stddev_order_by']: {
+    id?: ValueTypes['order_by'] | undefined | null;
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+    reply_id?: ValueTypes['order_by'] | undefined | null;
+  };
   /** aggregate stddev_pop on columns */
   ['replies_reactions_stddev_pop_fields']: AliasType<{
     id?: boolean | `@${string}`;
@@ -15503,6 +15645,12 @@ export type ValueTypes = {
     reply_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
+  /** order by stddev_pop() on columns of table "replies_reactions" */
+  ['replies_reactions_stddev_pop_order_by']: {
+    id?: ValueTypes['order_by'] | undefined | null;
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+    reply_id?: ValueTypes['order_by'] | undefined | null;
+  };
   /** aggregate stddev_samp on columns */
   ['replies_reactions_stddev_samp_fields']: AliasType<{
     id?: boolean | `@${string}`;
@@ -15510,6 +15658,12 @@ export type ValueTypes = {
     reply_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
+  /** order by stddev_samp() on columns of table "replies_reactions" */
+  ['replies_reactions_stddev_samp_order_by']: {
+    id?: ValueTypes['order_by'] | undefined | null;
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+    reply_id?: ValueTypes['order_by'] | undefined | null;
+  };
   /** Streaming cursor of the table "replies_reactions" */
   ['replies_reactions_stream_cursor_input']: {
     /** Stream column input with initial value */
@@ -15533,6 +15687,12 @@ export type ValueTypes = {
     reply_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
+  /** order by sum() on columns of table "replies_reactions" */
+  ['replies_reactions_sum_order_by']: {
+    id?: ValueTypes['order_by'] | undefined | null;
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+    reply_id?: ValueTypes['order_by'] | undefined | null;
+  };
   /** placeholder for update columns of table "replies_reactions" (current role has no relevant permissions) */
   ['replies_reactions_update_column']: replies_reactions_update_column;
   /** aggregate var_pop on columns */
@@ -15542,6 +15702,12 @@ export type ValueTypes = {
     reply_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
+  /** order by var_pop() on columns of table "replies_reactions" */
+  ['replies_reactions_var_pop_order_by']: {
+    id?: ValueTypes['order_by'] | undefined | null;
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+    reply_id?: ValueTypes['order_by'] | undefined | null;
+  };
   /** aggregate var_samp on columns */
   ['replies_reactions_var_samp_fields']: AliasType<{
     id?: boolean | `@${string}`;
@@ -15549,6 +15715,12 @@ export type ValueTypes = {
     reply_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
+  /** order by var_samp() on columns of table "replies_reactions" */
+  ['replies_reactions_var_samp_order_by']: {
+    id?: ValueTypes['order_by'] | undefined | null;
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+    reply_id?: ValueTypes['order_by'] | undefined | null;
+  };
   /** aggregate variance on columns */
   ['replies_reactions_variance_fields']: AliasType<{
     id?: boolean | `@${string}`;
@@ -15556,6 +15728,12 @@ export type ValueTypes = {
     reply_id?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
+  /** order by variance() on columns of table "replies_reactions" */
+  ['replies_reactions_variance_order_by']: {
+    id?: ValueTypes['order_by'] | undefined | null;
+    profile_id?: ValueTypes['order_by'] | undefined | null;
+    reply_id?: ValueTypes['order_by'] | undefined | null;
+  };
   /** select columns of table "replies" */
   ['replies_select_column']: replies_select_column;
   /** input type for updating data in table "replies" */
@@ -25569,6 +25747,10 @@ export type ModelTypes = {
     profile_id: number;
     /** An object relationship */
     profile_public?: GraphQLTypes['profiles_public'] | undefined;
+    /** An array relationship */
+    reactions: Array<GraphQLTypes['replies_reactions']>;
+    /** An aggregate relationship */
+    reactions_aggregate: GraphQLTypes['replies_reactions_aggregate'];
     reply: string;
     updated_at: GraphQLTypes['timestamptz'];
   };
@@ -25671,6 +25853,8 @@ export type ModelTypes = {
     aggregate?: GraphQLTypes['replies_reactions_aggregate_fields'] | undefined;
     nodes: Array<GraphQLTypes['replies_reactions']>;
   };
+  ['replies_reactions_aggregate_bool_exp']: GraphQLTypes['replies_reactions_aggregate_bool_exp'];
+  ['replies_reactions_aggregate_bool_exp_count']: GraphQLTypes['replies_reactions_aggregate_bool_exp_count'];
   /** aggregate fields of "replies_reactions" */
   ['replies_reactions_aggregate_fields']: {
     avg?: GraphQLTypes['replies_reactions_avg_fields'] | undefined;
@@ -25689,12 +25873,18 @@ export type ModelTypes = {
     var_samp?: GraphQLTypes['replies_reactions_var_samp_fields'] | undefined;
     variance?: GraphQLTypes['replies_reactions_variance_fields'] | undefined;
   };
+  /** order by aggregate values of table "replies_reactions" */
+  ['replies_reactions_aggregate_order_by']: GraphQLTypes['replies_reactions_aggregate_order_by'];
+  /** input type for inserting array relation for remote table "replies_reactions" */
+  ['replies_reactions_arr_rel_insert_input']: GraphQLTypes['replies_reactions_arr_rel_insert_input'];
   /** aggregate avg on columns */
   ['replies_reactions_avg_fields']: {
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
+  /** order by avg() on columns of table "replies_reactions" */
+  ['replies_reactions_avg_order_by']: GraphQLTypes['replies_reactions_avg_order_by'];
   /** Boolean expression to filter rows from the table "replies_reactions". All fields are combined with a logical 'AND'. */
   ['replies_reactions_bool_exp']: GraphQLTypes['replies_reactions_bool_exp'];
   /** unique or primary key constraints on table "replies_reactions" */
@@ -25710,6 +25900,8 @@ export type ModelTypes = {
     reply_id?: number | undefined;
     updated_at?: GraphQLTypes['timestamptz'] | undefined;
   };
+  /** order by max() on columns of table "replies_reactions" */
+  ['replies_reactions_max_order_by']: GraphQLTypes['replies_reactions_max_order_by'];
   /** aggregate min on columns */
   ['replies_reactions_min_fields']: {
     created_at?: GraphQLTypes['timestamptz'] | undefined;
@@ -25719,6 +25911,8 @@ export type ModelTypes = {
     reply_id?: number | undefined;
     updated_at?: GraphQLTypes['timestamptz'] | undefined;
   };
+  /** order by min() on columns of table "replies_reactions" */
+  ['replies_reactions_min_order_by']: GraphQLTypes['replies_reactions_min_order_by'];
   /** response of any mutation on the table "replies_reactions" */
   ['replies_reactions_mutation_response']: {
     /** number of rows affected by the mutation */
@@ -25738,18 +25932,24 @@ export type ModelTypes = {
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
+  /** order by stddev() on columns of table "replies_reactions" */
+  ['replies_reactions_stddev_order_by']: GraphQLTypes['replies_reactions_stddev_order_by'];
   /** aggregate stddev_pop on columns */
   ['replies_reactions_stddev_pop_fields']: {
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
+  /** order by stddev_pop() on columns of table "replies_reactions" */
+  ['replies_reactions_stddev_pop_order_by']: GraphQLTypes['replies_reactions_stddev_pop_order_by'];
   /** aggregate stddev_samp on columns */
   ['replies_reactions_stddev_samp_fields']: {
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
+  /** order by stddev_samp() on columns of table "replies_reactions" */
+  ['replies_reactions_stddev_samp_order_by']: GraphQLTypes['replies_reactions_stddev_samp_order_by'];
   /** Streaming cursor of the table "replies_reactions" */
   ['replies_reactions_stream_cursor_input']: GraphQLTypes['replies_reactions_stream_cursor_input'];
   /** Initial value of the column from where the streaming should start */
@@ -25760,6 +25960,8 @@ export type ModelTypes = {
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
+  /** order by sum() on columns of table "replies_reactions" */
+  ['replies_reactions_sum_order_by']: GraphQLTypes['replies_reactions_sum_order_by'];
   /** placeholder for update columns of table "replies_reactions" (current role has no relevant permissions) */
   ['replies_reactions_update_column']: GraphQLTypes['replies_reactions_update_column'];
   /** aggregate var_pop on columns */
@@ -25768,18 +25970,24 @@ export type ModelTypes = {
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
+  /** order by var_pop() on columns of table "replies_reactions" */
+  ['replies_reactions_var_pop_order_by']: GraphQLTypes['replies_reactions_var_pop_order_by'];
   /** aggregate var_samp on columns */
   ['replies_reactions_var_samp_fields']: {
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
+  /** order by var_samp() on columns of table "replies_reactions" */
+  ['replies_reactions_var_samp_order_by']: GraphQLTypes['replies_reactions_var_samp_order_by'];
   /** aggregate variance on columns */
   ['replies_reactions_variance_fields']: {
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
+  /** order by variance() on columns of table "replies_reactions" */
+  ['replies_reactions_variance_order_by']: GraphQLTypes['replies_reactions_variance_order_by'];
   /** select columns of table "replies" */
   ['replies_select_column']: GraphQLTypes['replies_select_column'];
   /** input type for updating data in table "replies" */
@@ -36823,6 +37031,10 @@ export type GraphQLTypes = {
     profile_id: number;
     /** An object relationship */
     profile_public?: GraphQLTypes['profiles_public'] | undefined;
+    /** An array relationship */
+    reactions: Array<GraphQLTypes['replies_reactions']>;
+    /** An aggregate relationship */
+    reactions_aggregate: GraphQLTypes['replies_reactions_aggregate'];
     reply: string;
     updated_at: GraphQLTypes['timestamptz'];
   };
@@ -36902,6 +37114,10 @@ export type GraphQLTypes = {
     profile?: GraphQLTypes['profiles_bool_exp'] | undefined;
     profile_id?: GraphQLTypes['Int_comparison_exp'] | undefined;
     profile_public?: GraphQLTypes['profiles_public_bool_exp'] | undefined;
+    reactions?: GraphQLTypes['replies_reactions_bool_exp'] | undefined;
+    reactions_aggregate?:
+      | GraphQLTypes['replies_reactions_aggregate_bool_exp']
+      | undefined;
     reply?: GraphQLTypes['String_comparison_exp'] | undefined;
     updated_at?: GraphQLTypes['timestamptz_comparison_exp'] | undefined;
   };
@@ -36911,6 +37127,9 @@ export type GraphQLTypes = {
   ['replies_insert_input']: {
     activity_actor_id?: number | undefined;
     activity_id?: number | undefined;
+    reactions?:
+      | GraphQLTypes['replies_reactions_arr_rel_insert_input']
+      | undefined;
     reply?: string | undefined;
   };
   /** aggregate max on columns */
@@ -36993,6 +37212,9 @@ export type GraphQLTypes = {
     profile?: GraphQLTypes['profiles_order_by'] | undefined;
     profile_id?: GraphQLTypes['order_by'] | undefined;
     profile_public?: GraphQLTypes['profiles_public_order_by'] | undefined;
+    reactions_aggregate?:
+      | GraphQLTypes['replies_reactions_aggregate_order_by']
+      | undefined;
     reply?: GraphQLTypes['order_by'] | undefined;
     updated_at?: GraphQLTypes['order_by'] | undefined;
   };
@@ -37022,6 +37244,19 @@ export type GraphQLTypes = {
     aggregate?: GraphQLTypes['replies_reactions_aggregate_fields'] | undefined;
     nodes: Array<GraphQLTypes['replies_reactions']>;
   };
+  ['replies_reactions_aggregate_bool_exp']: {
+    count?:
+      | GraphQLTypes['replies_reactions_aggregate_bool_exp_count']
+      | undefined;
+  };
+  ['replies_reactions_aggregate_bool_exp_count']: {
+    arguments?:
+      | Array<GraphQLTypes['replies_reactions_select_column']>
+      | undefined;
+    distinct?: boolean | undefined;
+    filter?: GraphQLTypes['replies_reactions_bool_exp'] | undefined;
+    predicate: GraphQLTypes['Int_comparison_exp'];
+  };
   /** aggregate fields of "replies_reactions" */
   ['replies_reactions_aggregate_fields']: {
     __typename: 'replies_reactions_aggregate_fields';
@@ -37041,12 +37276,42 @@ export type GraphQLTypes = {
     var_samp?: GraphQLTypes['replies_reactions_var_samp_fields'] | undefined;
     variance?: GraphQLTypes['replies_reactions_variance_fields'] | undefined;
   };
+  /** order by aggregate values of table "replies_reactions" */
+  ['replies_reactions_aggregate_order_by']: {
+    avg?: GraphQLTypes['replies_reactions_avg_order_by'] | undefined;
+    count?: GraphQLTypes['order_by'] | undefined;
+    max?: GraphQLTypes['replies_reactions_max_order_by'] | undefined;
+    min?: GraphQLTypes['replies_reactions_min_order_by'] | undefined;
+    stddev?: GraphQLTypes['replies_reactions_stddev_order_by'] | undefined;
+    stddev_pop?:
+      | GraphQLTypes['replies_reactions_stddev_pop_order_by']
+      | undefined;
+    stddev_samp?:
+      | GraphQLTypes['replies_reactions_stddev_samp_order_by']
+      | undefined;
+    sum?: GraphQLTypes['replies_reactions_sum_order_by'] | undefined;
+    var_pop?: GraphQLTypes['replies_reactions_var_pop_order_by'] | undefined;
+    var_samp?: GraphQLTypes['replies_reactions_var_samp_order_by'] | undefined;
+    variance?: GraphQLTypes['replies_reactions_variance_order_by'] | undefined;
+  };
+  /** input type for inserting array relation for remote table "replies_reactions" */
+  ['replies_reactions_arr_rel_insert_input']: {
+    data: Array<GraphQLTypes['replies_reactions_insert_input']>;
+    /** upsert condition */
+    on_conflict?: GraphQLTypes['replies_reactions_on_conflict'] | undefined;
+  };
   /** aggregate avg on columns */
   ['replies_reactions_avg_fields']: {
     __typename: 'replies_reactions_avg_fields';
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
+  };
+  /** order by avg() on columns of table "replies_reactions" */
+  ['replies_reactions_avg_order_by']: {
+    id?: GraphQLTypes['order_by'] | undefined;
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+    reply_id?: GraphQLTypes['order_by'] | undefined;
   };
   /** Boolean expression to filter rows from the table "replies_reactions". All fields are combined with a logical 'AND'. */
   ['replies_reactions_bool_exp']: {
@@ -37081,6 +37346,15 @@ export type GraphQLTypes = {
     reply_id?: number | undefined;
     updated_at?: GraphQLTypes['timestamptz'] | undefined;
   };
+  /** order by max() on columns of table "replies_reactions" */
+  ['replies_reactions_max_order_by']: {
+    created_at?: GraphQLTypes['order_by'] | undefined;
+    id?: GraphQLTypes['order_by'] | undefined;
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+    reaction?: GraphQLTypes['order_by'] | undefined;
+    reply_id?: GraphQLTypes['order_by'] | undefined;
+    updated_at?: GraphQLTypes['order_by'] | undefined;
+  };
   /** aggregate min on columns */
   ['replies_reactions_min_fields']: {
     __typename: 'replies_reactions_min_fields';
@@ -37090,6 +37364,15 @@ export type GraphQLTypes = {
     reaction?: string | undefined;
     reply_id?: number | undefined;
     updated_at?: GraphQLTypes['timestamptz'] | undefined;
+  };
+  /** order by min() on columns of table "replies_reactions" */
+  ['replies_reactions_min_order_by']: {
+    created_at?: GraphQLTypes['order_by'] | undefined;
+    id?: GraphQLTypes['order_by'] | undefined;
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+    reaction?: GraphQLTypes['order_by'] | undefined;
+    reply_id?: GraphQLTypes['order_by'] | undefined;
+    updated_at?: GraphQLTypes['order_by'] | undefined;
   };
   /** response of any mutation on the table "replies_reactions" */
   ['replies_reactions_mutation_response']: {
@@ -37126,6 +37409,12 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
+  /** order by stddev() on columns of table "replies_reactions" */
+  ['replies_reactions_stddev_order_by']: {
+    id?: GraphQLTypes['order_by'] | undefined;
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+    reply_id?: GraphQLTypes['order_by'] | undefined;
+  };
   /** aggregate stddev_pop on columns */
   ['replies_reactions_stddev_pop_fields']: {
     __typename: 'replies_reactions_stddev_pop_fields';
@@ -37133,12 +37422,24 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
+  /** order by stddev_pop() on columns of table "replies_reactions" */
+  ['replies_reactions_stddev_pop_order_by']: {
+    id?: GraphQLTypes['order_by'] | undefined;
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+    reply_id?: GraphQLTypes['order_by'] | undefined;
+  };
   /** aggregate stddev_samp on columns */
   ['replies_reactions_stddev_samp_fields']: {
     __typename: 'replies_reactions_stddev_samp_fields';
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
+  };
+  /** order by stddev_samp() on columns of table "replies_reactions" */
+  ['replies_reactions_stddev_samp_order_by']: {
+    id?: GraphQLTypes['order_by'] | undefined;
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+    reply_id?: GraphQLTypes['order_by'] | undefined;
   };
   /** Streaming cursor of the table "replies_reactions" */
   ['replies_reactions_stream_cursor_input']: {
@@ -37163,6 +37464,12 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
+  /** order by sum() on columns of table "replies_reactions" */
+  ['replies_reactions_sum_order_by']: {
+    id?: GraphQLTypes['order_by'] | undefined;
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+    reply_id?: GraphQLTypes['order_by'] | undefined;
+  };
   /** placeholder for update columns of table "replies_reactions" (current role has no relevant permissions) */
   ['replies_reactions_update_column']: replies_reactions_update_column;
   /** aggregate var_pop on columns */
@@ -37172,6 +37479,12 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
+  /** order by var_pop() on columns of table "replies_reactions" */
+  ['replies_reactions_var_pop_order_by']: {
+    id?: GraphQLTypes['order_by'] | undefined;
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+    reply_id?: GraphQLTypes['order_by'] | undefined;
+  };
   /** aggregate var_samp on columns */
   ['replies_reactions_var_samp_fields']: {
     __typename: 'replies_reactions_var_samp_fields';
@@ -37179,12 +37492,24 @@ export type GraphQLTypes = {
     profile_id?: number | undefined;
     reply_id?: number | undefined;
   };
+  /** order by var_samp() on columns of table "replies_reactions" */
+  ['replies_reactions_var_samp_order_by']: {
+    id?: GraphQLTypes['order_by'] | undefined;
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+    reply_id?: GraphQLTypes['order_by'] | undefined;
+  };
   /** aggregate variance on columns */
   ['replies_reactions_variance_fields']: {
     __typename: 'replies_reactions_variance_fields';
     id?: number | undefined;
     profile_id?: number | undefined;
     reply_id?: number | undefined;
+  };
+  /** order by variance() on columns of table "replies_reactions" */
+  ['replies_reactions_variance_order_by']: {
+    id?: GraphQLTypes['order_by'] | undefined;
+    profile_id?: GraphQLTypes['order_by'] | undefined;
+    reply_id?: GraphQLTypes['order_by'] | undefined;
   };
   /** select columns of table "replies" */
   ['replies_select_column']: replies_select_column;

--- a/src/pages/colinks/NotificationsPage.tsx
+++ b/src/pages/colinks/NotificationsPage.tsx
@@ -59,9 +59,21 @@ const fetchNotifications = async () => {
           },
           reaction: {
             reaction: true,
-            profile_id: true,
             activity_id: true,
             created_at: true,
+          },
+          reply_reaction: {
+            reaction: true,
+            activity_id: true,
+            created_at: true,
+            profile_id: true,
+            activity: {
+              actor_profile_public: {
+                id: true,
+                name: true,
+                address: true,
+              },
+            },
           },
           mention_reply: {
             id: true,
@@ -146,6 +158,7 @@ export type Reply = NonNullable<Notification['reply']>;
 export type MentionReply = NonNullable<Notification['mention_reply']>;
 export type MentionPost = NonNullable<Notification['mention_post']>;
 export type Reaction = NonNullable<Notification['reaction']>;
+export type ReplyReaction = NonNullable<Notification['reply_reaction']>;
 export type Invitee = NonNullable<Notification['invited_profile_public']>;
 export type Give = NonNullable<Notification['give']>;
 
@@ -271,6 +284,14 @@ export const NotificationsPage = () => {
                 );
             } else if (n.reaction) {
               content = <ReactionNotification reaction={n.reaction} n={n} />;
+            } else if (n.reply_reaction) {
+              content = (
+                <ReplyReactionNotification
+                  reaction={n.reply_reaction}
+                  n={n}
+                  profileId={profileId}
+                />
+              );
             }
 
             return content ? <Flex key={n.id}>{content}</Flex> : null;
@@ -553,6 +574,103 @@ export const LinkTxNotification = ({ tx }: { tx: LinkTx }) => {
             <Text size="xs" semibold color={tx.buy ? 'complete' : 'warning'}>
               {ethers.utils.formatEther(tx.eth_amount)} ETH
             </Text>
+          </Flex>
+        </Flex>
+      </Flex>
+    </NotificationItem>
+  );
+};
+
+export const ReplyReactionNotification = ({
+  reaction,
+  n,
+  profileId,
+}: {
+  reaction: ReplyReaction;
+  n: Notification;
+  profileId: number;
+}) => {
+  const navigate = useNavigate();
+  return (
+    <NotificationItem>
+      <Flex css={{ alignItems: 'center', gap: '$sm' }}>
+        <Icon
+          onClick={() => navigate(coLinksPaths.post(`${reaction.activity_id}`))}
+          pt={'-1px'}
+          css={{ cursor: 'pointer' }}
+        >
+          <Text size={'large'}>{reaction.reaction}</Text>
+        </Icon>
+        <Avatar
+          path={n.actor_profile_public?.avatar}
+          name={n.actor_profile_public?.name}
+          size="small"
+        />
+        <Flex column css={{ pl: '$xs', gap: '$xs' }}>
+          <Flex css={{ gap: '$xs', alignItems: 'flex-end', flexWrap: 'wrap' }}>
+            <Link
+              as={NavLink}
+              css={{
+                display: 'inline',
+                alignItems: 'center',
+                gap: '$xs',
+                mr: '$xs',
+              }}
+              to={coLinksPaths.profile(
+                n.actor_profile_public?.address ?? 'FIXME'
+              )}
+            >
+              <Text inline semibold size="small">
+                {n.actor_profile_public?.name}
+              </Text>
+            </Link>
+
+            <Flex
+              as={NavLink}
+              to={coLinksPaths.post(`${reaction.activity_id}`)}
+              css={{
+                alignItems: 'flex-end',
+                color: '$text',
+                textDecoration: 'none',
+              }}
+            >
+              <Text size="small" css={{ whiteSpace: 'pre' }}>
+                reacted to your reply on{' '}
+              </Text>
+              {reaction.activity?.actor_profile_public?.id === profileId ? (
+                <Text size="small">your post</Text>
+              ) : reaction.activity?.actor_profile_public?.id ===
+                reaction.profile_id ? (
+                <Text size="small">his post</Text>
+              ) : (
+                <>
+                  <Link
+                    as={NavLink}
+                    css={{
+                      display: 'inline',
+                      alignItems: 'center',
+                      gap: '$xs',
+                      mr: '$xs',
+                    }}
+                    to={coLinksPaths.profile(
+                      reaction.activity?.actor_profile_public?.address ??
+                        'FIXME'
+                    )}
+                  >
+                    <Text inline semibold size="small">
+                      {reaction.activity?.actor_profile_public?.name}
+                    </Text>
+                  </Link>
+                  <Text size="small" css={{ whiteSpace: 'pre' }}>
+                    &apos;s post
+                  </Text>
+                </>
+              )}
+
+              <Text size="xs" color="neutral" css={{ pl: '$sm' }}>
+                {DateTime.fromISO(reaction.created_at).toLocal().toRelative()}
+              </Text>
+            </Flex>
           </Flex>
         </Flex>
       </Flex>


### PR DESCRIPTION
## What

- [x] Create replies_reactions table
- [x] Add react button to replies
- [x] Create createNotificationReplyReactions to add notifications to reactions
- [x] Add notification to notification page

## Tests and screen shots
Reactions:
![image](https://github.com/coordinape/coordinape/assets/34943689/5c14f5d9-62cc-44da-97f3-3fdb67fe2c64)

![Screenshot from 2024-05-28 03-11-08](https://github.com/coordinape/coordinape/assets/34943689/cebe9da7-eb77-491d-a8a0-2b2902596776)

notifications:
![image](https://github.com/coordinape/coordinape/assets/34943689/0102fdca-900b-4276-8867-bcd4a9564937)
![Screenshot from 2024-05-28 03-50-17](https://github.com/coordinape/coordinape/assets/34943689/0d4f96e2-cff8-4e15-b01c-933f5d6c6b9f)

## permission

As long as the user can see the reply, he should be able to react.
I considered that if the reply is deleted, the user is muted, or the last key is sold "no visibility and the data is not refreshed yet, it won't create the reaction
The insert permission is as follows:
{"reply":{"_and":[{"deleted_at":{"_is_null":true}},{"_not":{"profile_public":{"mutes":{"profile_id":{"_eq":"X-Hasura-User-Id"}}}}},{"_or":[{"private_stream_visibility":{"profile_id":{"_eq":"X-Hasura-User-Id"}}},{"activity":{"big_question_id":{"_is_null":false}}}]}]}}