### PR TITLE
Fix: Correct array indexing for emission tiers

### DIFF
--- a/_api/hasura/actions/_handlers/createCoLinksGive.ts
+++ b/_api/hasura/actions/_handlers/createCoLinksGive.ts
@@ -150,7 +150,12 @@ export const fetchPoints = async (profileId: number) => {
   const canGive = points >= POINTS_PER_GIVE;
 
   if (!canGive && UNLIMITED_GIVE_PROFILES.includes(profileId)) {
-    return { points, give, canGive: true, giveCap: EMISSION_TIERS[-1].giveCap };
+    return {
+      points,
+      give,
+      canGive: true,
+      giveCap: EMISSION_TIERS[EMISSION_TIERS.length - 1].giveCap,
+    };
   }
 
   const giveCap = getGiveCap(profiles_by_pk.token_balances[0]?.balance);


### PR DESCRIPTION
Fixed bu
    in fetchPoints function where invalid negative array index was being used for
    EMISSION_TIERS. Changed from EMISSION_TIERS[-1] to EMISSION_TIERS[EMISSION_TIERS.lengt
    - 1]