### PR TITLE
Detect base CO and add to total CO token balance

### DIFF
--- a/_api/hasura/actions/_handlers/deleteCoLinksGive.ts
+++ b/_api/hasura/actions/_handlers/deleteCoLinksGive.ts
@@ -75,9 +75,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     assert(profiles_by_pk, 'current user profile not found');
 
     if (!profiles_by_pk) {
-      throw new UnprocessableError(
-        'could not find profile when deleting give'
-      );
+      throw new UnprocessableError('could not find profile when deleting give');
     }
 
     const totalTokenBalance = profiles_by_pk.token_balances.reduce(

--- a/_api/hasura/actions/_handlers/deleteCoLinksGive.ts
+++ b/_api/hasura/actions/_handlers/deleteCoLinksGive.ts
@@ -11,8 +11,6 @@ import {
   UnprocessableError,
 } from '../../../../api-lib/HttpError';
 import {
-  CO_CHAIN,
-  CO_CONTRACT,
   getAvailablePoints,
   POINTS_PER_GIVE,
 } from '../../../../src/features/points/getAvailablePoints';
@@ -60,12 +58,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             token_balances: [
               {
                 where: {
-                  contract: {
-                    _eq: CO_CONTRACT,
-                  },
-                  chain: { _eq: CO_CHAIN.toString() },
+                  symbol: { _eq: 'CO' },
                 },
-                limit: 1,
               },
               {
                 balance: true,
@@ -80,10 +74,21 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     );
     assert(profiles_by_pk, 'current user profile not found');
 
+    if (!profiles_by_pk) {
+      throw new UnprocessableError(
+        'could not find profile when deleting give'
+      );
+    }
+
+    const totalTokenBalance = profiles_by_pk.token_balances.reduce(
+      (sum, b) => sum + BigInt(b.balance ?? 0),
+      0n
+    );
+
     const points = getAvailablePoints(
       profiles_by_pk.points_balance,
       profiles_by_pk.points_checkpointed_at,
-      profiles_by_pk.token_balances[0].balance
+      totalTokenBalance
     );
     // delete the thing
     // checkpoint balance

--- a/api-lib/tokenBalances.ts
+++ b/api-lib/tokenBalances.ts
@@ -14,7 +14,7 @@ import { BE_ALCHEMY_API_KEY } from './config';
 const ALCHEMY_NETWORK: Record<number, Network> = {
   1: Network.ETH_MAINNET,
   // 10: Network.OPT_MAINNET,
-  // 8453: Network.BASE_MAINNET,
+  8453: Network.BASE_MAINNET,
 };
 
 export const getTokenBalance = async (

--- a/src/features/points/getAvailablePoints.ts
+++ b/src/features/points/getAvailablePoints.ts
@@ -7,20 +7,25 @@ export const POINTS_PER_GIVE = 60 * 60 * 24;
 
 export type TokenContract = {
   symbol: string;
-  chain: number;
   contract: string;
+  chain: number;
 };
 
 export const TOKENS: TokenContract[] = [
   {
     symbol: 'CO',
-    chain: 1,
     contract: '0xf828ba501b108fbc6c88ebdff81c401bb6b94848',
+    chain: 1,
+  },
+  {
+    symbol: 'CO',
+    contract: '0xe8A9ABa04e6807Cc77501862cC7eA17c9603291E',
+    chain: 8453,
   },
   {
     symbol: 'AAVE',
-    chain: 1,
     contract: '0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9',
+    chain: 1,
   },
 ];
 

--- a/src/features/points/getAvailablePoints.ts
+++ b/src/features/points/getAvailablePoints.ts
@@ -29,9 +29,6 @@ export const TOKENS: TokenContract[] = [
   },
 ];
 
-export const CO_CONTRACT = TOKENS.find(t => t.symbol === 'CO')!.contract;
-export const CO_CHAIN = TOKENS.find(t => t.symbol === 'CO')!.chain;
-
 export const getAvailablePoints = (
   balance: number,
   checkpoint: string,


### PR DESCRIPTION
## What

This change updates the application to check for a user's `CO` token balance on both the Ethereum and Base chains. It aggregates the balances from both chains to calculate a user's total `CO` token holdings, which is then used to determine their "GIVE" accrual rate and capacity.

## Why

Previously, the application only checked for a user's `CO` token balance on Ethereum. With the token also existing on Base, this change was necessary to ensure the application accurately reflects a user's total holdings across all supported chains. This provides a correct and consistent user experience, regardless of where their tokens are held.

## How

The implementation involved several key steps:

1.  **Enabled Base Chain Support:** The Alchemy configuration in `api-lib/tokenBalances.ts` was updated to include `BASE_MAINNET`.
2.  **Expanded Token Definitions:** The `TOKENS` constant in `src/features/points/getAvailablePoints.ts` was updated to include the contract address for the `CO` token on the Base chain.
3.  **Aggregated Balance on Frontend:** The `usePoints` hook was refactored to query for all token balances with the symbol 'CO' instead of querying for a single hardcoded contract. It then sums the balances from all returned chains to create a single aggregated total.
4.  **Aggregated Balance on Backend:** The logic in the backend Hasura action handlers (`createCoLinksGive.ts` and `deleteCoLinksGive.ts`) was updated to mirror the frontend. This ensures that all server-side validations for creating or deleting a GIVE use the same aggregated balance calculation, maintaining data integrity and consistency between the UI and the API.
5.  **Code Hygiene:** As part of the refactor, the now-obsolete `CO_CONTRACT` and `CO_CHAIN` constants were removed from `getAvailablePoints.ts` to prevent their misuse in the future.

## Test and Deployment Plan

To test this change:

1.  **Verify UI Display:** For a wallet holding `CO` tokens on both Ethereum and Base, confirm that the GIVE balance displayed in the application UI reflects the combined total from both chains.
2.  **Verify GIVE Functionality (UI):** Perform a GIVE action from the UI. The transaction should succeed based on the aggregated balance.
3.  **Verify GIVE Functionality (API):** Trigger the `createCoLinksGive` and `deleteCoLinksGive` Hasura actions directly via an API call. Confirm the actions succeed or fail based on the correct aggregated balance, not just the Ethereum balance.
4.  **Verify Zero Balance:** For a wallet with no `CO` tokens on either chain, confirm their GIVE balance is calculated correctly (based on the lowest emission tier).

No special deployment steps are required.
