### PR TITLE
export anongql

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "engines": {
     "node": "20"
   },
+  "exports": {
+    "./anongql": "./src/lib/anongql/index.ts"
+  },
   "dependencies": {
     "@apollo/client": "3.7.15",
     "@aws-sdk/client-bedrock-runtime": "^3.741.0",

--- a/src/lib/anongql/.gitignore
+++ b/src/lib/anongql/.gitignore
@@ -1,0 +1,4 @@
+dist
+node_modules
+*.log
+.DS_Store

--- a/src/lib/anongql/.npmignore
+++ b/src/lib/anongql/.npmignore
@@ -1,0 +1,5 @@
+__tests__
+*.ts
+!*.d.ts
+tsconfig.json
+.gitignore

--- a/src/lib/anongql/README.md
+++ b/src/lib/anongql/README.md
@@ -1,0 +1,100 @@
+# @coordinape/anongql
+
+Anonymous GraphQL client for Hasura, designed to work with GraphQL Zeus.
+
+## Installation
+
+```bash
+npm install @coordinape/anongql
+# or
+yarn add @coordinape/anongql
+# or
+pnpm add @coordinape/anongql
+```
+
+## Configuration
+
+The client will look for your Hasura URL in the following places (in order):
+1. `process.env.VITE_HASURA_URL` - Node.js environment
+2. `window.env.VITE_HASURA_URL` - Browser global
+3. `import.meta.env.VITE_HASURA_URL` - Vite/modern bundlers
+4. Default fallback: `http://localhost:8080/v1/graphql`
+
+Make sure to set the `VITE_HASURA_URL` environment variable in your application.
+
+## Usage
+
+```typescript
+import { anonClient } from '@coordinape/anongql';
+
+// Query example
+const result = await anonClient.query({
+  profiles: [
+    {
+      where: { address: { _eq: '0x123...' } }
+    },
+    {
+      id: true,
+      name: true,
+      address: true
+    }
+  ]
+}, {
+  operationName: 'GetProfile'
+});
+
+// Advanced usage with custom headers
+import { ThunderRequireOperationName } from '@coordinape/anongql';
+import { apiFetch } from 'graphql-zeus';
+
+const customClient = ThunderRequireOperationName(async (...params) => {
+  return apiFetch([
+    'https://your-hasura-url.com/v1/graphql',
+    {
+      method: 'POST',
+      headers: {
+        'Hasura-Client-Name': 'custom-client',
+        Authorization: 'Bearer your-token',
+      },
+    },
+  ])(...params);
+})('query');
+
+// Using with React and GraphQL subscriptions
+import { useTypedSubscription } from '@coordinape/anongql';
+
+function ProfileUpdates() {
+  const { data, loading, error } = useTypedSubscription({
+    profiles: [
+      { 
+        where: { updated_at: { _gt: "2023-01-01" } } 
+      },
+      {
+        id: true,
+        name: true,
+        updated_at: true
+      }
+    ]
+  }, {
+    // Apollo subscription options
+  }, {
+    operationName: 'ProfileUpdates'
+  });
+  
+  return /* rendering logic */;
+}
+```
+
+## GitHub Installation
+
+You can install directly from GitHub:
+
+```bash
+npm install coordinape/coordinape#main:src/lib/anongql
+# or for a specific branch
+npm install coordinape/coordinape#branch-name:src/lib/anongql
+```
+
+## License
+
+MIT

--- a/src/lib/anongql/anonClient.ts
+++ b/src/lib/anongql/anonClient.ts
@@ -1,8 +1,6 @@
 import type { SubscriptionHookOptions } from '@apollo/client';
 import { gql, useSubscription } from '@apollo/client';
 
-import { VITE_HASURA_URL } from '../../config/env';
-
 import { Ops } from './__generated__/zeus/const';
 import {
   apiFetch,
@@ -34,9 +32,20 @@ export const ThunderRequireOperationName =
     >;
 
 const makeThunder = (headers = {}) =>
-  ThunderRequireOperationName(async (...params) =>
-    apiFetch([
-      VITE_HASURA_URL,
+  ThunderRequireOperationName(async (...params) => {
+    // Get the Hasura URL from environment variables
+    const hasuraUrl =
+      typeof process !== 'undefined' && process.env.VITE_HASURA_URL
+        ? process.env.VITE_HASURA_URL
+        : typeof window !== 'undefined' && (window as any).env?.VITE_HASURA_URL
+          ? (window as any).env.VITE_HASURA_URL
+          : typeof import.meta !== 'undefined' &&
+              (import.meta as any).env?.VITE_HASURA_URL
+            ? (import.meta as any).env.VITE_HASURA_URL
+            : 'http://localhost:8080/v1/graphql'; // Fallback
+
+    return apiFetch([
+      hasuraUrl,
       {
         method: 'POST',
         headers: {
@@ -45,8 +54,8 @@ const makeThunder = (headers = {}) =>
           ...headers,
         },
       },
-    ])(...params)
-  );
+    ])(...params);
+  });
 
 const thunder = makeThunder();
 

--- a/src/lib/anongql/index.ts
+++ b/src/lib/anongql/index.ts
@@ -1,3 +1,7 @@
-import { anonClient } from './anonClient';
+import {
+  anonClient,
+  ThunderRequireOperationName,
+  useTypedSubscription,
+} from './anonClient';
 
-export { anonClient };
+export { anonClient, ThunderRequireOperationName, useTypedSubscription };

--- a/src/lib/anongql/index.ts
+++ b/src/lib/anongql/index.ts
@@ -1,0 +1,3 @@
+import { anonClient } from './anonClient';
+
+export { anonClient };

--- a/src/lib/anongql/package.json
+++ b/src/lib/anongql/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@coordinape/anongql",
+  "version": "0.1.0",
+  "description": "Anonymous GraphQL client for Hasura",
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "prepare": "npm run build"
+  },
+  "keywords": [
+    "graphql",
+    "hasura",
+    "zeus"
+  ],
+  "author": "Coordinape",
+  "license": "MIT",
+  "peerDependencies": {
+    "@apollo/client": "^3.7.0",
+    "graphql": "^16.0.0",
+    "graphql-zeus": "^5.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/coordinape/coordinape",
+    "directory": "src/lib/anongql"
+  }
+}

--- a/src/lib/anongql/tsconfig.json
+++ b/src/lib/anongql/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "./dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "lib": ["dom", "dom.iterable", "esnext"]
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## What

Exports the anongql client from the coordinape repo so other projects can use it. Unfortunately this carries all along the coordinape dependencies with it. We could potentially break this out at some point. 

Here is how to use it (example in the fv2 project):


```
# note this is currently branch tracked to the export_anongql branch
pnpm add github:coordinape/coordinape#export_anongql
```

then in code:
```
import { anonClient } from 'coordinape-app/anongql';
```

works!

## Why

<!-- Describe your changes and why -->

## Test and Deployment Plan

<!-- How have you tested your changes? Are there additional steps required to deploy this change? -->
<!-- Detail the steps needed to verify that this set of changes does what it's supposed to;
see for more details: https://github.com/coordinape/coordinape/blob/main/CONTRIBUTING.md#test-plan -->

## Screenshots (if appropriate):

<!-- This allows reviewers to begin reviewing your work without checking out your branch locally -->

## Reviewers

<!-- Tag any reviewers who have context on this PR, or are familiar with this part of the codebase. -->

## Related Issue

<!-- Please link to the issue here -->

## How
