### PR TITLE
change GIVE emission rates to more conservative amounts

### DIFF
--- a/src/features/points/emissionTiers.ts
+++ b/src/features/points/emissionTiers.ts
@@ -9,27 +9,27 @@ export interface EmissionTier {
 export const EMISSION_TIERS: EmissionTier[] = [
   {
     minTokens: 0n * 10n ** 18n,
-    maxTokens: 1000n * 10n ** 18n,
+    maxTokens: 1n * 10n ** 18n,
     multiplier: 1,
-    giveCap: 20,
+    giveCap: 1,
   }, // 1x = 1/day
   {
-    minTokens: 1000n * 10n ** 18n,
-    maxTokens: 10000n * 10n ** 18n,
-    multiplier: 4,
-    giveCap: 20,
-  }, // 4x = 4/day
+    minTokens: 1n * 10n ** 18n,
+    maxTokens: 100n * 10n ** 18n,
+    multiplier: 3,
+    giveCap: 3,
+  }, // 3x = 3/day
   {
-    minTokens: 10000n * 10n ** 18n,
-    maxTokens: 33000n * 10n ** 18n,
+    minTokens: 101n * 10n ** 18n,
+    maxTokens: 1000n * 10n ** 18n,
     multiplier: 10,
-    giveCap: 30,
+    giveCap: 10,
   }, // 10x = 10/day
   {
-    minTokens: 33000n * 10n ** 18n,
-    maxTokens: 100000n * 10n ** 18n,
+    minTokens: 1001n * 10n ** 18n,
+    maxTokens: 99999n * 10n ** 18n,
     multiplier: 20,
-    giveCap: 69,
+    giveCap: 20,
   }, // 20x = 20/day
   {
     minTokens: 100000n * 10n ** 18n,


### PR DESCRIPTION
## What
This PR adjusts the GIVE emission rates, which are tiered based on a user's CO token balance. The token thresholds, multipliers, and give caps for each tier have been updated to create a more conservative emission system with an additional low tier.
## Why
The previous emission tiers were not well-aligned with the desired incentive structure for holding CO tokens. This update aims to encourage token acquisition and holding by providing more distinct tiers and clearer benefits for users as they accumulate more tokens. The new structure provides a smoother progression and rewards users more effectively for their stake in the ecosystem.
## Test and Deployment Plan
**Testing:**
Verify on a staging environment that users with different CO token balances are assigned the correct emission tier and give cap as defined in the new EMISSION_TIERS array.
Confirm that the available GIVE for a user is calculated correctly based on their new emission multiplier.
Check that a user's ability to perform a "GIVE" action correctly respects the new giveCap.
## Deployment:
The changes are confined to the emissionTiers.ts file, and since this is a configuration change, no special deployment steps are required beyond the standard deployment process. The new rates will take effect once the changes are merged and deployed.
## How
The changes were made directly in the EMISSION_TIERS constant within src/features/points/emissionTiers.ts. The minTokens, maxTokens, multiplier, and giveCap values for each tier were updated to reflect the new desired emission schedule. No other code changes were necessary as the functions getEmissionTier and getGiveCap already utilize this constant to apply the logic.