### PR TITLE
Fix race in syncCoSoul

### DIFF
--- a/_api/hasura/actions/_handlers/syncCoSoul.ts
+++ b/_api/hasura/actions/_handlers/syncCoSoul.ts
@@ -158,13 +158,19 @@ export const burned = async (address: string, profileId?: number) => {
   );
 
   const burnedCosoul = delete_cosouls?.returning.pop();
-  assert(burnedCosoul);
+  if (burnedCosoul) {
+    // eslint-disable-next-line no-console
+    console.log('burned cosoul token_id:', burnedCosoul.token_id);
 
-  await insertInteractionEvents({
-    event_type: 'cosoul_burned',
-    profile_id: profileId,
-    data: { token_id: burnedCosoul.token_id },
-  });
+    await insertInteractionEvents({
+      event_type: 'cosoul_burned',
+      profile_id: profileId,
+      data: { token_id: burnedCosoul.token_id },
+    });
+  } else {
+    // eslint-disable-next-line no-console
+    console.log('no cosoul to burn, no-op');
+  }
 };
 
 async function syncPGive(address: string, tokenId: number) {


### PR DESCRIPTION
We were having a race condition in syncCoSoul where the alchemy webhook
would fire first, deleting the cosouls record from db, then the handler
syncCoSoul fires, and but does not find any cosoul to delete, and
errors. This changes makes the handler idempotent and handle the case
where the cosoul is already deleted (by the webhook).
