### PR TITLE
Cleanup and Refactor Alchemy tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,13 +60,11 @@ TEST_ON_HARDHAT_NODE=
 # used to submit contract verifications to etherscan during hardhat deploys
 #ETHERSCAN_API_KEY=your-api-key
 
-# Public FE keys for Alchemy
-VITE_ALCHEMY_OPTIMISM_SEPOLIA_API_KEY=get-a-key-from-alchemy-opt-sepolia
-VITE_ALCHEMY_OPTIMISM_API_KEY=get-a-key-from-alchemy-opt-mainnet
-VITE_ALCHEMY_ETH_MAINNET_API_KEY=get-a-key-from-alchemy-eth-mainnet
-
+# Public FE key for Alchemy
+VITE_FE_ALCHEMY_API_KEY=get-a-key-from-alchemy
 
 #Backend private keys for Alchemy
+BE_ALCHEMY_API_KEY=get-a-key-from-alchemy
 
 # HASURA_GRAPHQL auto used by hasura CLI (used with ./hasura/config.yaml)
 HASURA_GRAPHQL_ENDPOINT=http://localhost:8080

--- a/_api/hasura/actions/_handlers/syncCoSoul.ts
+++ b/_api/hasura/actions/_handlers/syncCoSoul.ts
@@ -12,10 +12,10 @@ import { adminClient } from '../../../../api-lib/gql/adminClient';
 import { insertInteractionEvents } from '../../../../api-lib/gql/mutations';
 import { getInput } from '../../../../api-lib/handlerHelpers';
 import { errorResponse } from '../../../../api-lib/HttpError';
+import { setOnChainPGive } from '../../../../api-lib/viem/contracts';
 import {
   getTokenId,
   PGIVE_SYNC_DURATION_DAYS,
-  setOnChainPGive,
 } from '../../../../src/features/cosoul/api/cosoul';
 import { getLocalPGIVE } from '../../../../src/features/cosoul/api/pgive';
 import { storeCoSoulImage } from '../../../../src/features/cosoul/art/screenshot';

--- a/_api/hasura/cron/cosoulMinter.ts
+++ b/_api/hasura/cron/cosoulMinter.ts
@@ -7,7 +7,7 @@ import { verifyHasuraRequestMiddleware } from '../../../api-lib/validate';
 import {
   getMintInfoFromReceipt,
   mintCoSoulForAddress,
-} from '../../../src/features/cosoul/api/cosoul';
+} from '../../../api-lib/viem/contracts';
 import { minted } from '../actions/_handlers/syncCoSoul';
 
 const LIMIT = 9;

--- a/_api/hasura/cron/syncCoSoulReputation.ts
+++ b/_api/hasura/cron/syncCoSoulReputation.ts
@@ -5,7 +5,7 @@ import { order_by } from '../../../api-lib/gql/__generated__/zeus';
 import { adminClient } from '../../../api-lib/gql/adminClient';
 import { errorResponseWithStatusCode } from '../../../api-lib/HttpError.ts';
 import { verifyHasuraRequestMiddleware } from '../../../api-lib/validate';
-import { setBatchOnChainRep } from '../../../src/features/cosoul/api/cosoul.ts';
+import { setBatchOnChainRep } from '../../../api-lib/viem/contracts.ts';
 
 const SYNC_BATCH_SIZE = 100;
 

--- a/_api/hasura/cron/syncCoSouls.ts
+++ b/_api/hasura/cron/syncCoSouls.ts
@@ -2,7 +2,7 @@
 import { VercelRequest, VercelResponse } from '@vercel/node';
 import { DateTime, Settings } from 'luxon';
 
-import { IS_LOCAL_ENV } from '../../../api-lib/config';
+import { BE_ALCHEMY_API_KEY, IS_LOCAL_ENV } from '../../../api-lib/config';
 import { adminClient } from '../../../api-lib/gql/adminClient';
 import { errorLog } from '../../../api-lib/HttpError';
 import { getCirclesNoPgiveWithDateFilter } from '../../../api-lib/pgives';
@@ -11,9 +11,10 @@ import { verifyHasuraRequestMiddleware } from '../../../api-lib/validate';
 import {
   getOnChainPGive,
   setOnChainPGive,
-} from '../../../src/features/cosoul/api/cosoul';
+} from '../../../api-lib/viem/contracts';
 import { getLocalPGIVE } from '../../../src/features/cosoul/api/pgive';
 import { storeCoSoulImage } from '../../../src/features/cosoul/art/screenshot';
+import { chain } from '../../../src/features/cosoul/chains';
 import { getReadOnlyClient } from '../../../src/utils/viem/publicClient';
 
 Settings.defaultZone = 'utc';
@@ -59,7 +60,9 @@ export async function syncCoSouls() {
   const ignored = [];
   for (const cosoul of cosouls) {
     const localPGIVE = await getLocalPGIVE(cosoul.address);
+
     const onChainPGIVE = await getOnChainPGive(cosoul.token_id);
+
     let success = true;
     if (localPGIVE !== Number(onChainPGIVE)) {
       // update the screenshot
@@ -171,7 +174,8 @@ const syncCoSoulToken = async (
     totalPGIVE = Math.floor(totalPGIVE);
     const txHash = await setOnChainPGive({ tokenId, amount: totalPGIVE });
 
-    const publicClient = getReadOnlyClient();
+    const chainId = Number(chain.chainId);
+    const publicClient = getReadOnlyClient(chainId, BE_ALCHEMY_API_KEY);
 
     await publicClient.getTransactionReceipt({
       hash: txHash,

--- a/api-lib/config.ts
+++ b/api-lib/config.ts
@@ -58,25 +58,9 @@ export const COORDINAPE_USER_ADDRESS: string = getEnvValue(
   'COORDINAPE_USER_ADDRESS'
 );
 
-export const ALCHEMY_OPTIMISM_SEPOLIA_API_KEY = getEnvValue(
-  'ALCHEMY_OPTIMISM_SEPOLIA_API_KEY',
-  'missing-alchemy-optimism-sepolia-api-key'
-);
-export const ALCHEMY_BASE_MAINNET_API_KEY = getEnvValue(
-  'ALCHEMY_BASE_MAINNET_API_KEY',
-  'missing-alchemy-base-mainnet-api-key'
-);
-export const ALCHEMY_BASE_SEPOLIA_API_KEY = getEnvValue(
-  'ALCHEMY_BASE_SEPOLIA_API_KEY',
-  'missing-alchemy-base-sepolia-api-key'
-);
-export const ALCHEMY_OPTIMISM_API_KEY = getEnvValue(
-  'ALCHEMY_OPTIMISM_API_KEY',
-  'missing-alchemy-optimism-api-key'
-);
-export const ALCHEMY_ETH_MAINNET_API_KEY = getEnvValue(
-  'ALCHEMY_ETH_MAINNET_API_KEY',
-  'missing-alchemy-eth-mainnet-api-key'
+export const BE_ALCHEMY_API_KEY = getEnvValue(
+  'BE_ALCHEMY_API_KEY',
+  'missing-alchemy-backend-api-key'
 );
 export const HARDHAT_GANACHE_PORT: number = getEnvValue(
   'HARDHAT_GANACHE_PORT',

--- a/api-lib/frames/personas/PersonaOneFrame.tsx
+++ b/api-lib/frames/personas/PersonaOneFrame.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 
 import { fetchPoints } from '../../../_api/hasura/actions/_handlers/createCoLinksGive.ts';
 import { minted } from '../../../_api/hasura/actions/_handlers/syncCoSoul.ts';
+import { insertInteractionEvents } from '../../gql/mutations.ts';
 import {
   getMintInfoFromReceipt,
   mintCoSoulForAddress,
-} from '../../../src/features/cosoul/api/cosoul.ts';
-import { insertInteractionEvents } from '../../gql/mutations.ts';
+} from '../../viem/contracts';
 import { FramePostInfo } from '../_getFramePostInfo.tsx';
 import { getViewerFromParams } from '../_getViewerFromParams.ts';
 import { staticResourceIdentifier } from '../_staticResourceIdentifier.ts';

--- a/api-lib/provider.ts
+++ b/api-lib/provider.ts
@@ -1,11 +1,7 @@
 import { JsonRpcProvider } from '@ethersproject/providers';
 
 import {
-  ALCHEMY_ETH_MAINNET_API_KEY,
-  ALCHEMY_OPTIMISM_API_KEY,
-  ALCHEMY_OPTIMISM_SEPOLIA_API_KEY,
-  ALCHEMY_BASE_MAINNET_API_KEY,
-  ALCHEMY_BASE_SEPOLIA_API_KEY,
+  BE_ALCHEMY_API_KEY,
   HARDHAT_GANACHE_PORT,
   HARDHAT_PORT,
 } from './config';
@@ -15,23 +11,23 @@ export function getProvider(chainId: number) {
     // TODO: return different providers for different production chains
     case 1: // mainnet
       return new JsonRpcProvider(
-        `https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_ETH_MAINNET_API_KEY}`
+        `https://eth-mainnet.g.alchemy.com/v2/${BE_ALCHEMY_API_KEY}`
       );
     case 10: // Optimism
       return new JsonRpcProvider(
-        `https://opt-mainnet.g.alchemy.com/v2/${ALCHEMY_OPTIMISM_API_KEY}`
+        `https://opt-mainnet.g.alchemy.com/v2/${BE_ALCHEMY_API_KEY}`
       );
     case 8453: // Base
       return new JsonRpcProvider(
-        `https://base-mainnet.g.alchemy.com/v2/${ALCHEMY_BASE_MAINNET_API_KEY}`
+        `https://base-mainnet.g.alchemy.com/v2/${BE_ALCHEMY_API_KEY}`
       );
     case 84532: // Base Sepolia
       return new JsonRpcProvider(
-        `https://base-sepolia.g.alchemy.com/v2/${ALCHEMY_BASE_SEPOLIA_API_KEY}`
+        `https://base-sepolia.g.alchemy.com/v2/${BE_ALCHEMY_API_KEY}`
       );
     case 11155420: {
       // Optimism Seplolia
-      const url = `https://opt-sepolia.g.alchemy.com/v2/${ALCHEMY_OPTIMISM_SEPOLIA_API_KEY}`;
+      const url = `https://opt-sepolia.g.alchemy.com/v2/${BE_ALCHEMY_API_KEY}`;
       return new JsonRpcProvider(url);
     }
     case 1337:

--- a/api-lib/signature.ts
+++ b/api-lib/signature.ts
@@ -14,7 +14,7 @@ import { z } from 'zod';
 
 import { zEthAddressOnly } from '../src/lib/zod/formHelpers';
 
-import { ALCHEMY_ETH_MAINNET_API_KEY } from './config';
+import { BE_ALCHEMY_API_KEY } from './config';
 import { errorLog } from './HttpError';
 
 const PERSONAL_SIGN_REGEX = /0x[0-9a-f]{130}/;
@@ -48,7 +48,7 @@ export type SignatureInput = ReturnType<typeof parseInput>;
 
 const provider = new ethers.providers.AlchemyProvider(
   'homestead',
-  ALCHEMY_ETH_MAINNET_API_KEY
+  BE_ALCHEMY_API_KEY
 );
 
 const eip1271WorkingAbi = [

--- a/api-lib/viem/contracts.test.ts
+++ b/api-lib/viem/contracts.test.ts
@@ -1,0 +1,80 @@
+import { Hex } from 'viem';
+
+import { getTokenId } from '../../src/features/cosoul/api/cosoul';
+import { testAccounts } from '../../src/utils/testing/accountsHelper';
+import { snapshotManager } from '../../src/utils/testing/snapshotManager';
+
+import {
+  mintCoSoulForAddress,
+  getOnChainPGive,
+  setOnChainPGive,
+  setBatchOnChainPGive,
+} from './contracts';
+
+describe('contracts.ts with LocalCI', () => {
+  let snapshotId: Hex;
+  const wallet = testAccounts.getWalletClient(8);
+
+  beforeEach(async () => {
+    snapshotId = await snapshotManager.takeSnapshot();
+  });
+
+  afterEach(async () => {
+    await snapshotManager.revertToSnapshot(snapshotId);
+  });
+
+  describe('mintCoSoulForAddress', () => {
+    it('should mint a CoSoul', async () => {
+      const receipt = await mintCoSoulForAddress(wallet.account.address);
+      expect(receipt.status).toBe('success');
+
+      const tokenId = await getTokenId(wallet.account.address);
+      expect(tokenId).toBeDefined();
+    });
+  });
+
+  describe('getOnChainPGive', () => {
+    it('should return 0 for newly minted token', async () => {
+      await mintCoSoulForAddress(wallet.account.address);
+      const tokenId = await getTokenId(wallet.account.address);
+      const pgive = await getOnChainPGive(Number(tokenId));
+      expect(pgive).toBe(0n);
+    });
+  });
+
+  describe('setOnChainPGive', () => {
+    it('should set PGIVE balance for a given token ID', async () => {
+      await mintCoSoulForAddress(wallet.account.address);
+      const tokenId = await getTokenId(wallet.account.address);
+
+      await setOnChainPGive({ tokenId: Number(tokenId), amount: 100 });
+
+      const pgive = await getOnChainPGive(Number(tokenId));
+      expect(pgive).toBe(100n);
+    });
+  });
+
+  describe('setBatchOnChainPGive', () => {
+    it('should set batch PGIVE balances', async () => {
+      await mintCoSoulForAddress(wallet.account.address);
+      const tokenId1 = await getTokenId(wallet.account.address);
+
+      const wallet2 = testAccounts.getWalletClient(1);
+      await mintCoSoulForAddress(wallet2.account.address);
+      const tokenId2 = await getTokenId(wallet2.account.address);
+
+      const params = [
+        { tokenId: Number(tokenId1), amount: 100 },
+        { tokenId: Number(tokenId2), amount: 200 },
+      ];
+
+      await setBatchOnChainPGive(params);
+
+      const pgive1 = await getOnChainPGive(Number(tokenId1));
+      const pgive2 = await getOnChainPGive(Number(tokenId2));
+
+      expect(pgive1).toBe(100n);
+      expect(pgive2).toBe(200n);
+    });
+  });
+});

--- a/api-lib/viem/contracts.ts
+++ b/api-lib/viem/contracts.ts
@@ -1,0 +1,219 @@
+import {
+  Address,
+  Hex,
+  TransactionReceipt,
+  WalletClient,
+  decodeEventLog,
+  getContract,
+  keccak256,
+  toBytes,
+} from 'viem';
+
+import { CoLinksABI, CoSoulABI } from '../../src/contracts/abis';
+import { chain } from '../../src/features/cosoul/chains';
+import { wagmiChain } from '../../src/features/wagmi/config';
+import {
+  getCoSoulContract,
+  getContractAddress,
+} from '../../src/utils/viem/contracts';
+import { getReadOnlyClient } from '../../src/utils/viem/publicClient';
+import { BE_ALCHEMY_API_KEY, COSOUL_SIGNER_ADDR_PK } from '../config';
+
+import { getWalletClient } from './walletClient';
+
+export const PGIVE_SLOT = 0;
+export const REP_SLOT = 1;
+
+type Slot = typeof PGIVE_SLOT | typeof REP_SLOT;
+type CoSoulArgs = { tokenId: number; amount: number };
+
+export type CoLinksWithWallet = ReturnType<typeof getCoLinksContractWithWallet>;
+export const getCoLinksContractWithWallet = (walletClient: WalletClient) => {
+  return getContract({
+    address: getContractAddress('CoLinks'),
+    abi: CoLinksABI,
+    client: {
+      wallet: walletClient,
+    },
+  });
+};
+
+function walletClient() {
+  const client = getWalletClient(COSOUL_SIGNER_ADDR_PK as Hex);
+  if (!client) {
+    throw new Error('Wallet client not found');
+  }
+  return client;
+}
+
+function walletAccount() {
+  const account = walletClient().account;
+  if (!account) {
+    throw new Error('Wallet account not found');
+  }
+  return account;
+}
+
+export type CoSoulWithWallet = ReturnType<typeof getCoSoulContractWithWallet>;
+export const getCoSoulContractWithWallet = () => {
+  return getContract({
+    address: getContractAddress('CoSoul'),
+    abi: CoSoulABI,
+    client: {
+      wallet: walletClient(),
+    },
+  });
+};
+
+export const mintCoSoulForAddress = async (address: string) => {
+  const cosoul = getCoSoulContractWithWallet();
+  const gasSettings = chain.gasSettings;
+
+  // eslint-disable-next-line no-console
+  console.log('minting CoSoul for address: ', address);
+
+  const txHash = await cosoul.write.mintTo([address as Address] as const, {
+    account: walletAccount(),
+    chain: wagmiChain,
+    ...gasSettings,
+  });
+
+  const publicClient = getReadOnlyClient(undefined, BE_ALCHEMY_API_KEY);
+  return await publicClient.waitForTransactionReceipt({
+    hash: txHash,
+  });
+};
+
+export async function getMintInfoFromReceipt(receipt: TransactionReceipt) {
+  const transferEventSignature = keccak256(
+    toBytes('Transfer(address,address,uint256)')
+  );
+
+  if (receipt.logs === undefined) {
+    throw new Error('No logs found in the transaction receipt');
+  }
+
+  for (const log of receipt.logs) {
+    if (log.topics[0] === transferEventSignature) {
+      const decodedLog = decodeEventLog({
+        abi: CoSoulABI,
+        data: log.data,
+        topics: log.topics,
+        eventName: 'Transfer',
+      });
+
+      const { from, to, tokenId } = decodedLog.args;
+
+      return { from, to, tokenId };
+    }
+  }
+
+  throw new Error('No Transfer event found in the transaction receipt');
+}
+
+export const getOnChainPGive = async (tokenId: number) => {
+  const cosoul = getCoSoulContract(
+    getReadOnlyClient(undefined, BE_ALCHEMY_API_KEY)
+  );
+  return await cosoul.read.getSlot([PGIVE_SLOT, BigInt(tokenId)] as const);
+};
+
+export const setOnChainPGive = async (params: CoSoulArgs) => {
+  return await setSlotOnChain(PGIVE_SLOT, params);
+};
+
+export const setOnChainRep = async (params: CoSoulArgs) => {
+  return await setSlotOnChain(REP_SLOT, params);
+};
+
+// set the on-chain PGIVE balance for a given token
+const setSlotOnChain = async (slot: Slot, params: CoSoulArgs) => {
+  const cosoul = getCoSoulContractWithWallet();
+
+  const amount = Math.floor(params.amount);
+  // eslint-disable-next-line no-console
+  console.log(
+    `updating on-chain cosoul tokenId: ${params.tokenId} slot ${slot} to ${amount}`
+  );
+
+  const gasSettings = chain.gasSettings;
+
+  return await cosoul.write.setSlot(
+    [BigInt(slot), amount, BigInt(params.tokenId)] as const,
+    {
+      account: walletAccount(),
+      chain: wagmiChain,
+      ...gasSettings,
+    }
+  );
+};
+
+const paddedHex = (n: number, length: number = 8): string => {
+  const _hex = n.toString(16); // convert number to hexadecimal
+  const hexLen = _hex.length;
+  const extra = '0'.repeat(length - hexLen);
+  if (hexLen === length) {
+    return _hex;
+  } else if (hexLen < length) {
+    return extra + _hex;
+  } else {
+    throw new Error(
+      `Number: ${n} is too large to be padded in length ${length} bytes, _hex: ${_hex}; hexLen: ${hexLen}; extra: ${extra}`
+    );
+  }
+};
+
+const getPayload = (amount: number, tokenId: number): string =>
+  paddedHex(amount) + paddedHex(tokenId);
+
+export const setBatchOnChainPGive = async (params: CoSoulArgs[]) => {
+  return await setBatchSlotOnChain(PGIVE_SLOT, params);
+};
+export const setBatchOnChainRep = async (params: CoSoulArgs[]) => {
+  return await setBatchSlotOnChain(REP_SLOT, params);
+};
+
+/*
+ * setBatchSlotOnChain: set a batch of cosoul slots to given values on chain
+ * @param params: an array of objects with tokenId and amounts
+ * @returns: a promise that resolves when the transaction is mined
+ *
+ * The contract expects data in the following format:
+ * @param _data bytes data
+ *    3 bits for slot | one byte
+ *    after previous byte, alternate bewteen next elements like a packed array
+ *    4 bytes for each amount
+ *    4 bytes for each token ID
+ */
+export const setBatchSlotOnChain = async (slot: Slot, params: CoSoulArgs[]) => {
+  let payload = '0x' + paddedHex(slot, 2); // 1byte for slot
+  for (const { tokenId, amount } of params) {
+    if (amount > 0) {
+      // four bytes for pgive and four bytes for tokenId
+      payload += getPayload(Math.floor(amount), tokenId);
+    }
+  }
+
+  // payload is only 0x00 if no pgive needs to be updated on chain
+  if (payload.length > 4) {
+    const cosoul = getCoSoulContractWithWallet();
+    const gasSettings = chain.gasSettings;
+
+    const txHash = await cosoul.write.batchSetSlot_UfO(
+      [payload as Hex] as const,
+      {
+        account: walletAccount(),
+        chain: wagmiChain,
+        ...gasSettings,
+      }
+    );
+
+    return await getReadOnlyClient().waitForTransactionReceipt({
+      hash: txHash,
+    });
+  } else {
+    // eslint-disable-next-line no-console
+    console.log('No cosouls to update on chain');
+    return;
+  }
+};

--- a/api-lib/viem/walletClient.ts
+++ b/api-lib/viem/walletClient.ts
@@ -1,8 +1,9 @@
 import { createWalletClient, Hex, http, WalletClient } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
-import { localhost, optimism, optimismSepolia } from 'viem/chains';
+import { optimism, optimismSepolia } from 'viem/chains';
 
 import { chain } from '../../src/features/cosoul/chains';
+import { localhost } from '../../src/utils/viem/chains';
 import { BE_ALCHEMY_API_KEY, HARDHAT_GANACHE_PORT } from '../config';
 
 export function getWalletClient(privateKey: Hex): WalletClient;

--- a/api-lib/viem/walletClient.ts
+++ b/api-lib/viem/walletClient.ts
@@ -2,12 +2,8 @@ import { createWalletClient, Hex, http, WalletClient } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 import { localhost, optimism, optimismSepolia } from 'viem/chains';
 
-import {
-  HARDHAT_GANACHE_PORT,
-  VITE_ALCHEMY_OPTIMISM_API_KEY,
-  VITE_ALCHEMY_OPTIMISM_SEPOLIA_API_KEY,
-} from '../../config/env';
-import { chain } from '../../features/cosoul/chains';
+import { chain } from '../../src/features/cosoul/chains';
+import { BE_ALCHEMY_API_KEY, HARDHAT_GANACHE_PORT } from '../config';
 
 export function getWalletClient(privateKey: Hex): WalletClient;
 export function getWalletClient(privateKey: Hex, chainId: number): WalletClient;
@@ -27,7 +23,7 @@ export function getWalletClient(
         account,
         chain: optimism,
         transport: http(
-          `https://opt-mainnet.g.alchemy.com/v2/${VITE_ALCHEMY_OPTIMISM_API_KEY}`
+          `https://opt-mainnet.g.alchemy.com/v2/${BE_ALCHEMY_API_KEY}`
         ),
       });
     case 11155420: // Optimism Sepolia
@@ -35,7 +31,7 @@ export function getWalletClient(
         account,
         chain: optimismSepolia,
         transport: http(
-          `https://opt-sepolia.g.alchemy.com/v2/${VITE_ALCHEMY_OPTIMISM_SEPOLIA_API_KEY}`
+          `https://opt-sepolia.g.alchemy.com/v2/${BE_ALCHEMY_API_KEY}`
         ),
       });
     case 1338: // Local development chain

--- a/hardhat/constants.ts
+++ b/hardhat/constants.ts
@@ -1,4 +1,4 @@
-//import assert from 'assert';
+import assert from 'assert';
 
 import { AddressZero } from '@ethersproject/constants';
 import dotenv from 'dotenv';
@@ -13,16 +13,16 @@ export const OPTIMISM_RPC_URL = process.env.OPTIMISM_RPC_URL;
 export const OPTIMISM_SEPOLIA_RPC_URL =
   process.env.OPTIMISM_SEPOLIA_RPC_URL || 'https://sepolia.optimism.io';
 
-//assert(
-//  OPTIMISM_RPC_URL,
-//  'process.env.OPTIMISM_RPC_URL is missing, provide one in .env'
-//);
-//
-//assert(
-//  process.env.VITE_ALCHEMY_ETH_MAINNET_API_KEY,
-//  'process.env.VITE_ALCHEMY_ETH_MAINNET_API_KEY is missing'
-//);
-//export const HARDHAT_ARCHIVE_RPC_URL = `https://eth-mainnet.g.alchemy.com/v2/${process.env.VITE_ALCHEMY_ETH_MAINNET_API_KEY}`;
+assert(
+  OPTIMISM_RPC_URL,
+  'process.env.OPTIMISM_RPC_URL is missing, provide one in .env'
+);
+
+assert(
+  process.env.VITE_FE_ALCHEMY_API_KEY,
+  'process.env.VITE_FE_ALCHEMY_API_KEY is missing'
+);
+export const HARDHAT_ARCHIVE_RPC_URL = `https://eth-mainnet.g.alchemy.com/v2/${process.env.VITE_FE_ALCHEMY_API_KEY}`;
 
 export const HARDHAT_OWNER_ADDRESS =
   process.env.HARDHAT_OWNER_ADDRESS ?? AddressZero;

--- a/hardhat/constants.ts
+++ b/hardhat/constants.ts
@@ -19,10 +19,10 @@ assert(
 );
 
 assert(
-  process.env.VITE_FE_ALCHEMY_API_KEY,
-  'process.env.VITE_FE_ALCHEMY_API_KEY is missing'
+  process.env.BE_ALCHEMY_API_KEY,
+  'process.env.BE_ALCHEMY_API_KEY is missing'
 );
-export const HARDHAT_ARCHIVE_RPC_URL = `https://eth-mainnet.g.alchemy.com/v2/${process.env.VITE_FE_ALCHEMY_API_KEY}`;
+export const HARDHAT_ARCHIVE_RPC_URL = `https://eth-mainnet.g.alchemy.com/v2/${process.env.BE_ALCHEMY_API_KEY}`;
 
 export const HARDHAT_OWNER_ADDRESS =
   process.env.HARDHAT_OWNER_ADDRESS ?? AddressZero;

--- a/hardhat/constants.ts
+++ b/hardhat/constants.ts
@@ -1,4 +1,4 @@
-import assert from 'assert';
+//import assert from 'assert';
 
 import { AddressZero } from '@ethersproject/constants';
 import dotenv from 'dotenv';
@@ -13,16 +13,16 @@ export const OPTIMISM_RPC_URL = process.env.OPTIMISM_RPC_URL;
 export const OPTIMISM_SEPOLIA_RPC_URL =
   process.env.OPTIMISM_SEPOLIA_RPC_URL || 'https://sepolia.optimism.io';
 
-assert(
-  OPTIMISM_RPC_URL,
-  'process.env.OPTIMISM_RPC_URL is missing, provide one in .env'
-);
-
-assert(
-  process.env.VITE_ALCHEMY_ETH_MAINNET_API_KEY,
-  'process.env.VITE_ALCHEMY_ETH_MAINNET_API_KEY is missing'
-);
-export const HARDHAT_ARCHIVE_RPC_URL = `https://eth-mainnet.g.alchemy.com/v2/${process.env.VITE_ALCHEMY_ETH_MAINNET_API_KEY}`;
+//assert(
+//  OPTIMISM_RPC_URL,
+//  'process.env.OPTIMISM_RPC_URL is missing, provide one in .env'
+//);
+//
+//assert(
+//  process.env.VITE_ALCHEMY_ETH_MAINNET_API_KEY,
+//  'process.env.VITE_ALCHEMY_ETH_MAINNET_API_KEY is missing'
+//);
+//export const HARDHAT_ARCHIVE_RPC_URL = `https://eth-mainnet.g.alchemy.com/v2/${process.env.VITE_ALCHEMY_ETH_MAINNET_API_KEY}`;
 
 export const HARDHAT_OWNER_ADDRESS =
   process.env.HARDHAT_OWNER_ADDRESS ?? AddressZero;

--- a/hardhat/scripts/start-ganache.sh
+++ b/hardhat/scripts/start-ganache.sh
@@ -27,11 +27,6 @@ if [ ! "$PORT" ]; then
   exit 1
 fi
 
-if [ ! "$VITE_ALCHEMY_ETH_MAINNET_API_KEY" ]; then
-  echo "Env doesn't have VITE_ALCHEMY_ETH_MAINNET_API_KEY set; can't continue."
-  exit 1
-fi
-
 if nc -z 127.0.0.1 $PORT >/dev/null 2>&1; then
   if [ "$NO_REUSE" ]; then
     echo "Error! Testchain is already running at port $PORT but --no-reuse was specified."

--- a/package.json
+++ b/package.json
@@ -205,6 +205,7 @@
     "test": "./scripts/ci/manager.sh test --jest -i",
     "test:ci": "./scripts/ci/manager.sh test --all",
     "test:up": "./scripts/ci/manager.sh up",
+    "test:down": "./scripts/ci/manager.sh down",
     "lint:check": "eslint \"{{api,_api,api-lib,cypress,hasura,src}/**/*.{js,ts,tsx,graphql},*.{js,ts,tsx,graphql}}\" --max-warnings 0",
     "lint:fix": "pnpm lint:check --fix",
     "lint:staged": "lint-staged --allow-empty",

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -26,12 +26,13 @@ while [[ "$#" > 0 ]]; do case $1 in
 esac; shift; done
 
 if [ "$SET_CI_VARS" ]; then
-  # backwards compatibility
-  if [ -z "$VITE_ALCHEMY_ETH_MAINNET_API_KEY" ]; then
-    echo '-----------------------------------------------------------------------'
-    echo 'Please add VITE_ALCHEMY_ETH_MAINNET_API_KEY to your .env.'
-    echo '-----------------------------------------------------------------------'
-  fi
+   # tests use a real key to query alchemy 
+   if [ -z "$VITE_FE_ALCHEMY_API_KEY" ]; then
+     echo '-----------------------------------------------------------------------'
+     echo 'Please add VITE_FE_ALCHEMY_API_KEY to your .env.'
+     echo '-----------------------------------------------------------------------'
+   fi
+
   export NODE_ENV=development
   export LOCAL_LOCALSTACK_PORT_RANGE="4666-4683"
   export LOCAL_HASURA_PORT=8087
@@ -55,8 +56,6 @@ if [ "$SET_CI_VARS" ]; then
   export MIXPANEL_PROJECT_TOKEN=mock-mixpanel-token
   export VITE_MIXPANEL_TOKEN=
   export POAP_API_KEY=forpoapdatafetching
-  export VITE_FE_ALCHEMY_API_KEY=get-a-key-from-alchemy
-  export BE_ALCHEMY_API_KEY=get-a-key-from-alchemy
 fi
 
 if [ "$OTHERARGS" ]; then

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -55,6 +55,8 @@ if [ "$SET_CI_VARS" ]; then
   export MIXPANEL_PROJECT_TOKEN=mock-mixpanel-token
   export VITE_MIXPANEL_TOKEN=
   export POAP_API_KEY=forpoapdatafetching
+  export VITE_FE_ALCHEMY_API_KEY=get-a-key-from-alchemy
+  export BE_ALCHEMY_API_KEY=get-a-key-from-alchemy
 fi
 
 if [ "$OTHERARGS" ]; then

--- a/scripts/repl.ts
+++ b/scripts/repl.ts
@@ -11,58 +11,25 @@
 import repl from 'repl';
 
 import fp from 'lodash/fp';
-import { DateTime } from 'luxon';
 
-import { syncCoSouls } from '../_api/hasura/cron/syncCoSouls';
-import {
-  sendCoLinksNotificationsEmail,
-  sendEpochEndedEmail,
-  sendEpochEndingSoonEmail,
-  sendEpochStartedEmail,
-} from '../api-lib/email/postmark';
-import { backfillCastActivity } from '../api-lib/farcaster/backfillCastActivity.ts';
 import { adminClient as client } from '../api-lib/gql/adminClient';
-import { generateWarpCastUrl, publishCast } from '../api-lib/neynar';
-import { genPgives } from '../api-lib/pgives';
 import { syncPoapDataForCoLinksUsers } from '../api-lib/poap/poap-api';
-import {
-  getOnChainPGive,
-  getTokenId,
-  setOnChainPGive,
-} from '../src/features/cosoul/api/cosoul';
 // uncomment and change this to import your own repl code
-import { getLocalPGIVE } from '../src/features/cosoul/api/pgive.ts';
-import { storeCoSoulImage } from '../src/features/cosoul/art/screenshot';
 
 import { init as initOrgMembership } from './repl/org_membership';
 
-const syncCirclePGive = async (circleId: number) => {
-  return await genPgives(
-    [circleId],
-    DateTime.fromISO('2022-01-01'),
-    DateTime.now()
-  );
-};
+//const syncCirclePGive = async (circleId: number) => {
+//  return await genPgives(
+//    [circleId],
+//    DateTime.fromISO('2022-01-01'),
+//    DateTime.now()
+//  );
+//};
 
 const init = async () => {
   return {
     // add your init code here
-    syncCirclePGive,
-    publishCast,
-    setOnChainPGive,
-    getTokenId,
-    getOnChainPGive,
-    syncCoSouls,
-    storeCoSoulImage,
-    sendEpochEndedEmail,
-    sendEpochStartedEmail,
-    sendEpochEndingSoonEmail,
-    // generateRandomMnemonics,
     syncPoapDataForCoLinksUsers,
-    sendCoLinksNotificationsEmail,
-    getLocalPGIVE,
-    generateWarpCastUrl,
-    backfillCastActivity,
     ...(await initOrgMembership()),
   };
 };

--- a/scripts/serve_dev.ts
+++ b/scripts/serve_dev.ts
@@ -241,4 +241,4 @@ app.listen(port, () => {
   /* eslint-enable */
 });
 
-export {};
+export { };

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -67,21 +67,9 @@ export const STORAGE_URL = getEnvValue(
   'https://missing-s3-url'
 ).replace(/\/$/, '');
 
-export const VITE_ALCHEMY_OPTIMISM_SEPOLIA_API_KEY = getEnvValue(
-  'VITE_ALCHEMY_OPTIMISM_SEPOLIA_API_KEY',
-  'missing-alchemy-optimism-sepolia-api-key'
-);
-export const VITE_ALCHEMY_OPTIMISM_API_KEY = getEnvValue(
-  'VITE_ALCHEMY_OPTIMISM_API_KEY',
-  'missing-alchemy-optimism-api-key'
-);
-export const VITE_ALCHEMY_ETH_MAINNET_API_KEY = getEnvValue(
-  'VITE_ALCHEMY_ETH_MAINNET_API_KEY',
-  'missing-alchemy-eth-mainnet-api-key'
-);
-export const VITE_ALCHEMY_ETH_SEPOLIA_API_KEY = getEnvValue(
-  'VITE_ETH_SEPOLIA_API_KEY',
-  'missing-alchemy-eth-mainnet-api-key'
+export const VITE_FE_ALCHEMY_API_KEY = getEnvValue(
+  'VITE_FE_ALCHEMY_API_KEY',
+  'missing-alchemy-fe-api-key'
 );
 export const DECENT_XYZ_API_KEY = getEnvValue(
   'VITE_DECENT_XYZ_API_KEY',

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -35,9 +35,12 @@ export const APP_MODE =
         'development'
       );
 
+export const NODE_ENV = getEnvValue<'unknown' | 'test'>('NODE_ENV', 'unknown');
+
 export const IN_PRODUCTION = APP_MODE === 'production';
 export const IN_PREVIEW = APP_MODE === 'preview';
 export const IN_DEVELOPMENT = APP_MODE === 'development';
+export const IN_TEST = NODE_ENV === 'test';
 
 export const BRANCH_URL =
   getEnvValue<string>('VITE_VERCEL_BRANCH_URL', '') ||

--- a/src/features/auth/magic.tsx
+++ b/src/features/auth/magic.tsx
@@ -10,8 +10,7 @@ import { DebugLogger } from '../../common-lib/log';
 import {
   IN_PRODUCTION,
   MAGIC_API_KEY,
-  VITE_ALCHEMY_OPTIMISM_API_KEY,
-  VITE_ALCHEMY_OPTIMISM_SEPOLIA_API_KEY,
+  VITE_FE_ALCHEMY_API_KEY,
 } from 'config/env';
 
 const logger = new DebugLogger('magic');
@@ -32,11 +31,11 @@ const networks: Record<string, EthNetworkConfiguration> = {
     chainId: 137,
   },
   optimism: {
-    rpcUrl: `https://opt-mainnet.g.alchemy.com/v2/${VITE_ALCHEMY_OPTIMISM_API_KEY}`,
+    rpcUrl: `https://opt-mainnet.g.alchemy.com/v2/${VITE_FE_ALCHEMY_API_KEY}`,
     chainId: 10,
   },
   optimism_sepolia: {
-    rpcUrl: `https://opt-sepolia.g.alchemy.com/v2/${VITE_ALCHEMY_OPTIMISM_SEPOLIA_API_KEY}`,
+    rpcUrl: `https://opt-sepolia.g.alchemy.com/v2/${VITE_FE_ALCHEMY_API_KEY}`,
     chainId: 11155420,
   },
 };

--- a/src/features/cosoul/api/cosoul.test.ts
+++ b/src/features/cosoul/api/cosoul.test.ts
@@ -1,18 +1,12 @@
 import { Hex } from 'viem';
 
+import { mintCoSoulForAddress } from '../../../../api-lib/viem/contracts';
 import { testAccounts } from '../../../utils/testing/accountsHelper';
 import { snapshotManager } from '../../../utils/testing/snapshotManager';
 import { localCI } from '../../../utils/viem/chains';
 import { getCoSoulContract } from '../../../utils/viem/contracts';
 
-import {
-  getTokenId,
-  mintCoSoulForAddress,
-  getOnChainPGive,
-  setOnChainPGive,
-  setBatchOnChainPGive,
-  getMintInfo,
-} from './cosoul';
+import { getTokenId, getMintInfo } from './cosoul';
 
 describe('cosoul.ts with LocalCI', () => {
   let snapshotId: Hex;
@@ -39,61 +33,6 @@ describe('cosoul.ts with LocalCI', () => {
       const result = await getTokenId(wallet.account.address);
       expect(result).toBeDefined();
       expect(typeof result).toBe('bigint');
-    });
-  });
-
-  describe('mintCoSoulForAddress', () => {
-    it('should mint a CoSoul', async () => {
-      const receipt = await mintCoSoulForAddress(wallet.account.address);
-      expect(receipt.status).toBe('success');
-
-      const tokenId = await getTokenId(wallet.account.address);
-      expect(tokenId).toBeDefined();
-    });
-  });
-
-  describe('getOnChainPGive', () => {
-    it('should return 0 for newly minted token', async () => {
-      await mintCoSoulForAddress(wallet.account.address);
-      const tokenId = await getTokenId(wallet.account.address);
-      const pgive = await getOnChainPGive(Number(tokenId));
-      expect(pgive).toBe(0n);
-    });
-  });
-
-  describe('setOnChainPGive', () => {
-    it('should set PGIVE balance for a given token ID', async () => {
-      await mintCoSoulForAddress(wallet.account.address);
-      const tokenId = await getTokenId(wallet.account.address);
-
-      await setOnChainPGive({ tokenId: Number(tokenId), amount: 100 });
-
-      const pgive = await getOnChainPGive(Number(tokenId));
-      expect(pgive).toBe(100n);
-    });
-  });
-
-  describe('setBatchOnChainPGive', () => {
-    it('should set batch PGIVE balances', async () => {
-      await mintCoSoulForAddress(wallet.account.address);
-      const tokenId1 = await getTokenId(wallet.account.address);
-
-      const wallet2 = testAccounts.getWalletClient(1);
-      await mintCoSoulForAddress(wallet2.account.address);
-      const tokenId2 = await getTokenId(wallet2.account.address);
-
-      const params = [
-        { tokenId: Number(tokenId1), amount: 100 },
-        { tokenId: Number(tokenId2), amount: 200 },
-      ];
-
-      await setBatchOnChainPGive(params);
-
-      const pgive1 = await getOnChainPGive(Number(tokenId1));
-      const pgive2 = await getOnChainPGive(Number(tokenId2));
-
-      expect(pgive1).toBe(100n);
-      expect(pgive2).toBe(200n);
     });
   });
 

--- a/src/features/cosoul/api/cosoul.ts
+++ b/src/features/cosoul/api/cosoul.ts
@@ -1,50 +1,10 @@
-import {
-  Address,
-  decodeEventLog,
-  Hex,
-  keccak256,
-  Log,
-  toBytes,
-  TransactionReceipt,
-} from 'viem';
+import { Address, decodeEventLog, keccak256, Log, toBytes } from 'viem';
 
-import { COSOUL_SIGNER_ADDR_PK } from '../../../../api-lib/config';
 import { CoSoulABI } from '../../../contracts/abis';
-import {
-  getCoSoulContract,
-  getCoSoulContractWithWallet,
-} from '../../../utils/viem/contracts';
+import { getCoSoulContract } from '../../../utils/viem/contracts';
 import { getReadOnlyClient } from '../../../utils/viem/publicClient';
-import { getWalletClient } from '../../../utils/viem/walletClient';
-import { wagmiChain } from '../../wagmi/config';
-import { chain } from '../chains';
 
-export const PGIVE_SLOT = 0;
-export const REP_SLOT = 1;
 export const PGIVE_SYNC_DURATION_DAYS = 30;
-
-type Slot = typeof PGIVE_SLOT | typeof REP_SLOT;
-type CoSoulArgs = { tokenId: number; amount: number };
-
-function walletClient() {
-  const client = getWalletClient(COSOUL_SIGNER_ADDR_PK as Hex);
-  if (!client) {
-    throw new Error('Wallet client not found');
-  }
-  return client;
-}
-
-function walletAccount() {
-  const account = walletClient().account;
-  if (!account) {
-    throw new Error('Wallet account not found');
-  }
-  return account;
-}
-
-function coSoulWithWallet() {
-  return getCoSoulContractWithWallet(walletClient());
-}
 
 // get the cosoul token id for a given address
 export const getTokenId = async (address: string) => {
@@ -66,52 +26,6 @@ export const getTokenId = async (address: string) => {
     0n,
   ] as const);
 };
-
-export const mintCoSoulForAddress = async (address: string) => {
-  const cosoul = coSoulWithWallet();
-  const gasSettings = chain.gasSettings;
-
-  // eslint-disable-next-line no-console
-  console.log('minting CoSoul for address: ', address);
-
-  const txHash = await cosoul.write.mintTo([address as Address] as const, {
-    account: walletAccount(),
-    chain: wagmiChain,
-    ...gasSettings,
-  });
-
-  const publicClient = getReadOnlyClient();
-  return await publicClient.waitForTransactionReceipt({
-    hash: txHash,
-  });
-};
-
-export async function getMintInfoFromReceipt(receipt: TransactionReceipt) {
-  const transferEventSignature = keccak256(
-    toBytes('Transfer(address,address,uint256)')
-  );
-
-  if (receipt.logs === undefined) {
-    throw new Error('No logs found in the transaction receipt');
-  }
-
-  for (const log of receipt.logs) {
-    if (log.topics[0] === transferEventSignature) {
-      const decodedLog = decodeEventLog({
-        abi: CoSoulABI,
-        data: log.data,
-        topics: log.topics,
-        eventName: 'Transfer',
-      });
-
-      const { from, to, tokenId } = decodedLog.args;
-
-      return { from, to, tokenId };
-    }
-  }
-
-  throw new Error('No Transfer event found in the transaction receipt');
-}
 
 // TODO: test this
 export async function getMintInfo(txHash: string, chainId: number) {
@@ -170,108 +84,3 @@ export async function getMintInfofromLogs(log: Log | undefined) {
     return null;
   }
 }
-
-export const getOnChainPGive = async (tokenId: number) => {
-  const cosoul = getCoSoulContract();
-  return await cosoul.read.getSlot([PGIVE_SLOT, BigInt(tokenId)] as const);
-};
-
-export const setOnChainPGive = async (params: CoSoulArgs) => {
-  return await setSlotOnChain(PGIVE_SLOT, params);
-};
-
-export const setOnChainRep = async (params: CoSoulArgs) => {
-  return await setSlotOnChain(REP_SLOT, params);
-};
-
-// set the on-chain PGIVE balance for a given token
-const setSlotOnChain = async (slot: Slot, params: CoSoulArgs) => {
-  const cosoul = coSoulWithWallet();
-
-  const amount = Math.floor(params.amount);
-  // eslint-disable-next-line no-console
-  console.log(
-    `updating on-chain cosoul tokenId: ${params.tokenId} slot ${slot} to ${amount}`
-  );
-
-  const gasSettings = chain.gasSettings;
-
-  return await cosoul.write.setSlot(
-    [BigInt(slot), amount, BigInt(params.tokenId)] as const,
-    {
-      account: walletAccount(),
-      chain: wagmiChain,
-      ...gasSettings,
-    }
-  );
-};
-
-const paddedHex = (n: number, length: number = 8): string => {
-  const _hex = n.toString(16); // convert number to hexadecimal
-  const hexLen = _hex.length;
-  const extra = '0'.repeat(length - hexLen);
-  if (hexLen === length) {
-    return _hex;
-  } else if (hexLen < length) {
-    return extra + _hex;
-  } else {
-    throw new Error(
-      `Number: ${n} is too large to be padded in length ${length} bytes, _hex: ${_hex}; hexLen: ${hexLen}; extra: ${extra}`
-    );
-  }
-};
-
-const getPayload = (amount: number, tokenId: number): string =>
-  paddedHex(amount) + paddedHex(tokenId);
-
-export const setBatchOnChainPGive = async (params: CoSoulArgs[]) => {
-  return await setBatchSlotOnChain(PGIVE_SLOT, params);
-};
-export const setBatchOnChainRep = async (params: CoSoulArgs[]) => {
-  return await setBatchSlotOnChain(REP_SLOT, params);
-};
-
-/*
- * setBatchSlotOnChain: set a batch of cosoul slots to given values on chain
- * @param params: an array of objects with tokenId and amounts
- * @returns: a promise that resolves when the transaction is mined
- *
- * The contract expects data in the following format:
- * @param _data bytes data
- *    3 bits for slot | one byte
- *    after previous byte, alternate bewteen next elements like a packed array
- *    4 bytes for each amount
- *    4 bytes for each token ID
- */
-export const setBatchSlotOnChain = async (slot: Slot, params: CoSoulArgs[]) => {
-  let payload = '0x' + paddedHex(slot, 2); // 1byte for slot
-  for (const { tokenId, amount } of params) {
-    if (amount > 0) {
-      // four bytes for pgive and four bytes for tokenId
-      payload += getPayload(Math.floor(amount), tokenId);
-    }
-  }
-
-  // payload is only 0x00 if no pgive needs to be updated on chain
-  if (payload.length > 4) {
-    const cosoul = coSoulWithWallet();
-    const gasSettings = chain.gasSettings;
-
-    const txHash = await cosoul.write.batchSetSlot_UfO(
-      [payload as Hex] as const,
-      {
-        account: walletAccount(),
-        chain: wagmiChain,
-        ...gasSettings,
-      }
-    );
-
-    return await getReadOnlyClient().waitForTransactionReceipt({
-      hash: txHash,
-    });
-  } else {
-    // eslint-disable-next-line no-console
-    console.log('No cosouls to update on chain');
-    return;
-  }
-};

--- a/src/features/magiclink/RainbowMagicConnector.ts
+++ b/src/features/magiclink/RainbowMagicConnector.ts
@@ -7,7 +7,7 @@ import { optimism } from '@wagmi/core/chains';
 import { createConnector as createWagmiConnector } from 'wagmi';
 import { Chain } from 'wagmi/chains';
 
-import { VITE_ALCHEMY_OPTIMISM_API_KEY } from '../../config/env';
+import { VITE_FE_ALCHEMY_API_KEY } from '../../config/env';
 
 export const getRainbowMagicWallet = (
   options: Parameters<typeof rainbowMagicWallet>[0]
@@ -37,7 +37,7 @@ export const rainbowMagicWallet = ({
           apiKey: apiKey,
           magicSdkConfiguration: {
             network: {
-              rpcUrl: `https://opt-mainnet.g.alchemy.com/v2/${VITE_ALCHEMY_OPTIMISM_API_KEY}`,
+              rpcUrl: `https://opt-mainnet.g.alchemy.com/v2/${VITE_FE_ALCHEMY_API_KEY}`,
               chainId: optimism.id,
             },
           },

--- a/src/features/wagmi/config.ts
+++ b/src/features/wagmi/config.ts
@@ -21,20 +21,18 @@ import {
   IN_PREVIEW,
   IN_PRODUCTION,
   MAGIC_API_KEY,
-  VITE_ALCHEMY_ETH_MAINNET_API_KEY,
-  VITE_ALCHEMY_ETH_SEPOLIA_API_KEY,
-  VITE_ALCHEMY_OPTIMISM_API_KEY,
-  VITE_ALCHEMY_OPTIMISM_SEPOLIA_API_KEY,
+  VITE_FE_ALCHEMY_API_KEY,
   WALLET_CONNECT_V2_PROJECT_ID,
 } from '../../config/env';
 import { isFeatureEnabled } from '../../config/features';
 import { localhost } from '../../utils/viem/chains';
 import { getRainbowMagicWallet } from '../magiclink/RainbowMagicConnector';
 
-export const OPTIMISM_RPC_URL = `https://opt-mainnet.g.alchemy.com/v2/${VITE_ALCHEMY_OPTIMISM_API_KEY}`;
-export const ETHEREUM_RPC_URL = `https://eth-mainnet.g.alchemy.com/v2/${VITE_ALCHEMY_ETH_MAINNET_API_KEY}`;
-export const OPTIMISM_SEPOLIA_RPC_URL = `https://opt-sepolia.g.alchemy.com/v2/${VITE_ALCHEMY_OPTIMISM_SEPOLIA_API_KEY}`;
-export const ETHEREUM_SEPOLIA_RPC_URL = `https://eth-sepolia.g.alchemy.com/v2/${VITE_ALCHEMY_ETH_SEPOLIA_API_KEY}`;
+// TODO: Refactor these to be defined in one place across entire app
+export const OPTIMISM_RPC_URL = `https://opt-mainnet.g.alchemy.com/v2/${VITE_FE_ALCHEMY_API_KEY}`;
+export const ETHEREUM_RPC_URL = `https://eth-mainnet.g.alchemy.com/v2/${VITE_FE_ALCHEMY_API_KEY}`;
+export const OPTIMISM_SEPOLIA_RPC_URL = `https://opt-sepolia.g.alchemy.com/v2/${VITE_FE_ALCHEMY_API_KEY}`;
+export const ETHEREUM_SEPOLIA_RPC_URL = `https://eth-sepolia.g.alchemy.com/v2/${VITE_FE_ALCHEMY_API_KEY}`;
 
 type Chains = Parameters<typeof createConfig>[0]['chains'];
 const wagmiChains: Chains = IN_PRODUCTION

--- a/src/lib/zod/formHelpers.ts
+++ b/src/lib/zod/formHelpers.ts
@@ -3,16 +3,13 @@ import { isAddress } from 'ethers/lib/utils';
 import { DateTime } from 'luxon';
 import { z } from 'zod';
 
-import { VITE_ALCHEMY_ETH_MAINNET_API_KEY } from '../../config/env';
+import { VITE_FE_ALCHEMY_API_KEY } from '../../config/env';
 
 let _provider: AlchemyProvider;
 
 export const provider = () => {
   if (!_provider) {
-    _provider = new AlchemyProvider(
-      'homestead',
-      VITE_ALCHEMY_ETH_MAINNET_API_KEY
-    );
+    _provider = new AlchemyProvider('homestead', VITE_FE_ALCHEMY_API_KEY);
   }
   return _provider;
 };

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -2,10 +2,6 @@ import type { Web3Provider } from '@ethersproject/providers';
 import { ethers } from 'ethers';
 import _ from 'lodash-es';
 
-import {
-  VITE_ALCHEMY_OPTIMISM_API_KEY,
-  VITE_ALCHEMY_OPTIMISM_SEPOLIA_API_KEY,
-} from '../config/env';
 import { chain } from '../features/cosoul/chains';
 
 export const getSignature = async (
@@ -145,21 +141,3 @@ export async function switchOrAddNetwork(
     }
   }
 }
-
-export const getReadOnlyProvider = (chainId: number) => {
-  switch (chainId) {
-    case 10:
-      return new ethers.providers.AlchemyProvider(
-        chainId,
-        VITE_ALCHEMY_OPTIMISM_API_KEY
-      );
-    case 11155420:
-      // ethers v6 required for optimism-sepolia support
-      return new ethers.providers.JsonRpcProvider(
-        `https://opt-sepolia.g.alchemy.com/v2/${VITE_ALCHEMY_OPTIMISM_SEPOLIA_API_KEY}`
-      );
-    case 1338:
-      // TODO: this is hacked for local - does it need to handle CI port?
-      return new ethers.providers.JsonRpcProvider(`http://localhost:8546`);
-  }
-};

--- a/src/utils/viem/chains.ts
+++ b/src/utils/viem/chains.ts
@@ -6,12 +6,6 @@ import {
   IN_TEST,
 } from '../../config/env';
 
-export const localhost = getLocalChain();
-
-function getLocalChain() {
-  return IN_TEST ? localCI : localGanache;
-}
-
 const localGanache = defineChain({
   id: 1338,
   name: 'Localhost 8546',
@@ -43,3 +37,9 @@ export const localCI = defineChain({
   },
   gasSettings: {},
 });
+
+function getLocalChain() {
+  return IN_TEST ? localCI : localGanache;
+}
+
+export const localhost = getLocalChain();

--- a/src/utils/viem/chains.ts
+++ b/src/utils/viem/chains.ts
@@ -3,9 +3,16 @@ import { defineChain } from 'viem';
 import {
   HARDHAT_GANACHE_CHAIN_ID,
   HARDHAT_GANACHE_PORT,
+  IN_TEST,
 } from '../../config/env';
 
-export const localhost = defineChain({
+export const localhost = getLocalChain();
+
+function getLocalChain() {
+  return IN_TEST ? localCI : localGanache;
+}
+
+const localGanache = defineChain({
   id: 1338,
   name: 'Localhost 8546',
   rpcUrls: {

--- a/src/utils/viem/contracts.ts
+++ b/src/utils/viem/contracts.ts
@@ -4,7 +4,7 @@ import { WalletClient, getContract } from 'viem';
 import { CoLinksABI, CoSoulABI } from '../../contracts/abis';
 import { chain } from '../../features/cosoul/chains';
 
-import { getReadOnlyClient } from './publicClient';
+import { ReadOnlyClient, getReadOnlyClient } from './publicClient';
 
 const requiredContracts = ['CoSoul'];
 
@@ -24,6 +24,8 @@ export const getCoLinksContract = () => {
 };
 
 export type CoLinksWithWallet = ReturnType<typeof getCoLinksContractWithWallet>;
+
+// only for use in FE
 export const getCoLinksContractWithWallet = (walletClient: WalletClient) => {
   return getContract({
     address: getContractAddress('CoLinks'),
@@ -36,13 +38,13 @@ export const getCoLinksContractWithWallet = (walletClient: WalletClient) => {
 };
 
 export type CoSoul = ReturnType<typeof getCoSoulContract>;
-export const getCoSoulContract = () => {
-  const publicClient = getReadOnlyClient();
+export const getCoSoulContract = (publicClient?: ReadOnlyClient) => {
+  const client = publicClient ?? getReadOnlyClient();
 
   return getContract({
     address: getContractAddress('CoSoul'),
     abi: CoSoulABI,
-    client: publicClient,
+    client: client,
   });
 };
 
@@ -53,14 +55,13 @@ export const getCoSoulContractWithWallet = (walletClient: WalletClient) => {
     abi: CoSoulABI,
     client: {
       wallet: walletClient,
-      public: getReadOnlyClient(),
     },
   });
 };
 
 type ContractNames = 'CoSoul' | 'CoLinks';
 
-const getContractAddress = (contractName: ContractNames) => {
+export const getContractAddress = (contractName: ContractNames) => {
   const chainId = Number(chain.chainId);
   const info = (deploymentInfo as any)[chainId];
   if (!info) {

--- a/src/utils/viem/publicClient.ts
+++ b/src/utils/viem/publicClient.ts
@@ -3,12 +3,14 @@ import { localhost, optimism, optimismSepolia } from 'viem/chains';
 
 import {
   HARDHAT_GANACHE_PORT,
-  VITE_ALCHEMY_OPTIMISM_API_KEY,
-  VITE_ALCHEMY_OPTIMISM_SEPOLIA_API_KEY,
+  VITE_FE_ALCHEMY_API_KEY,
 } from '../../config/env';
 import { chain } from '../../features/cosoul/chains';
 
-export function getReadOnlyClient(chainId?: number) {
+export type ReadOnlyClient = ReturnType<typeof getReadOnlyClient>;
+export function getReadOnlyClient(chainId?: number, alchemyApiKey?: string) {
+  const apiKey = alchemyApiKey ?? VITE_FE_ALCHEMY_API_KEY;
+
   if (chainId === undefined) {
     chainId = Number(chain.chainId);
   }
@@ -17,16 +19,12 @@ export function getReadOnlyClient(chainId?: number) {
     case 10: // Optimism
       return createPublicClient({
         chain: optimism,
-        transport: http(
-          `https://opt-mainnet.g.alchemy.com/v2/${VITE_ALCHEMY_OPTIMISM_API_KEY}`
-        ),
+        transport: http(`https://opt-mainnet.g.alchemy.com/v2/${apiKey}`),
       });
     case 11155420: // Optimism Sepolia
       return createPublicClient({
         chain: optimismSepolia,
-        transport: http(
-          `https://opt-sepolia.g.alchemy.com/v2/${VITE_ALCHEMY_OPTIMISM_SEPOLIA_API_KEY}`
-        ),
+        transport: http(`https://opt-sepolia.g.alchemy.com/v2/${apiKey}`),
       });
     case 1338: // Local development/CI chain
       return createPublicClient({


### PR DESCRIPTION
Alchemy (finally) supports multiple chains with one API key, so we can vastly simplify our env vars which use Alchemy tokens.

We have two API tokens:

VITE_FE_ALCHEMY_API_KEY - this is visible to clients and users and has domain origin limitations set on its use. Only use this from the FE where requests will have an origin.

BE_ALCHEMY_API_KEY - this is a private API_KEY and should not be exposed to clients, it is used for backend requests without origin.

Change all contract instance code to use appropriate versions of frontend or backend clients.
